### PR TITLE
Prime field modulus and Montgomery constants made static

### DIFF
--- a/crypto-primitives/src/field.rs
+++ b/crypto-primitives/src/field.rs
@@ -7,11 +7,11 @@ use num_traits::Inv;
 /// respective inverse operations.
 pub trait Field:
 Ring
-    // Arithmetic operations consuming rhs
-    + Div<Self, Output=Self>
-    // Arithmetic operations with rhs reference
-    + for<'a> Div<&'a Self, Output=Self>
-    {}
+// Arithmetic operations consuming rhs
++ Div<Self, Output=Self>
+// Arithmetic operations with rhs reference
++ for<'a> Div<&'a Self, Output=Self>
+{}
 
 /// Element of an integer field modulo prime number (F_p).
 pub trait PrimeField: Field + IntRing + for<'a> From<&'a [Limb]> + Inv {
@@ -29,5 +29,16 @@ pub trait PrimeField: Field + IntRing + for<'a> From<&'a [Limb]> + Inv {
 /// Element of a prime field in its Montgomery representation of - encoded in a way so that modular
 /// multiplication can be done without performing an explicit division by pp after each product.
 pub trait MontgomeryField: PrimeField {
-    // FIXME
+    /// Let `M` be the power of 2^64 nearest to `Self::MODULUS_BITS`. Then
+    /// `R = M % Self::MODULUS`.
+    const R: Self::Inner;
+
+    /// `R^2 = R * R mod MODULUS`
+    const R_SQUARED: Self::Inner;
+
+    /// Does the modulus have a spare unused bit
+    ///
+    /// This condition applies if
+    /// (a) `Self::MODULUS[N-1] >> 63 == 0`
+    const MODULUS_HAS_SPARE_BIT: bool;
 }

--- a/crypto-primitives/src/field.rs
+++ b/crypto-primitives/src/field.rs
@@ -1,16 +1,17 @@
-use crate::{IntRing, Limb, ring::Ring};
+use crate::ring::Ring;
+use crate::{IntRing, Limb};
 use core::ops::Div;
 use num_traits::Inv;
 
-/// Element of a field (F) - a group where addition and multiplication are
-/// defined with their respective inverse operations.
+/// Element of a field (F) - a group where addition and multiplication are defined with their
+/// respective inverse operations.
 pub trait Field:
 Ring
-// Arithmetic operations consuming rhs
-+ Div<Self, Output=Self>
-// Arithmetic operations with rhs reference
-+ for<'a> Div<&'a Self, Output=Self>
-{}
+    // Arithmetic operations consuming rhs
+    + Div<Self, Output=Self>
+    // Arithmetic operations with rhs reference
+    + for<'a> Div<&'a Self, Output=Self>
+    {}
 
 /// Element of an integer field modulo prime number (F_p).
 pub trait PrimeField: Field + IntRing + for<'a> From<&'a [Limb]> + Inv {
@@ -25,20 +26,8 @@ pub trait PrimeField: Field + IntRing + for<'a> From<&'a [Limb]> + Inv {
     fn from_u128(value: u32) -> Self;
 }
 
-/// Element of a prime field in its Montgomery representation of - encoded in a
-/// way so that modular multiplication can be done without performing an
-/// explicit division by pp after each product.
+/// Element of a prime field in its Montgomery representation of - encoded in a way so that modular
+/// multiplication can be done without performing an explicit division by pp after each product.
 pub trait MontgomeryField: PrimeField {
-    /// Let `M` be the power of 2^64 nearest to `Self::MODULUS_BITS`. Then
-    /// `R = M % Self::MODULUS`.
-    const R: Self::Inner;
-
-    /// `R^2 = R * R mod MODULUS`
-    const R_SQUARED: Self::Inner;
-
-    /// Does the modulus have a spare unused bit
-    ///
-    /// This condition applies if
-    /// (a) `Self::MODULUS[N-1] >> 63 == 0`
-    const MODULUS_HAS_SPARE_BIT: bool;
+    // FIXME
 }

--- a/crypto-primitives/src/field.rs
+++ b/crypto-primitives/src/field.rs
@@ -1,10 +1,9 @@
-use crate::ring::Ring;
-use crate::{IntRing, Limb};
+use crate::{IntRing, Limb, ring::Ring};
 use core::ops::Div;
 use num_traits::Inv;
 
-/// Element of a field (F) - a group where addition and multiplication are defined with their
-/// respective inverse operations.
+/// Element of a field (F) - a group where addition and multiplication are
+/// defined with their respective inverse operations.
 pub trait Field:
 Ring
 // Arithmetic operations consuming rhs
@@ -26,8 +25,9 @@ pub trait PrimeField: Field + IntRing + for<'a> From<&'a [Limb]> + Inv {
     fn from_u128(value: u32) -> Self;
 }
 
-/// Element of a prime field in its Montgomery representation of - encoded in a way so that modular
-/// multiplication can be done without performing an explicit division by pp after each product.
+/// Element of a prime field in its Montgomery representation of - encoded in a
+/// way so that modular multiplication can be done without performing an
+/// explicit division by pp after each product.
 pub trait MontgomeryField: PrimeField {
     /// Let `M` be the power of 2^64 nearest to `Self::MODULUS_BITS`. Then
     /// `R = M % Self::MODULUS`.

--- a/crypto-primitives/src/ring.rs
+++ b/crypto-primitives/src/ring.rs
@@ -2,12 +2,9 @@ use crate::{Limb, PrimeField};
 use core::{
     fmt::{Debug, Display},
     iter::{Product, Sum},
-    ops::{Add, AddAssign, Mul, MulAssign, Rem, RemAssign, Sub, SubAssign},
+    ops::{Add, AddAssign, Mul, MulAssign, Sub, SubAssign, Rem, RemAssign},
 };
-use num_traits::{
-    CheckedAdd, CheckedMul, CheckedNeg, CheckedRem, CheckedShl, CheckedShr, CheckedSub, ConstOne,
-    ConstZero, Pow,
-};
+use num_traits::{CheckedAdd, CheckedMul, CheckedNeg, CheckedRem, CheckedShl, CheckedShr, CheckedSub, ConstOne, ConstZero, Pow};
 
 /// A ring is like a field without a multiplicative inverse or division.
 pub trait Ring:
@@ -77,8 +74,7 @@ pub trait LimbedIntRing: IntRing + From<Limb> + for<'a> TryFrom<&'a [Limb]> {
 
     fn limbs(&self) -> &[Limb];
 
-    // Cannot implement it as From trait since both participants are of non-local
-    // types
+    // Cannot implement it as From trait since both participants are of non-local types
     fn to_field<F: PrimeField>(&self) -> F {
         F::from(self.limbs())
     }

--- a/crypto-primitives/src/ring.rs
+++ b/crypto-primitives/src/ring.rs
@@ -2,9 +2,12 @@ use crate::{Limb, PrimeField};
 use core::{
     fmt::{Debug, Display},
     iter::{Product, Sum},
-    ops::{Add, AddAssign, Mul, MulAssign, Sub, SubAssign, Rem, RemAssign},
+    ops::{Add, AddAssign, Mul, MulAssign, Rem, RemAssign, Sub, SubAssign},
 };
-use num_traits::{CheckedAdd, CheckedMul, CheckedNeg, CheckedRem, CheckedShl, CheckedShr, CheckedSub, ConstOne, ConstZero, Pow};
+use num_traits::{
+    CheckedAdd, CheckedMul, CheckedNeg, CheckedRem, CheckedShl, CheckedShr, CheckedSub, ConstOne,
+    ConstZero, Pow,
+};
 
 /// A ring is like a field without a multiplicative inverse or division.
 pub trait Ring:
@@ -74,7 +77,8 @@ pub trait LimbedIntRing: IntRing + From<Limb> + for<'a> TryFrom<&'a [Limb]> {
 
     fn limbs(&self) -> &[Limb];
 
-    // Cannot implement it as From trait since both participants are of non-local types
+    // Cannot implement it as From trait since both participants are of non-local
+    // types
     fn to_field<F: PrimeField>(&self) -> F {
         F::from(self.limbs())
     }

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "stable"
+channel = "nightly"
 components = ["rustfmt", "clippy"]

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "nightly"
+channel = "stable"
 components = ["rustfmt", "clippy"]

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -19,7 +19,8 @@ use_field_init_shorthand   = true          # `{ x, y }` instead of `{ x: x, y: y
 trailing_comma             = "Vertical"    # Comma-terminate every multi-line list
 
 # ---------- Implementation order -------------------------------------------
-reorder_impl_items         = true          # Deterministic ordering inside impl blocks
+reorder_impl_items         = false         # Deterministic ordering inside impl blocks
+                                           # Disabled because it currently sorts types alphabetically (unstable)
 
 # --- Misc -------------------------------------------------------------------
 edition                    = "2024"        # Controls the edition of the Rust Style Guide

--- a/zip-plus/Cargo.toml
+++ b/zip-plus/Cargo.toml
@@ -6,6 +6,9 @@ edition.workspace = true
 repository.workspace = true
 license.workspace = true
 
+[lib]
+bench = false
+
 [dependencies]
 crypto-primitives = { workspace = true }
 

--- a/zip-plus/Cargo.toml
+++ b/zip-plus/Cargo.toml
@@ -36,6 +36,7 @@ workspace = true
 
 [features]
 parallel = ["dep:rayon"]
+asm = ["ark-ff/asm", "sha3/asm"]
 
 [[bench]]
 name = "random_field_benches"

--- a/zip-plus/benches/random_field_benches.rs
+++ b/zip-plus/benches/random_field_benches.rs
@@ -12,14 +12,14 @@ use criterion::{
 };
 use zip_plus::{big_int, define_field_config, field::{ConfigRef, RandomField}, field_config, random_field};
 use zip_plus::field::config::ConstFieldConfig;
-use zip_plus::traits::FieldMap;
+use zip_plus::traits::{ConfigReference, FieldMap};
 
 define_field_config!(Fc, "695962179703626800597079116051991347");
 
 fn bench_random_field(group: &mut criterion::BenchmarkGroup<criterion::measurement::WallTime>) {
-    let field_config = ConfigRef::from(&Fc::<4>::FIELD_CONFIG);
+    let field_config = unsafe { ConfigRef::new(Box::leak(Box::new(Fc::<4>::field_config()))) };
 
-    let field_elem: RandomField<4, Fc<4>> = 695962179703.map_to_field(field_config);
+    let field_elem: RandomField<4, Fc<4>> = 695962179703_u64.map_to_field(field_config);
     group.bench_with_input(
         BenchmarkId::new("Multiply", "Random128BitFieldElement"),
         &field_elem,

--- a/zip-plus/benches/random_field_benches.rs
+++ b/zip-plus/benches/random_field_benches.rs
@@ -10,24 +10,23 @@ use criterion::{
     criterion_group, criterion_main, AxisScale, BenchmarkId, Criterion,
     PlotConfiguration,
 };
-use zip_plus::{
-    big_int,
-    field::{ConfigRef, RandomField},
-    field_config, random_field,
-};
+use zip_plus::{big_int, define_field_config, field::{ConfigRef, RandomField}, field_config, random_field};
+use zip_plus::field::config::ConstFieldConfig;
+use zip_plus::traits::FieldMap;
+
+define_field_config!(Fc, "695962179703626800597079116051991347");
 
 fn bench_random_field(group: &mut criterion::BenchmarkGroup<criterion::measurement::WallTime>) {
-    let config = field_config!(695962179703626800597079116051991347);
-    let field_config = ConfigRef::from(&config);
+    let field_config = ConfigRef::from(&Fc::<4>::FIELD_CONFIG);
 
-    let field_elem = random_field!(695962179703, 4, field_config);
+    let field_elem: RandomField<4, Fc<4>> = 695962179703.map_to_field(field_config);
     group.bench_with_input(
         BenchmarkId::new("Multiply", "Random128BitFieldElement"),
         &field_elem,
         |b, unop_elem| {
             b.iter(|| {
                 for _ in 0..10000 {
-                    let _ = black_box(*unop_elem * *unop_elem);
+                    let _ = black_box(unop_elem.clone() * unop_elem.clone());
                 }
             });
         },
@@ -39,7 +38,7 @@ fn bench_random_field(group: &mut criterion::BenchmarkGroup<criterion::measureme
         |b, unop_elem| {
             b.iter(|| {
                 for _ in 0..10000 {
-                    let _ = black_box(*unop_elem + *unop_elem);
+                    let _ = black_box(unop_elem.clone() + unop_elem.clone());
                 }
             });
         },
@@ -51,7 +50,7 @@ fn bench_random_field(group: &mut criterion::BenchmarkGroup<criterion::measureme
         |b, unop_elem| {
             b.iter(|| {
                 for _ in 0..10000 {
-                    let _ = black_box(*unop_elem / *unop_elem);
+                    let _ = black_box(unop_elem.clone() / unop_elem.clone());
                 }
             });
         },
@@ -63,7 +62,7 @@ fn bench_random_field(group: &mut criterion::BenchmarkGroup<criterion::measureme
         |b, unop_elem| {
             b.iter(|| {
                 for _ in 0..10000 {
-                    let _ = black_box(-*unop_elem);
+                    let _ = black_box(-unop_elem.clone());
                 }
             });
         },

--- a/zip-plus/benches/random_field_benches.rs
+++ b/zip-plus/benches/random_field_benches.rs
@@ -5,13 +5,28 @@ use ark_std::{
     test_rng,
     time::{Duration, Instant},
 };
-use criterion::{criterion_group, criterion_main, measurement::WallTime, AxisScale, BenchmarkGroup, BenchmarkId, Criterion, PlotConfiguration};
+use criterion::{
+    AxisScale, BenchmarkGroup, BenchmarkId, Criterion, PlotConfiguration, criterion_group,
+    criterion_main, measurement::WallTime,
+};
 use crypto_bigint::Random;
 use itertools::Itertools;
-use std::hint::black_box;
-use std::iter::{Product, Sum};
-use zip_plus::field::config::FieldConfigBase;
-use zip_plus::{code::{DefaultLinearCodeSpec, LinearCode}, code_raa::RaaCode, define_field_config, define_random_field_zip_types, field::RandomField, implement_random_field_zip_types, pcs::{structs::MultilinearZip, MerkleTree}, pcs_transcript::PcsTranscript, poly_z::mle::{DenseMultilinearExtension, MultilinearExtension}, traits::{FieldMap, ZipTypes}, transcript::KeccakTranscript};
+use std::{
+    hint::black_box,
+    iter::{Product, Sum},
+};
+use zip_plus::{
+    code::{DefaultLinearCodeSpec, LinearCode},
+    code_raa::RaaCode,
+    define_field_config, define_random_field_zip_types,
+    field::{RandomField, config::FieldConfigBase},
+    implement_random_field_zip_types,
+    pcs::{MerkleTree, structs::MultilinearZip},
+    pcs_transcript::PcsTranscript,
+    poly_z::mle::{DenseMultilinearExtension, MultilinearExtension},
+    traits::{FieldMap, ZipTypes},
+    transcript::KeccakTranscript,
+};
 
 define_field_config!(Fc, "695962179703626800597079116051991347");
 

--- a/zip-plus/benches/random_field_benches.rs
+++ b/zip-plus/benches/random_field_benches.rs
@@ -10,16 +10,13 @@ use criterion::{
     criterion_group, criterion_main, AxisScale, BenchmarkId, Criterion,
     PlotConfiguration,
 };
-use zip_plus::{big_int, define_field_config, field::{ConfigRef, RandomField}, field_config, random_field};
-use zip_plus::field::config::ConstFieldConfig;
-use zip_plus::traits::{ConfigReference, FieldMap};
+use zip_plus::{big_int, define_field_config, field::{RandomField, config::FieldConfig}, random_field};
+use zip_plus::traits::{FieldMap};
 
 define_field_config!(Fc, "695962179703626800597079116051991347");
 
 fn bench_random_field(group: &mut criterion::BenchmarkGroup<criterion::measurement::WallTime>) {
-    let field_config = unsafe { ConfigRef::new(Box::leak(Box::new(Fc::<4>::field_config()))) };
-
-    let field_elem: RandomField<4, Fc<4>> = 695962179703_u64.map_to_field(field_config);
+    let field_elem: RandomField<4, Fc<4>> = 695962179703_u64.map_to_field();
     group.bench_with_input(
         BenchmarkId::new("Multiply", "Random128BitFieldElement"),
         &field_elem,

--- a/zip-plus/benches/random_field_benches.rs
+++ b/zip-plus/benches/random_field_benches.rs
@@ -1,17 +1,17 @@
 #![allow(non_local_definitions)]
 #![allow(clippy::eq_op)]
 
-use std::hint::black_box;
 use ark_std::{
-    iter::{Product, Sum},
-    iterable::Iterable,
+    test_rng,
+    time::{Duration, Instant},
 };
-use criterion::{
-    criterion_group, criterion_main, AxisScale, BenchmarkId, Criterion,
-    PlotConfiguration,
-};
-use zip_plus::{big_int, define_field_config, field::{RandomField, config::FieldConfig}, random_field};
-use zip_plus::traits::{FieldMap};
+use criterion::{criterion_group, criterion_main, measurement::WallTime, AxisScale, BenchmarkGroup, BenchmarkId, Criterion, PlotConfiguration};
+use crypto_bigint::Random;
+use itertools::Itertools;
+use std::hint::black_box;
+use std::iter::{Product, Sum};
+use zip_plus::field::config::FieldConfigBase;
+use zip_plus::{code::{DefaultLinearCodeSpec, LinearCode}, code_raa::RaaCode, define_field_config, define_random_field_zip_types, field::RandomField, implement_random_field_zip_types, pcs::{structs::MultilinearZip, MerkleTree}, pcs_transcript::PcsTranscript, poly_z::mle::{DenseMultilinearExtension, MultilinearExtension}, traits::{FieldMap, ZipTypes}, transcript::KeccakTranscript};
 
 define_field_config!(Fc, "695962179703626800597079116051991347");
 

--- a/zip-plus/benches/zip_benches.rs
+++ b/zip-plus/benches/zip_benches.rs
@@ -141,6 +141,7 @@ fn open<const P: usize>(group: &mut BenchmarkGroup<WallTime>, spec: usize) {
     let poly = DenseMultilinearExtension::rand(P, &mut rng);
     let (data, _) = BenchZip::commit::<RandomField<FIELD_LIMBS, FC>>(&params, &poly).unwrap();
     let point = vec![1i64; P];
+    let field_point = point.map_to_field();
 
     group.bench_function(
         format!("Open: RandomField<{FIELD_LIMBS}>, poly_size = 2^{P}(Int limbs = {INT_LIMBS}), ZipSpec{spec}, modulus={}", FC::modulus()),
@@ -154,7 +155,7 @@ fn open<const P: usize>(group: &mut BenchmarkGroup<WallTime>, spec: usize) {
                         &params,
                         &poly,
                         &data,
-                        &point.map_to_field(),
+                        &field_point,
                         &mut transcript,
                     )
                     .expect("Failed to make opening");

--- a/zip-plus/benches/zip_benches.rs
+++ b/zip-plus/benches/zip_benches.rs
@@ -1,6 +1,7 @@
 #![allow(non_local_definitions)]
 #![allow(clippy::eq_op)]
 
+use zip_plus::field::config::ConstFieldConfig;
 use std::hint::black_box;
 use ark_std::{
     str::FromStr,
@@ -12,18 +13,7 @@ use criterion::{
 };
 use crypto_bigint::Random;
 use itertools::Itertools;
-use zip_plus::{
-    define_random_field_zip_types,
-    field::{BigInt, ConfigRef, FieldConfig, RandomField},
-    implement_random_field_zip_types,
-    poly_z::mle::{DenseMultilinearExtension, MultilinearExtension},
-    traits::{Config, ConfigReference, FieldMap, ZipTypes},
-    transcript::KeccakTranscript,
-    code::{DefaultLinearCodeSpec, LinearCode},
-    code_raa::RaaCode,
-    pcs::{structs::MultilinearZip, MerkleTree},
-    pcs_transcript::PcsTranscript,
-};
+use zip_plus::{define_random_field_zip_types, field::{BigInt, ConfigRef, FieldConfig, RandomField}, implement_random_field_zip_types, poly_z::mle::{DenseMultilinearExtension, MultilinearExtension}, traits::{Config, ConfigReference, FieldMap, ZipTypes}, transcript::KeccakTranscript, code::{DefaultLinearCodeSpec, LinearCode}, code_raa::RaaCode, pcs::{structs::MultilinearZip, MerkleTree}, pcs_transcript::PcsTranscript, define_field_config};
 
 const INT_LIMBS: usize = 1;
 const FIELD_LIMBS: usize = 4;
@@ -34,6 +24,9 @@ implement_random_field_zip_types!(INT_LIMBS);
 type ZT = RandomFieldZipTypes<INT_LIMBS>;
 type LC = RaaCode<ZT>;
 type BenchZip = MultilinearZip<ZT, LC>;
+
+define_field_config!(Fc, "106319353542452952636349991594949358997917625194731877894581586278529202198383");
+type FC = Fc<FIELD_LIMBS>;
 
 fn encode_rows<const P: usize>(group: &mut BenchmarkGroup<WallTime>, spec: usize) {
     group.bench_function(
@@ -113,7 +106,7 @@ fn commit<const P: usize>(group: &mut BenchmarkGroup<WallTime>, spec: usize) {
                 for _ in 0..iters {
                     let poly = DenseMultilinearExtension::rand(P, &mut rng);
                     let timer = Instant::now();
-                    let _ = BenchZip::commit::<RandomField<FIELD_LIMBS>>(&params, &poly)
+                    let _ = BenchZip::commit::<RandomField<FIELD_LIMBS, FC>>(&params, &poly)
                         .expect("Failed to commit");
                     total_duration += timer.elapsed()
                 }
@@ -124,10 +117,9 @@ fn commit<const P: usize>(group: &mut BenchmarkGroup<WallTime>, spec: usize) {
     );
 }
 
-fn open<const P: usize>(group: &mut BenchmarkGroup<WallTime>, modulus: &str, spec: usize) {
+fn open<const P: usize>(group: &mut BenchmarkGroup<WallTime>, spec: usize) {
     let mut rng = test_rng();
-    let config = FieldConfig::new(BigInt::<FIELD_LIMBS>::from_str(modulus).unwrap());
-    let field_config = ConfigRef::from(&config);
+    let field_config = ConfigRef::from(&FC::FIELD_CONFIG);
 
     type T = KeccakTranscript;
     let mut keccak_transcript = T::new();
@@ -136,16 +128,16 @@ fn open<const P: usize>(group: &mut BenchmarkGroup<WallTime>, modulus: &str, spe
     let params = BenchZip::setup(poly_size, linear_code);
 
     let poly = DenseMultilinearExtension::rand(P, &mut rng);
-    let (data, _) = BenchZip::commit::<RandomField<FIELD_LIMBS>>(&params, &poly).unwrap();
+    let (data, _) = BenchZip::commit::<RandomField<FIELD_LIMBS, FC>>(&params, &poly).unwrap();
     let point = vec![1i64; P];
 
     group.bench_function(
-        format!("Open: RandomField<{FIELD_LIMBS}>, poly_size = 2^{P}(Int limbs = {INT_LIMBS}), ZipSpec{spec}, modulus={modulus}"),
+        format!("Open: RandomField<{FIELD_LIMBS}>, poly_size = 2^{P}(Int limbs = {INT_LIMBS}), ZipSpec{spec}, modulus={}", FC::MODULUS),
         |b| {
             b.iter_custom(|iters| {
                 let mut total_duration = Duration::ZERO;
                 for _ in 0..iters {
-                    let mut transcript = PcsTranscript::<RandomField<FIELD_LIMBS>>::new();
+                    let mut transcript = PcsTranscript::<RandomField<FIELD_LIMBS, FC>>::new();
                     let timer = Instant::now();
                     BenchZip::open(
                         &params,
@@ -163,10 +155,9 @@ fn open<const P: usize>(group: &mut BenchmarkGroup<WallTime>, modulus: &str, spe
         },
     );
 }
-fn verify<const P: usize>(group: &mut BenchmarkGroup<WallTime>, modulus: &str, spec: usize) {
+fn verify<const P: usize>(group: &mut BenchmarkGroup<WallTime>, spec: usize) {
     let mut rng = test_rng();
-    let config = FieldConfig::new(BigInt::<FIELD_LIMBS>::from_str(modulus).unwrap());
-    let field_config = ConfigRef::from(&config);
+    let field_config = ConfigRef::from(&FC::FIELD_CONFIG);
 
     type T = KeccakTranscript;
     let mut keccak_transcript = T::new();
@@ -175,10 +166,10 @@ fn verify<const P: usize>(group: &mut BenchmarkGroup<WallTime>, modulus: &str, s
     let params = BenchZip::setup(poly_size, linear_code);
 
     let poly = DenseMultilinearExtension::rand(P, &mut rng);
-    let (data, commitment) = BenchZip::commit::<RandomField<FIELD_LIMBS>>(&params, &poly).unwrap();
+    let (data, commitment) = BenchZip::commit::<RandomField<FIELD_LIMBS, FC>>(&params, &poly).unwrap();
     let point = vec![1i64; P];
     let eval = poly.evaluations.last().unwrap();
-    let mut transcript = PcsTranscript::<RandomField<FIELD_LIMBS>>::new();
+    let mut transcript = PcsTranscript::<RandomField<FIELD_LIMBS, FC>>::new();
 
     BenchZip::open(
         &params,
@@ -195,12 +186,12 @@ fn verify<const P: usize>(group: &mut BenchmarkGroup<WallTime>, modulus: &str, s
         .reference()
         .expect("Field config cannot be none");
     group.bench_function(
-        format!("Verify: RandomField<{FIELD_LIMBS}>, poly_size = 2^{P}(Int limbs = {INT_LIMBS}), ZipSpec{spec}, modulus={modulus}"),
+        format!("Verify: RandomField<{FIELD_LIMBS}>, poly_size = 2^{P}(Int limbs = {INT_LIMBS}), ZipSpec{spec}, modulus={}", FC::MODULUS),
         |b| {
             b.iter_custom(|iters| {
                 let mut total_duration = Duration::ZERO;
                 for _ in 0..iters {
-                    let mut transcript = PcsTranscript::<RandomField<FIELD_LIMBS>>::from_proof(&proof);
+                    let mut transcript = PcsTranscript::<RandomField<FIELD_LIMBS, FC>>::from_proof(&proof);
                     let timer = Instant::now();
                     BenchZip::verify(
                         &params,
@@ -239,27 +230,11 @@ fn zip_benchmarks(c: &mut Criterion) {
     commit::<12>(&mut group, 1);
     commit::<16>(&mut group, 1);
 
-    open::<12>(
-        &mut group,
-        "106319353542452952636349991594949358997917625194731877894581586278529202198383",
-        1,
-    );
-    open::<16>(
-        &mut group,
-        "106319353542452952636349991594949358997917625194731877894581586278529202198383",
-        1,
-    );
+    open::<12>(&mut group, 1);
+    open::<16>(&mut group, 1);
 
-    verify::<12>(
-        &mut group,
-        "106319353542452952636349991594949358997917625194731877894581586278529202198383",
-        1,
-    );
-    verify::<16>(
-        &mut group,
-        "106319353542452952636349991594949358997917625194731877894581586278529202198383",
-        1,
-    );
+    verify::<12>(&mut group, 1);
+    verify::<16>(&mut group, 1);
 
     group.finish();
 }

--- a/zip-plus/benches/zip_benches.rs
+++ b/zip-plus/benches/zip_benches.rs
@@ -1,18 +1,28 @@
 #![allow(non_local_definitions)]
 #![allow(clippy::eq_op)]
 
-use zip_plus::field::config::{FieldConfigBase};
-use std::hint::black_box;
 use ark_std::{
     test_rng,
     time::{Duration, Instant},
 };
 use criterion::{
-    criterion_group, criterion_main, measurement::WallTime, BenchmarkGroup, Criterion,
+    BenchmarkGroup, Criterion, criterion_group, criterion_main, measurement::WallTime,
 };
 use crypto_bigint::Random;
 use itertools::Itertools;
-use zip_plus::{define_random_field_zip_types, field::{RandomField}, implement_random_field_zip_types, poly_z::mle::{DenseMultilinearExtension, MultilinearExtension}, traits::{FieldMap, ZipTypes}, transcript::KeccakTranscript, code::{DefaultLinearCodeSpec, LinearCode}, code_raa::RaaCode, pcs::{structs::MultilinearZip, MerkleTree}, pcs_transcript::PcsTranscript, define_field_config};
+use std::hint::black_box;
+use zip_plus::{
+    code::{DefaultLinearCodeSpec, LinearCode},
+    code_raa::RaaCode,
+    define_field_config, define_random_field_zip_types,
+    field::{RandomField, config::FieldConfigBase},
+    implement_random_field_zip_types,
+    pcs::{MerkleTree, structs::MultilinearZip},
+    pcs_transcript::PcsTranscript,
+    poly_z::mle::{DenseMultilinearExtension, MultilinearExtension},
+    traits::{FieldMap, ZipTypes},
+    transcript::KeccakTranscript,
+};
 
 const INT_LIMBS: usize = 1;
 const FIELD_LIMBS: usize = 4;
@@ -24,7 +34,10 @@ type ZT = RandomFieldZipTypes<INT_LIMBS>;
 type LC = RaaCode<ZT>;
 type BenchZip = MultilinearZip<ZT, LC>;
 
-define_field_config!(Fc, "106319353542452952636349991594949358997917625194731877894581586278529202198383");
+define_field_config!(
+    Fc,
+    "106319353542452952636349991594949358997917625194731877894581586278529202198383"
+);
 type FC = Fc<FIELD_LIMBS>;
 
 fn encode_rows<const P: usize>(group: &mut BenchmarkGroup<WallTime>, spec: usize) {
@@ -162,7 +175,8 @@ fn verify<const P: usize>(group: &mut BenchmarkGroup<WallTime>, spec: usize) {
     let params = BenchZip::setup(poly_size, linear_code);
 
     let poly = DenseMultilinearExtension::rand(P, &mut rng);
-    let (data, commitment) = BenchZip::commit::<RandomField<FIELD_LIMBS, FC>>(&params, &poly).unwrap();
+    let (data, commitment) =
+        BenchZip::commit::<RandomField<FIELD_LIMBS, FC>>(&params, &poly).unwrap();
     let point = vec![1i64; P];
     let eval = poly.evaluations.last().unwrap();
     let mut transcript = PcsTranscript::<RandomField<FIELD_LIMBS, FC>>::new();

--- a/zip-plus/benches/zip_benches.rs
+++ b/zip-plus/benches/zip_benches.rs
@@ -1,10 +1,9 @@
 #![allow(non_local_definitions)]
 #![allow(clippy::eq_op)]
 
-use zip_plus::field::config::ConstFieldConfig;
+use zip_plus::field::config::{FieldConfigBase};
 use std::hint::black_box;
 use ark_std::{
-    str::FromStr,
     test_rng,
     time::{Duration, Instant},
 };
@@ -13,7 +12,7 @@ use criterion::{
 };
 use crypto_bigint::Random;
 use itertools::Itertools;
-use zip_plus::{define_random_field_zip_types, field::{BigInt, ConfigRef, FieldConfig, RandomField}, implement_random_field_zip_types, poly_z::mle::{DenseMultilinearExtension, MultilinearExtension}, traits::{Config, ConfigReference, FieldMap, ZipTypes}, transcript::KeccakTranscript, code::{DefaultLinearCodeSpec, LinearCode}, code_raa::RaaCode, pcs::{structs::MultilinearZip, MerkleTree}, pcs_transcript::PcsTranscript, define_field_config};
+use zip_plus::{define_random_field_zip_types, field::{RandomField}, implement_random_field_zip_types, poly_z::mle::{DenseMultilinearExtension, MultilinearExtension}, traits::{FieldMap, ZipTypes}, transcript::KeccakTranscript, code::{DefaultLinearCodeSpec, LinearCode}, code_raa::RaaCode, pcs::{structs::MultilinearZip, MerkleTree}, pcs_transcript::PcsTranscript, define_field_config};
 
 const INT_LIMBS: usize = 1;
 const FIELD_LIMBS: usize = 4;
@@ -119,7 +118,6 @@ fn commit<const P: usize>(group: &mut BenchmarkGroup<WallTime>, spec: usize) {
 
 fn open<const P: usize>(group: &mut BenchmarkGroup<WallTime>, spec: usize) {
     let mut rng = test_rng();
-    let field_config = unsafe { ConfigRef::new(Box::leak(Box::new(FC::field_config()))) };
 
     type T = KeccakTranscript;
     let mut keccak_transcript = T::new();
@@ -143,8 +141,7 @@ fn open<const P: usize>(group: &mut BenchmarkGroup<WallTime>, spec: usize) {
                         &params,
                         &poly,
                         &data,
-                        &point.map_to_field(field_config),
-                        field_config,
+                        &point.map_to_field(),
                         &mut transcript,
                     )
                     .expect("Failed to make opening");
@@ -157,7 +154,6 @@ fn open<const P: usize>(group: &mut BenchmarkGroup<WallTime>, spec: usize) {
 }
 fn verify<const P: usize>(group: &mut BenchmarkGroup<WallTime>, spec: usize) {
     let mut rng = test_rng();
-    let field_config =  unsafe { ConfigRef::new(Box::leak(Box::new(FC::field_config()))) };
 
     type T = KeccakTranscript;
     let mut keccak_transcript = T::new();
@@ -175,16 +171,12 @@ fn verify<const P: usize>(group: &mut BenchmarkGroup<WallTime>, spec: usize) {
         &params,
         &poly,
         &data,
-        &point.map_to_field(field_config),
-        field_config,
+        &point.map_to_field(),
         &mut transcript,
     )
     .unwrap();
 
     let proof = transcript.into_proof();
-    field_config
-        .reference()
-        .expect("Field config cannot be none");
     group.bench_function(
         format!("Verify: RandomField<{FIELD_LIMBS}>, poly_size = 2^{P}(Int limbs = {INT_LIMBS}), ZipSpec{spec}, modulus={}", FC::modulus()),
         |b| {
@@ -196,10 +188,9 @@ fn verify<const P: usize>(group: &mut BenchmarkGroup<WallTime>, spec: usize) {
                     BenchZip::verify(
                         &params,
                         &commitment,
-                        &point.map_to_field(field_config),
-                        eval.map_to_field(field_config),
+                        &point.map_to_field(),
+                        eval.map_to_field(),
                         &mut transcript,
-                        field_config,
                     )
                     .expect("Failed to verify");
                     total_duration += timer.elapsed();

--- a/zip-plus/benches/zip_benches.rs
+++ b/zip-plus/benches/zip_benches.rs
@@ -119,7 +119,7 @@ fn commit<const P: usize>(group: &mut BenchmarkGroup<WallTime>, spec: usize) {
 
 fn open<const P: usize>(group: &mut BenchmarkGroup<WallTime>, spec: usize) {
     let mut rng = test_rng();
-    let field_config = ConfigRef::from(&FC::FIELD_CONFIG);
+    let field_config = unsafe { ConfigRef::new(Box::leak(Box::new(FC::field_config()))) };
 
     type T = KeccakTranscript;
     let mut keccak_transcript = T::new();
@@ -132,7 +132,7 @@ fn open<const P: usize>(group: &mut BenchmarkGroup<WallTime>, spec: usize) {
     let point = vec![1i64; P];
 
     group.bench_function(
-        format!("Open: RandomField<{FIELD_LIMBS}>, poly_size = 2^{P}(Int limbs = {INT_LIMBS}), ZipSpec{spec}, modulus={}", FC::MODULUS),
+        format!("Open: RandomField<{FIELD_LIMBS}>, poly_size = 2^{P}(Int limbs = {INT_LIMBS}), ZipSpec{spec}, modulus={}", FC::modulus()),
         |b| {
             b.iter_custom(|iters| {
                 let mut total_duration = Duration::ZERO;
@@ -157,7 +157,7 @@ fn open<const P: usize>(group: &mut BenchmarkGroup<WallTime>, spec: usize) {
 }
 fn verify<const P: usize>(group: &mut BenchmarkGroup<WallTime>, spec: usize) {
     let mut rng = test_rng();
-    let field_config = ConfigRef::from(&FC::FIELD_CONFIG);
+    let field_config =  unsafe { ConfigRef::new(Box::leak(Box::new(FC::field_config()))) };
 
     type T = KeccakTranscript;
     let mut keccak_transcript = T::new();
@@ -186,7 +186,7 @@ fn verify<const P: usize>(group: &mut BenchmarkGroup<WallTime>, spec: usize) {
         .reference()
         .expect("Field config cannot be none");
     group.bench_function(
-        format!("Verify: RandomField<{FIELD_LIMBS}>, poly_size = 2^{P}(Int limbs = {INT_LIMBS}), ZipSpec{spec}, modulus={}", FC::MODULUS),
+        format!("Verify: RandomField<{FIELD_LIMBS}>, poly_size = 2^{P}(Int limbs = {INT_LIMBS}), ZipSpec{spec}, modulus={}", FC::modulus()),
         |b| {
             b.iter_custom(|iters| {
                 let mut total_duration = Duration::ZERO;

--- a/zip-plus/src/code.rs
+++ b/zip-plus/src/code.rs
@@ -57,7 +57,7 @@ pub trait LinearCode<ZT: ZipTypes>: Sync + Send {
     ///
     /// # Returns
     /// A vector of field elements representing the encoded row
-    fn encode_f<F: Field>(&self, row: &[F], field: F::R) -> Vec<F>
+    fn encode_f<F: Field>(&self, row: &[F]) -> Vec<F>
     where
         ZT::L: FieldMap<F, Output = F>;
 }

--- a/zip-plus/src/code.rs
+++ b/zip-plus/src/code.rs
@@ -17,10 +17,12 @@ pub trait LinearCode<ZT: ZipTypes>: Sync + Send {
     /// Number of proximity tests to perform (security parameter)
     fn num_proximity_testing(&self) -> usize;
 
-    /// Encodes a row of cryptographic integers using this linear encoding scheme.
+    /// Encodes a row of cryptographic integers using this linear encoding
+    /// scheme.
     ///
-    /// This function is optimized for the prover's context where we work with cryptographic integers.
-    /// It's more efficient than `encode_f` as it avoids field conversions.
+    /// This function is optimized for the prover's context where we work with
+    /// cryptographic integers. It's more efficient than `encode_f` as it
+    /// avoids field conversions.
     ///
     /// # Parameters
     /// - `row`: Slice of cryptographic integers to encode
@@ -31,10 +33,12 @@ pub trait LinearCode<ZT: ZipTypes>: Sync + Send {
         self.encode_wide(row)
     }
 
-    /// Encodes a row of cryptographic integers using this linear encoding scheme.
+    /// Encodes a row of cryptographic integers using this linear encoding
+    /// scheme.
     ///
-    /// This function is optimized for the prover's context where we work with cryptographic integers.
-    /// It's more efficient than `encode_f` as it avoids field conversions.
+    /// This function is optimized for the prover's context where we work with
+    /// cryptographic integers. It's more efficient than `encode_f` as it
+    /// avoids field conversions.
     ///
     /// # Parameters
     /// - `row`: Slice of cryptographic integers to encode
@@ -48,8 +52,9 @@ pub trait LinearCode<ZT: ZipTypes>: Sync + Send {
 
     /// Encodes a row of field elements using this linear encoding scheme.
     ///
-    /// This function is used when working with field elements directly and performs the encoding
-    /// by first converting the sparse matrices to field elements.
+    /// This function is used when working with field elements directly and
+    /// performs the encoding by first converting the sparse matrices to
+    /// field elements.
     ///
     /// # Parameters
     /// - `row`: Slice of field elements to encode

--- a/zip-plus/src/code_raa.rs
+++ b/zip-plus/src/code_raa.rs
@@ -38,7 +38,11 @@ impl<ZT: ZipTypes> RaaCode<ZT> {
         // Taken from original Zip codes
 
         let num_vars = poly_size.ilog2() as usize;
-        let row_len = ((1 << num_vars) as u64).isqrt().next_power_of_two() as usize;
+        let row_len: usize = (1_u64 << num_vars)
+            .isqrt()
+            .next_power_of_two()
+            .try_into()
+            .expect("row_len overflow");
         let repetition_factor = spec.repetition_factor();
 
         let num_column_opening = spec.num_column_opening();

--- a/zip-plus/src/code_raa.rs
+++ b/zip-plus/src/code_raa.rs
@@ -2,14 +2,14 @@ use ark_std::{fmt::Debug, marker::PhantomData, ops::AddAssign, vec::Vec};
 use num_traits::Zero;
 
 use crate::{
-    traits::{Field, FieldMap, Integer, Words, ZipTypes},
     code::{LinearCode, LinearCodeSpec},
     pcs::structs::ZipTranscript,
+    traits::{Field, FieldMap, Integer, Words, ZipTypes},
     utils::shuffle_seeded,
 };
 
-/// Implementation of a repeat-accumulate-accumulate (RAA) codes over the binary field,
-/// as defined by the Blaze paper (https://eprint.iacr.org/2024/1609)
+/// Implementation of a repeat-accumulate-accumulate (RAA) codes over the binary
+/// field, as defined by the Blaze paper (https://eprint.iacr.org/2024/1609)
 #[derive(Debug, Clone)]
 pub struct RaaCode<ZT: ZipTypes> {
     row_len: usize,
@@ -149,9 +149,9 @@ fn repeat<In, Out: for<'a> From<&'a In> + Clone>(
         .collect()
 }
 
-/// Perform an operation equivalent to multiplying the slice in-place by the accumulation matrix
-/// from the RAA code - a lower triangular matrix of the appropriate size, i.e. a matrix looking
-/// like this:
+/// Perform an operation equivalent to multiplying the slice in-place by the
+/// accumulation matrix from the RAA code - a lower triangular matrix of the
+/// appropriate size, i.e. a matrix looking like this:
 ///
 /// ```text
 /// 1 0 0 0
@@ -174,13 +174,13 @@ mod tests {
     use num_traits::Zero;
 
     use crate::{
+        code::{DefaultLinearCodeSpec, LinearCode},
+        code_raa::{RaaCode, accumulate, repeat},
         define_random_field_zip_types,
         field::Int,
         implement_random_field_zip_types,
-        traits::ZipTypes,
-        code::{DefaultLinearCodeSpec, LinearCode},
-        code_raa::{RaaCode, accumulate, repeat},
         pcs::tests::MockTranscript,
+        traits::ZipTypes,
         utils::shuffle_seeded,
     };
 
@@ -316,10 +316,13 @@ mod tests {
         #[derive(Debug, Clone)]
         struct MismatchedZipTypes;
         impl ZipTypes for MismatchedZipTypes {
-            type N = Int<1>; // 64 bits
-            type L = Int<2>; // 128 bits
-            type K = Int<1>; // 64 bits - INSUFFICIENT
-            type M = Int<4>; // 256 bits
+            // 128 bits
+            type K = Int<1>;
+            // 64 bits
+            type L = Int<2>;
+            // 64 bits - INSUFFICIENT
+            type M = Int<4>;
+            type N = Int<1>; // 256 bits
         }
 
         let mut transcript = MockTranscript::default();

--- a/zip-plus/src/code_raa.rs
+++ b/zip-plus/src/code_raa.rs
@@ -320,10 +320,10 @@ mod tests {
         #[derive(Debug, Clone)]
         struct MismatchedZipTypes;
         impl ZipTypes for MismatchedZipTypes {
-            type K = Int<1>; // 128 bits
-            type L = Int<2>; // 64 bits
-            type M = Int<4>; // 64 bits - INSUFFICIENT
-            type N = Int<1>; // 256 bits
+            type N = Int<1>; // 64 bits
+            type L = Int<2>; // 128 bits
+            type K = Int<1>; // 64 bits - INSUFFICIENT
+            type M = Int<4>; // 256 bits
         }
 
         let mut transcript = MockTranscript::default();

--- a/zip-plus/src/code_raa.rs
+++ b/zip-plus/src/code_raa.rs
@@ -320,12 +320,9 @@ mod tests {
         #[derive(Debug, Clone)]
         struct MismatchedZipTypes;
         impl ZipTypes for MismatchedZipTypes {
-            // 128 bits
-            type K = Int<1>;
-            // 64 bits
-            type L = Int<2>;
-            // 64 bits - INSUFFICIENT
-            type M = Int<4>;
+            type K = Int<1>; // 128 bits
+            type L = Int<2>; // 64 bits
+            type M = Int<4>; // 64 bits - INSUFFICIENT
             type N = Int<1>; // 256 bits
         }
 

--- a/zip-plus/src/code_raa.rs
+++ b/zip-plus/src/code_raa.rs
@@ -128,7 +128,7 @@ impl<ZT: ZipTypes> LinearCode<ZT> for RaaCode<ZT> {
         self.encode_inner(row)
     }
 
-    fn encode_f<F: Field>(&self, row: &[F], _field: F::R) -> Vec<F>
+    fn encode_f<F: Field>(&self, row: &[F]) -> Vec<F>
     where
         ZT::L: FieldMap<F, Output = F>,
     {

--- a/zip-plus/src/const_helpers.rs
+++ b/zip-plus/src/const_helpers.rs
@@ -69,6 +69,7 @@ impl<const N: usize> MulBuffer<N> {
 
 impl<const N: usize> Index<usize> for MulBuffer<N> {
     type Output = u64;
+
     #[inline(always)]
     fn index(&self, index: usize) -> &Self::Output {
         self.get(index)
@@ -209,6 +210,7 @@ impl<const N: usize> SerBuffer<N> {
 
 impl<const N: usize> Index<usize> for SerBuffer<N> {
     type Output = u8;
+
     #[inline(always)]
     fn index(&self, index: usize) -> &Self::Output {
         self.get(index)

--- a/zip-plus/src/conversion.rs
+++ b/zip-plus/src/conversion.rs
@@ -455,7 +455,7 @@ mod bigint_field_map_tests {
     use super::*;
     use crate::{
         big_int, define_field_config,
-        field::{BigInt, FieldConfig, RandomField},
+        field::{BigInt, RandomField},
     };
     use num_traits::ConstZero;
 

--- a/zip-plus/src/conversion.rs
+++ b/zip-plus/src/conversion.rs
@@ -1,9 +1,8 @@
-use ark_std::{vec::Vec, Zero};
-use crate::field::config::{FieldConfigBase, FieldConfigOps};
-use crate::traits::{
-    BigInteger, Field, FieldMap, Integer, PrimitiveConversion, Uinteger,
-    Words,
+use crate::{
+    field::config::{FieldConfigBase, FieldConfigOps},
+    traits::{BigInteger, Field, FieldMap, Integer, PrimitiveConversion, Uinteger, Words},
 };
+use ark_std::{Zero, vec::Vec};
 
 // Implementation of FieldMap for signed integers
 macro_rules! impl_field_map_for_int {
@@ -66,6 +65,7 @@ impl<F: Field> FieldMap<F> for bool {
 
 impl<F: Field> FieldMap<F> for &bool {
     type Output = F;
+
     fn map_to_field(&self) -> Self::Output {
         (*self).map_to_field()
     }
@@ -116,13 +116,20 @@ impl<F: Field, T: FieldMap<F>> FieldMap<F> for &[T] {
 
 #[cfg(test)]
 mod tests {
+    use crate::{
+        big_int, define_field_config,
+        field::{BigInt, FieldConfig, RandomField},
+        traits::{FieldMap, FromBytes},
+    };
     use ark_std::{fmt::Debug, format, str::FromStr};
     use num_traits::{ConstZero, Zero};
-    use crate::{big_int, define_field_config, field::{BigInt, FieldConfig, RandomField}, traits::{FieldMap, FromBytes}};
 
     define_field_config!(Fc23, "23");
     define_field_config!(FcSmall, "243043087159742188419721163456177567");
-    define_field_config!(FcBig, "3618502788666131213697322783095070105623107215331596699973092056135872020481");
+    define_field_config!(
+        FcBig,
+        "3618502788666131213697322783095070105623107215331596699973092056135872020481"
+    );
 
     fn test_from<const N: usize, FC: FieldConfig<BigInt<N>>, T: Clone>(value: T, value_str: &str)
     where
@@ -178,7 +185,7 @@ mod tests {
         let bytes = [0x05, 0, 0, 0, 0, 0, 0, 0];
         let expected = big_int!(5);
 
-        let result = <RandomField::<1, Fc23<1>> as FromBytes>::from_bytes_le(&bytes).unwrap();
+        let result = <RandomField<1, Fc23<1>> as FromBytes>::from_bytes_le(&bytes).unwrap();
         assert_eq!(result.into_bigint(), expected);
     }
 
@@ -238,9 +245,7 @@ mod tests {
     #[test]
     fn converts_from_bytes_le_with_config_leading_zeros() {
         let bytes = [0b0000_0001]; // Value: 1 with leading zeros
-        let expected = BigInt::<1>::from_bytes_le(&bytes)
-            .unwrap()
-            .map_to_field();
+        let expected = BigInt::<1>::from_bytes_le(&bytes).unwrap().map_to_field();
 
         let result = RandomField::<1, Fc23<1>>::from_bytes_le(&bytes);
         assert_eq!(result, Some(expected));
@@ -302,7 +307,7 @@ mod tests {
 
             // Test minimum value
             let min = -<$type>::from_str(&format!("{}", <$type>::MAX)).unwrap();
-            let min_f = <$type as FieldMap<RandomField<$N, $FC>>>::map_to_field(&min, );
+            let min_f = <$type as FieldMap<RandomField<$N, $FC>>>::map_to_field(&min);
             assert!(
                 min_f.into_bigint() < BigInt::<$N>::from($field),
                 "Minimum value should wrap to valid field element"
@@ -447,9 +452,12 @@ mod tests {
 
 #[cfg(test)]
 mod bigint_field_map_tests {
-    use num_traits::ConstZero;
     use super::*;
-    use crate::{big_int, define_field_config, field::{BigInt, FieldConfig, RandomField}};
+    use crate::{
+        big_int, define_field_config,
+        field::{BigInt, FieldConfig, RandomField},
+    };
+    use num_traits::ConstZero;
 
     define_field_config!(FC, "18446744069414584321");
 
@@ -508,8 +516,8 @@ mod bigint_field_map_tests {
     #[test]
     fn test_bigint_reference() {
         let value = big_int!(12345, 2);
-        let result: RandomField<2, FC::<2>> = value.map_to_field();
-        let direct_result: RandomField<2, FC::<2>> = value.map_to_field();
+        let result: RandomField<2, FC<2>> = value.map_to_field();
+        let direct_result: RandomField<2, FC<2>> = value.map_to_field();
 
         assert_eq!(
             result.into_bigint(),

--- a/zip-plus/src/conversion.rs
+++ b/zip-plus/src/conversion.rs
@@ -130,66 +130,59 @@ mod tests {
     use ark_std::{fmt::Debug, format, str::FromStr};
     use num_traits::{ConstZero, Zero};
     use crate::{big_int, define_field_config, field::{BigInt, ConfigRef, FieldConfig, RandomField}, field_config, traits::{Config, ConfigReference, Field, FieldMap, FromBytes}};
-
+    use crate::field::config::ConstFieldConfig;
 
     define_field_config!(Fc23, "23");
     define_field_config!(FcSmall, "243043087159742188419721163456177567");
     define_field_config!(FcBig, "3618502788666131213697322783095070105623107215331596699973092056135872020481");
 
-    fn test_from<F: Field + From<T>, T: Clone>(value: T, value_str: &str)
+    fn test_from<const N: usize, FC: ConstFieldConfig<N>, T: Clone>(value: T, value_str: &str)
     where
-        F::B: FromStr,
-        <F::B as FromStr>::Err: Debug,
+        for <'a> RandomField<'a, N, FC>: From<T>,
     {
-        let raw_element = F::from(value);
+        let raw_element = RandomField::<N, FC>::from(value);
         assert_eq!(
             raw_element,
-            F::without_config(F::B::from_str(value_str).unwrap())
+            BigInt::<N>::from_str(value_str).unwrap().map_to_field(ConfigRef::from(&FC::FIELD_CONFIG))
         )
     }
 
     #[test]
     fn converts_u128_to_random_field() {
-        test_from::<RandomField<2, FcSmall<2>>, u128>(
+        test_from::<2, FcSmall<2>, u128>(
             243043087159742188419721163456177516,
             "243043087159742188419721163456177516",
         );
     }
 
     #[test]
-    #[should_panic(expected = "Integer is 128 bits but field is 64 bits")]
-    fn panics_when_u128_does_not_fit_in_n1() {
-        test_from::<RandomField<1, FcSmall<1>>, u128>(243043087159742188419721163456177516, "");
-    }
-
-    #[test]
     fn converts_u64_to_random_field() {
-        test_from::<RandomField<1, FcSmall<1>>, u64>(23, "23");
+        test_from::<2, FcSmall<2>, u64>(23, "23");
     }
 
     #[test]
     fn converts_u32_to_random_field() {
-        test_from::<RandomField<1, FcSmall<1>>, u32>(23, "23");
+        test_from::<2, FcSmall<2>, u32>(23, "23");
     }
 
     #[test]
     fn converts_u16_to_random_field() {
-        test_from::<RandomField<1, FcSmall<1>>, u16>(23, "23");
+        test_from::<2, FcSmall<2>, u16>(23, "23");
     }
 
     #[test]
     fn converts_u8_to_random_field() {
-        test_from::<RandomField<1, FcSmall<1>>, u8>(23, "23");
+        test_from::<2, FcSmall<2>, u8>(23, "23");
     }
 
     #[test]
     fn converts_false_to_zero() {
-        test_from::<RandomField<1, FcSmall<1>>, bool>(false, "0");
+        test_from::<2, FcSmall<2>, bool>(false, "0");
     }
 
     #[test]
     fn converts_true_to_one() {
-        test_from::<RandomField<1, FcSmall<1>>, bool>(true, "1");
+        test_from::<2, FcSmall<2>, bool>(true, "1");
     }
 
     #[test]

--- a/zip-plus/src/conversion.rs
+++ b/zip-plus/src/conversion.rs
@@ -143,7 +143,7 @@ mod tests {
         let raw_element = RandomField::<N, FC>::from(value);
         assert_eq!(
             raw_element,
-            BigInt::<N>::from_str(value_str).unwrap().map_to_field(ConfigRef::from(&FC::FIELD_CONFIG))
+            BigInt::<N>::from_str(value_str).unwrap().map_to_field(unsafe { ConfigRef::new(Box::leak(Box::new(FC::field_config()))) })
         )
     }
 
@@ -505,7 +505,7 @@ mod bigint_field_map_tests {
     #[test]
     fn test_bigint_smaller_than_field() {
         // Using a 2-limb field config with 1-limb BigInt
-        let config = FieldConfig::new(FC::<2>::MODULUS);
+        let config = FieldConfig::new(FC::<2>::modulus());
         let config_ptr = ConfigRef::from(&config);
 
         let small_bigint = BigInt::<1>::from(12345u64);
@@ -520,7 +520,7 @@ mod bigint_field_map_tests {
 
     #[test]
     fn test_bigint_equal_size() {
-        let config = FieldConfig::new(FC::<2>::MODULUS);
+        let config = FieldConfig::new(FC::<2>::modulus());
         let config_ptr = ConfigRef::from(&config);
 
         let value = big_int!(12345678901234567890, 2);
@@ -538,7 +538,7 @@ mod bigint_field_map_tests {
     #[test]
     fn test_bigint_larger_than_field() {
         // Using a 1-limb field config with 2-limb BigInt
-        let config = FieldConfig::new(FC::<1>::MODULUS);
+        let config = FieldConfig::new(FC::<1>::modulus());
         let config_ptr = ConfigRef::from(&config);
 
         let large_value = big_int!(123456789012345678901, 2);
@@ -554,7 +554,7 @@ mod bigint_field_map_tests {
 
     #[test]
     fn test_bigint_zero() {
-        let config = FieldConfig::new(FC::<2>::MODULUS);
+        let config = FieldConfig::new(FC::<2>::modulus());
         let config_ptr = ConfigRef::from(&config);
 
         let zero = BigInt::<2>::ZERO;
@@ -568,7 +568,7 @@ mod bigint_field_map_tests {
 
     #[test]
     fn test_bigint_reference() {
-        let config = FieldConfig::new(FC::<2>::MODULUS);
+        let config = FieldConfig::new(FC::<2>::modulus());
         let config_ptr = ConfigRef::from(&config);
 
         let value = big_int!(12345, 2);
@@ -584,7 +584,7 @@ mod bigint_field_map_tests {
 
     #[test]
     fn test_bigint_max_value() {
-        let config = FieldConfig::new(FC::<2>::MODULUS);
+        let config = FieldConfig::new(FC::<2>::modulus());
         let config_ptr = ConfigRef::from(&config);
 
         // Create a BigInt with all bits set to 1

--- a/zip-plus/src/conversion.rs
+++ b/zip-plus/src/conversion.rs
@@ -128,13 +128,13 @@ impl<F: Field, T: FieldMap<F>> FieldMap<F> for &[T] {
 #[cfg(test)]
 mod tests {
     use ark_std::{fmt::Debug, format, str::FromStr};
-    use num_traits::ConstZero;
-    use crate::{
-        big_int,
-        field::{BigInt, ConfigRef, FieldConfig, RandomField},
-        field_config,
-        traits::{Config, ConfigReference, Field, FieldMap, FromBytes},
-    };
+    use num_traits::{ConstZero, Zero};
+    use crate::{big_int, define_field_config, field::{BigInt, ConfigRef, FieldConfig, RandomField}, field_config, traits::{Config, ConfigReference, Field, FieldMap, FromBytes}};
+
+
+    define_field_config!(Fc23, "23");
+    define_field_config!(FcSmall, "243043087159742188419721163456177567");
+    define_field_config!(FcBig, "3618502788666131213697322783095070105623107215331596699973092056135872020481");
 
     fn test_from<F: Field + From<T>, T: Clone>(value: T, value_str: &str)
     where
@@ -150,7 +150,7 @@ mod tests {
 
     #[test]
     fn converts_u128_to_random_field() {
-        test_from::<RandomField<2>, u128>(
+        test_from::<RandomField<2, FcSmall<2>>, u128>(
             243043087159742188419721163456177516,
             "243043087159742188419721163456177516",
         );
@@ -159,37 +159,37 @@ mod tests {
     #[test]
     #[should_panic(expected = "Integer is 128 bits but field is 64 bits")]
     fn panics_when_u128_does_not_fit_in_n1() {
-        test_from::<RandomField<1>, u128>(243043087159742188419721163456177516, "");
+        test_from::<RandomField<1, FcSmall<1>>, u128>(243043087159742188419721163456177516, "");
     }
 
     #[test]
     fn converts_u64_to_random_field() {
-        test_from::<RandomField<1>, u64>(23, "23");
+        test_from::<RandomField<1, FcSmall<1>>, u64>(23, "23");
     }
 
     #[test]
     fn converts_u32_to_random_field() {
-        test_from::<RandomField<1>, u32>(23, "23");
+        test_from::<RandomField<1, FcSmall<1>>, u32>(23, "23");
     }
 
     #[test]
     fn converts_u16_to_random_field() {
-        test_from::<RandomField<1>, u16>(23, "23");
+        test_from::<RandomField<1, FcSmall<1>>, u16>(23, "23");
     }
 
     #[test]
     fn converts_u8_to_random_field() {
-        test_from::<RandomField<1>, u8>(23, "23");
+        test_from::<RandomField<1, FcSmall<1>>, u8>(23, "23");
     }
 
     #[test]
     fn converts_false_to_zero() {
-        test_from::<RandomField<1>, bool>(false, "0");
+        test_from::<RandomField<1, FcSmall<1>>, bool>(false, "0");
     }
 
     #[test]
     fn converts_true_to_one() {
-        test_from::<RandomField<1>, bool>(true, "1");
+        test_from::<RandomField<1, FcSmall<1>>, bool>(true, "1");
     }
 
     #[test]
@@ -200,7 +200,7 @@ mod tests {
         let bytes = [0x05, 0, 0, 0, 0, 0, 0, 0];
         let expected = big_int!(5);
 
-        let result = RandomField::<1>::from_bytes_le_with_config(config, &bytes).unwrap();
+        let result = RandomField::<1, Fc23<1>>::from_bytes_le_with_config(config, &bytes).unwrap();
         assert_eq!(result.into_bigint(), expected);
     }
 
@@ -221,38 +221,22 @@ mod tests {
         ]; // Value: 5 (big-endian)
         let expected = BigInt::<32>::from_bytes_be(&bytes).unwrap();
 
-        let result = RandomField::<32>::from_bytes_be_with_config(config_ptr, &bytes);
+        let result = RandomField::<32, FcBig<32>>::from_bytes_be_with_config(config_ptr, &bytes);
         assert_eq!(result.map(|x| x.into_bigint()), Some(expected));
     }
 
     #[test]
-    fn converts_from_bytes_le_with_config_zero() {
+    fn converts_from_bytes_with_config_zero() {
         let config = field_config!(23);
         let config = ConfigRef::from(&config);
 
         let bytes = [0x00; 8]; // All zeros
-        let expected = RandomField {
-            value: BigInt::<1>::ZERO,
-            config: Some(config),
-        };
+        let expected = RandomField::<1, Fc23<1>>::zero();
 
-        let result = RandomField::<1>::from_bytes_le_with_config(config, &bytes);
-        assert_eq!(result, Some(expected));
-    }
-
-    #[test]
-    fn converts_from_bytes_be_with_config_zero() {
-        let config = field_config!(23);
-        let config = ConfigRef::from(&config);
-
-        let bytes = [0x00; 8]; // All zeros
-        let expected = RandomField {
-            value: BigInt::<1>::ZERO,
-            config: Some(config),
-        };
-
-        let result = RandomField::<1>::from_bytes_be_with_config(config, &bytes);
-        assert_eq!(result, Some(expected));
+        let result = RandomField::<1, _>::from_bytes_le_with_config(config, &bytes);
+        assert_eq!(result, Some(expected.clone()));
+        let result = RandomField::<1, _>::from_bytes_be_with_config(config, &bytes);
+        assert_eq!(result, Some(expected.clone()));
     }
 
     #[test]
@@ -261,17 +245,18 @@ mod tests {
         let config = ConfigRef::from(&config);
 
         let bytes = [0x65, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00]; // Value: 101 (modulus is 23)
-        let result = RandomField::<1>::from_bytes_le_with_config(config, &bytes);
+        let result = RandomField::<1, Fc23<1>>::from_bytes_le_with_config(config, &bytes);
         assert!(result.is_none());
     }
 
     #[test]
     fn converts_from_bytes_be_with_config_out_of_range() {
+        define_field_config!(Fc37129241769965749, "37129241769965749");
         let config = field_config!(37129241769965749);
         let config = ConfigRef::from(&config);
 
         let bytes = [0x65, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00]; // Value: 101
-        let result = RandomField::<32>::from_bytes_be_with_config(config, &bytes);
+        let result = RandomField::<32, Fc37129241769965749<32>>::from_bytes_be_with_config(config, &bytes);
         assert!(result.is_none());
     }
 
@@ -281,7 +266,7 @@ mod tests {
         let config = ConfigRef::from(&config);
 
         let bytes = [0x17, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00]; // Value: 23 (modulus)
-        let result = RandomField::<1>::from_bytes_le_with_config(config, &bytes);
+        let result = RandomField::<1, Fc23<1>>::from_bytes_le_with_config(config, &bytes);
         assert!(result.is_none()); // Must be strictly less than modulus
     }
 
@@ -291,7 +276,7 @@ mod tests {
         let config = ConfigRef::from(&config);
 
         let bytes = [0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x17]; // Value: 23 (big-endian)
-        let result = RandomField::<1>::from_bytes_be_with_config(config, &bytes);
+        let result = RandomField::<1, Fc23<1>>::from_bytes_be_with_config(config, &bytes);
         assert!(result.is_none());
     }
 
@@ -305,7 +290,7 @@ mod tests {
             .unwrap()
             .map_to_field(config);
 
-        let result = RandomField::<1>::from_bytes_le_with_config(config, &bytes);
+        let result = RandomField::<1, Fc23<1>>::from_bytes_le_with_config(config, &bytes);
         assert_eq!(result, Some(expected));
     }
 
@@ -316,16 +301,16 @@ mod tests {
 
         let bytes = [0x01]; //1 with leading zeros (big-endian);
 
-        let result = RandomField::<1>::from_bytes_be_with_config(config, &bytes).unwrap();
+        let result = RandomField::<1, Fc23<1>>::from_bytes_be_with_config(config, &bytes).unwrap();
         assert_eq!(result.into_bigint(), BigInt::one());
     }
 
     macro_rules! test_signed_type_full_range {
-        ($type:ty, $field:expr, $config:expr, $N:expr) => {{
+        ($type:ty, $field:expr, $config:expr, $N:expr, $FC:ty) => {{
             // Test full range for primitive types
             for x in <$type>::MIN..=<$type>::MAX {
-                let result: RandomField<$N> = x.map_to_field($config);
-                let ref_result: RandomField<$N> = (&x).map_to_field($config);
+                let result: RandomField<$N, $FC> = x.map_to_field($config);
+                let ref_result: RandomField<$N, $FC> = (&x).map_to_field($config);
                 let expected = if x < 0 {
                     BigInt::<$N>::from(($field as i64 + x as i64) as u64)
                 } else {
@@ -348,10 +333,10 @@ mod tests {
     }
 
     macro_rules! test_signed_type_edge_cases {
-        ($type:ty, $field:expr, $config:expr, $N:expr) => {{
+        ($type:ty, $field:expr, $config:expr, $N:expr, $FC:ty) => {{
             // Test zero
             let zero = <$type>::from_str("0").unwrap();
-            let zero_result: RandomField<$N> = zero.map_to_field($config);
+            let zero_result: RandomField<$N, $FC> = zero.map_to_field($config);
             assert_eq!(
                 zero_result.into_bigint(),
                 BigInt::<$N>::ZERO,
@@ -360,7 +345,7 @@ mod tests {
 
             // Test maximum value
             let max = <$type>::from_str(&format!("{}", <$type>::MAX)).unwrap();
-            let max_result: RandomField<$N> = max.map_to_field($config);
+            let max_result: RandomField<$N, $FC> = max.map_to_field($config);
             assert!(
                 max_result.into_bigint() < BigInt::<$N>::from($field),
                 "Maximum value should be less than field modulus"
@@ -368,7 +353,7 @@ mod tests {
 
             // Test minimum value
             let min = -<$type>::from_str(&format!("{}", <$type>::MAX)).unwrap();
-            let min_f = <$type as FieldMap<RandomField<$N>>>::map_to_field(&min, $config);
+            let min_f = <$type as FieldMap<RandomField<$N, $FC>>>::map_to_field(&min, $config);
             assert!(
                 min_f.into_bigint() < BigInt::<$N>::from($field),
                 "Minimum value should wrap to valid field element"
@@ -376,7 +361,7 @@ mod tests {
 
             // Test positive boundary
             let pos = <$type>::from_str("5").unwrap();
-            let pos_result: RandomField<$N> = pos.map_to_field($config);
+            let pos_result: RandomField<$N, $FC> = pos.map_to_field($config);
             assert_eq!(
                 pos_result.into_bigint(),
                 BigInt::<$N>::from(5u64),
@@ -385,7 +370,7 @@ mod tests {
 
             // Test negative boundary
             let neg = <$type>::from_str("-5").unwrap();
-            let neg_result: RandomField<$N> = neg.map_to_field($config);
+            let neg_result: RandomField<$N, $FC> = neg.map_to_field($config);
             assert_eq!(
                 neg_result.into_bigint(),
                 BigInt::<$N>::from(($field as i64 - 5) as u64),
@@ -393,20 +378,20 @@ mod tests {
             );
 
             // Test reference conversions
-            let ref_zero: RandomField<$N> = (&zero).map_to_field($config);
+            let ref_zero: RandomField<$N, $FC> = (&zero).map_to_field($config);
             assert_eq!(
                 ref_zero.into_bigint(),
                 BigInt::<$N>::ZERO,
                 "Reference to zero should map to field zero"
             );
 
-            let ref_max: RandomField<$N> = (&max).map_to_field($config);
+            let ref_max: RandomField<$N, $FC> = (&max).map_to_field($config);
             assert!(
                 ref_max.into_bigint() < BigInt::<$N>::from($field),
                 "Reference to maximum value should be less than field modulus"
             );
 
-            let ref_min: RandomField<$N> = (&min).map_to_field($config);
+            let ref_min: RandomField<$N, $FC> = (&min).map_to_field($config);
             assert!(
                 ref_min.into_bigint() < BigInt::<$N>::from($field),
                 "Reference to minimum value should wrap to valid field element"
@@ -416,26 +401,27 @@ mod tests {
 
     #[test]
     fn test_signed_integers_field_map() {
+        define_field_config!(FC, "18446744069414584321");
         let field = 18446744069414584321_u64;
         let config = field_config!(18446744069414584321);
         let config: ConfigRef<1> = ConfigRef::from(&config);
 
         // Test primitive types with full range
-        test_signed_type_full_range!(i8, field, config, 1);
-        test_signed_type_full_range!(i16, field, config, 1);
+        test_signed_type_full_range!(i8, field, config, 1, FC<1>);
+        test_signed_type_full_range!(i16, field, config, 1, FC<1>);
 
         // Test larger primitive types with edge cases only
-        test_signed_type_edge_cases!(i32, field, config, 1);
-        test_signed_type_edge_cases!(i64, field, config, 1);
-        test_signed_type_edge_cases!(i128, field, config, 1);
+        test_signed_type_edge_cases!(i32, field, config, 1, FC<1>);
+        test_signed_type_edge_cases!(i64, field, config, 1, FC<1>);
+        test_signed_type_edge_cases!(i128, field, config, 1, FC<1>);
     }
 
     macro_rules! test_unsigned_type_full_range {
-        ($type:ty, $field:expr, $config:expr, $N:expr) => {{
+        ($type:ty, $field:expr, $config:expr, $N:expr, $FC:ty) => {{
             // Test full range for small unsigned types
             for x in <$type>::MIN..=<$type>::MAX {
-                let result: RandomField<$N> = x.map_to_field($config);
-                let ref_result: RandomField<$N> = (&x).map_to_field($config);
+                let result: RandomField<$N, $FC> = x.map_to_field($config);
+                let ref_result: RandomField<$N, $FC> = (&x).map_to_field($config);
                 let expected = BigInt::<$N>::from(x as u64);
                 assert_eq!(
                     result.into_bigint(),
@@ -454,10 +440,10 @@ mod tests {
     }
 
     macro_rules! test_unsigned_type_edge_cases {
-        ($type:ty, $field:expr, $config:expr, $N:expr) => {{
+        ($type:ty, $field:expr, $config:expr, $N:expr, $FC:ty) => {{
             // Test zero
             let zero = <$type>::MIN;
-            let zero_result: RandomField<$N> = zero.map_to_field($config);
+            let zero_result: RandomField<$N, $FC> = zero.map_to_field($config);
             assert_eq!(
                 zero_result.into_bigint(),
                 BigInt::<$N>::ZERO,
@@ -466,7 +452,7 @@ mod tests {
 
             // Test maximum value
             let max = <$type>::MAX;
-            let max_result: RandomField<$N> = max.map_to_field($config);
+            let max_result: RandomField<$N, $FC> = max.map_to_field($config);
             assert!(
                 max_result.into_bigint() < BigInt::<$N>::from($field),
                 "Maximum value should be less than field modulus"
@@ -474,7 +460,7 @@ mod tests {
 
             // Test boundary value - using literal instead of From
             let boundary: $type = 5;
-            let boundary_result: RandomField<$N> = boundary.map_to_field($config);
+            let boundary_result: RandomField<$N, $FC> = boundary.map_to_field($config);
             assert_eq!(
                 boundary_result.into_bigint(),
                 BigInt::<$N>::from(5u64),
@@ -482,14 +468,14 @@ mod tests {
             );
 
             // Test reference conversions
-            let ref_zero: RandomField<$N> = (&zero).map_to_field($config);
+            let ref_zero: RandomField<$N, $FC> = (&zero).map_to_field($config);
             assert_eq!(
                 ref_zero.into_bigint(),
                 BigInt::<$N>::ZERO,
                 "Reference to zero should map to field zero"
             );
 
-            let ref_max: RandomField<$N> = (&max).map_to_field($config);
+            let ref_max: RandomField<$N, $FC> = (&max).map_to_field($config);
             assert!(
                 ref_max.into_bigint() < BigInt::<$N>::from($field),
                 "Reference to maximum value should be less than field modulus"
@@ -499,31 +485,18 @@ mod tests {
 
     #[test]
     fn test_unsigned_integers_field_map() {
+        define_field_config!(FC, "18446744069414584321");
         let field_1 = 18446744069414584321_u64;
         let config_1 = field_config!(18446744069414584321);
         let config = ConfigRef::from(&config_1);
         // Test small types with full range
-        test_unsigned_type_full_range!(u8, field_1, config, 1);
-        test_unsigned_type_full_range!(u16, field_1, config, 1);
+        test_unsigned_type_full_range!(u8, field_1, config, 1, FC<1>);
+        test_unsigned_type_full_range!(u16, field_1, config, 1, FC<1>);
 
         // Test larger types with edge cases only
-        test_unsigned_type_edge_cases!(u32, field_1, config, 1);
-        test_unsigned_type_edge_cases!(u64, field_1, config, 1);
-        test_unsigned_type_edge_cases!(u128, field_1, config, 1);
-    }
-
-    #[test]
-    #[should_panic(expected = "Cannot convert integer to prime field element without a modulus")]
-    fn test_signed_field_map_null_config() {
-        let i32_val: i32 = 5;
-        <i32 as FieldMap<RandomField<1>>>::map_to_field(&i32_val, ConfigRef::<1>::NONE);
-    }
-
-    #[test]
-    #[should_panic(expected = "Cannot convert integer to prime field element without a modulus")]
-    fn test_unsigned_field_map_null_config() {
-        let u32_val: u32 = 5;
-        <u32 as FieldMap<RandomField<1>>>::map_to_field(&u32_val, ConfigRef::<1>::NONE);
+        test_unsigned_type_edge_cases!(u32, field_1, config, 1, FC<1>);
+        test_unsigned_type_edge_cases!(u64, field_1, config, 1, FC<1>);
+        test_unsigned_type_edge_cases!(u128, field_1, config, 1, FC<1>);
     }
 }
 
@@ -531,20 +504,19 @@ mod tests {
 mod bigint_field_map_tests {
     use num_traits::ConstZero;
     use super::*;
-    use crate::{
-        big_int,
-        field::{BigInt, ConfigRef, FieldConfig, RandomField},
-    };
+    use crate::{big_int, define_field_config, field::{BigInt, ConfigRef, FieldConfig, RandomField}};
+    use crate::field::config::ConstFieldConfig;
+
+    define_field_config!(FC, "18446744069414584321");
 
     #[test]
     fn test_bigint_smaller_than_field() {
         // Using a 2-limb field config with 1-limb BigInt
-        let modulus = big_int!(18446744069414584321);
-        let config = FieldConfig::new(modulus);
+        let config = FieldConfig::new(FC::<2>::MODULUS);
         let config_ptr = ConfigRef::from(&config);
 
         let small_bigint = BigInt::<1>::from(12345u64);
-        let result: RandomField<2> = small_bigint.map_to_field(config_ptr);
+        let result: RandomField<2, FC<2>> = small_bigint.map_to_field(config_ptr);
 
         assert_eq!(
             result.into_bigint().first(),
@@ -555,12 +527,11 @@ mod bigint_field_map_tests {
 
     #[test]
     fn test_bigint_equal_size() {
-        let modulus = big_int!(18446744069414584321);
-        let config = FieldConfig::new(modulus);
+        let config = FieldConfig::new(FC::<2>::MODULUS);
         let config_ptr = ConfigRef::from(&config);
 
         let value = big_int!(12345678901234567890, 2);
-        let result: RandomField<2> = value.map_to_field(config_ptr);
+        let result: RandomField<2, FC<2>> = value.map_to_field(config_ptr);
 
         // The result should be the value modulo the field modulus
         let expected = big_int!(12345678901234567890);
@@ -574,12 +545,11 @@ mod bigint_field_map_tests {
     #[test]
     fn test_bigint_larger_than_field() {
         // Using a 1-limb field config with 2-limb BigInt
-        let modulus = big_int!(18446744069414584321);
-        let config = FieldConfig::new(modulus);
+        let config = FieldConfig::new(FC::<1>::MODULUS);
         let config_ptr = ConfigRef::from(&config);
 
         let large_value = big_int!(123456789012345678901, 2);
-        let result: RandomField<1> = large_value.map_to_field(config_ptr);
+        let result: RandomField<1, FC<1>> = large_value.map_to_field(config_ptr);
 
         let expected = BigInt::<1>::from(12776324595858172975u64);
         assert_eq!(
@@ -591,12 +561,11 @@ mod bigint_field_map_tests {
 
     #[test]
     fn test_bigint_zero() {
-        let modulus = big_int!(18446744069414584321);
-        let config = FieldConfig::new(modulus);
+        let config = FieldConfig::new(FC::<2>::MODULUS);
         let config_ptr = ConfigRef::from(&config);
 
         let zero = BigInt::<2>::ZERO;
-        let result: RandomField<2> = zero.map_to_field(config_ptr);
+        let result: RandomField<2, FC<2>> = zero.map_to_field(config_ptr);
 
         assert!(
             result.into_bigint().is_zero(),
@@ -606,13 +575,12 @@ mod bigint_field_map_tests {
 
     #[test]
     fn test_bigint_reference() {
-        let modulus = big_int!(18446744069414584321);
-        let config = FieldConfig::new(modulus);
+        let config = FieldConfig::new(FC::<2>::MODULUS);
         let config_ptr = ConfigRef::from(&config);
 
         let value = big_int!(12345, 2);
-        let result: RandomField<2> = value.map_to_field(config_ptr);
-        let direct_result: RandomField<2> = value.map_to_field(config_ptr);
+        let result: RandomField<2, FC::<2>> = value.map_to_field(config_ptr);
+        let direct_result: RandomField<2, FC::<2>> = value.map_to_field(config_ptr);
 
         assert_eq!(
             result.into_bigint(),
@@ -622,25 +590,17 @@ mod bigint_field_map_tests {
     }
 
     #[test]
-    #[should_panic(expected = "Cannot convert BigInt to prime field element without a modulus")]
-    fn test_null_config() {
-        let value = BigInt::<2>::from(123u64);
-        let _result: RandomField<2> = value.map_to_field(ConfigRef::NONE);
-    }
-
-    #[test]
     fn test_bigint_max_value() {
-        let modulus = big_int!(18446744069414584321);
-        let config = FieldConfig::new(modulus);
+        let config = FieldConfig::new(FC::<2>::MODULUS);
         let config_ptr = ConfigRef::from(&config);
 
         // Create a BigInt with all bits set to 1
         let max_value = BigInt::from([u64::MAX, u64::MAX]);
 
-        let result: RandomField<2> = max_value.map_to_field(config_ptr);
+        let result: RandomField<2, FC<2>> = max_value.map_to_field(config_ptr);
 
         assert!(
-            result.into_bigint() < modulus,
+            result.into_bigint() < *config.modulus(),
             "Result should be properly reduced modulo field modulus"
         );
     }

--- a/zip-plus/src/conversion.rs
+++ b/zip-plus/src/conversion.rs
@@ -4,7 +4,6 @@ use crate::{
 };
 use ark_std::{Zero, vec::Vec};
 
-// Implementation of FieldMap for signed integers
 macro_rules! impl_field_map_for_int {
     ($t:ty) => {
         impl<F: Field> FieldMap<F> for $t {
@@ -178,85 +177,6 @@ mod tests {
     #[test]
     fn converts_true_to_one() {
         test_from::<2, FcSmall<2>, bool>(true, "1");
-    }
-
-    #[test]
-    fn converts_from_bytes_le_with_config_valid() {
-        let bytes = [0x05, 0, 0, 0, 0, 0, 0, 0];
-        let expected = big_int!(5);
-
-        let result = <RandomField<1, Fc23<1>> as FromBytes>::from_bytes_le(&bytes).unwrap();
-        assert_eq!(result.into_bigint(), expected);
-    }
-
-    #[test]
-    fn converts_from_bytes_be_with_config_valid() {
-        let bytes = [
-            0x05, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-            0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-            0x00, 0x00, 0x00, 0x00,
-        ]; // Value: 5 (big-endian)
-        let expected = BigInt::<32>::from_bytes_be(&bytes).unwrap();
-
-        let result = RandomField::<32, FcBig<32>>::from_bytes_be(&bytes);
-        assert_eq!(result.map(|x| x.into_bigint()), Some(expected));
-    }
-
-    #[test]
-    fn converts_from_bytes_with_config_zero() {
-        let bytes = [0x00; 8]; // All zeros
-        let expected = RandomField::<1, Fc23<1>>::zero();
-
-        let result = RandomField::<1, _>::from_bytes_le(&bytes);
-        assert_eq!(result, Some(expected.clone()));
-        let result = RandomField::<1, _>::from_bytes_be(&bytes);
-        assert_eq!(result, Some(expected.clone()));
-    }
-
-    #[test]
-    fn converts_from_bytes_le_with_config_out_of_range() {
-        let bytes = [0x65, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00]; // Value: 101 (modulus is 23)
-        let result = RandomField::<1, Fc23<1>>::from_bytes_le(&bytes);
-        assert!(result.is_none());
-    }
-
-    #[test]
-    fn converts_from_bytes_be_with_config_out_of_range() {
-        define_field_config!(Fc37129241769965749, "37129241769965749");
-        let bytes = [0x65, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00]; // Value: 101
-        let result = RandomField::<32, Fc37129241769965749<32>>::from_bytes_be(&bytes);
-        assert!(result.is_none());
-    }
-
-    #[test]
-    fn converts_from_bytes_le_with_config_exact_modulus() {
-        let bytes = [0x17, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00]; // Value: 23 (modulus)
-        let result = RandomField::<1, Fc23<1>>::from_bytes_le(&bytes);
-        assert!(result.is_none()); // Must be strictly less than modulus
-    }
-
-    #[test]
-    fn converts_from_bytes_be_with_config_exact_modulus() {
-        let bytes = [0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x17]; // Value: 23 (big-endian)
-        let result = RandomField::<1, Fc23<1>>::from_bytes_be(&bytes);
-        assert!(result.is_none());
-    }
-
-    #[test]
-    fn converts_from_bytes_le_with_config_leading_zeros() {
-        let bytes = [0b0000_0001]; // Value: 1 with leading zeros
-        let expected = BigInt::<1>::from_bytes_le(&bytes).unwrap().map_to_field();
-
-        let result = RandomField::<1, Fc23<1>>::from_bytes_le(&bytes);
-        assert_eq!(result, Some(expected));
-    }
-
-    #[test]
-    fn converts_from_bytes_be_with_config_leading_zeros() {
-        let bytes = [0x01]; //1 with leading zeros (big-endian);
-
-        let result = RandomField::<1, Fc23<1>>::from_bytes_be(&bytes).unwrap();
-        assert_eq!(result.into_bigint(), BigInt::one());
     }
 
     macro_rules! test_signed_type_full_range {

--- a/zip-plus/src/conversion.rs
+++ b/zip-plus/src/conversion.rs
@@ -1,7 +1,7 @@
 use ark_std::{vec::Vec, Zero};
-
+use crate::field::config::{FieldConfigBase, FieldConfigOps};
 use crate::traits::{
-    BigInteger, Config, ConfigReference, Field, FieldMap, Integer, PrimitiveConversion, Uinteger,
+    BigInteger, Field, FieldMap, Integer, PrimitiveConversion, Uinteger,
     Words,
 };
 
@@ -11,13 +11,7 @@ macro_rules! impl_field_map_for_int {
         impl<F: Field> FieldMap<F> for $t {
             type Output = F;
 
-            fn map_to_field(&self, config_ref: F::R) -> Self::Output {
-                let config = match config_ref.reference() {
-                    Some(config) => config,
-                    None => {
-                        panic!("Cannot convert integer to prime field element without a modulus")
-                    }
-                };
+            fn map_to_field(&self) -> Self::Output {
                 let value = self.abs_diff(0);
                 let mut words = F::W::default();
 
@@ -28,13 +22,13 @@ macro_rules! impl_field_map_for_int {
                         PrimitiveConversion::from_primitive(u128::from_primitive(value) >> 64);
                 }
                 let mut value = F::U::from_words(words).as_int();
-                let modulus = F::I::from_words(config.modulus().to_words());
+                let modulus = F::I::from_words(F::C::modulus().to_words());
 
                 value %= modulus;
                 let mut value = F::B::from(value);
-                config.mul_assign(&mut value, config.r2());
+                F::C::mul_assign(&mut value, &F::C::r_squared());
 
-                let mut r = F::new_unchecked(config_ref, value);
+                let mut r = F::new_unchecked(value);
 
                 if self < &<$t>::zero() {
                     r = -r;
@@ -63,22 +57,17 @@ impl_field_map_for_int!(usize);
 impl<F: Field> FieldMap<F> for bool {
     type Output = F;
 
-    fn map_to_field(&self, config_ref: F::R) -> Self::Output {
-        let config = match config_ref.reference() {
-            Some(config) => config,
-            None => panic!("Cannot convert boolean to prime field element without a modulus"),
-        };
-
+    fn map_to_field(&self) -> Self::Output {
         let mut r = F::B::from(*self as u64);
-        config.mul_assign(&mut r, config.r2());
-        F::new_unchecked(config_ref, r)
+        F::C::mul_assign(&mut r, &F::C::r_squared());
+        F::new_unchecked(r)
     }
 }
 
 impl<F: Field> FieldMap<F> for &bool {
     type Output = F;
-    fn map_to_field(&self, config_ref: F::R) -> Self::Output {
-        (*self).map_to_field(config_ref)
+    fn map_to_field(&self) -> Self::Output {
+        (*self).map_to_field()
     }
 }
 
@@ -89,9 +78,9 @@ where
 {
     type Output = F;
 
-    fn map_to_field(&self, config_ref: F::R) -> Self::Output {
+    fn map_to_field(&self) -> Self::Output {
         let local_type_bigint = T::I::from(self);
-        let res = local_type_bigint.map_to_field(config_ref);
+        let res = local_type_bigint.map_to_field();
         if self < &<T as Zero>::zero() {
             return -res;
         }
@@ -104,24 +93,24 @@ where
 impl<F: Field, T: FieldMap<F>> FieldMap<F> for Vec<T> {
     type Output = Vec<T::Output>;
 
-    fn map_to_field(&self, config_ref: F::R) -> Self::Output {
-        self.iter().map(|x| x.map_to_field(config_ref)).collect()
+    fn map_to_field(&self) -> Self::Output {
+        self.iter().map(|x| x.map_to_field()).collect()
     }
 }
 
 impl<F: Field, T: FieldMap<F>> FieldMap<F> for &Vec<T> {
     type Output = Vec<T::Output>;
 
-    fn map_to_field(&self, config_ref: F::R) -> Self::Output {
-        self.iter().map(|x| x.map_to_field(config_ref)).collect()
+    fn map_to_field(&self) -> Self::Output {
+        self.iter().map(|x| x.map_to_field()).collect()
     }
 }
 
 impl<F: Field, T: FieldMap<F>> FieldMap<F> for &[T] {
     type Output = Vec<T::Output>;
 
-    fn map_to_field(&self, config_ref: F::R) -> Self::Output {
-        self.iter().map(|x| x.map_to_field(config_ref)).collect()
+    fn map_to_field(&self) -> Self::Output {
+        self.iter().map(|x| x.map_to_field()).collect()
     }
 }
 
@@ -129,21 +118,20 @@ impl<F: Field, T: FieldMap<F>> FieldMap<F> for &[T] {
 mod tests {
     use ark_std::{fmt::Debug, format, str::FromStr};
     use num_traits::{ConstZero, Zero};
-    use crate::{big_int, define_field_config, field::{BigInt, ConfigRef, FieldConfig, RandomField}, field_config, traits::{Config, ConfigReference, Field, FieldMap, FromBytes}};
-    use crate::field::config::ConstFieldConfig;
+    use crate::{big_int, define_field_config, field::{BigInt, FieldConfig, RandomField}, traits::{Field, FieldMap, FromBytes}};
 
     define_field_config!(Fc23, "23");
     define_field_config!(FcSmall, "243043087159742188419721163456177567");
     define_field_config!(FcBig, "3618502788666131213697322783095070105623107215331596699973092056135872020481");
 
-    fn test_from<const N: usize, FC: ConstFieldConfig<N>, T: Clone>(value: T, value_str: &str)
+    fn test_from<const N: usize, FC: FieldConfig<BigInt<N>>, T: Clone>(value: T, value_str: &str)
     where
-        for <'a> RandomField<'a, N, FC>: From<T>,
+        RandomField<N, FC>: From<T>,
     {
         let raw_element = RandomField::<N, FC>::from(value);
         assert_eq!(
             raw_element,
-            BigInt::<N>::from_str(value_str).unwrap().map_to_field(unsafe { ConfigRef::new(Box::leak(Box::new(FC::field_config()))) })
+            BigInt::<N>::from_str(value_str).unwrap().map_to_field()
         )
     }
 
@@ -187,26 +175,15 @@ mod tests {
 
     #[test]
     fn converts_from_bytes_le_with_config_valid() {
-        let config = field_config!(23);
-        let config = ConfigRef::from(&config);
-
         let bytes = [0x05, 0, 0, 0, 0, 0, 0, 0];
         let expected = big_int!(5);
 
-        let result = RandomField::<1, Fc23<1>>::from_bytes_le_with_config(config, &bytes).unwrap();
+        let result = <RandomField::<1, Fc23<1>> as FromBytes>::from_bytes_le(&bytes).unwrap();
         assert_eq!(result.into_bigint(), expected);
     }
 
     #[test]
     fn converts_from_bytes_be_with_config_valid() {
-        let config = FieldConfig::new(
-            BigInt::<32>::from_str(
-                "3618502788666131213697322783095070105623107215331596699973092056135872020481",
-            )
-            .unwrap(),
-        );
-        let config_ptr = ConfigRef::from(&config);
-
         let bytes = [
             0x05, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
             0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
@@ -214,96 +191,75 @@ mod tests {
         ]; // Value: 5 (big-endian)
         let expected = BigInt::<32>::from_bytes_be(&bytes).unwrap();
 
-        let result = RandomField::<32, FcBig<32>>::from_bytes_be_with_config(config_ptr, &bytes);
+        let result = RandomField::<32, FcBig<32>>::from_bytes_be(&bytes);
         assert_eq!(result.map(|x| x.into_bigint()), Some(expected));
     }
 
     #[test]
     fn converts_from_bytes_with_config_zero() {
-        let config = field_config!(23);
-        let config = ConfigRef::from(&config);
-
         let bytes = [0x00; 8]; // All zeros
         let expected = RandomField::<1, Fc23<1>>::zero();
 
-        let result = RandomField::<1, _>::from_bytes_le_with_config(config, &bytes);
+        let result = RandomField::<1, _>::from_bytes_le(&bytes);
         assert_eq!(result, Some(expected.clone()));
-        let result = RandomField::<1, _>::from_bytes_be_with_config(config, &bytes);
+        let result = RandomField::<1, _>::from_bytes_be(&bytes);
         assert_eq!(result, Some(expected.clone()));
     }
 
     #[test]
     fn converts_from_bytes_le_with_config_out_of_range() {
-        let config = field_config!(23);
-        let config = ConfigRef::from(&config);
-
         let bytes = [0x65, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00]; // Value: 101 (modulus is 23)
-        let result = RandomField::<1, Fc23<1>>::from_bytes_le_with_config(config, &bytes);
+        let result = RandomField::<1, Fc23<1>>::from_bytes_le(&bytes);
         assert!(result.is_none());
     }
 
     #[test]
     fn converts_from_bytes_be_with_config_out_of_range() {
         define_field_config!(Fc37129241769965749, "37129241769965749");
-        let config = field_config!(37129241769965749);
-        let config = ConfigRef::from(&config);
-
         let bytes = [0x65, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00]; // Value: 101
-        let result = RandomField::<32, Fc37129241769965749<32>>::from_bytes_be_with_config(config, &bytes);
+        let result = RandomField::<32, Fc37129241769965749<32>>::from_bytes_be(&bytes);
         assert!(result.is_none());
     }
 
     #[test]
     fn converts_from_bytes_le_with_config_exact_modulus() {
-        let config = field_config!(23);
-        let config = ConfigRef::from(&config);
-
         let bytes = [0x17, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00]; // Value: 23 (modulus)
-        let result = RandomField::<1, Fc23<1>>::from_bytes_le_with_config(config, &bytes);
+        let result = RandomField::<1, Fc23<1>>::from_bytes_le(&bytes);
         assert!(result.is_none()); // Must be strictly less than modulus
     }
 
     #[test]
     fn converts_from_bytes_be_with_config_exact_modulus() {
-        let config = field_config!(23);
-        let config = ConfigRef::from(&config);
-
         let bytes = [0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x17]; // Value: 23 (big-endian)
-        let result = RandomField::<1, Fc23<1>>::from_bytes_be_with_config(config, &bytes);
+        let result = RandomField::<1, Fc23<1>>::from_bytes_be(&bytes);
         assert!(result.is_none());
     }
 
     #[test]
     fn converts_from_bytes_le_with_config_leading_zeros() {
-        let config = field_config!(23);
-        let config = ConfigRef::from(&config);
-
         let bytes = [0b0000_0001]; // Value: 1 with leading zeros
         let expected = BigInt::<1>::from_bytes_le(&bytes)
             .unwrap()
-            .map_to_field(config);
+            .map_to_field();
 
-        let result = RandomField::<1, Fc23<1>>::from_bytes_le_with_config(config, &bytes);
+        let result = RandomField::<1, Fc23<1>>::from_bytes_le(&bytes);
         assert_eq!(result, Some(expected));
     }
 
     #[test]
     fn converts_from_bytes_be_with_config_leading_zeros() {
-        let config = field_config!(23);
-        let config = ConfigRef::from(&config);
-
         let bytes = [0x01]; //1 with leading zeros (big-endian);
 
-        let result = RandomField::<1, Fc23<1>>::from_bytes_be_with_config(config, &bytes).unwrap();
+        let result = RandomField::<1, Fc23<1>>::from_bytes_be(&bytes).unwrap();
         assert_eq!(result.into_bigint(), BigInt::one());
     }
 
     macro_rules! test_signed_type_full_range {
-        ($type:ty, $field:expr, $config:expr, $N:expr, $FC:ty) => {{
+        ($type:ty, $field:expr, $N:expr, $FC:ty) => {{
             // Test full range for primitive types
             for x in <$type>::MIN..=<$type>::MAX {
-                let result: RandomField<$N, $FC> = x.map_to_field($config);
-                let ref_result: RandomField<$N, $FC> = (&x).map_to_field($config);
+                let result: RandomField<$N, $FC> = x.map_to_field();
+                let ref_result: RandomField<$N, $FC> = (&x).map_to_field();
                 let expected = if x < 0 {
                     BigInt::<$N>::from(($field as i64 + x as i64) as u64)
                 } else {
@@ -326,10 +282,10 @@ mod tests {
     }
 
     macro_rules! test_signed_type_edge_cases {
-        ($type:ty, $field:expr, $config:expr, $N:expr, $FC:ty) => {{
+        ($type:ty, $field:expr, $N:expr, $FC:ty) => {{
             // Test zero
             let zero = <$type>::from_str("0").unwrap();
-            let zero_result: RandomField<$N, $FC> = zero.map_to_field($config);
+            let zero_result: RandomField<$N, $FC> = zero.map_to_field();
             assert_eq!(
                 zero_result.into_bigint(),
                 BigInt::<$N>::ZERO,
@@ -338,7 +294,7 @@ mod tests {
 
             // Test maximum value
             let max = <$type>::from_str(&format!("{}", <$type>::MAX)).unwrap();
-            let max_result: RandomField<$N, $FC> = max.map_to_field($config);
+            let max_result: RandomField<$N, $FC> = max.map_to_field();
             assert!(
                 max_result.into_bigint() < BigInt::<$N>::from($field),
                 "Maximum value should be less than field modulus"
@@ -346,7 +302,7 @@ mod tests {
 
             // Test minimum value
             let min = -<$type>::from_str(&format!("{}", <$type>::MAX)).unwrap();
-            let min_f = <$type as FieldMap<RandomField<$N, $FC>>>::map_to_field(&min, $config);
+            let min_f = <$type as FieldMap<RandomField<$N, $FC>>>::map_to_field(&min, );
             assert!(
                 min_f.into_bigint() < BigInt::<$N>::from($field),
                 "Minimum value should wrap to valid field element"
@@ -354,7 +310,7 @@ mod tests {
 
             // Test positive boundary
             let pos = <$type>::from_str("5").unwrap();
-            let pos_result: RandomField<$N, $FC> = pos.map_to_field($config);
+            let pos_result: RandomField<$N, $FC> = pos.map_to_field();
             assert_eq!(
                 pos_result.into_bigint(),
                 BigInt::<$N>::from(5u64),
@@ -363,7 +319,7 @@ mod tests {
 
             // Test negative boundary
             let neg = <$type>::from_str("-5").unwrap();
-            let neg_result: RandomField<$N, $FC> = neg.map_to_field($config);
+            let neg_result: RandomField<$N, $FC> = neg.map_to_field();
             assert_eq!(
                 neg_result.into_bigint(),
                 BigInt::<$N>::from(($field as i64 - 5) as u64),
@@ -371,20 +327,20 @@ mod tests {
             );
 
             // Test reference conversions
-            let ref_zero: RandomField<$N, $FC> = (&zero).map_to_field($config);
+            let ref_zero: RandomField<$N, $FC> = (&zero).map_to_field();
             assert_eq!(
                 ref_zero.into_bigint(),
                 BigInt::<$N>::ZERO,
                 "Reference to zero should map to field zero"
             );
 
-            let ref_max: RandomField<$N, $FC> = (&max).map_to_field($config);
+            let ref_max: RandomField<$N, $FC> = (&max).map_to_field();
             assert!(
                 ref_max.into_bigint() < BigInt::<$N>::from($field),
                 "Reference to maximum value should be less than field modulus"
             );
 
-            let ref_min: RandomField<$N, $FC> = (&min).map_to_field($config);
+            let ref_min: RandomField<$N, $FC> = (&min).map_to_field();
             assert!(
                 ref_min.into_bigint() < BigInt::<$N>::from($field),
                 "Reference to minimum value should wrap to valid field element"
@@ -396,25 +352,23 @@ mod tests {
     fn test_signed_integers_field_map() {
         define_field_config!(FC, "18446744069414584321");
         let field = 18446744069414584321_u64;
-        let config = field_config!(18446744069414584321);
-        let config: ConfigRef<1> = ConfigRef::from(&config);
 
         // Test primitive types with full range
-        test_signed_type_full_range!(i8, field, config, 1, FC<1>);
-        test_signed_type_full_range!(i16, field, config, 1, FC<1>);
+        test_signed_type_full_range!(i8, field, 1, FC<1>);
+        test_signed_type_full_range!(i16, field, 1, FC<1>);
 
         // Test larger primitive types with edge cases only
-        test_signed_type_edge_cases!(i32, field, config, 1, FC<1>);
-        test_signed_type_edge_cases!(i64, field, config, 1, FC<1>);
-        test_signed_type_edge_cases!(i128, field, config, 1, FC<1>);
+        test_signed_type_edge_cases!(i32, field, 1, FC<1>);
+        test_signed_type_edge_cases!(i64, field, 1, FC<1>);
+        test_signed_type_edge_cases!(i128, field, 1, FC<1>);
     }
 
     macro_rules! test_unsigned_type_full_range {
-        ($type:ty, $field:expr, $config:expr, $N:expr, $FC:ty) => {{
+        ($type:ty, $field:expr, $N:expr, $FC:ty) => {{
             // Test full range for small unsigned types
             for x in <$type>::MIN..=<$type>::MAX {
-                let result: RandomField<$N, $FC> = x.map_to_field($config);
-                let ref_result: RandomField<$N, $FC> = (&x).map_to_field($config);
+                let result: RandomField<$N, $FC> = x.map_to_field();
+                let ref_result: RandomField<$N, $FC> = (&x).map_to_field();
                 let expected = BigInt::<$N>::from(x as u64);
                 assert_eq!(
                     result.into_bigint(),
@@ -433,10 +387,10 @@ mod tests {
     }
 
     macro_rules! test_unsigned_type_edge_cases {
-        ($type:ty, $field:expr, $config:expr, $N:expr, $FC:ty) => {{
+        ($type:ty, $field:expr, $N:expr, $FC:ty) => {{
             // Test zero
             let zero = <$type>::MIN;
-            let zero_result: RandomField<$N, $FC> = zero.map_to_field($config);
+            let zero_result: RandomField<$N, $FC> = zero.map_to_field();
             assert_eq!(
                 zero_result.into_bigint(),
                 BigInt::<$N>::ZERO,
@@ -445,7 +399,7 @@ mod tests {
 
             // Test maximum value
             let max = <$type>::MAX;
-            let max_result: RandomField<$N, $FC> = max.map_to_field($config);
+            let max_result: RandomField<$N, $FC> = max.map_to_field();
             assert!(
                 max_result.into_bigint() < BigInt::<$N>::from($field),
                 "Maximum value should be less than field modulus"
@@ -453,7 +407,7 @@ mod tests {
 
             // Test boundary value - using literal instead of From
             let boundary: $type = 5;
-            let boundary_result: RandomField<$N, $FC> = boundary.map_to_field($config);
+            let boundary_result: RandomField<$N, $FC> = boundary.map_to_field();
             assert_eq!(
                 boundary_result.into_bigint(),
                 BigInt::<$N>::from(5u64),
@@ -461,14 +415,14 @@ mod tests {
             );
 
             // Test reference conversions
-            let ref_zero: RandomField<$N, $FC> = (&zero).map_to_field($config);
+            let ref_zero: RandomField<$N, $FC> = (&zero).map_to_field();
             assert_eq!(
                 ref_zero.into_bigint(),
                 BigInt::<$N>::ZERO,
                 "Reference to zero should map to field zero"
             );
 
-            let ref_max: RandomField<$N, $FC> = (&max).map_to_field($config);
+            let ref_max: RandomField<$N, $FC> = (&max).map_to_field();
             assert!(
                 ref_max.into_bigint() < BigInt::<$N>::from($field),
                 "Reference to maximum value should be less than field modulus"
@@ -480,16 +434,14 @@ mod tests {
     fn test_unsigned_integers_field_map() {
         define_field_config!(FC, "18446744069414584321");
         let field_1 = 18446744069414584321_u64;
-        let config_1 = field_config!(18446744069414584321);
-        let config = ConfigRef::from(&config_1);
         // Test small types with full range
-        test_unsigned_type_full_range!(u8, field_1, config, 1, FC<1>);
-        test_unsigned_type_full_range!(u16, field_1, config, 1, FC<1>);
+        test_unsigned_type_full_range!(u8, field_1, 1, FC<1>);
+        test_unsigned_type_full_range!(u16, field_1, 1, FC<1>);
 
         // Test larger types with edge cases only
-        test_unsigned_type_edge_cases!(u32, field_1, config, 1, FC<1>);
-        test_unsigned_type_edge_cases!(u64, field_1, config, 1, FC<1>);
-        test_unsigned_type_edge_cases!(u128, field_1, config, 1, FC<1>);
+        test_unsigned_type_edge_cases!(u32, field_1, 1, FC<1>);
+        test_unsigned_type_edge_cases!(u64, field_1, 1, FC<1>);
+        test_unsigned_type_edge_cases!(u128, field_1, 1, FC<1>);
     }
 }
 
@@ -497,19 +449,15 @@ mod tests {
 mod bigint_field_map_tests {
     use num_traits::ConstZero;
     use super::*;
-    use crate::{big_int, define_field_config, field::{BigInt, ConfigRef, FieldConfig, RandomField}};
-    use crate::field::config::ConstFieldConfig;
+    use crate::{big_int, define_field_config, field::{BigInt, FieldConfig, RandomField}};
 
     define_field_config!(FC, "18446744069414584321");
 
     #[test]
     fn test_bigint_smaller_than_field() {
         // Using a 2-limb field config with 1-limb BigInt
-        let config = FieldConfig::new(FC::<2>::modulus());
-        let config_ptr = ConfigRef::from(&config);
-
         let small_bigint = BigInt::<1>::from(12345u64);
-        let result: RandomField<2, FC<2>> = small_bigint.map_to_field(config_ptr);
+        let result: RandomField<2, FC<2>> = small_bigint.map_to_field();
 
         assert_eq!(
             result.into_bigint().first(),
@@ -520,11 +468,8 @@ mod bigint_field_map_tests {
 
     #[test]
     fn test_bigint_equal_size() {
-        let config = FieldConfig::new(FC::<2>::modulus());
-        let config_ptr = ConfigRef::from(&config);
-
         let value = big_int!(12345678901234567890, 2);
-        let result: RandomField<2, FC<2>> = value.map_to_field(config_ptr);
+        let result: RandomField<2, FC<2>> = value.map_to_field();
 
         // The result should be the value modulo the field modulus
         let expected = big_int!(12345678901234567890);
@@ -538,11 +483,8 @@ mod bigint_field_map_tests {
     #[test]
     fn test_bigint_larger_than_field() {
         // Using a 1-limb field config with 2-limb BigInt
-        let config = FieldConfig::new(FC::<1>::modulus());
-        let config_ptr = ConfigRef::from(&config);
-
         let large_value = big_int!(123456789012345678901, 2);
-        let result: RandomField<1, FC<1>> = large_value.map_to_field(config_ptr);
+        let result: RandomField<1, FC<1>> = large_value.map_to_field();
 
         let expected = BigInt::<1>::from(12776324595858172975u64);
         assert_eq!(
@@ -554,11 +496,8 @@ mod bigint_field_map_tests {
 
     #[test]
     fn test_bigint_zero() {
-        let config = FieldConfig::new(FC::<2>::modulus());
-        let config_ptr = ConfigRef::from(&config);
-
         let zero = BigInt::<2>::ZERO;
-        let result: RandomField<2, FC<2>> = zero.map_to_field(config_ptr);
+        let result: RandomField<2, FC<2>> = zero.map_to_field();
 
         assert!(
             result.into_bigint().is_zero(),
@@ -568,12 +507,9 @@ mod bigint_field_map_tests {
 
     #[test]
     fn test_bigint_reference() {
-        let config = FieldConfig::new(FC::<2>::modulus());
-        let config_ptr = ConfigRef::from(&config);
-
         let value = big_int!(12345, 2);
-        let result: RandomField<2, FC::<2>> = value.map_to_field(config_ptr);
-        let direct_result: RandomField<2, FC::<2>> = value.map_to_field(config_ptr);
+        let result: RandomField<2, FC::<2>> = value.map_to_field();
+        let direct_result: RandomField<2, FC::<2>> = value.map_to_field();
 
         assert_eq!(
             result.into_bigint(),
@@ -584,16 +520,13 @@ mod bigint_field_map_tests {
 
     #[test]
     fn test_bigint_max_value() {
-        let config = FieldConfig::new(FC::<2>::modulus());
-        let config_ptr = ConfigRef::from(&config);
-
         // Create a BigInt with all bits set to 1
         let max_value = BigInt::from([u64::MAX, u64::MAX]);
 
-        let result: RandomField<2, FC<2>> = max_value.map_to_field(config_ptr);
+        let result: RandomField<2, FC<2>> = max_value.map_to_field();
 
         assert!(
-            result.into_bigint() < *config.modulus(),
+            result.into_bigint() < FC::modulus(),
             "Result should be properly reduced modulo field modulus"
         );
     }

--- a/zip-plus/src/conversion.rs
+++ b/zip-plus/src/conversion.rs
@@ -434,19 +434,6 @@ mod bigint_field_map_tests {
     }
 
     #[test]
-    fn test_bigint_reference() {
-        let value = big_int!(12345, 2);
-        let result: RandomField<2, FC<2>> = value.map_to_field();
-        let direct_result: RandomField<2, FC<2>> = value.map_to_field();
-
-        assert_eq!(
-            result.into_bigint(),
-            direct_result.into_bigint(),
-            "Reference implementation should match direct implementation"
-        );
-    }
-
-    #[test]
     fn test_bigint_max_value() {
         // Create a BigInt with all bits set to 1
         let max_value = BigInt::from([u64::MAX, u64::MAX]);

--- a/zip-plus/src/conversion.rs
+++ b/zip-plus/src/conversion.rs
@@ -118,7 +118,7 @@ impl<F: Field, T: FieldMap<F>> FieldMap<F> for &[T] {
 mod tests {
     use ark_std::{fmt::Debug, format, str::FromStr};
     use num_traits::{ConstZero, Zero};
-    use crate::{big_int, define_field_config, field::{BigInt, FieldConfig, RandomField}, traits::{Field, FieldMap, FromBytes}};
+    use crate::{big_int, define_field_config, field::{BigInt, FieldConfig, RandomField}, traits::{FieldMap, FromBytes}};
 
     define_field_config!(Fc23, "23");
     define_field_config!(FcSmall, "243043087159742188419721163456177567");

--- a/zip-plus/src/field.rs
+++ b/zip-plus/src/field.rs
@@ -35,35 +35,6 @@ use crate::{
 };
 
 impl<const N: usize, FC: FieldConfig<BigInt<N>>> RandomField<N, FC> {
-    /// Convert from `BigInteger` to `RandomField`
-    ///
-    /// If `BigInteger` is greater then field modulus return `None`
-    pub fn from_bigint(value: BigInt<N>) -> Option<RandomField<N, FC>> {
-        if value >= FC::modulus() {
-            None
-        } else {
-            let mut r = value;
-            FC::mul_assign(&mut r, &FC::r_squared());
-
-            Some(RandomField::new_unchecked(r))
-        }
-    }
-
-    pub fn from_i64(value: i64) -> Option<RandomField<N, FC>> {
-        if BigInt::from(value.unsigned_abs()) >= FC::modulus() {
-            None
-        } else {
-            let mut r = value.unsigned_abs().into();
-            FC::mul_assign(&mut r, &FC::r_squared());
-
-            let mut elem = RandomField::new_unchecked(r);
-            if value.is_negative() {
-                elem = -elem;
-            }
-            Some(elem)
-        }
-    }
-
     #[inline]
     pub fn into_bigint(self) -> BigInt<N> {
         self.value.demontgomery(&FC::modulus(), FC::inv())
@@ -81,28 +52,6 @@ impl<const N: usize, FC: FieldConfig<BigInt<N>>> Field for RandomField<N, FC> {
         Self {
             value,
             phantom_data: PhantomData,
-        }
-    }
-
-    fn rand<R: ark_std::rand::Rng + ?Sized>(rng: &mut R) -> Self {
-        loop {
-            let mut value = BigInt::rand(rng);
-            let modulus = FC::modulus();
-            let shave_bits = 64 * N - modulus.num_bits() as usize;
-            // Mask away the unused bits at the beginning.
-            assert!(shave_bits <= 64);
-            let mask = if shave_bits == 64 {
-                0
-            } else {
-                u64::MAX >> shave_bits
-            };
-
-            let val = value.last_mut();
-            *val &= mask;
-
-            if value < modulus {
-                return value.map_to_field();
-            }
         }
     }
 
@@ -127,24 +76,26 @@ impl<const N: usize, FC: FieldConfig<BigInt<N>>> Field for RandomField<N, FC> {
     }
 }
 
-impl<const N: usize, FC: FieldConfig<BigInt<N>>> UniformRand for RandomField<N, FC> {
-    fn rand<R: ark_std::rand::Rng + ?Sized>(rng: &mut R) -> Self {
-        let value = BigInt::rand(rng);
-
-        Self {
-            value,
-            phantom_data: PhantomData,
-        }
-    }
-}
-
 impl<const N: usize, FC: FieldConfig<BigInt<N>>> Random for RandomField<N, FC> {
     fn random(rng: &mut (impl ark_std::rand::RngCore + ?Sized)) -> Self {
-        let value = BigInt::rand(rng);
+        loop {
+            let mut value = BigInt::rand(rng);
+            let modulus = FC::modulus();
+            let shave_bits = 64 * N - modulus.num_bits() as usize;
+            // Mask away the unused bits at the beginning.
+            assert!(shave_bits <= 64);
+            let mask = if shave_bits == 64 {
+                0
+            } else {
+                u64::MAX >> shave_bits
+            };
 
-        Self {
-            value,
-            phantom_data: PhantomData,
+            let val = value.last_mut();
+            *val &= mask;
+
+            if value < modulus {
+                return value.map_to_field();
+            }
         }
     }
 }
@@ -197,16 +148,6 @@ impl_from_uint!(u8);
 impl<const N: usize, FC: FieldConfig<BigInt<N>>> From<bool> for RandomField<N, FC> {
     fn from(value: bool) -> Self {
         value.map_to_field()
-    }
-}
-
-impl<const N: usize, FC: FieldConfig<BigInt<N>>> FromBytes for RandomField<N, FC> {
-    fn from_bytes_le(bytes: &[u8]) -> Option<Self> {
-        Self::from_bigint(BigInt::<N>::from_bytes_le(bytes)?)
-    }
-
-    fn from_bytes_be(bytes: &[u8]) -> Option<Self> {
-        Self::from_bigint(BigInt::<N>::from_bytes_be(bytes)?)
     }
 }
 

--- a/zip-plus/src/field.rs
+++ b/zip-plus/src/field.rs
@@ -9,7 +9,7 @@ use crate::traits::{Config, ConfigReference, FieldMap, FromBytes, Words as Words
 mod arithmetic;
 mod biginteger;
 mod comparison;
-pub(crate) mod config;
+pub mod config;
 mod constant;
 mod int;
 mod uint;
@@ -24,7 +24,7 @@ pub use uint::Uint;
 #[derive(Copy, Clone)]
 pub struct RandomField<'cfg, const N: usize, FC: ConstFieldConfig<N>> {
     pub value: BigInt<N>,
-    pub config: Option<ConfigRef<'cfg, N>>,
+    pub config: ConfigRef<'cfg, N>,
     phantom_data: PhantomData<FC>
 }
 
@@ -35,47 +35,6 @@ use crate::{
 use crate::field::config::ConstFieldConfig;
 
 impl<'cfg, const N: usize, FC: ConstFieldConfig<N>> RandomField<'cfg, N, FC> {
-    pub fn with_either<R, I, A>(&self, raw_fn: R, init_fn: I) -> A
-    where
-        I: Fn(&FieldConfig<N>, &BigInt<N>) -> A,
-        R: Fn(&BigInt<N>) -> A,
-    {
-        match self.config {
-            None => raw_fn(&self.value),
-            Some(config) => init_fn(
-                config.reference().expect("Field config cannot be none"),
-                &self.value,
-            ),
-        }
-    }
-
-    pub fn with_either_mut<R, I, A>(&mut self, raw_fn: R, init_fn: I) -> A
-    where
-        I: Fn(&FieldConfig<N>, &mut BigInt<N>) -> A,
-        R: Fn(&mut BigInt<N>) -> A,
-    {
-        match self.config {
-            None => raw_fn(&mut self.value),
-            Some(config) => init_fn(
-                config.reference().expect("Field config cannot be none"),
-                &mut self.value,
-            ),
-        }
-    }
-
-    pub fn with_either_owned<R, I, A>(self, raw_fn: R, init_fn: I) -> A
-    where
-        I: Fn(&FieldConfig<N>, BigInt<N>) -> A,
-        R: Fn(BigInt<N>) -> A,
-    {
-        match self.config {
-            None => raw_fn(self.value),
-            Some(config) => init_fn(
-                config.reference().expect("Field config cannot be none"),
-                self.value,
-            ),
-        }
-    }
 
     pub fn with_aligned_config_mut<F, G, A>(
         &mut self,
@@ -87,35 +46,16 @@ impl<'cfg, const N: usize, FC: ConstFieldConfig<N>> RandomField<'cfg, N, FC> {
         F: Fn(&mut BigInt<N>, &BigInt<N>, &FieldConfig<N>) -> A,
         G: Fn(&mut BigInt<N>, &BigInt<N>) -> A,
     {
-        match (self.config, rhs.config) {
-            (None, None) => fn_without_config(&mut self.value, &rhs.value),
-            (Some(config), Some(_)) => fn_with_config(
-                &mut self.value,
-                &rhs.value,
-                config.reference().expect("Field config cannot be none"),
-            ),
-            (Some(config), None) => {
-                let rhs = rhs.clone().with_config(config);
-                fn_with_config(
-                    &mut self.value,
-                    &rhs.value,
-                    config.reference().expect("Field config cannot be none"),
-                )
-            }
-            (None, Some(config)) => {
-                *self = self.clone().with_config(config);
-                fn_with_config(
-                    &mut self.value,
-                    &rhs.value,
-                    config.reference().expect("Field config cannot be none"),
-                )
-            }
-        }
+        fn_with_config(
+            &mut self.value,
+            &rhs.value,
+            self.config.reference().expect("Field config cannot be none"),
+        )
     }
 
     pub fn zero_with_config(config: ConfigRef<'cfg, N>) -> Self {
         Self {
-            config: Some(config),
+            config,
             value: BigInt::ZERO,
             phantom_data: PhantomData,
         }
@@ -123,10 +63,7 @@ impl<'cfg, const N: usize, FC: ConstFieldConfig<N>> RandomField<'cfg, N, FC> {
 
     #[inline(always)]
     pub fn config_ptr(&self) -> ConfigRef<'cfg, N> {
-        match self.config {
-            None => ConfigRef::NONE,
-            Some(config) => config,
-        }
+        self.config
     }
 
     /// Convert from `BigInteger` to `RandomField`
@@ -136,10 +73,7 @@ impl<'cfg, const N: usize, FC: ConstFieldConfig<N>> RandomField<'cfg, N, FC> {
     where
         'cfg: 'a,
     {
-        let config_ref = match config.reference() {
-            Some(config) => config,
-            None => return Some(Self { value, config: None, phantom_data: PhantomData }),
-        };
+        let config_ref = config.reference().expect("Field config cannot be none");
 
         if value >= *config_ref.modulus() {
             None
@@ -152,12 +86,7 @@ impl<'cfg, const N: usize, FC: ConstFieldConfig<N>> RandomField<'cfg, N, FC> {
     }
 
     pub fn from_i64(value: i64, config: ConfigRef<'cfg, N>) -> Option<RandomField<'cfg, N, FC>> {
-        let config_ref = match config.reference() {
-            Some(config) => config,
-            None => {
-                panic!("Cannot convert signed integer to prime field element without a modulus")
-            }
-        };
+        let config_ref = config.reference().expect("Field config cannot be none");
 
         if BigInt::from(value.unsigned_abs()) >= *config_ref.modulus() {
             None
@@ -175,7 +104,7 @@ impl<'cfg, const N: usize, FC: ConstFieldConfig<N>> RandomField<'cfg, N, FC> {
 
     #[inline]
     pub fn into_bigint(self) -> BigInt<N> {
-        self.with_either_owned(|value| value, Self::demontgomery)
+        Self::demontgomery(self.config.reference().expect("Field config cannot be none"), self.value)
     }
 
     #[inline]
@@ -194,11 +123,7 @@ impl<'cfg, const N: usize, FC: ConstFieldConfig<N>> Field for RandomField<'cfg, 
     type DebugField = DebugRandomField;
 
     fn new_unchecked(config: ConfigRef<'cfg, N>, value: BigInt<N>) -> Self {
-        Self { config: Some(config), value, phantom_data: PhantomData }
-    }
-
-    fn without_config(value: Self::B) -> Self {
-        Self { value, config: None, phantom_data: PhantomData }
+        Self { config, value, phantom_data: PhantomData }
     }
 
     fn rand_with_config<R: ark_std::rand::Rng + ?Sized>(rng: &mut R, config: Self::R) -> Self {
@@ -226,31 +151,6 @@ impl<'cfg, const N: usize, FC: ConstFieldConfig<N>> Field for RandomField<'cfg, 
         }
     }
 
-    fn with_config(self, config: Self::R) -> Self {
-        let value = match self.config {
-            None => {
-                // Ideally we should do something like:
-                //
-                // ```
-                // let modulus: BigInt<N> = unsafe { (*config).modulus };
-                // *value = *value % modulus;
-                // ```
-                //
-                // but we don't have `mod` out of the box.
-                // So let's hope we don't exceed the modulus.
-
-                // TODO: prettify this
-
-                *Self::from_bigint(config, self.value)
-                    .expect("Should not end up with a None here.")
-                    .value()
-            }
-            Some(_) => { panic!("Cannot convert initialized field to raw field without a value") },
-        };
-
-        Self { config: Some(config), value, phantom_data: PhantomData }
-    }
-
     #[inline(always)]
     fn value(&self) -> &BigInt<N> {
         &self.value
@@ -262,13 +162,11 @@ impl<'cfg, const N: usize, FC: ConstFieldConfig<N>> Field for RandomField<'cfg, 
     }
 
     fn absorb_into_transcript(&self, transcript: &mut KeccakTranscript) {
-        if let Some(config) = self.config {
-            let config = config.reference().expect("Field config cannot be none");
+        let config = self.config.reference().expect("Field config cannot be none");
 
-            transcript.absorb(&[0x3]);
-            transcript.absorb(&config.modulus().to_bytes_be());
-            transcript.absorb(&[0x5]);
-        }
+        transcript.absorb(&[0x3]);
+        transcript.absorb(&config.modulus().to_bytes_be());
+        transcript.absorb(&[0x5]);
 
         transcript.absorb(&[0x1]);
         transcript.absorb(&self.value.to_bytes_be());
@@ -280,7 +178,7 @@ impl<const N: usize, FC: ConstFieldConfig<N>> UniformRand for RandomField<'_, N,
     fn rand<R: ark_std::rand::Rng + ?Sized>(rng: &mut R) -> Self {
         let value = BigInt::rand(rng);
 
-        Self { value, config: None, phantom_data: PhantomData }
+        Self { value, config: ConfigRef::from(&FC::FIELD_CONFIG), phantom_data: PhantomData }
     }
 }
 
@@ -288,35 +186,24 @@ impl<const N: usize, FC: ConstFieldConfig<N>> Random for RandomField<'_, N, FC> 
     fn random(rng: &mut (impl ark_std::rand::RngCore + ?Sized)) -> Self {
         let value = BigInt::rand(rng);
 
-        Self { value, config: None, phantom_data: PhantomData }
+        Self { value, config: ConfigRef::from(&FC::FIELD_CONFIG), phantom_data: PhantomData }
     }
 }
 
 impl<const N: usize, FC: ConstFieldConfig<N>> ark_std::fmt::Debug for RandomField<'_, N, FC> {
     fn fmt(&self, f: &mut ark_std::fmt::Formatter<'_>) -> ark_std::fmt::Result {
-        match self.config {
-            None => write!(f, "{}, no config", self.value),
-            Some(_) => write!(
-                f,
-                "{} in Z_{}",
-                self.clone().into_bigint(),
-                self.config_ptr().reference().unwrap().modulus()
-            ),
-        }
+        write!(
+            f,
+            "{} in Z_{}",
+            self.clone().into_bigint(),
+            self.config_ptr().reference().unwrap().modulus()
+        )
     }
 }
 
 impl<const N: usize, FC: ConstFieldConfig<N>> ark_std::fmt::Display for RandomField<'_, N, FC> {
     fn fmt(&self, f: &mut ark_std::fmt::Formatter<'_>) -> ark_std::fmt::Result {
-        // TODO: we should go back from Montgomery here.
-        match self.config {
-            None => {
-                write!(f, "{}", self.value)
-            }
-            Some(_) => {
-                write!(f, "{}", self.clone().into_bigint())
-            }
-        }
+        write!(f, "{}", self.clone().into_bigint())
     }
 }
 
@@ -324,7 +211,7 @@ impl<const N: usize, FC: ConstFieldConfig<N>> Default for RandomField<'_, N, FC>
     fn default() -> Self {
         Self {
             value: BigInt::ZERO,
-            config: None,
+            config: ConfigRef::from(&FC::FIELD_CONFIG),
             phantom_data: PhantomData
         }
     }
@@ -347,14 +234,9 @@ pub enum DebugRandomField {
 
 impl<const N: usize, FC: ConstFieldConfig<N>> From<RandomField<'_, N, FC>> for DebugRandomField {
     fn from(value: RandomField<'_, N, FC>) -> Self {
-        match value.config {
-            None => Self::Raw {
-                value: value.value.into(),
-            },
-            Some(config) => Self::Initialized {
-                config: (*config.reference().unwrap()).into(),
-                value: value.value.into(),
-            },
+        Self::Initialized {
+            config: (*value.config.reference().unwrap()).into(),
+            value: value.value.into(),
         }
     }
 }
@@ -374,9 +256,7 @@ impl ark_std::fmt::Display for DebugRandomField {
 
 impl<const N: usize, FC: ConstFieldConfig<N>> From<u128> for RandomField<'_, N, FC> {
     fn from(value: u128) -> Self {
-        let value = BigInt::from(value);
-
-        RandomField { value, config: None, phantom_data: PhantomData }
+        value.map_to_field(ConfigRef::from(&FC::FIELD_CONFIG))
     }
 }
 
@@ -384,8 +264,7 @@ macro_rules! impl_from_uint {
     ($type:ty) => {
         impl<const N: usize, FC: ConstFieldConfig<N>> From<$type> for RandomField<'_, N, FC> {
             fn from(value: $type) -> Self {
-                let value = BigInt::from(value);
-                RandomField { value, config: None, phantom_data: PhantomData }
+                value.map_to_field(ConfigRef::from(&FC::FIELD_CONFIG))
             }
         }
     };
@@ -398,8 +277,7 @@ impl_from_uint!(u8);
 
 impl<const N: usize, FC: ConstFieldConfig<N>> From<bool> for RandomField<'_, N, FC> {
     fn from(value: bool) -> Self {
-        let value = BigInt::from(value as u8);
-        RandomField { value, config: None, phantom_data: PhantomData }
+        value.map_to_field(ConfigRef::from(&FC::FIELD_CONFIG))
     }
 }
 
@@ -407,7 +285,7 @@ impl<const N: usize, FC: ConstFieldConfig<N>> FromBytes for RandomField<'_, N, F
     fn from_bytes_le(bytes: &[u8]) -> Option<Self> {
         Some(RandomField {
             value: BigInt::<N>::from_bytes_le(bytes)?,
-            config: None,
+            config: ConfigRef::from(&FC::FIELD_CONFIG),
             phantom_data: PhantomData
         })
     }
@@ -415,7 +293,7 @@ impl<const N: usize, FC: ConstFieldConfig<N>> FromBytes for RandomField<'_, N, F
     fn from_bytes_be(bytes: &[u8]) -> Option<Self> {
         Some(RandomField {
             value: BigInt::<N>::from_bytes_be(bytes)?,
-            config: None,
+            config: ConfigRef::from(&FC::FIELD_CONFIG),
             phantom_data: PhantomData
         })
     }

--- a/zip-plus/src/field.rs
+++ b/zip-plus/src/field.rs
@@ -1,5 +1,6 @@
 #![allow(non_snake_case)]
 
+use std::marker::PhantomData;
 use ark_ff::UniformRand;
 use crypto_bigint::Random;
 use num_traits::ConstZero;
@@ -8,7 +9,7 @@ use crate::traits::{Config, ConfigReference, FieldMap, FromBytes, Words as Words
 mod arithmetic;
 mod biginteger;
 mod comparison;
-mod config;
+pub(crate) mod config;
 mod constant;
 mod int;
 mod uint;
@@ -21,17 +22,19 @@ pub use config::{ConfigRef, DebugFieldConfig, FieldConfig};
 pub use int::Int;
 pub use uint::Uint;
 #[derive(Copy, Clone)]
-pub struct RandomField<'cfg, const N: usize> {
+pub struct RandomField<'cfg, const N: usize, FC: ConstFieldConfig<N>> {
     pub value: BigInt<N>,
     pub config: Option<ConfigRef<'cfg, N>>,
+    phantom_data: PhantomData<FC>
 }
 
 use crate::{
     traits::{BigInteger, Field},
     transcript::KeccakTranscript,
 };
+use crate::field::config::ConstFieldConfig;
 
-impl<'cfg, const N: usize> RandomField<'cfg, N> {
+impl<'cfg, const N: usize, FC: ConstFieldConfig<N>> RandomField<'cfg, N, FC> {
     pub fn with_either<R, I, A>(&self, raw_fn: R, init_fn: I) -> A
     where
         I: Fn(&FieldConfig<N>, &BigInt<N>) -> A,
@@ -92,7 +95,7 @@ impl<'cfg, const N: usize> RandomField<'cfg, N> {
                 config.reference().expect("Field config cannot be none"),
             ),
             (Some(config), None) => {
-                let rhs = rhs.with_config(config);
+                let rhs = rhs.clone().with_config(config);
                 fn_with_config(
                     &mut self.value,
                     &rhs.value,
@@ -100,7 +103,7 @@ impl<'cfg, const N: usize> RandomField<'cfg, N> {
                 )
             }
             (None, Some(config)) => {
-                *self = self.with_config(config);
+                *self = self.clone().with_config(config);
                 fn_with_config(
                     &mut self.value,
                     &rhs.value,
@@ -114,6 +117,7 @@ impl<'cfg, const N: usize> RandomField<'cfg, N> {
         Self {
             config: Some(config),
             value: BigInt::ZERO,
+            phantom_data: PhantomData,
         }
     }
 
@@ -128,13 +132,13 @@ impl<'cfg, const N: usize> RandomField<'cfg, N> {
     /// Convert from `BigInteger` to `RandomField`
     ///
     /// If `BigInteger` is greater then field modulus return `None`
-    pub fn from_bigint<'a>(config: ConfigRef<'a, N>, value: BigInt<N>) -> Option<RandomField<'a, N>>
+    pub fn from_bigint<'a>(config: ConfigRef<'a, N>, value: BigInt<N>) -> Option<RandomField<'a, N, FC>>
     where
         'cfg: 'a,
     {
         let config_ref = match config.reference() {
             Some(config) => config,
-            None => return Some(Self { value, config: None }),
+            None => return Some(Self { value, config: None, phantom_data: PhantomData }),
         };
 
         if value >= *config_ref.modulus() {
@@ -147,7 +151,7 @@ impl<'cfg, const N: usize> RandomField<'cfg, N> {
         }
     }
 
-    pub fn from_i64(value: i64, config: ConfigRef<'cfg, N>) -> Option<RandomField<'cfg, N>> {
+    pub fn from_i64(value: i64, config: ConfigRef<'cfg, N>) -> Option<RandomField<'cfg, N, FC>> {
         let config_ref = match config.reference() {
             Some(config) => config,
             None => {
@@ -180,7 +184,7 @@ impl<'cfg, const N: usize> RandomField<'cfg, N> {
     }
 }
 
-impl<'cfg, const N: usize> Field for RandomField<'cfg, N> {
+impl<'cfg, const N: usize, FC: ConstFieldConfig<N>> Field for RandomField<'cfg, N, FC> {
     type B = BigInt<N>;
     type C = FieldConfig<N>;
     type R = ConfigRef<'cfg, N>;
@@ -190,11 +194,11 @@ impl<'cfg, const N: usize> Field for RandomField<'cfg, N> {
     type DebugField = DebugRandomField;
 
     fn new_unchecked(config: ConfigRef<'cfg, N>, value: BigInt<N>) -> Self {
-        Self { config: Some(config), value }
+        Self { config: Some(config), value, phantom_data: PhantomData }
     }
 
     fn without_config(value: Self::B) -> Self {
-        Self { value, config: None }
+        Self { value, config: None, phantom_data: PhantomData }
     }
 
     fn rand_with_config<R: ark_std::rand::Rng + ?Sized>(rng: &mut R, config: Self::R) -> Self {
@@ -244,7 +248,7 @@ impl<'cfg, const N: usize> Field for RandomField<'cfg, N> {
             Some(_) => { panic!("Cannot convert initialized field to raw field without a value") },
         };
 
-        Self { config: Some(config), value }
+        Self { config: Some(config), value, phantom_data: PhantomData }
     }
 
     #[inline(always)]
@@ -272,37 +276,37 @@ impl<'cfg, const N: usize> Field for RandomField<'cfg, N> {
     }
 }
 
-impl<const N: usize> UniformRand for RandomField<'_, N> {
+impl<const N: usize, FC: ConstFieldConfig<N>> UniformRand for RandomField<'_, N, FC> {
     fn rand<R: ark_std::rand::Rng + ?Sized>(rng: &mut R) -> Self {
         let value = BigInt::rand(rng);
 
-        Self { value, config: None }
+        Self { value, config: None, phantom_data: PhantomData }
     }
 }
 
-impl<const N: usize> Random for RandomField<'_, N> {
+impl<const N: usize, FC: ConstFieldConfig<N>> Random for RandomField<'_, N, FC> {
     fn random(rng: &mut (impl ark_std::rand::RngCore + ?Sized)) -> Self {
         let value = BigInt::rand(rng);
 
-        Self { value, config: None }
+        Self { value, config: None, phantom_data: PhantomData }
     }
 }
 
-impl<const N: usize> ark_std::fmt::Debug for RandomField<'_, N> {
+impl<const N: usize, FC: ConstFieldConfig<N>> ark_std::fmt::Debug for RandomField<'_, N, FC> {
     fn fmt(&self, f: &mut ark_std::fmt::Formatter<'_>) -> ark_std::fmt::Result {
         match self.config {
             None => write!(f, "{}, no config", self.value),
             Some(_) => write!(
                 f,
                 "{} in Z_{}",
-                self.into_bigint(),
+                self.clone().into_bigint(),
                 self.config_ptr().reference().unwrap().modulus()
             ),
         }
     }
 }
 
-impl<const N: usize> ark_std::fmt::Display for RandomField<'_, N> {
+impl<const N: usize, FC: ConstFieldConfig<N>> ark_std::fmt::Display for RandomField<'_, N, FC> {
     fn fmt(&self, f: &mut ark_std::fmt::Formatter<'_>) -> ark_std::fmt::Result {
         // TODO: we should go back from Montgomery here.
         match self.config {
@@ -310,23 +314,24 @@ impl<const N: usize> ark_std::fmt::Display for RandomField<'_, N> {
                 write!(f, "{}", self.value)
             }
             Some(_) => {
-                write!(f, "{}", self.into_bigint())
+                write!(f, "{}", self.clone().into_bigint())
             }
         }
     }
 }
 
-impl<const N: usize> Default for RandomField<'_, N> {
+impl<const N: usize, FC: ConstFieldConfig<N>> Default for RandomField<'_, N, FC> {
     fn default() -> Self {
         Self {
             value: BigInt::ZERO,
             config: None,
+            phantom_data: PhantomData
         }
     }
 }
 
-unsafe impl<const N: usize> Send for RandomField<'_, N> {}
-unsafe impl<const N: usize> Sync for RandomField<'_, N> {}
+unsafe impl<const N: usize, FC: ConstFieldConfig<N>> Send for RandomField<'_, N, FC> {}
+unsafe impl<const N: usize, FC: ConstFieldConfig<N>> Sync for RandomField<'_, N, FC> {}
 
 #[derive(Debug)]
 pub enum DebugRandomField {
@@ -340,8 +345,8 @@ pub enum DebugRandomField {
     },
 }
 
-impl<const N: usize> From<RandomField<'_, N>> for DebugRandomField {
-    fn from(value: RandomField<'_, N>) -> Self {
+impl<const N: usize, FC: ConstFieldConfig<N>> From<RandomField<'_, N, FC>> for DebugRandomField {
+    fn from(value: RandomField<'_, N, FC>) -> Self {
         match value.config {
             None => Self::Raw {
                 value: value.value.into(),
@@ -367,20 +372,20 @@ impl ark_std::fmt::Display for DebugRandomField {
     }
 }
 
-impl<const N: usize> From<u128> for RandomField<'_, N> {
+impl<const N: usize, FC: ConstFieldConfig<N>> From<u128> for RandomField<'_, N, FC> {
     fn from(value: u128) -> Self {
         let value = BigInt::from(value);
 
-        RandomField { value, config: None }
+        RandomField { value, config: None, phantom_data: PhantomData }
     }
 }
 
 macro_rules! impl_from_uint {
     ($type:ty) => {
-        impl<const N: usize> From<$type> for RandomField<'_, N> {
+        impl<const N: usize, FC: ConstFieldConfig<N>> From<$type> for RandomField<'_, N, FC> {
             fn from(value: $type) -> Self {
                 let value = BigInt::from(value);
-                RandomField { value, config: None }
+                RandomField { value, config: None, phantom_data: PhantomData }
             }
         }
     };
@@ -391,18 +396,19 @@ impl_from_uint!(u32);
 impl_from_uint!(u16);
 impl_from_uint!(u8);
 
-impl<const N: usize> From<bool> for RandomField<'_, N> {
+impl<const N: usize, FC: ConstFieldConfig<N>> From<bool> for RandomField<'_, N, FC> {
     fn from(value: bool) -> Self {
         let value = BigInt::from(value as u8);
-        RandomField { value, config: None }
+        RandomField { value, config: None, phantom_data: PhantomData }
     }
 }
 
-impl<const N: usize> FromBytes for RandomField<'_, N> {
+impl<const N: usize, FC: ConstFieldConfig<N>> FromBytes for RandomField<'_, N, FC> {
     fn from_bytes_le(bytes: &[u8]) -> Option<Self> {
         Some(RandomField {
             value: BigInt::<N>::from_bytes_le(bytes)?,
             config: None,
+            phantom_data: PhantomData
         })
     }
 
@@ -410,11 +416,12 @@ impl<const N: usize> FromBytes for RandomField<'_, N> {
         Some(RandomField {
             value: BigInt::<N>::from_bytes_be(bytes)?,
             config: None,
+            phantom_data: PhantomData
         })
     }
 }
 
-impl<'cfg, const N: usize> RandomField<'cfg, N> {
+impl<'cfg, const N: usize, FC: ConstFieldConfig<N>> RandomField<'cfg, N, FC> {
     pub fn from_bytes_le_with_config(config: ConfigRef<'cfg, N>, bytes: &[u8]) -> Option<Self> {
         let value = BigInt::<N>::from_bytes_le(bytes);
 

--- a/zip-plus/src/field.rs
+++ b/zip-plus/src/field.rs
@@ -28,8 +28,8 @@ pub struct RandomField<const N: usize, FC: FieldConfig<BigInt<N>>> {
     phantom_data: PhantomData<FC>,
 }
 
-use crate::field::config::{FieldConfigBase, FieldConfigOps};
 use crate::{
+    field::config::{FieldConfigBase, FieldConfigOps},
     traits::{BigInteger, Field},
     transcript::KeccakTranscript,
 };
@@ -73,9 +73,9 @@ impl<const N: usize, FC: FieldConfig<BigInt<N>>> RandomField<N, FC> {
 impl<const N: usize, FC: FieldConfig<BigInt<N>>> Field for RandomField<N, FC> {
     type B = BigInt<N>;
     type C = FC;
-    type W = Words<N>;
     type I = Int<N>;
     type U = Uint<N>;
+    type W = Words<N>;
 
     fn new_unchecked(value: BigInt<N>) -> Self {
         Self {
@@ -246,6 +246,7 @@ where
     BigInt<M>: FieldMap<F, Output = F>,
 {
     type Output = F;
+
     fn map_to_field(&self) -> Self::Output {
         (*self).map_to_field()
     }

--- a/zip-plus/src/field.rs
+++ b/zip-plus/src/field.rs
@@ -77,10 +77,6 @@ impl<const N: usize, FC: FieldConfig<BigInt<N>>> Field for RandomField<N, FC> {
     type I = Int<N>;
     type U = Uint<N>;
 
-    fn modulus() -> Self::B {
-        FC::modulus()
-    }
-
     fn new_unchecked(value: BigInt<N>) -> Self {
         Self {
             value,

--- a/zip-plus/src/field.rs
+++ b/zip-plus/src/field.rs
@@ -36,21 +36,8 @@ use crate::field::config::ConstFieldConfig;
 
 impl<'cfg, const N: usize, FC: ConstFieldConfig<N>> RandomField<'cfg, N, FC> {
 
-    pub fn with_aligned_config_mut<F, G, A>(
-        &mut self,
-        rhs: &Self,
-        fn_with_config: F,
-        fn_without_config: G,
-    ) -> A
-    where
-        F: Fn(&mut BigInt<N>, &BigInt<N>, &FieldConfig<N>) -> A,
-        G: Fn(&mut BigInt<N>, &BigInt<N>) -> A,
-    {
-        fn_with_config(
-            &mut self.value,
-            &rhs.value,
-            self.config.reference().expect("Field config cannot be none"),
-        )
+    pub fn config(&self) -> &FieldConfig<N>  {
+        self.config.reference().expect("Field config cannot be none")
     }
 
     pub fn zero_with_config(config: ConfigRef<'cfg, N>) -> Self {
@@ -104,7 +91,7 @@ impl<'cfg, const N: usize, FC: ConstFieldConfig<N>> RandomField<'cfg, N, FC> {
 
     #[inline]
     pub fn into_bigint(self) -> BigInt<N> {
-        Self::demontgomery(self.config.reference().expect("Field config cannot be none"), self.value)
+        Self::demontgomery(self.config(), self.value)
     }
 
     #[inline]
@@ -162,7 +149,7 @@ impl<'cfg, const N: usize, FC: ConstFieldConfig<N>> Field for RandomField<'cfg, 
     }
 
     fn absorb_into_transcript(&self, transcript: &mut KeccakTranscript) {
-        let config = self.config.reference().expect("Field config cannot be none");
+        let config = self.config();
 
         transcript.absorb(&[0x3]);
         transcript.absorb(&config.modulus().to_bytes_be());

--- a/zip-plus/src/field.rs
+++ b/zip-plus/src/field.rs
@@ -178,7 +178,7 @@ impl<const N: usize, FC: ConstFieldConfig<N>> UniformRand for RandomField<'_, N,
     fn rand<R: ark_std::rand::Rng + ?Sized>(rng: &mut R) -> Self {
         let value = BigInt::rand(rng);
 
-        Self { value, config: ConfigRef::from(&FC::FIELD_CONFIG), phantom_data: PhantomData }
+        Self { value, config: unsafe { ConfigRef::new(Box::leak(Box::new(FC::field_config()))) }, phantom_data: PhantomData }
     }
 }
 
@@ -186,7 +186,7 @@ impl<const N: usize, FC: ConstFieldConfig<N>> Random for RandomField<'_, N, FC> 
     fn random(rng: &mut (impl ark_std::rand::RngCore + ?Sized)) -> Self {
         let value = BigInt::rand(rng);
 
-        Self { value, config: ConfigRef::from(&FC::FIELD_CONFIG), phantom_data: PhantomData }
+        Self { value, config: unsafe { ConfigRef::new(Box::leak(Box::new(FC::field_config()))) }, phantom_data: PhantomData }
     }
 }
 
@@ -211,7 +211,7 @@ impl<const N: usize, FC: ConstFieldConfig<N>> Default for RandomField<'_, N, FC>
     fn default() -> Self {
         Self {
             value: BigInt::ZERO,
-            config: ConfigRef::from(&FC::FIELD_CONFIG),
+            config: unsafe { ConfigRef::new(Box::leak(Box::new(FC::field_config()))) },
             phantom_data: PhantomData
         }
     }
@@ -256,7 +256,7 @@ impl ark_std::fmt::Display for DebugRandomField {
 
 impl<const N: usize, FC: ConstFieldConfig<N>> From<u128> for RandomField<'_, N, FC> {
     fn from(value: u128) -> Self {
-        value.map_to_field(ConfigRef::from(&FC::FIELD_CONFIG))
+        value.map_to_field(unsafe { ConfigRef::new(Box::leak(Box::new(FC::field_config()))) })
     }
 }
 
@@ -264,7 +264,7 @@ macro_rules! impl_from_uint {
     ($type:ty) => {
         impl<const N: usize, FC: ConstFieldConfig<N>> From<$type> for RandomField<'_, N, FC> {
             fn from(value: $type) -> Self {
-                value.map_to_field(ConfigRef::from(&FC::FIELD_CONFIG))
+                value.map_to_field(unsafe { ConfigRef::new(Box::leak(Box::new(FC::field_config()))) })
             }
         }
     };
@@ -277,7 +277,7 @@ impl_from_uint!(u8);
 
 impl<const N: usize, FC: ConstFieldConfig<N>> From<bool> for RandomField<'_, N, FC> {
     fn from(value: bool) -> Self {
-        value.map_to_field(ConfigRef::from(&FC::FIELD_CONFIG))
+        value.map_to_field(unsafe { ConfigRef::new(Box::leak(Box::new(FC::field_config()))) })
     }
 }
 
@@ -285,7 +285,7 @@ impl<const N: usize, FC: ConstFieldConfig<N>> FromBytes for RandomField<'_, N, F
     fn from_bytes_le(bytes: &[u8]) -> Option<Self> {
         Some(RandomField {
             value: BigInt::<N>::from_bytes_le(bytes)?,
-            config: ConfigRef::from(&FC::FIELD_CONFIG),
+            config: unsafe { ConfigRef::new(Box::leak(Box::new(FC::field_config()))) },
             phantom_data: PhantomData
         })
     }
@@ -293,7 +293,7 @@ impl<const N: usize, FC: ConstFieldConfig<N>> FromBytes for RandomField<'_, N, F
     fn from_bytes_be(bytes: &[u8]) -> Option<Self> {
         Some(RandomField {
             value: BigInt::<N>::from_bytes_be(bytes)?,
-            config: ConfigRef::from(&FC::FIELD_CONFIG),
+            config: unsafe { ConfigRef::new(Box::leak(Box::new(FC::field_config()))) },
             phantom_data: PhantomData
         })
     }

--- a/zip-plus/src/field.rs
+++ b/zip-plus/src/field.rs
@@ -1,10 +1,10 @@
 #![allow(non_snake_case)]
 
-use std::marker::PhantomData;
+use crate::traits::{FieldMap, FromBytes, Words as WordsTrait};
 use ark_ff::UniformRand;
 use crypto_bigint::Random;
 use num_traits::ConstZero;
-use crate::traits::{Config, ConfigReference, FieldMap, FromBytes, Words as WordsTrait};
+use std::marker::PhantomData;
 
 mod arithmetic;
 mod biginteger;
@@ -18,70 +18,45 @@ pub use biginteger::{
     BigInt, BigInteger64, BigInteger128, BigInteger256, BigInteger320, BigInteger384,
     BigInteger448, BigInteger768, BigInteger832, Words, signed_mod_reduction,
 };
-pub use config::{ConfigRef, DebugFieldConfig, FieldConfig};
+pub use config::FieldConfig;
 pub use int::Int;
 pub use uint::Uint;
+
 #[derive(Copy, Clone)]
-pub struct RandomField<'cfg, const N: usize, FC: ConstFieldConfig<N>> {
+pub struct RandomField<const N: usize, FC: FieldConfig<BigInt<N>>> {
     pub value: BigInt<N>,
-    pub config: ConfigRef<'cfg, N>,
-    phantom_data: PhantomData<FC>
+    phantom_data: PhantomData<FC>,
 }
 
+use crate::field::config::{FieldConfigBase, FieldConfigOps};
 use crate::{
     traits::{BigInteger, Field},
     transcript::KeccakTranscript,
 };
-use crate::field::config::ConstFieldConfig;
 
-impl<'cfg, const N: usize, FC: ConstFieldConfig<N>> RandomField<'cfg, N, FC> {
-
-    pub fn config(&self) -> &FieldConfig<N>  {
-        self.config.reference().expect("Field config cannot be none")
-    }
-
-    pub fn zero_with_config(config: ConfigRef<'cfg, N>) -> Self {
-        Self {
-            config,
-            value: BigInt::ZERO,
-            phantom_data: PhantomData,
-        }
-    }
-
-    #[inline(always)]
-    pub fn config_ptr(&self) -> ConfigRef<'cfg, N> {
-        self.config
-    }
-
+impl<const N: usize, FC: FieldConfig<BigInt<N>>> RandomField<N, FC> {
     /// Convert from `BigInteger` to `RandomField`
     ///
     /// If `BigInteger` is greater then field modulus return `None`
-    pub fn from_bigint<'a>(config: ConfigRef<'a, N>, value: BigInt<N>) -> Option<RandomField<'a, N, FC>>
-    where
-        'cfg: 'a,
-    {
-        let config_ref = config.reference().expect("Field config cannot be none");
-
-        if value >= *config_ref.modulus() {
+    pub fn from_bigint(value: BigInt<N>) -> Option<RandomField<N, FC>> {
+        if value >= FC::modulus() {
             None
         } else {
             let mut r = value;
-            config_ref.mul_assign(&mut r, config_ref.r2());
+            FC::mul_assign(&mut r, &FC::r_squared());
 
-            Some(RandomField::new_unchecked(config, r))
+            Some(RandomField::new_unchecked(r))
         }
     }
 
-    pub fn from_i64(value: i64, config: ConfigRef<'cfg, N>) -> Option<RandomField<'cfg, N, FC>> {
-        let config_ref = config.reference().expect("Field config cannot be none");
-
-        if BigInt::from(value.unsigned_abs()) >= *config_ref.modulus() {
+    pub fn from_i64(value: i64) -> Option<RandomField<N, FC>> {
+        if BigInt::from(value.unsigned_abs()) >= FC::modulus() {
             None
         } else {
             let mut r = value.unsigned_abs().into();
-            config_ref.mul_assign(&mut r, config_ref.r2());
+            FC::mul_assign(&mut r, &FC::r_squared());
 
-            let mut elem = RandomField::new_unchecked(config, r);
+            let mut elem = RandomField::new_unchecked(r);
             if value.is_negative() {
                 elem = -elem;
             }
@@ -91,35 +66,32 @@ impl<'cfg, const N: usize, FC: ConstFieldConfig<N>> RandomField<'cfg, N, FC> {
 
     #[inline]
     pub fn into_bigint(self) -> BigInt<N> {
-        Self::demontgomery(self.config(), self.value)
-    }
-
-    #[inline]
-    fn demontgomery(config: &FieldConfig<N>, value: BigInt<N>) -> BigInt<N> {
-        value.demontgomery(config.modulus(), config.inv())
+        self.value.demontgomery(&FC::modulus(), FC::inv())
     }
 }
 
-impl<'cfg, const N: usize, FC: ConstFieldConfig<N>> Field for RandomField<'cfg, N, FC> {
+impl<const N: usize, FC: FieldConfig<BigInt<N>>> Field for RandomField<N, FC> {
     type B = BigInt<N>;
-    type C = FieldConfig<N>;
-    type R = ConfigRef<'cfg, N>;
+    type C = FC;
     type W = Words<N>;
     type I = Int<N>;
     type U = Uint<N>;
-    type DebugField = DebugRandomField;
 
-    fn new_unchecked(config: ConfigRef<'cfg, N>, value: BigInt<N>) -> Self {
-        Self { config, value, phantom_data: PhantomData }
+    fn modulus() -> Self::B {
+        FC::modulus()
     }
 
-    fn rand_with_config<R: ark_std::rand::Rng + ?Sized>(rng: &mut R, config: Self::R) -> Self {
+    fn new_unchecked(value: BigInt<N>) -> Self {
+        Self {
+            value,
+            phantom_data: PhantomData,
+        }
+    }
+
+    fn rand<R: ark_std::rand::Rng + ?Sized>(rng: &mut R) -> Self {
         loop {
             let mut value = BigInt::rand(rng);
-            let modulus = config
-                .reference()
-                .expect("Field config cannot be none")
-                .modulus();
+            let modulus = FC::modulus();
             let shave_bits = 64 * N - modulus.num_bits() as usize;
             // Mask away the unused bits at the beginning.
             assert!(shave_bits <= 64);
@@ -132,8 +104,8 @@ impl<'cfg, const N: usize, FC: ConstFieldConfig<N>> Field for RandomField<'cfg, 
             let val = value.last_mut();
             *val &= mask;
 
-            if value < *modulus {
-                return value.map_to_field(config);
+            if value < modulus {
+                return value.map_to_field();
             }
         }
     }
@@ -149,10 +121,8 @@ impl<'cfg, const N: usize, FC: ConstFieldConfig<N>> Field for RandomField<'cfg, 
     }
 
     fn absorb_into_transcript(&self, transcript: &mut KeccakTranscript) {
-        let config = self.config();
-
         transcript.absorb(&[0x3]);
-        transcript.absorb(&config.modulus().to_bytes_be());
+        transcript.absorb(&FC::modulus().to_bytes_be());
         transcript.absorb(&[0x5]);
 
         transcript.absorb(&[0x1]);
@@ -161,97 +131,63 @@ impl<'cfg, const N: usize, FC: ConstFieldConfig<N>> Field for RandomField<'cfg, 
     }
 }
 
-impl<const N: usize, FC: ConstFieldConfig<N>> UniformRand for RandomField<'_, N, FC> {
+impl<const N: usize, FC: FieldConfig<BigInt<N>>> UniformRand for RandomField<N, FC> {
     fn rand<R: ark_std::rand::Rng + ?Sized>(rng: &mut R) -> Self {
         let value = BigInt::rand(rng);
 
-        Self { value, config: unsafe { ConfigRef::new(Box::leak(Box::new(FC::field_config()))) }, phantom_data: PhantomData }
+        Self {
+            value,
+            phantom_data: PhantomData,
+        }
     }
 }
 
-impl<const N: usize, FC: ConstFieldConfig<N>> Random for RandomField<'_, N, FC> {
+impl<const N: usize, FC: FieldConfig<BigInt<N>>> Random for RandomField<N, FC> {
     fn random(rng: &mut (impl ark_std::rand::RngCore + ?Sized)) -> Self {
         let value = BigInt::rand(rng);
 
-        Self { value, config: unsafe { ConfigRef::new(Box::leak(Box::new(FC::field_config()))) }, phantom_data: PhantomData }
+        Self {
+            value,
+            phantom_data: PhantomData,
+        }
     }
 }
 
-impl<const N: usize, FC: ConstFieldConfig<N>> ark_std::fmt::Debug for RandomField<'_, N, FC> {
+impl<const N: usize, FC: FieldConfig<BigInt<N>>> ark_std::fmt::Debug for RandomField<N, FC> {
     fn fmt(&self, f: &mut ark_std::fmt::Formatter<'_>) -> ark_std::fmt::Result {
-        write!(
-            f,
-            "{} in Z_{}",
-            self.clone().into_bigint(),
-            self.config_ptr().reference().unwrap().modulus()
-        )
+        write!(f, "{} in Z_{}", self.clone().into_bigint(), FC::modulus())
     }
 }
 
-impl<const N: usize, FC: ConstFieldConfig<N>> ark_std::fmt::Display for RandomField<'_, N, FC> {
+impl<const N: usize, FC: FieldConfig<BigInt<N>>> ark_std::fmt::Display for RandomField<N, FC> {
     fn fmt(&self, f: &mut ark_std::fmt::Formatter<'_>) -> ark_std::fmt::Result {
         write!(f, "{}", self.clone().into_bigint())
     }
 }
 
-impl<const N: usize, FC: ConstFieldConfig<N>> Default for RandomField<'_, N, FC> {
+impl<const N: usize, FC: FieldConfig<BigInt<N>>> Default for RandomField<N, FC> {
     fn default() -> Self {
         Self {
             value: BigInt::ZERO,
-            config: unsafe { ConfigRef::new(Box::leak(Box::new(FC::field_config()))) },
-            phantom_data: PhantomData
+            phantom_data: PhantomData,
         }
     }
 }
 
-unsafe impl<const N: usize, FC: ConstFieldConfig<N>> Send for RandomField<'_, N, FC> {}
-unsafe impl<const N: usize, FC: ConstFieldConfig<N>> Sync for RandomField<'_, N, FC> {}
+unsafe impl<const N: usize, FC: FieldConfig<BigInt<N>>> Send for RandomField<N, FC> {}
+unsafe impl<const N: usize, FC: FieldConfig<BigInt<N>>> Sync for RandomField<N, FC> {}
 
-#[derive(Debug)]
-pub enum DebugRandomField {
-    Raw {
-        value: num_bigint::BigInt,
-    },
-
-    Initialized {
-        config: DebugFieldConfig,
-        value: num_bigint::BigInt,
-    },
-}
-
-impl<const N: usize, FC: ConstFieldConfig<N>> From<RandomField<'_, N, FC>> for DebugRandomField {
-    fn from(value: RandomField<'_, N, FC>) -> Self {
-        Self::Initialized {
-            config: (*value.config.reference().unwrap()).into(),
-            value: value.value.into(),
-        }
-    }
-}
-
-impl ark_std::fmt::Display for DebugRandomField {
-    fn fmt(&self, f: &mut ark_std::fmt::Formatter<'_>) -> ark_std::fmt::Result {
-        match self {
-            Self::Raw { value } => {
-                write!(f, "{value}")
-            }
-            self_ @ Self::Initialized { .. } => {
-                write!(f, "{self_}")
-            }
-        }
-    }
-}
-
-impl<const N: usize, FC: ConstFieldConfig<N>> From<u128> for RandomField<'_, N, FC> {
+impl<const N: usize, FC: FieldConfig<BigInt<N>>> From<u128> for RandomField<N, FC> {
     fn from(value: u128) -> Self {
-        value.map_to_field(unsafe { ConfigRef::new(Box::leak(Box::new(FC::field_config()))) })
+        value.map_to_field()
     }
 }
 
 macro_rules! impl_from_uint {
     ($type:ty) => {
-        impl<const N: usize, FC: ConstFieldConfig<N>> From<$type> for RandomField<'_, N, FC> {
+        impl<const N: usize, FC: FieldConfig<BigInt<N>>> From<$type> for RandomField<N, FC> {
             fn from(value: $type) -> Self {
-                value.map_to_field(unsafe { ConfigRef::new(Box::leak(Box::new(FC::field_config()))) })
+                value.map_to_field()
             }
         }
     };
@@ -262,41 +198,19 @@ impl_from_uint!(u32);
 impl_from_uint!(u16);
 impl_from_uint!(u8);
 
-impl<const N: usize, FC: ConstFieldConfig<N>> From<bool> for RandomField<'_, N, FC> {
+impl<const N: usize, FC: FieldConfig<BigInt<N>>> From<bool> for RandomField<N, FC> {
     fn from(value: bool) -> Self {
-        value.map_to_field(unsafe { ConfigRef::new(Box::leak(Box::new(FC::field_config()))) })
+        value.map_to_field()
     }
 }
 
-impl<const N: usize, FC: ConstFieldConfig<N>> FromBytes for RandomField<'_, N, FC> {
+impl<const N: usize, FC: FieldConfig<BigInt<N>>> FromBytes for RandomField<N, FC> {
     fn from_bytes_le(bytes: &[u8]) -> Option<Self> {
-        Some(RandomField {
-            value: BigInt::<N>::from_bytes_le(bytes)?,
-            config: unsafe { ConfigRef::new(Box::leak(Box::new(FC::field_config()))) },
-            phantom_data: PhantomData
-        })
+        Self::from_bigint(BigInt::<N>::from_bytes_le(bytes)?)
     }
 
     fn from_bytes_be(bytes: &[u8]) -> Option<Self> {
-        Some(RandomField {
-            value: BigInt::<N>::from_bytes_be(bytes)?,
-            config: unsafe { ConfigRef::new(Box::leak(Box::new(FC::field_config()))) },
-            phantom_data: PhantomData
-        })
-    }
-}
-
-impl<'cfg, const N: usize, FC: ConstFieldConfig<N>> RandomField<'cfg, N, FC> {
-    pub fn from_bytes_le_with_config(config: ConfigRef<'cfg, N>, bytes: &[u8]) -> Option<Self> {
-        let value = BigInt::<N>::from_bytes_le(bytes);
-
-        Self::from_bigint(config, value?)
-    }
-
-    pub fn from_bytes_be_with_config(config: ConfigRef<'cfg, N>, bytes: &[u8]) -> Option<Self> {
-        let value = BigInt::<N>::from_bytes_be(bytes);
-
-        Self::from_bigint(config, value?)
+        Self::from_bigint(BigInt::<N>::from_bytes_be(bytes)?)
     }
 }
 
@@ -309,29 +223,24 @@ where
 {
     type Output = F;
 
-    fn map_to_field(&self, config_ref: F::R) -> Self::Output {
-        let config = match config_ref.reference() {
-            Some(config) => config,
-            None => panic!("Cannot convert BigInt to prime field element without a modulus"),
-        };
-
+    fn map_to_field(&self) -> Self::Output {
         let mut value = if M > F::W::num_words() {
-            let modulus: Int<M> = config.modulus().into();
+            let modulus: Int<M> = (&F::C::modulus()).into();
             let mut value: Int<M> = self.into();
             value %= modulus;
 
             F::B::from(value)
         } else {
-            let modulus: F::I = config.modulus().into();
+            let modulus: F::I = (&F::C::modulus()).into();
             let mut value: F::I = self.into();
             value %= modulus;
 
             value.into()
         };
 
-        config.mul_assign(&mut value, config.r2());
+        F::C::mul_assign(&mut value, &F::C::r_squared());
 
-        F::new_unchecked(config_ref, value)
+        F::new_unchecked(value)
     }
 }
 
@@ -341,7 +250,7 @@ where
     BigInt<M>: FieldMap<F, Output = F>,
 {
     type Output = F;
-    fn map_to_field(&self, config_ref: F::R) -> Self::Output {
-        (*self).map_to_field(config_ref)
+    fn map_to_field(&self) -> Self::Output {
+        (*self).map_to_field()
     }
 }

--- a/zip-plus/src/field/arithmetic.rs
+++ b/zip-plus/src/field/arithmetic.rs
@@ -76,15 +76,7 @@ impl<const N: usize, FC: ConstFieldConfig<N>> Add<u32> for RandomField<'_, N, FC
 
 impl<const N: usize, FC: ConstFieldConfig<N>> AddAssign<&Self> for RandomField<'_, N, FC> {
     fn add_assign(&mut self, rhs: &Self) {
-        self.with_aligned_config_mut(
-            rhs,
-            |lhs, rhs, config| {
-                config.add_assign(lhs, rhs);
-            },
-            |lhs, rhs| {
-                lhs.add_with_carry(rhs);
-            },
-        );
+        self.config.reference().unwrap().add_assign(&mut self.value, &rhs.value);
     }
 }
 
@@ -105,29 +97,13 @@ impl<const N: usize, FC: ConstFieldConfig<N>> AddAssign<u32> for RandomField<'_,
 
 impl<const N: usize, FC: ConstFieldConfig<N>> SubAssign<&Self> for RandomField<'_, N, FC> {
     fn sub_assign(&mut self, rhs: &Self) {
-        self.with_aligned_config_mut(
-            rhs,
-            |lhs, rhs, config| {
-                config.sub_assign(lhs, rhs);
-            },
-            |lhs, rhs| {
-                lhs.sub_with_borrow(rhs);
-            },
-        );
+        self.config.reference().unwrap().sub_assign(&mut self.value, &rhs.value);
     }
 }
 
 impl<const N: usize, FC: ConstFieldConfig<N>> MulAssign<&Self> for RandomField<'_, N, FC> {
     fn mul_assign(&mut self, rhs: &Self) {
-        self.with_aligned_config_mut(
-            rhs,
-            |lhs, rhs, config| {
-                config.mul_assign(lhs, rhs);
-            },
-            |lhs, rhs| {
-                lhs.mul(rhs);
-            },
-        );
+        self.config.reference().unwrap().mul_assign(&mut self.value, &rhs.value);
     }
 }
 
@@ -136,14 +112,9 @@ impl<const N: usize, FC: ConstFieldConfig<N>> DivAssign<&Self> for RandomField<'
         if rhs.is_zero() {
             panic!("Attempt to divide by zero");
         }
+        let config = self.config.reference().unwrap();
 
-        self.with_aligned_config_mut(
-            rhs,
-            |lhs, rhs, config| {
-                config.mul_assign(lhs, &config.inverse(rhs).unwrap());
-            },
-            |_, _| panic!("Cannot divide without a field config"),
-        );
+        config.mul_assign(&mut self.value, &config.inverse(&rhs.value).unwrap());
     }
 }
 
@@ -161,9 +132,8 @@ impl<const N: usize, FC: ConstFieldConfig<N>> Neg for RandomField<'_, N, FC> {
             return self;
         }
 
-        let config = self.config.reference().expect("Field config cannot be none");
         let tmp = self.value;
-        self.value = *config.modulus();
+        self.value = *self.config().modulus();
         self.value.sub_with_borrow(&tmp);
 
         self
@@ -252,7 +222,6 @@ mod test {
         let rhs = RandomField::one();
         let config = unsafe { ConfigRef::new(Box::leak(Box::new(Fc23::<1>::field_config()))) };
         let expected = RandomField::from_bigint(config, BigInt::from(2_u32)).unwrap();
-        let zz = expected.clone().into_bigint();
 
         assert_eq!(lhs + rhs, expected);
     }

--- a/zip-plus/src/field/arithmetic.rs
+++ b/zip-plus/src/field/arithmetic.rs
@@ -206,6 +206,7 @@ mod test {
 
     use crate::{big_int, define_field_config, field::{biginteger::BigInt, config::ConfigRef, RandomField}, field_config, random_field};
     use crate::field::config::ConstFieldConfig;
+    use crate::traits::ConfigReference;
 
     define_field_config!(Fc23, "23");
 
@@ -249,7 +250,7 @@ mod test {
     fn test_add_two_ones() {
         let lhs: RandomField<1, Fc23<1>> = RandomField::one();
         let rhs = RandomField::one();
-        let config = ConfigRef::from(&Fc23::<1>::FIELD_CONFIG);
+        let config = unsafe { ConfigRef::new(Box::leak(Box::new(Fc23::<1>::field_config()))) };
         let expected = RandomField::from_bigint(config, BigInt::from(2_u32)).unwrap();
         let zz = expected.clone().into_bigint();
 

--- a/zip-plus/src/field/arithmetic.rs
+++ b/zip-plus/src/field/arithmetic.rs
@@ -17,6 +17,7 @@ macro_rules! impl_ops {
         impl<$($gen)*> $trait<Self> for $type {
             type Output = Self;
 
+            #[inline(always)]
             fn $op(mut self, rhs: Self) -> Self::Output {
                 self.$op_assign(&rhs);
                 self
@@ -26,6 +27,7 @@ macro_rules! impl_ops {
         impl<$($gen)*> $trait<&Self> for $type {
             type Output = Self;
 
+            #[inline(always)]
             fn $op(mut self, rhs: &Self) -> Self::Output {
                 self.$op_assign(rhs);
                 self
@@ -35,6 +37,7 @@ macro_rules! impl_ops {
         impl<$($gen)*> $trait<Self> for &$type {
             type Output = $type;
 
+            #[inline(always)]
             fn $op(self, rhs: Self) -> Self::Output {
                 let mut res = self.clone();
                 res.$op_assign(rhs);
@@ -45,6 +48,7 @@ macro_rules! impl_ops {
         impl<$($gen)*> $trait<$type> for &$type {
             type Output = $type;
 
+            #[inline(always)]
             fn $op(self, rhs: $type) -> Self::Output {
                 let mut res = self.clone();
                 res.$op_assign(&rhs);
@@ -53,6 +57,7 @@ macro_rules! impl_ops {
         }
 
         impl<$($gen)*> $trait_assign<Self> for $type {
+            #[inline(always)]
             fn $op_assign(&mut self, rhs: Self) {
                 self.$op_assign(&rhs);
             }
@@ -82,16 +87,7 @@ impl<const N: usize, FC: FieldConfig<BigInt<N>>> AddAssign<&Self> for RandomFiel
 
 impl<const N: usize, FC: FieldConfig<BigInt<N>>> AddAssign<u32> for RandomField<N, FC> {
     fn add_assign(&mut self, rhs: u32) {
-        todo!()
-        // self.with_aligned_config_mut(
-        //     rhs.into(),
-        //     |lhs, rhs, config| {
-        //         config.add_assign(lhs, rhs);
-        //     },
-        //     |lhs, rhs| {
-        //         panic!();
-        //     },
-        // );
+        FC::add_assign(&mut self.value, &rhs.into());
     }
 }
 
@@ -102,6 +98,7 @@ impl<const N: usize, FC: FieldConfig<BigInt<N>>> SubAssign<&Self> for RandomFiel
 }
 
 impl<const N: usize, FC: FieldConfig<BigInt<N>>> MulAssign<&Self> for RandomField<N, FC> {
+    #[inline(always)]
     fn mul_assign(&mut self, rhs: &Self) {
         FC::mul_assign(&mut self.value, &rhs.value);
     }

--- a/zip-plus/src/field/arithmetic.rs
+++ b/zip-plus/src/field/arithmetic.rs
@@ -4,9 +4,7 @@ use ark_std::{
     ops::{Add, AddAssign, Div, DivAssign, Mul, MulAssign, Neg, Sub, SubAssign},
 };
 
-use crate::{field::RandomField};
-use crate::field::BigInt;
-use crate::field::config::FieldConfig;
+use crate::field::{BigInt, RandomField, config::FieldConfig};
 
 macro_rules! impl_ops {
     (
@@ -153,7 +151,9 @@ impl<const N: usize, FC: FieldConfig<BigInt<N>>> Sum for RandomField<N, FC> {
     }
 }
 
-impl<'a, const N: usize, FC: FieldConfig<BigInt<N>>> core::iter::Product<&'a Self> for RandomField<N, FC> {
+impl<'a, const N: usize, FC: FieldConfig<BigInt<N>>> core::iter::Product<&'a Self>
+    for RandomField<N, FC>
+{
     fn product<I: Iterator<Item = &'a Self>>(iter: I) -> Self {
         iter.fold(Self::one(), core::ops::Mul::mul)
     }
@@ -169,8 +169,11 @@ impl<'a, const N: usize, FC: FieldConfig<BigInt<N>>> From<&'a Self> for RandomFi
 mod test {
     use ark_ff::{One, Zero};
 
-    use crate::{big_int, define_field_config, field::{biginteger::BigInt, RandomField}, random_field};
-    use crate::field::config::FieldConfig;
+    use crate::{
+        big_int, define_field_config,
+        field::{RandomField, biginteger::BigInt, config::FieldConfig},
+        random_field,
+    };
 
     define_field_config!(Fc23, "23");
 
@@ -525,11 +528,7 @@ mod test {
 
     #[test]
     fn test_product_with_one() {
-        let values = [
-            RandomField::one(),
-            random_field!(5u32),
-            random_field!(7u32),
-        ];
+        let values = [RandomField::one(), random_field!(5u32), random_field!(7u32)];
 
         let product: RandomField<1, Fc23<1>> = values.iter().product();
 
@@ -564,7 +563,8 @@ mod test {
 
     #[test]
     fn test_product_empty_iterator() {
-        let product: RandomField<1, Fc23<1>> = ark_std::iter::empty::<&RandomField<1, Fc23<1>>>().product();
+        let product: RandomField<1, Fc23<1>> =
+            ark_std::iter::empty::<&RandomField<1, Fc23<1>>>().product();
         assert!(product.is_one()); // Empty product should return one
     }
 

--- a/zip-plus/src/field/arithmetic.rs
+++ b/zip-plus/src/field/arithmetic.rs
@@ -171,7 +171,7 @@ mod test {
 
     use crate::{
         big_int, define_field_config,
-        field::{RandomField, biginteger::BigInt, config::FieldConfig},
+        field::{RandomField, biginteger::BigInt},
         random_field,
     };
 

--- a/zip-plus/src/field/arithmetic.rs
+++ b/zip-plus/src/field/arithmetic.rs
@@ -5,6 +5,7 @@ use ark_std::{
 };
 
 use crate::field::{BigInt, RandomField, config::FieldConfig};
+use crate::traits::FieldMap;
 
 macro_rules! impl_ops {
     (
@@ -63,10 +64,10 @@ macro_rules! impl_ops {
     };
 }
 
-impl_ops!(impl('cfg, const N: usize, FC: FieldConfig<BigInt<N>>) for RandomField<N, FC>, Add, add, AddAssign, add_assign);
-impl_ops!(impl('cfg, const N: usize, FC: FieldConfig<BigInt<N>>) for RandomField<N, FC>, Sub, sub, SubAssign, sub_assign);
-impl_ops!(impl('cfg, const N: usize, FC: FieldConfig<BigInt<N>>) for RandomField<N, FC>, Mul, mul, MulAssign, mul_assign);
-impl_ops!(impl('cfg, const N: usize, FC: FieldConfig<BigInt<N>>) for RandomField<N, FC>, Div, div, DivAssign, div_assign);
+impl_ops!(impl(const N: usize, FC: FieldConfig<BigInt<N>>) for RandomField<N, FC>, Add, add, AddAssign, add_assign);
+impl_ops!(impl(const N: usize, FC: FieldConfig<BigInt<N>>) for RandomField<N, FC>, Sub, sub, SubAssign, sub_assign);
+impl_ops!(impl(const N: usize, FC: FieldConfig<BigInt<N>>) for RandomField<N, FC>, Mul, mul, MulAssign, mul_assign);
+impl_ops!(impl(const N: usize, FC: FieldConfig<BigInt<N>>) for RandomField<N, FC>, Div, div, DivAssign, div_assign);
 
 impl<const N: usize, FC: FieldConfig<BigInt<N>>> Add<u32> for RandomField<N, FC> {
     type Output = Self;
@@ -85,7 +86,8 @@ impl<const N: usize, FC: FieldConfig<BigInt<N>>> AddAssign<&Self> for RandomFiel
 
 impl<const N: usize, FC: FieldConfig<BigInt<N>>> AddAssign<u32> for RandomField<N, FC> {
     fn add_assign(&mut self, rhs: u32) {
-        FC::add_assign(&mut self.value, &rhs.into());
+        let rhs_f: RandomField<N, FC> = rhs.map_to_field();
+        FC::add_assign(&mut self.value, &rhs_f.value);
     }
 }
 
@@ -202,15 +204,6 @@ mod test {
 
         let sum = lhs + rhs;
         assert_eq!(sum.into_bigint(), BigInt::zero());
-    }
-
-    #[test]
-    fn test_add_two_ones() {
-        let lhs: RandomField<1, Fc23<1>> = RandomField::one();
-        let rhs = RandomField::one();
-        let expected = RandomField::<1, Fc23<1>>::from_bigint(BigInt::from(2_u32)).unwrap();
-
-        assert_eq!(lhs + rhs, expected);
     }
 
     #[test]

--- a/zip-plus/src/field/arithmetic.rs
+++ b/zip-plus/src/field/arithmetic.rs
@@ -5,6 +5,7 @@ use ark_std::{
 };
 
 use crate::{field::RandomField, traits::Config};
+use crate::field::config::ConstFieldConfig;
 
 macro_rules! impl_ops {
     (
@@ -34,7 +35,7 @@ macro_rules! impl_ops {
             type Output = $type;
 
             fn $op(self, rhs: Self) -> Self::Output {
-                let mut res = *self;
+                let mut res = self.clone();
                 res.$op_assign(rhs);
                 res
             }
@@ -44,7 +45,7 @@ macro_rules! impl_ops {
             type Output = $type;
 
             fn $op(self, rhs: $type) -> Self::Output {
-                let mut res = *self;
+                let mut res = self.clone();
                 res.$op_assign(&rhs);
                 res
             }
@@ -58,12 +59,12 @@ macro_rules! impl_ops {
     };
 }
 
-impl_ops!(impl('cfg, const N: usize) for RandomField<'cfg, N>, Add, add, AddAssign, add_assign);
-impl_ops!(impl('cfg, const N: usize) for RandomField<'cfg, N>, Sub, sub, SubAssign, sub_assign);
-impl_ops!(impl('cfg, const N: usize) for RandomField<'cfg, N>, Mul, mul, MulAssign, mul_assign);
-impl_ops!(impl('cfg, const N: usize) for RandomField<'cfg, N>, Div, div, DivAssign, div_assign);
+impl_ops!(impl('cfg, const N: usize, FC: ConstFieldConfig<N>) for RandomField<'cfg, N, FC>, Add, add, AddAssign, add_assign);
+impl_ops!(impl('cfg, const N: usize, FC: ConstFieldConfig<N>) for RandomField<'cfg, N, FC>, Sub, sub, SubAssign, sub_assign);
+impl_ops!(impl('cfg, const N: usize, FC: ConstFieldConfig<N>) for RandomField<'cfg, N, FC>, Mul, mul, MulAssign, mul_assign);
+impl_ops!(impl('cfg, const N: usize, FC: ConstFieldConfig<N>) for RandomField<'cfg, N, FC>, Div, div, DivAssign, div_assign);
 
-impl<const N: usize> Add<u32> for RandomField<'_, N> {
+impl<const N: usize, FC: ConstFieldConfig<N>> Add<u32> for RandomField<'_, N, FC> {
     type Output = Self;
 
     fn add(mut self, rhs: u32) -> Self::Output {
@@ -72,7 +73,7 @@ impl<const N: usize> Add<u32> for RandomField<'_, N> {
     }
 }
 
-impl<const N: usize> AddAssign<&Self> for RandomField<'_, N> {
+impl<const N: usize, FC: ConstFieldConfig<N>> AddAssign<&Self> for RandomField<'_, N, FC> {
     fn add_assign(&mut self, rhs: &Self) {
         self.with_aligned_config_mut(
             rhs,
@@ -86,7 +87,7 @@ impl<const N: usize> AddAssign<&Self> for RandomField<'_, N> {
     }
 }
 
-impl<const N: usize> AddAssign<u32> for RandomField<'_, N> {
+impl<const N: usize, FC: ConstFieldConfig<N>> AddAssign<u32> for RandomField<'_, N, FC> {
     fn add_assign(&mut self, rhs: u32) {
         todo!()
         // self.with_aligned_config_mut(
@@ -101,7 +102,7 @@ impl<const N: usize> AddAssign<u32> for RandomField<'_, N> {
     }
 }
 
-impl<const N: usize> SubAssign<&Self> for RandomField<'_, N> {
+impl<const N: usize, FC: ConstFieldConfig<N>> SubAssign<&Self> for RandomField<'_, N, FC> {
     fn sub_assign(&mut self, rhs: &Self) {
         self.with_aligned_config_mut(
             rhs,
@@ -115,7 +116,7 @@ impl<const N: usize> SubAssign<&Self> for RandomField<'_, N> {
     }
 }
 
-impl<const N: usize> MulAssign<&Self> for RandomField<'_, N> {
+impl<const N: usize, FC: ConstFieldConfig<N>> MulAssign<&Self> for RandomField<'_, N, FC> {
     fn mul_assign(&mut self, rhs: &Self) {
         self.with_aligned_config_mut(
             rhs,
@@ -129,7 +130,7 @@ impl<const N: usize> MulAssign<&Self> for RandomField<'_, N> {
     }
 }
 
-impl<const N: usize> DivAssign<&Self> for RandomField<'_, N> {
+impl<const N: usize, FC: ConstFieldConfig<N>> DivAssign<&Self> for RandomField<'_, N, FC> {
     fn div_assign(&mut self, rhs: &Self) {
         if rhs.is_zero() {
             panic!("Attempt to divide by zero");
@@ -145,13 +146,13 @@ impl<const N: usize> DivAssign<&Self> for RandomField<'_, N> {
     }
 }
 
-impl<const N: usize> DivAssign<&mut Self> for RandomField<'_, N> {
+impl<const N: usize, FC: ConstFieldConfig<N>> DivAssign<&mut Self> for RandomField<'_, N, FC> {
     fn div_assign(&mut self, rhs: &mut Self) {
-        *self /= *rhs;
+        *self /= rhs.clone();
     }
 }
 
-impl<const N: usize> Neg for RandomField<'_, N> {
+impl<const N: usize, FC: ConstFieldConfig<N>> Neg for RandomField<'_, N, FC> {
     type Output = Self;
 
     fn neg(mut self) -> Self::Output {
@@ -172,7 +173,7 @@ impl<const N: usize> Neg for RandomField<'_, N> {
     }
 }
 
-impl<'a, const N: usize> Sum<&'a Self> for RandomField<'_, N> {
+impl<'a, const N: usize, FC: ConstFieldConfig<N>> Sum<&'a Self> for RandomField<'_, N, FC> {
     fn sum<I: Iterator<Item = &'a Self>>(iter: I) -> Self {
         iter.fold(Self::zero(), |mut acc, x| {
             acc.add_assign(x);
@@ -181,7 +182,7 @@ impl<'a, const N: usize> Sum<&'a Self> for RandomField<'_, N> {
     }
 }
 
-impl<const N: usize> Sum for RandomField<'_, N> {
+impl<const N: usize, FC: ConstFieldConfig<N>> Sum for RandomField<'_, N, FC> {
     fn sum<I: Iterator<Item = Self>>(iter: I) -> Self {
         iter.fold(Self::zero(), |mut acc, x| {
             acc.add_assign(&x);
@@ -190,15 +191,15 @@ impl<const N: usize> Sum for RandomField<'_, N> {
     }
 }
 
-impl<'a, const N: usize> core::iter::Product<&'a Self> for RandomField<'_, N> {
+impl<'a, const N: usize, FC: ConstFieldConfig<N>> core::iter::Product<&'a Self> for RandomField<'_, N, FC> {
     fn product<I: Iterator<Item = &'a Self>>(iter: I) -> Self {
         iter.fold(Self::one(), core::ops::Mul::mul)
     }
 }
 
-impl<'a, const N: usize> From<&'a Self> for RandomField<'_, N> {
+impl<'a, const N: usize, FC: ConstFieldConfig<N>> From<&'a Self> for RandomField<'_, N, FC> {
     fn from(value: &'a Self) -> Self {
-        *value
+        value.clone()
     }
 }
 
@@ -206,19 +207,18 @@ impl<'a, const N: usize> From<&'a Self> for RandomField<'_, N> {
 mod test {
     use ark_ff::{One, Zero};
 
-    use crate::{
-        big_int,
-        field::{biginteger::BigInt, config::ConfigRef, RandomField},
-        field_config, random_field,
-    };
+    use crate::{big_int, define_field_config, field::{biginteger::BigInt, config::ConfigRef, RandomField}, field_config, random_field};
+    use crate::field::config::ConstFieldConfig;
+
+    define_field_config!(Fc23, "23");
 
     #[test]
     fn test_add_wrapping_around_modulus() {
         let config = field_config!(23);
         let config = ConfigRef::<1>::from(&config);
 
-        let lhs: RandomField<1> = random_field!(22u32, config);
-        let rhs: RandomField<1> = random_field!(2u32, config);
+        let lhs: RandomField<1, Fc23<1>> = random_field!(22u32, config);
+        let rhs: RandomField<1, Fc23<1>> = random_field!(2u32, config);
 
         let sum = lhs + rhs;
         assert_eq!(sum.into_bigint(), BigInt::one());
@@ -229,8 +229,8 @@ mod test {
         let config = field_config!(23);
         let config = ConfigRef::from(&config);
 
-        let lhs: RandomField<1> = random_field!(20u32, config);
-        let rhs: RandomField<1> = random_field!(20u32, config);
+        let lhs: RandomField<1, Fc23<1>> = random_field!(20u32, config);
+        let rhs: RandomField<1, Fc23<1>> = random_field!(20u32, config);
 
         let sum = lhs + rhs;
         assert_eq!(sum.into_bigint(), big_int!(17));
@@ -241,8 +241,8 @@ mod test {
         let config = field_config!(23);
         let config = ConfigRef::<1>::from(&config);
 
-        let lhs: RandomField<1> = random_field!(22u32, config);
-        let rhs: RandomField<1> = RandomField::one();
+        let lhs: RandomField<1, Fc23<1>> = random_field!(22u32, config);
+        let rhs: RandomField<1, Fc23<1>> = RandomField::one();
 
         let sum = lhs + rhs;
         assert_eq!(sum.into_bigint(), BigInt::zero());
@@ -250,16 +250,13 @@ mod test {
 
     #[test]
     fn test_add_two_ones() {
-        let lhs: RandomField<1> = RandomField::one();
+        let lhs: RandomField<1, Fc23<1>> = RandomField::one();
         let rhs = RandomField::one();
+        let config = ConfigRef::from(&Fc23::<1>::FIELD_CONFIG);
+        let expected = RandomField::from_bigint(config, BigInt::from(2_u32)).unwrap();
+        let zz = expected.clone().into_bigint();
 
-        assert_eq!(
-            lhs + rhs,
-            RandomField {
-                value: BigInt::from(2u32),
-                config: None,
-            }
-        );
+        assert_eq!(lhs + rhs, expected);
     }
 
     #[test]
@@ -267,8 +264,8 @@ mod test {
         let config = field_config!(23);
         let config = ConfigRef::from(&config);
 
-        let lhs: RandomField<1> = random_field!(2u32, config);
-        let rhs: RandomField<1> = random_field!(22u32, config);
+        let lhs: RandomField<1, Fc23<1>> = random_field!(2u32, config);
+        let rhs: RandomField<1, Fc23<1>> = random_field!(22u32, config);
 
         let difference = lhs - rhs;
         assert_eq!(difference.into_bigint(), big_int!(3));
@@ -279,8 +276,8 @@ mod test {
         let config = field_config!(23);
         let config = ConfigRef::<1>::from(&config);
 
-        let lhs: RandomField<1> = random_field!(20u32, config);
-        let rhs: RandomField<1> = random_field!(20u32, config);
+        let lhs: RandomField<1, Fc23<1>> = random_field!(20u32, config);
+        let rhs: RandomField<1, Fc23<1>> = random_field!(20u32, config);
 
         let difference = lhs - rhs;
         assert_eq!(difference.into_bigint(), BigInt::zero());
@@ -291,9 +288,9 @@ mod test {
         let config = field_config!(23);
         let config = ConfigRef::<1>::from(&config);
 
-        let lhs: RandomField<1> = random_field!(2u32, config);
+        let lhs: RandomField<1, Fc23<1>> = random_field!(2u32, config);
         let rhs = RandomField::one();
-        let res = lhs - rhs;
+        let res = lhs.clone() - rhs;
         let mut expected = lhs;
         expected.set_one();
         assert_eq!(res, expected)
@@ -304,8 +301,8 @@ mod test {
         let config = field_config!(23);
         let config = ConfigRef::<1>::from(&config);
 
-        let mut lhs: RandomField<1> = random_field!(10u32, config);
-        let rhs: RandomField<1> = random_field!(7u32, config);
+        let mut lhs: RandomField<1, Fc23<1>> = random_field!(10u32, config);
+        let rhs: RandomField<1, Fc23<1>> = random_field!(7u32, config);
 
         lhs -= rhs;
 
@@ -317,8 +314,8 @@ mod test {
         let config = field_config!(23);
         let config = ConfigRef::<1>::from(&config);
 
-        let mut lhs: RandomField<1> = random_field!(3u32, config);
-        let rhs: RandomField<1> = random_field!(7u32, config);
+        let mut lhs: RandomField<1, Fc23<1>> = random_field!(3u32, config);
+        let rhs: RandomField<1, Fc23<1>> = random_field!(7u32, config);
 
         lhs -= rhs;
 
@@ -330,8 +327,8 @@ mod test {
         let config = field_config!(23);
         let config = ConfigRef::from(&config);
 
-        let lhs: RandomField<1> = random_field!(22u32, config);
-        let rhs: RandomField<1> = random_field!(2u32, config);
+        let lhs: RandomField<1, Fc23<1>> = random_field!(22u32, config);
+        let rhs: RandomField<1, Fc23<1>> = random_field!(2u32, config);
 
         let product = lhs * rhs;
         assert_eq!(product.into_bigint(), big_int!(21));
@@ -342,8 +339,8 @@ mod test {
         let config = field_config!(23);
         let config = ConfigRef::from(&config);
 
-        let lhs: RandomField<1> = random_field!(20u32, config);
-        let rhs: RandomField<1> = random_field!(20u32, config);
+        let lhs: RandomField<1, Fc23<1>> = random_field!(20u32, config);
+        let rhs: RandomField<1, Fc23<1>> = random_field!(20u32, config);
 
         let product = lhs * rhs;
         assert_eq!(product.into_bigint(), big_int!(9));
@@ -354,7 +351,7 @@ mod test {
         let config = field_config!(23);
         let config = ConfigRef::<1>::from(&config);
 
-        let lhs: RandomField<1> = random_field!(22u32, config);
+        let lhs: RandomField<1, Fc23<1>> = random_field!(22u32, config);
         let rhs = RandomField::zero();
 
         let product = lhs * rhs;
@@ -366,8 +363,8 @@ mod test {
         let config = field_config!(23);
         let config = ConfigRef::<1>::from(&config);
 
-        let lhs: RandomField<1> = RandomField::zero();
-        let rhs: RandomField<1> = random_field!(22u32, config);
+        let lhs: RandomField<1, Fc23<1>> = RandomField::zero();
+        let rhs: RandomField<1, Fc23<1>> = random_field!(22u32, config);
 
         let product = lhs * rhs;
         assert!(product.is_zero());
@@ -378,8 +375,8 @@ mod test {
         let config = field_config!(23);
         let config = ConfigRef::<1>::from(&config);
 
-        let mut lhs: RandomField<1> = random_field!(5u32, config);
-        let rhs: RandomField<1> = random_field!(4u32, config);
+        let mut lhs: RandomField<1, Fc23<1>> = random_field!(5u32, config);
+        let rhs: RandomField<1, Fc23<1>> = random_field!(4u32, config);
 
         lhs *= rhs;
 
@@ -391,8 +388,8 @@ mod test {
         let config = field_config!(23);
         let config = ConfigRef::<1>::from(&config);
 
-        let mut lhs: RandomField<1> = random_field!(6u32, config);
-        let rhs: RandomField<1> = random_field!(4u32, config);
+        let mut lhs: RandomField<1, Fc23<1>> = random_field!(6u32, config);
+        let rhs: RandomField<1, Fc23<1>> = random_field!(4u32, config);
 
         lhs *= rhs;
 
@@ -404,8 +401,8 @@ mod test {
         let config = field_config!(23);
         let config = ConfigRef::<1>::from(&config);
 
-        let lhs: RandomField<1> = random_field!(22u32, config);
-        let rhs: RandomField<1> = random_field!(2u32, config);
+        let lhs: RandomField<1, Fc23<1>> = random_field!(22u32, config);
+        let rhs: RandomField<1, Fc23<1>> = random_field!(2u32, config);
 
         let quotient = lhs / rhs;
         assert_eq!(quotient.into_bigint(), big_int!(11));
@@ -416,8 +413,8 @@ mod test {
         let config = field_config!(23);
         let config = ConfigRef::from(&config);
 
-        let lhs: RandomField<1> = random_field!(20u32, config);
-        let rhs: RandomField<1> = random_field!(20u32, config);
+        let lhs: RandomField<1, Fc23<1>> = random_field!(20u32, config);
+        let rhs: RandomField<1, Fc23<1>> = random_field!(20u32, config);
 
         let quotient = lhs / rhs;
         assert_eq!(quotient.into_bigint(), big_int!(1));
@@ -428,8 +425,8 @@ mod test {
         let config = field_config!(23);
         let config = ConfigRef::from(&config);
 
-        let lhs: RandomField<1> = random_field!(17u32, config);
-        let rhs: RandomField<1> = random_field!(4u32, config);
+        let lhs: RandomField<1, Fc23<1>> = random_field!(17u32, config);
+        let rhs: RandomField<1, Fc23<1>> = random_field!(4u32, config);
 
         let quotient = lhs / rhs;
         assert_eq!(quotient.into_bigint(), big_int!(10));
@@ -441,18 +438,19 @@ mod test {
         let config = field_config!(23);
         let config = ConfigRef::<1>::from(&config);
 
-        let lhs: RandomField<1> = random_field!(17u32, config);
-        let rhs: RandomField<1> = random_field!(0u32, config);
+        let lhs: RandomField<1, Fc23<1>> = random_field!(17u32, config);
+        let rhs: RandomField<1, Fc23<1>> = random_field!(0u32, config);
 
         let _sum = lhs / rhs;
     }
 
     #[test]
     fn test_div_bigint256() {
+        define_field_config!(Fc, "695962179703626800597079116051991347");
         let config = field_config!(695962179703626800597079116051991347);
         let config = ConfigRef::<4>::from(&config);
 
-        let a: RandomField<4> = random_field!(3u32, config);
+        let a: RandomField<4, Fc<4>> = random_field!(3u32, config);
         let mut b = RandomField::one();
         b /= a;
         assert_eq!(
@@ -460,9 +458,9 @@ mod test {
             big_int!(231987393234542266865693038683997116)
         );
 
-        let a: RandomField<4> = random_field!(19382769832175u64, config);
+        let a: RandomField<4, Fc<4>> = random_field!(19382769832175u64, config);
 
-        let b: RandomField<4> = random_field!(97133987132135u64, config);
+        let b: RandomField<4, Fc<4>> = random_field!(97133987132135u64, config);
 
         assert_eq!(
             big_int!(243043087159742188419721163456177516),
@@ -475,7 +473,7 @@ mod test {
         let config = field_config!(23);
         let config = ConfigRef::from(&config);
 
-        let lhs: RandomField<1> = random_field!(15u32, config);
+        let lhs: RandomField<1, Fc23<1>> = random_field!(15u32, config);
         let rhs = random_field!(3u32, config);
 
         #[allow(clippy::op_ref)] // This implementation could be removed?
@@ -489,7 +487,7 @@ mod test {
         let config = field_config!(23);
         let config = ConfigRef::from(&config);
 
-        let lhs: RandomField<1> = random_field!(9u32, config);
+        let lhs: RandomField<1, Fc23<1>> = random_field!(9u32, config);
         let rhs = random_field!(3u32, config);
 
         #[allow(clippy::op_ref)] // This implementation could be removed?
@@ -503,8 +501,8 @@ mod test {
         let config = field_config!(23);
         let config = ConfigRef::from(&config);
 
-        let mut lhs: RandomField<1> = random_field!(15u32, config);
-        let rhs: RandomField<1> = random_field!(3u32, config);
+        let mut lhs: RandomField<1, Fc23<1>> = random_field!(15u32, config);
+        let rhs: RandomField<1, Fc23<1>> = random_field!(3u32, config);
 
         lhs /= rhs;
 
@@ -517,7 +515,7 @@ mod test {
         let config = field_config!(23);
         let config = ConfigRef::<1>::from(&config);
 
-        let mut lhs: RandomField<1> = random_field!(15u32, config);
+        let mut lhs: RandomField<1, Fc23<1>> = random_field!(15u32, config);
         let rhs = RandomField::zero();
 
         lhs /= rhs;
@@ -528,7 +526,7 @@ mod test {
         let config = field_config!(23);
         let config = ConfigRef::<1>::from(&config);
 
-        let mut lhs: RandomField<1> = random_field!(18u32, config);
+        let mut lhs: RandomField<1, Fc23<1>> = random_field!(18u32, config);
         let mut rhs = random_field!(3u32, config);
 
         lhs /= &mut rhs;
@@ -541,7 +539,7 @@ mod test {
         let config = field_config!(23);
         let config = ConfigRef::<1>::from(&config);
 
-        let operand: RandomField<1> = random_field!(22u32, config);
+        let operand: RandomField<1, Fc23<1>> = random_field!(22u32, config);
         let negated = -operand;
 
         assert_eq!(negated.into_bigint(), big_int!(1));
@@ -552,7 +550,7 @@ mod test {
         let config = field_config!(23);
         let config = ConfigRef::from(&config);
 
-        let operand: RandomField<1> = random_field!(17u32, config);
+        let operand: RandomField<1, Fc23<1>> = random_field!(17u32, config);
         let negated = -operand;
 
         assert_eq!(negated.into_bigint(), big_int!(6));
@@ -563,7 +561,7 @@ mod test {
         let config = field_config!(23);
         let config = ConfigRef::<1>::from(&config);
 
-        let operand: RandomField<1> = random_field!(0u32, config);
+        let operand: RandomField<1, Fc23<1>> = random_field!(0u32, config);
         let negated = -operand;
 
         assert_eq!(negated.into_bigint(), BigInt::zero());
@@ -580,7 +578,7 @@ mod test {
             random_field!(6u32, config),
         ];
 
-        let sum: RandomField<1> = values.iter().sum();
+        let sum: RandomField<1, Fc23<1>> = values.iter().sum();
 
         assert_eq!(sum.into_bigint(), big_int!(12));
     }
@@ -596,7 +594,7 @@ mod test {
             random_field!(7u32, config),
         ];
 
-        let sum: RandomField<1> = values.iter().sum();
+        let sum: RandomField<1, Fc23<1>> = values.iter().sum();
 
         assert_eq!(sum.into_bigint(), big_int!(12));
     }
@@ -612,14 +610,14 @@ mod test {
             random_field!(21u32, config),
         ];
 
-        let sum: RandomField<1> = values.iter().sum();
+        let sum: RandomField<1, Fc23<1>> = values.iter().sum();
 
         assert_eq!(sum.into_bigint(), big_int!(0));
     }
 
     #[test]
     fn test_sum_empty_iterator() {
-        let sum: RandomField<1> = ark_std::iter::empty::<&RandomField<1>>().sum();
+        let sum: RandomField<1, Fc23<1>> = ark_std::iter::empty::<&RandomField<1, Fc23<1>>>().sum();
         assert!(sum.is_zero()); // Empty sum should return zero
     }
 
@@ -630,7 +628,7 @@ mod test {
 
         let values = [random_field!(9u32, config)];
 
-        let sum: RandomField<1> = values.iter().sum();
+        let sum: RandomField<1, Fc23<1>> = values.iter().sum();
 
         assert_eq!(sum.into_bigint(), big_int!(9));
     }
@@ -642,7 +640,7 @@ mod test {
 
         let values = [random_field!(12u32, config), random_field!(15u32, config)];
 
-        let sum: RandomField<1> = values.iter().sum();
+        let sum: RandomField<1, Fc23<1>> = values.iter().sum();
 
         assert_eq!(sum.into_bigint(), big_int!(4));
     }
@@ -658,7 +656,7 @@ mod test {
             random_field!(6u32, config),
         ];
 
-        let product: RandomField<1> = values.iter().product();
+        let product: RandomField<1, Fc23<1>> = values.iter().product();
 
         assert_eq!(product.into_bigint(), big_int!(2));
     }
@@ -674,7 +672,7 @@ mod test {
             random_field!(7u32, config),
         ];
 
-        let product: RandomField<1> = values.iter().product();
+        let product: RandomField<1, Fc23<1>> = values.iter().product();
 
         assert_eq!(product.into_bigint(), big_int!(12));
     }
@@ -689,7 +687,7 @@ mod test {
             random_field!(9u32, config),
         ];
 
-        let product: RandomField<1> = values.iter().product();
+        let product: RandomField<1, Fc23<1>> = values.iter().product();
 
         assert!(product.is_zero());
     }
@@ -705,14 +703,14 @@ mod test {
             random_field!(21u32, config),
         ];
 
-        let product: RandomField<1> = values.iter().product();
+        let product: RandomField<1, Fc23<1>> = values.iter().product();
 
         assert_eq!(product.into_bigint(), big_int!(22));
     }
 
     #[test]
     fn test_product_empty_iterator() {
-        let product: RandomField<1> = ark_std::iter::empty::<&RandomField<1>>().product();
+        let product: RandomField<1, Fc23<1>> = ark_std::iter::empty::<&RandomField<1, Fc23<1>>>().product();
         assert!(product.is_one()); // Empty product should return one
     }
 
@@ -723,7 +721,7 @@ mod test {
 
         let values = [random_field!(9u32, config)];
 
-        let product: RandomField<1> = values.iter().product();
+        let product: RandomField<1, Fc23<1>> = values.iter().product();
 
         assert_eq!(product.into_bigint(), big_int!(9));
     }
@@ -735,7 +733,7 @@ mod test {
 
         let values = [random_field!(12u32, config), random_field!(15u32, config)];
 
-        let product: RandomField<1> = values.iter().product();
+        let product: RandomField<1, Fc23<1>> = values.iter().product();
 
         assert_eq!(product.into_bigint(), big_int!(19));
     }

--- a/zip-plus/src/field/arithmetic.rs
+++ b/zip-plus/src/field/arithmetic.rs
@@ -6,6 +6,7 @@ use ark_std::{
 
 use crate::{field::RandomField, traits::Config};
 use crate::field::config::ConstFieldConfig;
+use crate::traits::ConfigReference;
 
 macro_rules! impl_ops {
     (
@@ -160,14 +161,10 @@ impl<const N: usize, FC: ConstFieldConfig<N>> Neg for RandomField<'_, N, FC> {
             return self;
         }
 
-        self.with_either_mut(
-            |_| panic!("Cannot negate without a field config"),
-            |config, value| {
-                let tmp = *value;
-                *value = *config.modulus();
-                value.sub_with_borrow(&tmp);
-            },
-        );
+        let config = self.config.reference().expect("Field config cannot be none");
+        let tmp = self.value;
+        self.value = *config.modulus();
+        self.value.sub_with_borrow(&tmp);
 
         self
     }

--- a/zip-plus/src/field/arithmetic.rs
+++ b/zip-plus/src/field/arithmetic.rs
@@ -4,9 +4,9 @@ use ark_std::{
     ops::{Add, AddAssign, Div, DivAssign, Mul, MulAssign, Neg, Sub, SubAssign},
 };
 
-use crate::{field::RandomField, traits::Config};
-use crate::field::config::ConstFieldConfig;
-use crate::traits::ConfigReference;
+use crate::{field::RandomField};
+use crate::field::BigInt;
+use crate::field::config::FieldConfig;
 
 macro_rules! impl_ops {
     (
@@ -60,12 +60,12 @@ macro_rules! impl_ops {
     };
 }
 
-impl_ops!(impl('cfg, const N: usize, FC: ConstFieldConfig<N>) for RandomField<'cfg, N, FC>, Add, add, AddAssign, add_assign);
-impl_ops!(impl('cfg, const N: usize, FC: ConstFieldConfig<N>) for RandomField<'cfg, N, FC>, Sub, sub, SubAssign, sub_assign);
-impl_ops!(impl('cfg, const N: usize, FC: ConstFieldConfig<N>) for RandomField<'cfg, N, FC>, Mul, mul, MulAssign, mul_assign);
-impl_ops!(impl('cfg, const N: usize, FC: ConstFieldConfig<N>) for RandomField<'cfg, N, FC>, Div, div, DivAssign, div_assign);
+impl_ops!(impl('cfg, const N: usize, FC: FieldConfig<BigInt<N>>) for RandomField<N, FC>, Add, add, AddAssign, add_assign);
+impl_ops!(impl('cfg, const N: usize, FC: FieldConfig<BigInt<N>>) for RandomField<N, FC>, Sub, sub, SubAssign, sub_assign);
+impl_ops!(impl('cfg, const N: usize, FC: FieldConfig<BigInt<N>>) for RandomField<N, FC>, Mul, mul, MulAssign, mul_assign);
+impl_ops!(impl('cfg, const N: usize, FC: FieldConfig<BigInt<N>>) for RandomField<N, FC>, Div, div, DivAssign, div_assign);
 
-impl<const N: usize, FC: ConstFieldConfig<N>> Add<u32> for RandomField<'_, N, FC> {
+impl<const N: usize, FC: FieldConfig<BigInt<N>>> Add<u32> for RandomField<N, FC> {
     type Output = Self;
 
     fn add(mut self, rhs: u32) -> Self::Output {
@@ -74,13 +74,13 @@ impl<const N: usize, FC: ConstFieldConfig<N>> Add<u32> for RandomField<'_, N, FC
     }
 }
 
-impl<const N: usize, FC: ConstFieldConfig<N>> AddAssign<&Self> for RandomField<'_, N, FC> {
+impl<const N: usize, FC: FieldConfig<BigInt<N>>> AddAssign<&Self> for RandomField<N, FC> {
     fn add_assign(&mut self, rhs: &Self) {
-        self.config.reference().unwrap().add_assign(&mut self.value, &rhs.value);
+        FC::add_assign(&mut self.value, &rhs.value);
     }
 }
 
-impl<const N: usize, FC: ConstFieldConfig<N>> AddAssign<u32> for RandomField<'_, N, FC> {
+impl<const N: usize, FC: FieldConfig<BigInt<N>>> AddAssign<u32> for RandomField<N, FC> {
     fn add_assign(&mut self, rhs: u32) {
         todo!()
         // self.with_aligned_config_mut(
@@ -95,36 +95,34 @@ impl<const N: usize, FC: ConstFieldConfig<N>> AddAssign<u32> for RandomField<'_,
     }
 }
 
-impl<const N: usize, FC: ConstFieldConfig<N>> SubAssign<&Self> for RandomField<'_, N, FC> {
+impl<const N: usize, FC: FieldConfig<BigInt<N>>> SubAssign<&Self> for RandomField<N, FC> {
     fn sub_assign(&mut self, rhs: &Self) {
-        self.config.reference().unwrap().sub_assign(&mut self.value, &rhs.value);
+        FC::sub_assign(&mut self.value, &rhs.value);
     }
 }
 
-impl<const N: usize, FC: ConstFieldConfig<N>> MulAssign<&Self> for RandomField<'_, N, FC> {
+impl<const N: usize, FC: FieldConfig<BigInt<N>>> MulAssign<&Self> for RandomField<N, FC> {
     fn mul_assign(&mut self, rhs: &Self) {
-        self.config.reference().unwrap().mul_assign(&mut self.value, &rhs.value);
+        FC::mul_assign(&mut self.value, &rhs.value);
     }
 }
 
-impl<const N: usize, FC: ConstFieldConfig<N>> DivAssign<&Self> for RandomField<'_, N, FC> {
+impl<const N: usize, FC: FieldConfig<BigInt<N>>> DivAssign<&Self> for RandomField<N, FC> {
     fn div_assign(&mut self, rhs: &Self) {
         if rhs.is_zero() {
             panic!("Attempt to divide by zero");
         }
-        let config = self.config.reference().unwrap();
-
-        config.mul_assign(&mut self.value, &config.inverse(&rhs.value).unwrap());
+        FC::mul_assign(&mut self.value, &FC::inverse(&rhs.value).unwrap());
     }
 }
 
-impl<const N: usize, FC: ConstFieldConfig<N>> DivAssign<&mut Self> for RandomField<'_, N, FC> {
+impl<const N: usize, FC: FieldConfig<BigInt<N>>> DivAssign<&mut Self> for RandomField<N, FC> {
     fn div_assign(&mut self, rhs: &mut Self) {
         *self /= rhs.clone();
     }
 }
 
-impl<const N: usize, FC: ConstFieldConfig<N>> Neg for RandomField<'_, N, FC> {
+impl<const N: usize, FC: FieldConfig<BigInt<N>>> Neg for RandomField<N, FC> {
     type Output = Self;
 
     fn neg(mut self) -> Self::Output {
@@ -133,14 +131,14 @@ impl<const N: usize, FC: ConstFieldConfig<N>> Neg for RandomField<'_, N, FC> {
         }
 
         let tmp = self.value;
-        self.value = *self.config().modulus();
+        self.value = FC::modulus();
         self.value.sub_with_borrow(&tmp);
 
         self
     }
 }
 
-impl<'a, const N: usize, FC: ConstFieldConfig<N>> Sum<&'a Self> for RandomField<'_, N, FC> {
+impl<'a, const N: usize, FC: FieldConfig<BigInt<N>>> Sum<&'a Self> for RandomField<N, FC> {
     fn sum<I: Iterator<Item = &'a Self>>(iter: I) -> Self {
         iter.fold(Self::zero(), |mut acc, x| {
             acc.add_assign(x);
@@ -149,7 +147,7 @@ impl<'a, const N: usize, FC: ConstFieldConfig<N>> Sum<&'a Self> for RandomField<
     }
 }
 
-impl<const N: usize, FC: ConstFieldConfig<N>> Sum for RandomField<'_, N, FC> {
+impl<const N: usize, FC: FieldConfig<BigInt<N>>> Sum for RandomField<N, FC> {
     fn sum<I: Iterator<Item = Self>>(iter: I) -> Self {
         iter.fold(Self::zero(), |mut acc, x| {
             acc.add_assign(&x);
@@ -158,13 +156,13 @@ impl<const N: usize, FC: ConstFieldConfig<N>> Sum for RandomField<'_, N, FC> {
     }
 }
 
-impl<'a, const N: usize, FC: ConstFieldConfig<N>> core::iter::Product<&'a Self> for RandomField<'_, N, FC> {
+impl<'a, const N: usize, FC: FieldConfig<BigInt<N>>> core::iter::Product<&'a Self> for RandomField<N, FC> {
     fn product<I: Iterator<Item = &'a Self>>(iter: I) -> Self {
         iter.fold(Self::one(), core::ops::Mul::mul)
     }
 }
 
-impl<'a, const N: usize, FC: ConstFieldConfig<N>> From<&'a Self> for RandomField<'_, N, FC> {
+impl<'a, const N: usize, FC: FieldConfig<BigInt<N>>> From<&'a Self> for RandomField<N, FC> {
     fn from(value: &'a Self) -> Self {
         value.clone()
     }
@@ -174,19 +172,15 @@ impl<'a, const N: usize, FC: ConstFieldConfig<N>> From<&'a Self> for RandomField
 mod test {
     use ark_ff::{One, Zero};
 
-    use crate::{big_int, define_field_config, field::{biginteger::BigInt, config::ConfigRef, RandomField}, field_config, random_field};
-    use crate::field::config::ConstFieldConfig;
-    use crate::traits::ConfigReference;
+    use crate::{big_int, define_field_config, field::{biginteger::BigInt, RandomField}, random_field};
+    use crate::field::config::FieldConfig;
 
     define_field_config!(Fc23, "23");
 
     #[test]
     fn test_add_wrapping_around_modulus() {
-        let config = field_config!(23);
-        let config = ConfigRef::<1>::from(&config);
-
-        let lhs: RandomField<1, Fc23<1>> = random_field!(22u32, config);
-        let rhs: RandomField<1, Fc23<1>> = random_field!(2u32, config);
+        let lhs: RandomField<1, Fc23<1>> = random_field!(22u32);
+        let rhs: RandomField<1, Fc23<1>> = random_field!(2u32);
 
         let sum = lhs + rhs;
         assert_eq!(sum.into_bigint(), BigInt::one());
@@ -194,11 +188,8 @@ mod test {
 
     #[test]
     fn test_add_without_wrapping() {
-        let config = field_config!(23);
-        let config = ConfigRef::from(&config);
-
-        let lhs: RandomField<1, Fc23<1>> = random_field!(20u32, config);
-        let rhs: RandomField<1, Fc23<1>> = random_field!(20u32, config);
+        let lhs: RandomField<1, Fc23<1>> = random_field!(20u32);
+        let rhs: RandomField<1, Fc23<1>> = random_field!(20u32);
 
         let sum = lhs + rhs;
         assert_eq!(sum.into_bigint(), big_int!(17));
@@ -206,10 +197,7 @@ mod test {
 
     #[test]
     fn test_add_one() {
-        let config = field_config!(23);
-        let config = ConfigRef::<1>::from(&config);
-
-        let lhs: RandomField<1, Fc23<1>> = random_field!(22u32, config);
+        let lhs: RandomField<1, Fc23<1>> = random_field!(22u32);
         let rhs: RandomField<1, Fc23<1>> = RandomField::one();
 
         let sum = lhs + rhs;
@@ -220,19 +208,15 @@ mod test {
     fn test_add_two_ones() {
         let lhs: RandomField<1, Fc23<1>> = RandomField::one();
         let rhs = RandomField::one();
-        let config = unsafe { ConfigRef::new(Box::leak(Box::new(Fc23::<1>::field_config()))) };
-        let expected = RandomField::from_bigint(config, BigInt::from(2_u32)).unwrap();
+        let expected = RandomField::<1, Fc23<1>>::from_bigint(BigInt::from(2_u32)).unwrap();
 
         assert_eq!(lhs + rhs, expected);
     }
 
     #[test]
     fn test_sub_wrapping_around_modulus() {
-        let config = field_config!(23);
-        let config = ConfigRef::from(&config);
-
-        let lhs: RandomField<1, Fc23<1>> = random_field!(2u32, config);
-        let rhs: RandomField<1, Fc23<1>> = random_field!(22u32, config);
+        let lhs: RandomField<1, Fc23<1>> = random_field!(2u32);
+        let rhs: RandomField<1, Fc23<1>> = random_field!(22u32);
 
         let difference = lhs - rhs;
         assert_eq!(difference.into_bigint(), big_int!(3));
@@ -240,11 +224,8 @@ mod test {
 
     #[test]
     fn test_sub_identical_values_results_in_zero() {
-        let config = field_config!(23);
-        let config = ConfigRef::<1>::from(&config);
-
-        let lhs: RandomField<1, Fc23<1>> = random_field!(20u32, config);
-        let rhs: RandomField<1, Fc23<1>> = random_field!(20u32, config);
+        let lhs: RandomField<1, Fc23<1>> = random_field!(20u32);
+        let rhs: RandomField<1, Fc23<1>> = random_field!(20u32);
 
         let difference = lhs - rhs;
         assert_eq!(difference.into_bigint(), BigInt::zero());
@@ -252,10 +233,7 @@ mod test {
 
     #[test]
     fn test_init_sub_raw() {
-        let config = field_config!(23);
-        let config = ConfigRef::<1>::from(&config);
-
-        let lhs: RandomField<1, Fc23<1>> = random_field!(2u32, config);
+        let lhs: RandomField<1, Fc23<1>> = random_field!(2u32);
         let rhs = RandomField::one();
         let res = lhs.clone() - rhs;
         let mut expected = lhs;
@@ -265,11 +243,8 @@ mod test {
 
     #[test]
     fn test_sub_assign_works() {
-        let config = field_config!(23);
-        let config = ConfigRef::<1>::from(&config);
-
-        let mut lhs: RandomField<1, Fc23<1>> = random_field!(10u32, config);
-        let rhs: RandomField<1, Fc23<1>> = random_field!(7u32, config);
+        let mut lhs: RandomField<1, Fc23<1>> = random_field!(10u32);
+        let rhs: RandomField<1, Fc23<1>> = random_field!(7u32);
 
         lhs -= rhs;
 
@@ -278,11 +253,8 @@ mod test {
 
     #[test]
     fn test_sub_assign_wraps_modulus() {
-        let config = field_config!(23);
-        let config = ConfigRef::<1>::from(&config);
-
-        let mut lhs: RandomField<1, Fc23<1>> = random_field!(3u32, config);
-        let rhs: RandomField<1, Fc23<1>> = random_field!(7u32, config);
+        let mut lhs: RandomField<1, Fc23<1>> = random_field!(3u32);
+        let rhs: RandomField<1, Fc23<1>> = random_field!(7u32);
 
         lhs -= rhs;
 
@@ -291,11 +263,8 @@ mod test {
 
     #[test]
     fn test_mul_wraps_modulus() {
-        let config = field_config!(23);
-        let config = ConfigRef::from(&config);
-
-        let lhs: RandomField<1, Fc23<1>> = random_field!(22u32, config);
-        let rhs: RandomField<1, Fc23<1>> = random_field!(2u32, config);
+        let lhs: RandomField<1, Fc23<1>> = random_field!(22u32);
+        let rhs: RandomField<1, Fc23<1>> = random_field!(2u32);
 
         let product = lhs * rhs;
         assert_eq!(product.into_bigint(), big_int!(21));
@@ -303,11 +272,8 @@ mod test {
 
     #[test]
     fn test_mul_without_wrapping() {
-        let config = field_config!(23);
-        let config = ConfigRef::from(&config);
-
-        let lhs: RandomField<1, Fc23<1>> = random_field!(20u32, config);
-        let rhs: RandomField<1, Fc23<1>> = random_field!(20u32, config);
+        let lhs: RandomField<1, Fc23<1>> = random_field!(20u32);
+        let rhs: RandomField<1, Fc23<1>> = random_field!(20u32);
 
         let product = lhs * rhs;
         assert_eq!(product.into_bigint(), big_int!(9));
@@ -315,10 +281,7 @@ mod test {
 
     #[test]
     fn test_left_mul_by_zero() {
-        let config = field_config!(23);
-        let config = ConfigRef::<1>::from(&config);
-
-        let lhs: RandomField<1, Fc23<1>> = random_field!(22u32, config);
+        let lhs: RandomField<1, Fc23<1>> = random_field!(22u32);
         let rhs = RandomField::zero();
 
         let product = lhs * rhs;
@@ -327,11 +290,8 @@ mod test {
 
     #[test]
     fn test_right_mul_by_zero() {
-        let config = field_config!(23);
-        let config = ConfigRef::<1>::from(&config);
-
         let lhs: RandomField<1, Fc23<1>> = RandomField::zero();
-        let rhs: RandomField<1, Fc23<1>> = random_field!(22u32, config);
+        let rhs: RandomField<1, Fc23<1>> = random_field!(22u32);
 
         let product = lhs * rhs;
         assert!(product.is_zero());
@@ -339,11 +299,8 @@ mod test {
 
     #[test]
     fn test_mul_assign_works() {
-        let config = field_config!(23);
-        let config = ConfigRef::<1>::from(&config);
-
-        let mut lhs: RandomField<1, Fc23<1>> = random_field!(5u32, config);
-        let rhs: RandomField<1, Fc23<1>> = random_field!(4u32, config);
+        let mut lhs: RandomField<1, Fc23<1>> = random_field!(5u32);
+        let rhs: RandomField<1, Fc23<1>> = random_field!(4u32);
 
         lhs *= rhs;
 
@@ -352,11 +309,8 @@ mod test {
 
     #[test]
     fn test_mul_assign_wraps_modulus() {
-        let config = field_config!(23);
-        let config = ConfigRef::<1>::from(&config);
-
-        let mut lhs: RandomField<1, Fc23<1>> = random_field!(6u32, config);
-        let rhs: RandomField<1, Fc23<1>> = random_field!(4u32, config);
+        let mut lhs: RandomField<1, Fc23<1>> = random_field!(6u32);
+        let rhs: RandomField<1, Fc23<1>> = random_field!(4u32);
 
         lhs *= rhs;
 
@@ -365,11 +319,8 @@ mod test {
 
     #[test]
     fn test_div_wraps_modulus() {
-        let config = field_config!(23);
-        let config = ConfigRef::<1>::from(&config);
-
-        let lhs: RandomField<1, Fc23<1>> = random_field!(22u32, config);
-        let rhs: RandomField<1, Fc23<1>> = random_field!(2u32, config);
+        let lhs: RandomField<1, Fc23<1>> = random_field!(22u32);
+        let rhs: RandomField<1, Fc23<1>> = random_field!(2u32);
 
         let quotient = lhs / rhs;
         assert_eq!(quotient.into_bigint(), big_int!(11));
@@ -377,11 +328,8 @@ mod test {
 
     #[test]
     fn test_div_identical_values_results_in_one() {
-        let config = field_config!(23);
-        let config = ConfigRef::from(&config);
-
-        let lhs: RandomField<1, Fc23<1>> = random_field!(20u32, config);
-        let rhs: RandomField<1, Fc23<1>> = random_field!(20u32, config);
+        let lhs: RandomField<1, Fc23<1>> = random_field!(20u32);
+        let rhs: RandomField<1, Fc23<1>> = random_field!(20u32);
 
         let quotient = lhs / rhs;
         assert_eq!(quotient.into_bigint(), big_int!(1));
@@ -389,11 +337,8 @@ mod test {
 
     #[test]
     fn test_div_without_wrapping() {
-        let config = field_config!(23);
-        let config = ConfigRef::from(&config);
-
-        let lhs: RandomField<1, Fc23<1>> = random_field!(17u32, config);
-        let rhs: RandomField<1, Fc23<1>> = random_field!(4u32, config);
+        let lhs: RandomField<1, Fc23<1>> = random_field!(17u32);
+        let rhs: RandomField<1, Fc23<1>> = random_field!(4u32);
 
         let quotient = lhs / rhs;
         assert_eq!(quotient.into_bigint(), big_int!(10));
@@ -402,11 +347,8 @@ mod test {
     #[test]
     #[should_panic]
     fn test_div_by_zero_should_panic() {
-        let config = field_config!(23);
-        let config = ConfigRef::<1>::from(&config);
-
-        let lhs: RandomField<1, Fc23<1>> = random_field!(17u32, config);
-        let rhs: RandomField<1, Fc23<1>> = random_field!(0u32, config);
+        let lhs: RandomField<1, Fc23<1>> = random_field!(17u32);
+        let rhs: RandomField<1, Fc23<1>> = random_field!(0u32);
 
         let _sum = lhs / rhs;
     }
@@ -414,10 +356,8 @@ mod test {
     #[test]
     fn test_div_bigint256() {
         define_field_config!(Fc, "695962179703626800597079116051991347");
-        let config = field_config!(695962179703626800597079116051991347);
-        let config = ConfigRef::<4>::from(&config);
 
-        let a: RandomField<4, Fc<4>> = random_field!(3u32, config);
+        let a: RandomField<4, Fc<4>> = random_field!(3u32);
         let mut b = RandomField::one();
         b /= a;
         assert_eq!(
@@ -425,9 +365,9 @@ mod test {
             big_int!(231987393234542266865693038683997116)
         );
 
-        let a: RandomField<4, Fc<4>> = random_field!(19382769832175u64, config);
+        let a: RandomField<4, Fc<4>> = random_field!(19382769832175u64);
 
-        let b: RandomField<4, Fc<4>> = random_field!(97133987132135u64, config);
+        let b: RandomField<4, Fc<4>> = random_field!(97133987132135u64);
 
         assert_eq!(
             big_int!(243043087159742188419721163456177516),
@@ -437,11 +377,8 @@ mod test {
 
     #[test]
     fn test_div_by_reference_works() {
-        let config = field_config!(23);
-        let config = ConfigRef::from(&config);
-
-        let lhs: RandomField<1, Fc23<1>> = random_field!(15u32, config);
-        let rhs = random_field!(3u32, config);
+        let lhs: RandomField<1, Fc23<1>> = random_field!(15u32);
+        let rhs = random_field!(3u32);
 
         #[allow(clippy::op_ref)] // This implementation could be removed?
         let quotient = lhs / &rhs;
@@ -451,11 +388,8 @@ mod test {
 
     #[test]
     fn test_div_by_mutable_reference_works() {
-        let config = field_config!(23);
-        let config = ConfigRef::from(&config);
-
-        let lhs: RandomField<1, Fc23<1>> = random_field!(9u32, config);
-        let rhs = random_field!(3u32, config);
+        let lhs: RandomField<1, Fc23<1>> = random_field!(9u32);
+        let rhs = random_field!(3u32);
 
         #[allow(clippy::op_ref)] // This implementation could be removed?
         let quotient = lhs / &rhs;
@@ -465,11 +399,8 @@ mod test {
 
     #[test]
     fn test_div_assign_works() {
-        let config = field_config!(23);
-        let config = ConfigRef::from(&config);
-
-        let mut lhs: RandomField<1, Fc23<1>> = random_field!(15u32, config);
-        let rhs: RandomField<1, Fc23<1>> = random_field!(3u32, config);
+        let mut lhs: RandomField<1, Fc23<1>> = random_field!(15u32);
+        let rhs: RandomField<1, Fc23<1>> = random_field!(3u32);
 
         lhs /= rhs;
 
@@ -479,10 +410,7 @@ mod test {
     #[test]
     #[should_panic(expected = "Attempt to divide by zero")]
     fn test_div_assign_by_zero_should_panic() {
-        let config = field_config!(23);
-        let config = ConfigRef::<1>::from(&config);
-
-        let mut lhs: RandomField<1, Fc23<1>> = random_field!(15u32, config);
+        let mut lhs: RandomField<1, Fc23<1>> = random_field!(15u32);
         let rhs = RandomField::zero();
 
         lhs /= rhs;
@@ -490,11 +418,8 @@ mod test {
 
     #[test]
     fn test_div_assign_by_mutable_reference() {
-        let config = field_config!(23);
-        let config = ConfigRef::<1>::from(&config);
-
-        let mut lhs: RandomField<1, Fc23<1>> = random_field!(18u32, config);
-        let mut rhs = random_field!(3u32, config);
+        let mut lhs: RandomField<1, Fc23<1>> = random_field!(18u32);
+        let mut rhs = random_field!(3u32);
 
         lhs /= &mut rhs;
 
@@ -503,10 +428,7 @@ mod test {
 
     #[test]
     fn test_neg_large_value() {
-        let config = field_config!(23);
-        let config = ConfigRef::<1>::from(&config);
-
-        let operand: RandomField<1, Fc23<1>> = random_field!(22u32, config);
+        let operand: RandomField<1, Fc23<1>> = random_field!(22u32);
         let negated = -operand;
 
         assert_eq!(negated.into_bigint(), big_int!(1));
@@ -514,10 +436,7 @@ mod test {
 
     #[test]
     fn test_neg_mid_value() {
-        let config = field_config!(23);
-        let config = ConfigRef::from(&config);
-
-        let operand: RandomField<1, Fc23<1>> = random_field!(17u32, config);
+        let operand: RandomField<1, Fc23<1>> = random_field!(17u32);
         let negated = -operand;
 
         assert_eq!(negated.into_bigint(), big_int!(6));
@@ -525,10 +444,7 @@ mod test {
 
     #[test]
     fn test_neg_zero() {
-        let config = field_config!(23);
-        let config = ConfigRef::<1>::from(&config);
-
-        let operand: RandomField<1, Fc23<1>> = random_field!(0u32, config);
+        let operand: RandomField<1, Fc23<1>> = random_field!(0u32);
         let negated = -operand;
 
         assert_eq!(negated.into_bigint(), BigInt::zero());
@@ -536,13 +452,10 @@ mod test {
 
     #[test]
     fn test_sum_of_multiple_values() {
-        let config = field_config!(23);
-        let config = ConfigRef::from(&config);
-
         let values = [
-            random_field!(2u32, config),
-            random_field!(4u32, config),
-            random_field!(6u32, config),
+            random_field!(2u32),
+            random_field!(4u32),
+            random_field!(6u32),
         ];
 
         let sum: RandomField<1, Fc23<1>> = values.iter().sum();
@@ -552,13 +465,10 @@ mod test {
 
     #[test]
     fn test_sum_with_zero() {
-        let config = field_config!(23);
-        let config = ConfigRef::from(&config);
-
         let values = [
             RandomField::zero(),
-            random_field!(5u32, config),
-            random_field!(7u32, config),
+            random_field!(5u32),
+            random_field!(7u32),
         ];
 
         let sum: RandomField<1, Fc23<1>> = values.iter().sum();
@@ -568,13 +478,10 @@ mod test {
 
     #[test]
     fn test_sum_wraps_modulus() {
-        let config = field_config!(23);
-        let config = ConfigRef::from(&config);
-
         let values = [
-            random_field!(10u32, config),
-            random_field!(15u32, config),
-            random_field!(21u32, config),
+            random_field!(10u32),
+            random_field!(15u32),
+            random_field!(21u32),
         ];
 
         let sum: RandomField<1, Fc23<1>> = values.iter().sum();
@@ -590,10 +497,7 @@ mod test {
 
     #[test]
     fn test_sum_single_element() {
-        let config = field_config!(23);
-        let config = ConfigRef::from(&config);
-
-        let values = [random_field!(9u32, config)];
+        let values = [random_field!(9u32)];
 
         let sum: RandomField<1, Fc23<1>> = values.iter().sum();
 
@@ -602,10 +506,7 @@ mod test {
 
     #[test]
     fn test_sum_with_modulus_wrapping() {
-        let config = field_config!(23);
-        let config = ConfigRef::from(&config);
-
-        let values = [random_field!(12u32, config), random_field!(15u32, config)];
+        let values = [random_field!(12u32), random_field!(15u32)];
 
         let sum: RandomField<1, Fc23<1>> = values.iter().sum();
 
@@ -614,13 +515,10 @@ mod test {
 
     #[test]
     fn test_product_of_multiple_values() {
-        let config = field_config!(23);
-        let config = ConfigRef::from(&config);
-
         let values = [
-            random_field!(2u32, config),
-            random_field!(4u32, config),
-            random_field!(6u32, config),
+            random_field!(2u32),
+            random_field!(4u32),
+            random_field!(6u32),
         ];
 
         let product: RandomField<1, Fc23<1>> = values.iter().product();
@@ -630,13 +528,10 @@ mod test {
 
     #[test]
     fn test_product_with_one() {
-        let config = field_config!(23);
-        let config = ConfigRef::from(&config);
-
         let values = [
             RandomField::one(),
-            random_field!(5u32, config),
-            random_field!(7u32, config),
+            random_field!(5u32),
+            random_field!(7u32),
         ];
 
         let product: RandomField<1, Fc23<1>> = values.iter().product();
@@ -646,12 +541,10 @@ mod test {
 
     #[test]
     fn test_product_with_zero() {
-        let config = field_config!(23);
-        let config = ConfigRef::from(&config);
         let values = [
-            random_field!(3u32, config),
+            random_field!(3u32),
             RandomField::zero(),
-            random_field!(9u32, config),
+            random_field!(9u32),
         ];
 
         let product: RandomField<1, Fc23<1>> = values.iter().product();
@@ -661,13 +554,10 @@ mod test {
 
     #[test]
     fn test_product_negative_modular_complements() {
-        let config = field_config!(23);
-        let config = ConfigRef::from(&config);
-
         let values = [
-            random_field!(10u32, config),
-            random_field!(15u32, config),
-            random_field!(21u32, config),
+            random_field!(10u32),
+            random_field!(15u32),
+            random_field!(21u32),
         ];
 
         let product: RandomField<1, Fc23<1>> = values.iter().product();
@@ -683,10 +573,7 @@ mod test {
 
     #[test]
     fn test_product_single_element() {
-        let config = field_config!(23);
-        let config = ConfigRef::from(&config);
-
-        let values = [random_field!(9u32, config)];
+        let values = [random_field!(9u32)];
 
         let product: RandomField<1, Fc23<1>> = values.iter().product();
 
@@ -695,10 +582,7 @@ mod test {
 
     #[test]
     fn test_product_with_modulus_wrapping() {
-        let config = field_config!(23);
-        let config = ConfigRef::from(&config);
-
-        let values = [random_field!(12u32, config), random_field!(15u32, config)];
+        let values = [random_field!(12u32), random_field!(15u32)];
 
         let product: RandomField<1, Fc23<1>> = values.iter().product();
 

--- a/zip-plus/src/field/biginteger/arithmetic.rs
+++ b/zip-plus/src/field/biginteger/arithmetic.rs
@@ -1,6 +1,6 @@
 #![allow(unused)]
 
-use ark_std::{vec, vec::Vec, Zero};
+use ark_std::{Zero, vec, vec::Vec};
 
 /// Sets a = a + b + carry, and returns the new carry.
 #[inline(always)]
@@ -201,16 +201,19 @@ pub fn find_naf(num: &[u64]) -> Vec<i8> {
 
 /// We define relaxed NAF as a variant of NAF with a very small tweak.
 ///
-/// Note that the cost of scalar multiplication grows with the length of the sequence (for doubling)
-/// plus the Hamming weight of the sequence (for addition, or subtraction).
+/// Note that the cost of scalar multiplication grows with the length of the
+/// sequence (for doubling) plus the Hamming weight of the sequence (for
+/// addition, or subtraction).
 ///
-/// NAF is optimizing for the Hamming weight only and therefore can be suboptimal.
-/// For example, NAF may generate a sequence (in little-endian) of the form ...0 -1 0 1.
+/// NAF is optimizing for the Hamming weight only and therefore can be
+/// suboptimal. For example, NAF may generate a sequence (in little-endian) of
+/// the form ...0 -1 0 1.
 ///
-/// This can be rewritten as ...0 1 1 to avoid one doubling, at the cost that we are making an
-/// exception of non-adjacence for the most significant bit.
+/// This can be rewritten as ...0 1 1 to avoid one doubling, at the cost that we
+/// are making an exception of non-adjacence for the most significant bit.
 ///
-/// Since this representation is no longer a strict NAF, we call it "relaxed NAF".
+/// Since this representation is no longer a strict NAF, we call it "relaxed
+/// NAF".
 pub fn find_relaxed_naf(num: &[u64]) -> Vec<i8> {
     let mut res = find_naf(num);
 

--- a/zip-plus/src/field/biginteger/mod.rs
+++ b/zip-plus/src/field/biginteger/mod.rs
@@ -119,9 +119,10 @@ impl<const N: usize> CanonicalDeserialize for BigInt<N> {
 #[macro_export]
 macro_rules! BigInt {
     ($c0:expr) => {{
+        use num_traits::ConstZero;
         let (is_positive, limbs) = ark_ff::ark_ff_macros::to_sign_and_limbs!($c0);
         assert!(is_positive);
-        let mut integer = <$crate::field::BigInt<_> as num_traits::ConstZero>::ZERO;
+        let mut integer = $crate::field::BigInt::ZERO;
         assert!(integer.0.len() >= limbs.len());
         $crate::const_for!((i in 0..(limbs.len())) {
             integer.0[i] = limbs[i];

--- a/zip-plus/src/field/biginteger/mod.rs
+++ b/zip-plus/src/field/biginteger/mod.rs
@@ -1,4 +1,4 @@
-use std::ops::{Add, Mul};
+use std::ops::{Add};
 #[allow(unused)]
 use ark_ff::ark_ff_macros::unroll_for_loops;
 use ark_ff::const_for;
@@ -26,7 +26,6 @@ use ark_std::{
 use num_bigint::BigUint;
 use num_traits::{CheckedAdd, ConstZero};
 use zeroize::Zeroize;
-use crypto_primitives::{IntRing, Ring};
 use crate::{
     adc,
     const_helpers::SerBuffer,

--- a/zip-plus/src/field/biginteger/mod.rs
+++ b/zip-plus/src/field/biginteger/mod.rs
@@ -38,7 +38,7 @@ use crate::{
 pub mod arithmetic;
 mod bits;
 #[derive(Copy, Clone, PartialEq, Eq, Hash, Zeroize)]
-pub struct BigInt<const N: usize>([u64; N]);
+pub struct BigInt<const N: usize>(pub [u64; N]);
 
 impl<const N: usize> From<[u64; N]> for BigInt<N> {
     #[inline]
@@ -119,9 +119,9 @@ impl<const N: usize> CanonicalDeserialize for BigInt<N> {
 #[macro_export]
 macro_rules! BigInt {
     ($c0:expr) => {{
-        let (is_positive, limbs) = $crate::ark_ff_macros::to_sign_and_limbs!($c0);
+        let (is_positive, limbs) = ark_ff::ark_ff_macros::to_sign_and_limbs!($c0);
         assert!(is_positive);
-        let mut integer = $crate::BigInt::zero();
+        let mut integer = <$crate::field::BigInt<_> as num_traits::ConstZero>::ZERO;
         assert!(integer.0.len() >= limbs.len());
         $crate::const_for!((i in 0..(limbs.len())) {
             integer.0[i] = limbs[i];

--- a/zip-plus/src/field/biginteger/mod.rs
+++ b/zip-plus/src/field/biginteger/mod.rs
@@ -462,7 +462,7 @@ impl<const N: usize> BigInt<N> {
         (lo, hi)
     }
 
-    #[inline]
+    // #[inline]
     pub fn div2(&mut self) {
         let mut t = 0;
         for a in self.0.iter_mut().rev() {

--- a/zip-plus/src/field/biginteger/mod.rs
+++ b/zip-plus/src/field/biginteger/mod.rs
@@ -1,4 +1,9 @@
-use std::ops::{Add};
+use crate::{
+    adc,
+    const_helpers::SerBuffer,
+    field::{Int, config},
+    traits::{BigInteger, FromBytes, Integer, Uinteger},
+};
 #[allow(unused)]
 use ark_ff::ark_ff_macros::unroll_for_loops;
 use ark_ff::const_for;
@@ -7,6 +12,7 @@ use ark_serialize::{
 };
 use ark_std::ops::{Index, IndexMut, Range, RangeTo};
 use ark_std::{
+    Zero,
     borrow::Borrow,
     // convert::TryFrom,
     fmt::{Debug, Display, UpperHex},
@@ -16,22 +22,16 @@ use ark_std::{
         ShrAssign,
     },
     rand::{
-        distributions::{Distribution, Standard},
         Rng,
+        distributions::{Distribution, Standard},
     },
     str::FromStr,
     vec::Vec,
-    Zero,
 };
 use num_bigint::BigUint;
 use num_traits::{CheckedAdd, ConstZero};
+use std::ops::Add;
 use zeroize::Zeroize;
-use crate::{
-    adc,
-    const_helpers::SerBuffer,
-    field::{config, Int},
-    traits::{BigInteger, FromBytes, Integer, Uinteger},
-};
 
 #[macro_use]
 pub mod arithmetic;
@@ -211,7 +211,8 @@ impl<const N: usize> BigInt<N> {
         true
     }
 
-    /// Compute the largest integer `s` such that `self = 2**s * t + 1` for odd `t`.
+    /// Compute the largest integer `s` such that `self = 2**s * t + 1` for odd
+    /// `t`.
     #[doc(hidden)]
     pub const fn two_adic_valuation(mut self) -> u32 {
         assert!(self.const_is_odd());
@@ -226,8 +227,8 @@ impl<const N: usize> BigInt<N> {
         two_adicity
     }
 
-    /// Compute the smallest odd integer `t` such that `self = 2**s * t + 1` for some
-    /// integer `s = self.two_adic_valuation()`.
+    /// Compute the smallest odd integer `t` such that `self = 2**s * t + 1` for
+    /// some integer `s = self.two_adic_valuation()`.
     #[doc(hidden)]
     pub const fn two_adic_coefficient(mut self) -> Self {
         assert!(self.const_is_odd());
@@ -620,6 +621,7 @@ impl<const N: usize> CheckedAdd for BigInt<N> {
 
 impl<const N: usize> BigInteger for BigInt<N> {
     type W = Words<N>;
+
     fn to_words(&self) -> Words<N> {
         Words(self.0)
     }
@@ -1136,8 +1138,8 @@ impl<const N: usize> FromBytes for BigInt<N> {
     }
 }
 
-/// Compute the signed modulo operation on a u64 representation, returning the result.
-/// If n % modulus > modulus / 2, return modulus - n
+/// Compute the signed modulo operation on a u64 representation, returning the
+/// result. If n % modulus > modulus / 2, return modulus - n
 /// # Example
 /// ```
 /// use ark_ff::signed_mod_reduction;

--- a/zip-plus/src/field/comparison.rs
+++ b/zip-plus/src/field/comparison.rs
@@ -1,12 +1,6 @@
 use ark_ff::{One, Zero};
 
-use crate::{
-    field::{
-        RandomField,
-        BigInt,
-    },
-};
-use crate::field::config::FieldConfig;
+use crate::field::{BigInt, RandomField, config::FieldConfig};
 
 impl<const N: usize, FC: FieldConfig<BigInt<N>>> PartialEq for RandomField<N, FC> {
     fn eq(&self, other: &Self) -> bool {

--- a/zip-plus/src/field/comparison.rs
+++ b/zip-plus/src/field/comparison.rs
@@ -6,8 +6,9 @@ use crate::{
     },
     traits::Field,
 };
+use crate::field::config::ConstFieldConfig;
 
-impl<const N: usize> PartialEq for RandomField<'_, N> {
+impl<const N: usize, FC: ConstFieldConfig<N>> PartialEq for RandomField<'_, N, FC> {
     fn eq(&self, other: &Self) -> bool {
         if self.is_one() & other.is_one() {
             return true;
@@ -26,4 +27,4 @@ impl<const N: usize> PartialEq for RandomField<'_, N> {
     }
 }
 
-impl<const N: usize> Eq for RandomField<'_, N> {} // Eq requires PartialEq and ensures reflexivity.
+impl<const N: usize, FC: ConstFieldConfig<N>> Eq for RandomField<'_, N, FC> {} // Eq requires PartialEq and ensures reflexivity.

--- a/zip-plus/src/field/comparison.rs
+++ b/zip-plus/src/field/comparison.rs
@@ -3,12 +3,12 @@ use ark_ff::{One, Zero};
 use crate::{
     field::{
         RandomField,
+        BigInt,
     },
-    traits::Field,
 };
-use crate::field::config::ConstFieldConfig;
+use crate::field::config::FieldConfig;
 
-impl<const N: usize, FC: ConstFieldConfig<N>> PartialEq for RandomField<'_, N, FC> {
+impl<const N: usize, FC: FieldConfig<BigInt<N>>> PartialEq for RandomField<N, FC> {
     fn eq(&self, other: &Self) -> bool {
         if self.is_one() & other.is_one() {
             return true;
@@ -17,8 +17,8 @@ impl<const N: usize, FC: ConstFieldConfig<N>> PartialEq for RandomField<'_, N, F
             return true;
         }
 
-        self.value == other.value && self.config_ptr() == other.config_ptr()
+        self.value == other.value
     }
 }
 
-impl<const N: usize, FC: ConstFieldConfig<N>> Eq for RandomField<'_, N, FC> {} // Eq requires PartialEq and ensures reflexivity.
+impl<const N: usize, FC: FieldConfig<BigInt<N>>> Eq for RandomField<N, FC> {} // Eq requires PartialEq and ensures reflexivity.

--- a/zip-plus/src/field/comparison.rs
+++ b/zip-plus/src/field/comparison.rs
@@ -17,13 +17,7 @@ impl<const N: usize, FC: ConstFieldConfig<N>> PartialEq for RandomField<'_, N, F
             return true;
         }
 
-        match (self.config, other.config) {
-            (Some(_), None) | (None, Some(_)) => false,
-            (None, None) => self.value() == other.value(),
-            (Some(_), Some(_)) => {
-                self.value() == other.value() && self.config_ptr() == other.config_ptr()
-            }
-        }
+        self.value == other.value && self.config_ptr() == other.config_ptr()
     }
 }
 

--- a/zip-plus/src/field/config.rs
+++ b/zip-plus/src/field/config.rs
@@ -52,28 +52,52 @@ pub struct FieldConfig<const N: usize> {
 
 pub trait ConstFieldConfig<const N: usize>: Clone {
     /// The modulus of the field.
-    const MODULUS: BigInt<N>;
+    // const MODULUS: BigInt<N>;
+
+    fn modulus() -> BigInt<N>;
 
     /// Let `M` be the power of 2^64 nearest to `Self::MODULUS_BITS`. Then
     /// `R = M % Self::MODULUS`.
-    const R: BigInt<N> = Self::MODULUS.montgomery_r();
+    // const R: BigInt<N> = Self::MODULUS.montgomery_r();
+
+    fn r() -> BigInt<N> {
+        Self::modulus().montgomery_r()
+    }
 
     /// `R^2 = R * R mod MODULUS`
-    const R_SQUARED: BigInt<N> = Self::MODULUS.montgomery_r2();
+    // const R_SQUARED: BigInt<N> = Self::MODULUS.montgomery_r2();
+
+    fn r_squared() -> BigInt<N> {
+        Self::modulus().montgomery_r2()
+    }
 
     /// Does the modulus have a spare unused bit
     ///
     /// This condition applies if
     /// (a) `Self::MODULUS[N-1] >> 63 == 0`
-    const MODULUS_HAS_SPARE_BIT: bool = Self::MODULUS.has_spare_bit();
+    // const MODULUS_HAS_SPARE_BIT: bool = Self::MODULUS.has_spare_bit();
 
-    const FIELD_CONFIG: FieldConfig<N> = FieldConfig {
-        modulus: Self::MODULUS,
-        r: Self::R,
-        r2: Self::R_SQUARED,
-        inv: inv(Self::MODULUS),
-        modulus_has_spare_bit: Self::MODULUS_HAS_SPARE_BIT,
-    };
+    fn modulus_has_spare_bit() -> bool {
+        Self::modulus().has_spare_bit()
+    }
+
+    // const FIELD_CONFIG: FieldConfig<N> = FieldConfig {
+    //     modulus: Self::MODULUS,
+    //     r: Self::R,
+    //     r2: Self::R_SQUARED,
+    //     inv: inv(Self::MODULUS),
+    //     modulus_has_spare_bit: Self::MODULUS_HAS_SPARE_BIT,
+    // };
+
+    fn field_config() -> FieldConfig<N> {
+        FieldConfig {
+            modulus: Self::modulus(),
+            r: Self::r(),
+            r2: Self::r_squared(),
+            inv: inv(Self::modulus()),
+            modulus_has_spare_bit: Self::modulus_has_spare_bit(),
+        }
+    }
 }
 
 #[macro_export]
@@ -83,7 +107,10 @@ macro_rules! define_field_config {
         struct $name<const N: usize>;
 
         impl<const N: usize> $crate::field::config::ConstFieldConfig<N> for $name<N> {
-            const MODULUS: $crate::field::BigInt<N> = $crate::BigInt!($modulus);
+            //const MODULUS: $crate::field::BigInt<N> = $crate::BigInt!($modulus);
+            fn modulus() -> $crate::field::BigInt<N> {
+                $crate::BigInt!($modulus)
+            }
         }
     };
 }

--- a/zip-plus/src/field/config.rs
+++ b/zip-plus/src/field/config.rs
@@ -1,7 +1,5 @@
+use crate::field::BigInt;
 use num_traits::Zero;
-use crate::{
-    field::BigInt,
-};
 
 #[macro_export]
 macro_rules! mac_with_carry {
@@ -51,7 +49,6 @@ pub trait ConstFieldConfigBase1<T> {
     /// The modulus of the field.
     const MODULUS: T;
 }
-
 
 pub trait ConstFieldConfigBase2<T> {
     /// Let `M` be the power of 2^64 nearest to `Self::MODULUS_BITS`. Then
@@ -105,10 +102,10 @@ impl<const N: usize, C> ConstFieldConfigBase2<BigInt<N>> for C
 where
     C: ConstFieldConfigBase1<BigInt<N>>,
 {
+    const INV: u64 = inv(C::MODULUS);
+    const MODULUS_HAS_SPARE_BIT: bool = C::MODULUS.has_spare_bit();
     const R: BigInt<N> = C::MODULUS.montgomery_r();
     const R_SQUARED: BigInt<N> = C::MODULUS.montgomery_r2();
-    const MODULUS_HAS_SPARE_BIT: bool = C::MODULUS.has_spare_bit();
-    const INV: u64 = inv(C::MODULUS);
 }
 
 pub trait FieldConfigOps<T> {
@@ -217,11 +214,7 @@ where
             }
         }
 
-        if u == one {
-            Some(b)
-        } else {
-            Some(c)
-        }
+        if u == one { Some(b) } else { Some(c) }
     }
 
     #[inline(always)]
@@ -245,7 +238,9 @@ macro_rules! define_field_config {
         #[derive(Clone, Debug)]
         struct $name<const N: usize>;
 
-        impl<const N: usize> $crate::field::config::ConstFieldConfigBase1<$crate::field::BigInt<N>> for $name<N> {
+        impl<const N: usize> $crate::field::config::ConstFieldConfigBase1<$crate::field::BigInt<N>>
+            for $name<N>
+        {
             const MODULUS: $crate::field::BigInt<N> = $crate::BigInt!($modulus);
         }
     };
@@ -278,10 +273,12 @@ fn widening_mul(a: u64, b: u64) -> u128 {
 
 #[cfg(test)]
 mod tests {
+    use super::{ConstFieldConfigBase1, FieldConfig, FieldConfigOps};
+    use crate::{
+        big_int,
+        field::{BigInt, BigInteger128},
+    };
     use num_traits::ConstZero;
-    use super::{FieldConfig, ConstFieldConfigBase1, FieldConfigOps};
-    use crate::{big_int, field::BigInteger128};
-    use crate::field::BigInt;
 
     //BIGINTS ARE LITTLE ENDIAN!!
     #[test]
@@ -290,9 +287,8 @@ mod tests {
         struct Fc;
 
         impl ConstFieldConfigBase1<BigInt<2>> for Fc {
-            const MODULUS: BigInteger128 = {
-                BigInteger128::new([9307119299070690521, 9320126393725433252])
-            };
+            const MODULUS: BigInteger128 =
+                { BigInteger128::new([9307119299070690521, 9320126393725433252]) };
         }
 
         let mut a = BigInteger128::new([2, 0]);
@@ -307,9 +303,8 @@ mod tests {
         struct Fc;
 
         impl ConstFieldConfigBase1<BigInt<2>> for Fc {
-            const MODULUS: BigInteger128 = {
-                BigInteger128::new([9307119299070690521, 9320126393725433252])
-            };
+            const MODULUS: BigInteger128 =
+                { BigInteger128::new([9307119299070690521, 9320126393725433252]) };
         }
 
         let mut a = BigInteger128::new([2, 0]);

--- a/zip-plus/src/field/config.rs
+++ b/zip-plus/src/field/config.rs
@@ -50,6 +50,44 @@ pub struct FieldConfig<const N: usize> {
     modulus_has_spare_bit: bool,
 }
 
+pub trait ConstFieldConfig<const N: usize>: Clone {
+    /// The modulus of the field.
+    const MODULUS: BigInt<N>;
+
+    /// Let `M` be the power of 2^64 nearest to `Self::MODULUS_BITS`. Then
+    /// `R = M % Self::MODULUS`.
+    const R: BigInt<N> = Self::MODULUS.montgomery_r();
+
+    /// `R^2 = R * R mod MODULUS`
+    const R_SQUARED: BigInt<N> = Self::MODULUS.montgomery_r2();
+
+    /// Does the modulus have a spare unused bit
+    ///
+    /// This condition applies if
+    /// (a) `Self::MODULUS[N-1] >> 63 == 0`
+    const MODULUS_HAS_SPARE_BIT: bool = Self::MODULUS.has_spare_bit();
+
+    const FIELD_CONFIG: FieldConfig<N> = FieldConfig {
+        modulus: Self::MODULUS,
+        r: Self::R,
+        r2: Self::R_SQUARED,
+        inv: inv(Self::MODULUS),
+        modulus_has_spare_bit: Self::MODULUS_HAS_SPARE_BIT,
+    };
+}
+
+#[macro_export]
+macro_rules! define_field_config {
+    ($name:ident, $modulus:expr) => {
+        #[derive(Clone, Debug)]
+        struct $name<const N: usize>;
+
+        impl<const N: usize> $crate::field::config::ConstFieldConfig<N> for $name<N> {
+            const MODULUS: $crate::field::BigInt<N> = $crate::BigInt!($modulus);
+        }
+    };
+}
+
 impl<const N: usize> FieldConfig<N> {
     pub fn add_assign(&self, a: &mut BigInt<N>, b: &BigInt<N>) {
         // This cannot exceed the backing capacity.

--- a/zip-plus/src/field/config.rs
+++ b/zip-plus/src/field/config.rs
@@ -1,7 +1,6 @@
 use num_traits::Zero;
 use crate::{
     field::BigInt,
-    traits::{Config, ConfigReference},
 };
 
 #[macro_export]
@@ -27,121 +26,90 @@ pub fn mac_with_carry(a: u64, b: u64, c: u64, carry: &mut u64) -> u64 {
     tmp as u64
 }
 
-#[derive(Clone, Copy, Default)]
-pub struct FieldConfig<const N: usize> {
+pub trait FieldConfigBase<T> {
     /// The modulus of the field.
-    modulus: BigInt<N>,
+    fn modulus() -> T;
+}
 
+pub trait FieldConfigOps<T> {
     /// Let `M` be the power of 2^64 nearest to `Self::MODULUS_BITS`. Then
     /// `R = M % Self::MODULUS`.
-    r: BigInt<N>,
+    fn r() -> T;
 
-    /// R2 = R^2 % Self::MODULUS
-    r2: BigInt<N>,
-
-    /// INV = -MODULUS^{-1} mod 2^64
-    inv: u64,
+    /// `R^2 = R * R mod MODULUS`
+    fn r_squared() -> T;
 
     /// Does the modulus have a spare unused bit
     ///
     /// This condition applies if
     /// (a) `Self::MODULUS[N-1] >> 63 == 0`
-    #[doc(hidden)]
-    modulus_has_spare_bit: bool,
+    fn modulus_has_spare_bit() -> bool;
+
+    /// INV = -MODULUS^{-1} mod 2^64
+    fn inv() -> u64;
+
+    fn add_assign(a: &mut T, b: &T);
+
+    fn sub_assign(a: &mut T, b: &T);
+
+    fn reduce_modulus(a: &mut T, carry: bool);
+
+    fn inverse(a: &T) -> Option<T>;
+
+    fn mul_assign(a: &mut T, b: &T);
 }
 
-pub trait ConstFieldConfig<const N: usize>: Clone {
-    /// The modulus of the field.
-    // const MODULUS: BigInt<N>;
 
-    fn modulus() -> BigInt<N>;
-
-    /// Let `M` be the power of 2^64 nearest to `Self::MODULUS_BITS`. Then
-    /// `R = M % Self::MODULUS`.
-    // const R: BigInt<N> = Self::MODULUS.montgomery_r();
-
+impl<const N: usize, T> FieldConfigOps<BigInt<N>> for T
+where
+    T: FieldConfigBase<BigInt<N>>,
+{
+    #[inline(always)]
     fn r() -> BigInt<N> {
         Self::modulus().montgomery_r()
     }
 
-    /// `R^2 = R * R mod MODULUS`
-    // const R_SQUARED: BigInt<N> = Self::MODULUS.montgomery_r2();
-
+    #[inline(always)]
     fn r_squared() -> BigInt<N> {
         Self::modulus().montgomery_r2()
     }
 
-    /// Does the modulus have a spare unused bit
-    ///
-    /// This condition applies if
-    /// (a) `Self::MODULUS[N-1] >> 63 == 0`
-    // const MODULUS_HAS_SPARE_BIT: bool = Self::MODULUS.has_spare_bit();
-
+    #[inline(always)]
     fn modulus_has_spare_bit() -> bool {
         Self::modulus().has_spare_bit()
     }
 
-    // const FIELD_CONFIG: FieldConfig<N> = FieldConfig {
-    //     modulus: Self::MODULUS,
-    //     r: Self::R,
-    //     r2: Self::R_SQUARED,
-    //     inv: inv(Self::MODULUS),
-    //     modulus_has_spare_bit: Self::MODULUS_HAS_SPARE_BIT,
-    // };
-
-    fn field_config() -> FieldConfig<N> {
-        FieldConfig {
-            modulus: Self::modulus(),
-            r: Self::r(),
-            r2: Self::r_squared(),
-            inv: inv(Self::modulus()),
-            modulus_has_spare_bit: Self::modulus_has_spare_bit(),
-        }
+    #[inline(always)]
+    fn inv() -> u64 {
+        inv(Self::modulus())
     }
-}
 
-#[macro_export]
-macro_rules! define_field_config {
-    ($name:ident, $modulus:expr) => {
-        #[derive(Clone, Debug)]
-        struct $name<const N: usize>;
-
-        impl<const N: usize> $crate::field::config::ConstFieldConfig<N> for $name<N> {
-            //const MODULUS: $crate::field::BigInt<N> = $crate::BigInt!($modulus);
-            fn modulus() -> $crate::field::BigInt<N> {
-                $crate::BigInt!($modulus)
-            }
-        }
-    };
-}
-
-impl<const N: usize> FieldConfig<N> {
-    pub fn add_assign(&self, a: &mut BigInt<N>, b: &BigInt<N>) {
+    fn add_assign(a: &mut BigInt<N>, b: &BigInt<N>) {
         // This cannot exceed the backing capacity.
         let c = a.add_with_carry(b);
         // However, it may need to be reduced
-        self.reduce_modulus(a, c);
+        Self::reduce_modulus(a, c);
     }
 
-    pub fn sub_assign(&self, a: &mut BigInt<N>, b: &BigInt<N>) {
+    fn sub_assign(a: &mut BigInt<N>, b: &BigInt<N>) {
         // If `other` is larger than `self`, add the modulus to self first.
         if b > a {
-            a.add_with_carry(&self.modulus);
+            a.add_with_carry(&Self::modulus());
         }
         a.sub_with_borrow(b);
     }
 
-    fn reduce_modulus(&self, a: &mut BigInt<{ N }>, carry: bool) {
-        if self.modulus_has_spare_bit {
-            if *a >= self.modulus {
-                a.sub_with_borrow(&self.modulus);
+    fn reduce_modulus(a: &mut BigInt<{ N }>, carry: bool) {
+        if Self::modulus_has_spare_bit() {
+            if *a >= Self::modulus() {
+                a.sub_with_borrow(&Self::modulus());
             }
-        } else if carry || *a >= self.modulus {
-            a.sub_with_borrow(&self.modulus);
+        } else if carry || *a >= Self::modulus() {
+            a.sub_with_borrow(&Self::modulus());
         }
     }
 
-    pub fn inverse(&self, a: &BigInt<N>) -> Option<BigInt<N>> {
+    fn inverse(a: &BigInt<N>) -> Option<BigInt<N>> {
         if a.is_zero() {
             return None;
         }
@@ -154,8 +122,8 @@ impl<const N: usize> FieldConfig<N> {
         let one = BigInt::one();
 
         let mut u = *a;
-        let mut v = self.modulus;
-        let mut b = self.r2; // Avoids unnecessary reduction step.
+        let mut v = Self::modulus();
+        let mut b = Self::r_squared(); // Avoids unnecessary reduction step.
         let mut c = BigInt::zero();
 
         while u != one && v != one {
@@ -165,9 +133,9 @@ impl<const N: usize> FieldConfig<N> {
                 if b.is_even() {
                     b.div2();
                 } else {
-                    let carry = b.add_with_carry(&self.modulus);
+                    let carry = b.add_with_carry(&Self::modulus());
                     b.div2();
-                    if !self.modulus_has_spare_bit && carry {
+                    if !Self::modulus_has_spare_bit() && carry {
                         *b.last_mut() |= 1 << 63;
                     }
                 }
@@ -179,10 +147,10 @@ impl<const N: usize> FieldConfig<N> {
                 if c.is_even() {
                     c.div2();
                 } else {
-                    let carry = c.add_with_carry(&self.modulus);
+                    let carry = c.add_with_carry(&Self::modulus());
                     c.div2();
 
-                    if !self.modulus_has_spare_bit && carry {
+                    if !Self::modulus_has_spare_bit() && carry {
                         *c.last_mut() |= 1 << 63;
                     }
                 }
@@ -192,14 +160,14 @@ impl<const N: usize> FieldConfig<N> {
                 u.sub_with_borrow(&v);
 
                 if c > b {
-                    b.add_with_carry(&self.modulus);
+                    b.add_with_carry(&Self::modulus());
                 }
                 b.sub_with_borrow(&c);
             } else {
                 v.sub_with_borrow(&u);
 
                 if b > c {
-                    c.add_with_carry(&self.modulus);
+                    c.add_with_carry(&Self::modulus());
                 }
 
                 c.sub_with_borrow(&b);
@@ -213,53 +181,37 @@ impl<const N: usize> FieldConfig<N> {
         }
     }
 
-    #[inline]
-    pub fn r(&self) -> &BigInt<N> {
-        &self.r
-    }
-
-    #[inline]
-    pub fn inv(&self) -> u64 {
-        self.inv
-    }
-}
-
-impl<const N: usize> Config for FieldConfig<N> {
-    type B = BigInt<N>;
-    fn modulus(&self) -> &BigInt<N> {
-        &self.modulus
-    }
-
-    fn mul_assign(&self, a: &mut BigInt<N>, b: &BigInt<N>) {
+    fn mul_assign(a: &mut BigInt<N>, b: &BigInt<N>) {
         let (mut lo, mut hi) = a.mul_naive(b);
 
         // Montgomery reduction
-        let carry = a.montgomery_reduction(&mut lo, &mut hi, &self.modulus, self.inv);
+        let carry = a.montgomery_reduction(&mut lo, &mut hi, &Self::modulus(), Self::inv());
 
-        self.reduce_modulus(a, carry);
-    }
-
-    fn r2(&self) -> &BigInt<N> {
-        &self.r2
-    }
-
-    fn new(modulus: BigInt<N>) -> Self {
-        let modulus_has_spare_bit = modulus.has_spare_bit();
-        Self {
-            modulus,
-            r: modulus.montgomery_r(),
-            r2: modulus.montgomery_r2(),
-            inv: inv(modulus),
-
-            modulus_has_spare_bit,
-        }
+        Self::reduce_modulus(a, carry);
     }
 }
 
-impl<const N: usize> ark_std::fmt::Debug for FieldConfig<N> {
-    fn fmt(&self, f: &mut ark_std::fmt::Formatter<'_>) -> ark_std::fmt::Result {
-        write!(f, " Z_{}", self.modulus,)
-    }
+pub trait FieldConfig<T>: FieldConfigBase<T> + FieldConfigOps<T> + Clone {}
+
+impl<T> FieldConfig<T> for T where T: FieldConfigBase<T> + FieldConfigOps<T> + Clone {}
+
+#[macro_export]
+macro_rules! define_field_config {
+    ($name:ident, $modulus:expr) => {
+        #[derive(Clone, Debug)]
+        struct $name<const N: usize>;
+
+        impl<const N: usize> $crate::field::config::FieldConfigBase<$crate::field::BigInt<N>> for $name<N> {
+            //const MODULUS: $crate::field::BigInt<N> = $crate::BigInt!($modulus);
+            #[inline(always)]
+            fn modulus() -> $crate::field::BigInt<N> {
+                $crate::BigInt!($modulus)
+            }
+        }
+
+        // TODO: Why is this not covered by the blanket impl above?
+        impl<const N: usize> $crate::field::config::FieldConfig<$crate::field::BigInt<N>> for $name<N> {}
+    };
 }
 
 /// Compute -M^{-1} mod 2^64.
@@ -287,130 +239,55 @@ fn widening_mul(a: u64, b: u64) -> u128 {
     a as u128 * b as u128
 }
 
-impl<const N: usize> PartialEq for FieldConfig<N> {
-    fn eq(&self, other: &Self) -> bool {
-        self.modulus == other.modulus
-    }
-}
-
-impl<const N: usize> Eq for FieldConfig<N> {}
-
-#[allow(dead_code)]
-#[derive(Debug)]
-pub struct DebugFieldConfig {
-    /// The modulus of the field.
-    modulus: num_bigint::BigInt,
-
-    /// Let `M` be the power of 2^64 nearest to `Self::MODULUS_BITS`. Then
-    /// `R = M % Self::MODULUS`.
-    r: num_bigint::BigInt,
-
-    /// R2 = R^2 % Self::MODULUS
-    r2: num_bigint::BigInt,
-
-    /// INV = -MODULUS^{-1} mod 2^64
-    inv: u64,
-
-    /// Does the modulus have a spare unused bit
-    ///
-    /// This condition applies if
-    /// (a) `Self::MODULUS[N-1] >> 63 == 0`
-    #[doc(hidden)]
-    modulus_has_spare_bit: bool,
-}
-
-impl<const N: usize> From<FieldConfig<N>> for DebugFieldConfig {
-    fn from(value: FieldConfig<N>) -> Self {
-        Self {
-            modulus: value.modulus.into(),
-            r: value.r.into(),
-            r2: value.r2.into(),
-            inv: value.inv,
-            modulus_has_spare_bit: value.modulus_has_spare_bit,
-        }
-    }
-}
-
-/// A wrapper around an optional reference to a `FieldConfig`.
-///
-/// This struct is used to represent a pointer to a `FieldConfig` instance,
-/// allowing for safe handling of nullable references. It provides methods
-/// to access the underlying reference or raw pointer.
-///
-/// # Type Parameters
-/// - `'cfg`: The lifetime of the `FieldConfig` reference.
-/// - `N`: The size of the `FieldConfig` (e.g., the number of limbs in the `BigInt` modulus).
-#[derive(Debug, Copy, Clone, Eq)]
-pub struct ConfigRef<'cfg, const N: usize>(Option<&'cfg FieldConfig<N>>);
-
-impl<'cfg, const N: usize> ConfigReference for ConfigRef<'cfg, N> {
-    type C = FieldConfig<N>;
-    fn reference(&self) -> Option<&'cfg FieldConfig<N>> {
-        self.0
-    }
-
-    unsafe fn new(config_ptr: *mut FieldConfig<N>) -> Self {
-        Self(Option::from(unsafe { config_ptr.as_ref() }.unwrap()))
-    }
-
-    fn pointer(&self) -> Option<*mut FieldConfig<N>> {
-        self.0.map(|p| p as *const _ as *mut _)
-    }
-
-    const NONE: Self = Self(None);
-}
-
-impl<const N: usize> PartialEq for ConfigRef<'_, N> {
-    fn eq(&self, other: &Self) -> bool {
-        self.reference() == other.reference()
-    }
-}
-
-impl<'cfg, const N: usize> From<&'cfg FieldConfig<N>> for ConfigRef<'cfg, N> {
-    fn from(value: &'cfg FieldConfig<N>) -> Self {
-        Self(Some(value))
-    }
-}
-
-unsafe impl<const N: usize> Sync for ConfigRef<'_, N> {}
-unsafe impl<const N: usize> Send for ConfigRef<'_, N> {}
-
 #[cfg(test)]
 mod tests {
     use num_traits::ConstZero;
-    use super::FieldConfig;
-    use crate::{big_int, field::BigInteger128, field_config, traits::Config};
+    use super::{FieldConfig, FieldConfigBase, FieldConfigOps};
+    use crate::{big_int, field::BigInteger128};
+    use crate::field::BigInt;
+
     //BIGINTS ARE LITTLE ENDIAN!!
     #[test]
     fn test_addition() {
-        let field = FieldConfig::new(BigInteger128::new([
-            9307119299070690521,
-            9320126393725433252,
-        ]));
+        #[derive(Clone, Debug)]
+        struct Fc;
+
+        impl FieldConfigBase<BigInt<2>> for Fc {
+            fn modulus() -> BigInteger128 {
+                BigInteger128::new([9307119299070690521, 9320126393725433252])
+            }
+        }
+
         let mut a = BigInteger128::new([2, 0]);
         let b = BigInteger128::new([2, 0]);
-        field.add_assign(&mut a, &b);
+        Fc::add_assign(&mut a, &b);
         assert_eq!(a, BigInteger128::new([4, 0]));
     }
 
     #[test]
     fn test_subtraction() {
-        let field = FieldConfig::new(BigInteger128::new([
-            9307119299070690521,
-            9320126393725433252,
-        ]));
+        #[derive(Clone, Debug)]
+        struct Fc;
+
+        impl FieldConfigBase<BigInt<2>> for Fc {
+            fn modulus() -> BigInteger128 {
+                BigInteger128::new([9307119299070690521, 9320126393725433252])
+            }
+        }
+
         let mut a = BigInteger128::new([2, 0]);
         let b = BigInteger128::new([2, 0]);
-        field.sub_assign(&mut a, &b);
+        Fc::sub_assign(&mut a, &b);
         assert_eq!(a, BigInteger128::ZERO);
     }
 
     #[test]
     fn test_multiplication() {
-        let field = field_config!(695962179703626800597079116051991347);
+        define_field_config!(Fc, "695962179703626800597079116051991347");
+
         let mut a = big_int!(423024736033, 4);
         let b = big_int!(246308734);
-        field.mul_assign(&mut a, &b);
+        Fc::mul_assign(&mut a, &b);
 
         assert_eq!(big_int!(504579159360957705315139767875358506), a);
     }

--- a/zip-plus/src/field/config.rs
+++ b/zip-plus/src/field/config.rs
@@ -29,9 +29,7 @@ pub fn mac_with_carry(a: u64, b: u64, c: u64, carry: &mut u64) -> u64 {
 pub trait FieldConfigBase<T> {
     /// The modulus of the field.
     fn modulus() -> T;
-}
 
-pub trait FieldConfigOps<T> {
     /// Let `M` be the power of 2^64 nearest to `Self::MODULUS_BITS`. Then
     /// `R = M % Self::MODULUS`.
     fn r() -> T;
@@ -47,7 +45,73 @@ pub trait FieldConfigOps<T> {
 
     /// INV = -MODULUS^{-1} mod 2^64
     fn inv() -> u64;
+}
 
+pub trait ConstFieldConfigBase1<T> {
+    /// The modulus of the field.
+    const MODULUS: T;
+}
+
+
+pub trait ConstFieldConfigBase2<T> {
+    /// Let `M` be the power of 2^64 nearest to `Self::MODULUS_BITS`. Then
+    /// `R = M % Self::MODULUS`.
+    const R: T;
+
+    /// `R^2 = R * R mod MODULUS`
+    const R_SQUARED: T;
+
+    /// Does the modulus have a spare unused bit
+    ///
+    /// This condition applies if
+    /// (a) `Self::MODULUS[N-1] >> 63 == 0`
+    const MODULUS_HAS_SPARE_BIT: bool;
+
+    /// INV = -MODULUS^{-1} mod 2^64
+    const INV: u64;
+}
+
+impl<T, C> FieldConfigBase<T> for C
+where
+    C: ConstFieldConfigBase1<T> + ConstFieldConfigBase2<T>,
+{
+    #[inline(always)]
+    fn modulus() -> T {
+        C::MODULUS
+    }
+
+    #[inline(always)]
+    fn r() -> T {
+        C::R
+    }
+
+    #[inline(always)]
+    fn r_squared() -> T {
+        C::R_SQUARED
+    }
+
+    #[inline(always)]
+    fn modulus_has_spare_bit() -> bool {
+        C::MODULUS_HAS_SPARE_BIT
+    }
+
+    #[inline(always)]
+    fn inv() -> u64 {
+        C::INV
+    }
+}
+
+impl<const N: usize, C> ConstFieldConfigBase2<BigInt<N>> for C
+where
+    C: ConstFieldConfigBase1<BigInt<N>>,
+{
+    const R: BigInt<N> = C::MODULUS.montgomery_r();
+    const R_SQUARED: BigInt<N> = C::MODULUS.montgomery_r2();
+    const MODULUS_HAS_SPARE_BIT: bool = C::MODULUS.has_spare_bit();
+    const INV: u64 = inv(C::MODULUS);
+}
+
+pub trait FieldConfigOps<T> {
     fn add_assign(a: &mut T, b: &T);
 
     fn sub_assign(a: &mut T, b: &T);
@@ -59,31 +123,10 @@ pub trait FieldConfigOps<T> {
     fn mul_assign(a: &mut T, b: &T);
 }
 
-
 impl<const N: usize, T> FieldConfigOps<BigInt<N>> for T
 where
     T: FieldConfigBase<BigInt<N>>,
 {
-    #[inline(always)]
-    fn r() -> BigInt<N> {
-        Self::modulus().montgomery_r()
-    }
-
-    #[inline(always)]
-    fn r_squared() -> BigInt<N> {
-        Self::modulus().montgomery_r2()
-    }
-
-    #[inline(always)]
-    fn modulus_has_spare_bit() -> bool {
-        Self::modulus().has_spare_bit()
-    }
-
-    #[inline(always)]
-    fn inv() -> u64 {
-        inv(Self::modulus())
-    }
-
     fn add_assign(a: &mut BigInt<N>, b: &BigInt<N>) {
         // This cannot exceed the backing capacity.
         let c = a.add_with_carry(b);
@@ -181,6 +224,7 @@ where
         }
     }
 
+    #[inline(always)]
     fn mul_assign(a: &mut BigInt<N>, b: &BigInt<N>) {
         let (mut lo, mut hi) = a.mul_naive(b);
 
@@ -193,7 +237,7 @@ where
 
 pub trait FieldConfig<T>: FieldConfigBase<T> + FieldConfigOps<T> + Clone {}
 
-impl<T> FieldConfig<T> for T where T: FieldConfigBase<T> + FieldConfigOps<T> + Clone {}
+impl<T, C> FieldConfig<T> for C where C: FieldConfigBase<T> + FieldConfigOps<T> + Clone {}
 
 #[macro_export]
 macro_rules! define_field_config {
@@ -201,16 +245,9 @@ macro_rules! define_field_config {
         #[derive(Clone, Debug)]
         struct $name<const N: usize>;
 
-        impl<const N: usize> $crate::field::config::FieldConfigBase<$crate::field::BigInt<N>> for $name<N> {
-            //const MODULUS: $crate::field::BigInt<N> = $crate::BigInt!($modulus);
-            #[inline(always)]
-            fn modulus() -> $crate::field::BigInt<N> {
-                $crate::BigInt!($modulus)
-            }
+        impl<const N: usize> $crate::field::config::ConstFieldConfigBase1<$crate::field::BigInt<N>> for $name<N> {
+            const MODULUS: $crate::field::BigInt<N> = $crate::BigInt!($modulus);
         }
-
-        // TODO: Why is this not covered by the blanket impl above?
-        impl<const N: usize> $crate::field::config::FieldConfig<$crate::field::BigInt<N>> for $name<N> {}
     };
 }
 
@@ -242,7 +279,7 @@ fn widening_mul(a: u64, b: u64) -> u128 {
 #[cfg(test)]
 mod tests {
     use num_traits::ConstZero;
-    use super::{FieldConfig, FieldConfigBase, FieldConfigOps};
+    use super::{FieldConfig, ConstFieldConfigBase1, FieldConfigOps};
     use crate::{big_int, field::BigInteger128};
     use crate::field::BigInt;
 
@@ -252,10 +289,10 @@ mod tests {
         #[derive(Clone, Debug)]
         struct Fc;
 
-        impl FieldConfigBase<BigInt<2>> for Fc {
-            fn modulus() -> BigInteger128 {
+        impl ConstFieldConfigBase1<BigInt<2>> for Fc {
+            const MODULUS: BigInteger128 = {
                 BigInteger128::new([9307119299070690521, 9320126393725433252])
-            }
+            };
         }
 
         let mut a = BigInteger128::new([2, 0]);
@@ -269,10 +306,10 @@ mod tests {
         #[derive(Clone, Debug)]
         struct Fc;
 
-        impl FieldConfigBase<BigInt<2>> for Fc {
-            fn modulus() -> BigInteger128 {
+        impl ConstFieldConfigBase1<BigInt<2>> for Fc {
+            const MODULUS: BigInteger128 = {
                 BigInteger128::new([9307119299070690521, 9320126393725433252])
-            }
+            };
         }
 
         let mut a = BigInteger128::new([2, 0]);

--- a/zip-plus/src/field/config.rs
+++ b/zip-plus/src/field/config.rs
@@ -236,6 +236,7 @@ impl<T, C> FieldConfig<T> for C where C: FieldConfigBase<T> + FieldConfigOps<T> 
 macro_rules! define_field_config {
     ($name:ident, $modulus:expr) => {
         #[derive(Clone, Debug)]
+        #[allow(dead_code)]
         struct $name<const N: usize>;
 
         impl<const N: usize> $crate::field::config::ConstFieldConfigBase1<$crate::field::BigInt<N>>
@@ -273,7 +274,7 @@ fn widening_mul(a: u64, b: u64) -> u128 {
 
 #[cfg(test)]
 mod tests {
-    use super::{ConstFieldConfigBase1, FieldConfig, FieldConfigOps};
+    use super::{ConstFieldConfigBase1, FieldConfigOps};
     use crate::{
         big_int,
         field::{BigInt, BigInteger128},

--- a/zip-plus/src/field/config.rs
+++ b/zip-plus/src/field/config.rs
@@ -134,6 +134,8 @@ where
     fn sub_assign(a: &mut BigInt<N>, b: &BigInt<N>) {
         // If `other` is larger than `self`, add the modulus to self first.
         if b > a {
+            // Add modulus first so the subtraction doesn't underflow; carry is intentionally
+            // ignored (we operate modulo 2^(64*N) here and the subsequent subtraction pulls it back).
             a.add_with_carry(&Self::modulus());
         }
         a.sub_with_borrow(b);

--- a/zip-plus/src/field/constant.rs
+++ b/zip-plus/src/field/constant.rs
@@ -49,7 +49,7 @@ mod tests {
     use ark_ff::{One, Zero};
     use zeroize::Zeroize;
 
-    use crate::{big_int, define_field_config, field::RandomField, random_field};
+    use crate::{define_field_config, field::RandomField, random_field};
 
     define_field_config!(FC, "23");
 

--- a/zip-plus/src/field/constant.rs
+++ b/zip-plus/src/field/constant.rs
@@ -6,15 +6,13 @@ use crate::{
     field::{biginteger::BigInt, RandomField},
     traits::Field,
 };
-use crate::field::config::ConstFieldConfig;
-use crate::field::ConfigRef;
-use crate::traits::{ConfigReference, FieldMap};
+use crate::field::config::FieldConfig;
+use crate::traits::{FieldMap};
 
-impl<const N: usize, FC: ConstFieldConfig<N>> Zero for RandomField<'_, N, FC> {
+impl<const N: usize, FC: FieldConfig<BigInt<N>>> Zero for RandomField<N, FC> {
     fn zero() -> Self {
         RandomField {
             value: BigInt::zero(),
-            config: unsafe { ConfigRef::new(Box::leak(Box::new(FC::field_config()))) },
             phantom_data: PhantomData,
         }
     }
@@ -28,21 +26,21 @@ impl<const N: usize, FC: ConstFieldConfig<N>> Zero for RandomField<'_, N, FC> {
     }
 }
 
-impl<const N: usize, FC: ConstFieldConfig<N>> One for RandomField<'_, N, FC> {
+impl<const N: usize, FC: FieldConfig<BigInt<N>>> One for RandomField<N, FC> {
     fn one() -> Self {
-        BigInt::<N>::one().map_to_field(unsafe { ConfigRef::new(Box::leak(Box::new(FC::field_config()))) })
+        BigInt::<N>::one().map_to_field()
     }
 
     fn set_one(&mut self) {
-        *self.value_mut() = *self.config().r();
+        *self.value_mut() = FC::r();
     }
 
     fn is_one(&self) -> bool {
-        self.value == *self.config().r()
+        self.value == FC::r()
     }
 }
 
-impl<const N: usize, FC: ConstFieldConfig<N>> Zeroize for RandomField<'_, N, FC> {
+impl<const N: usize, FC: FieldConfig<BigInt<N>>> Zeroize for RandomField<N, FC> {
     fn zeroize(&mut self) {
         unsafe { *self = ark_std::mem::zeroed() }
     }
@@ -53,7 +51,7 @@ mod tests {
     use ark_ff::{One, Zero};
     use zeroize::Zeroize;
 
-    use crate::{big_int, define_field_config, field::{config::ConfigRef, RandomField}, field_config, random_field};
+    use crate::{big_int, define_field_config, field::{RandomField}, random_field};
 
     define_field_config!(FC, "23");
 
@@ -65,9 +63,7 @@ mod tests {
 
     #[test]
     fn test_set_zero() {
-        let config = field_config!(23, 1);
-        let config = ConfigRef::from(&config);
-        let mut elem: RandomField<1, FC<1>> = random_field!(7u32, config);
+        let mut elem: RandomField<1, FC<1>> = random_field!(7u32);
         elem.set_zero();
         assert!(elem.is_zero());
     }
@@ -80,9 +76,7 @@ mod tests {
 
     #[test]
     fn test_set_one() {
-        let config = field_config!(23, 1);
-        let config = ConfigRef::from(&config);
-        let mut elem: RandomField<1, FC<1>> = random_field!(5u32, config);
+        let mut elem: RandomField<1, FC<1>> = random_field!(5u32);
         elem.set_one();
         assert!(elem.is_one());
     }
@@ -123,9 +117,7 @@ mod tests {
 
     #[test]
     fn test_zeroize() {
-        let config = field_config!(23, 1);
-        let config = ConfigRef::from(&config);
-        let mut elem: RandomField<1, FC<1>> = random_field!(12, config);
+        let mut elem: RandomField<1, FC<1>> = random_field!(12);
         elem.zeroize();
         assert!(elem.is_zero());
     }

--- a/zip-plus/src/field/constant.rs
+++ b/zip-plus/src/field/constant.rs
@@ -26,7 +26,7 @@ impl<const N: usize, FC: FieldConfig<BigInt<N>>> Zero for RandomField<N, FC> {
 
 impl<const N: usize, FC: FieldConfig<BigInt<N>>> One for RandomField<N, FC> {
     fn one() -> Self {
-        BigInt::<N>::one().map_to_field()
+        RandomField::new_unchecked(FC::r())
     }
 
     fn set_one(&mut self) {

--- a/zip-plus/src/field/constant.rs
+++ b/zip-plus/src/field/constant.rs
@@ -1,3 +1,4 @@
+use std::marker::PhantomData;
 use ark_ff::{One, Zero};
 use zeroize::Zeroize;
 
@@ -5,12 +6,16 @@ use crate::{
     field::{biginteger::BigInt, RandomField},
     traits::Field,
 };
+use crate::field::config::ConstFieldConfig;
+use crate::field::ConfigRef;
+use crate::traits::FieldMap;
 
-impl<const N: usize> Zero for RandomField<'_, N> {
+impl<const N: usize, FC: ConstFieldConfig<N>> Zero for RandomField<'_, N, FC> {
     fn zero() -> Self {
         RandomField {
             value: BigInt::zero(),
             config: None,
+            phantom_data: PhantomData,
         }
     }
 
@@ -23,12 +28,9 @@ impl<const N: usize> Zero for RandomField<'_, N> {
     }
 }
 
-impl<const N: usize> One for RandomField<'_, N> {
+impl<const N: usize, FC: ConstFieldConfig<N>> One for RandomField<'_, N, FC> {
     fn one() -> Self {
-        RandomField {
-            value: BigInt::one(),
-            config: None,
-        }
+        BigInt::<N>::one().map_to_field(ConfigRef::from(&FC::FIELD_CONFIG))
     }
 
     fn set_one(&mut self) {
@@ -50,7 +52,7 @@ impl<const N: usize> One for RandomField<'_, N> {
     }
 }
 
-impl<const N: usize> Zeroize for RandomField<'_, N> {
+impl<const N: usize, FC: ConstFieldConfig<N>> Zeroize for RandomField<'_, N, FC> {
     fn zeroize(&mut self) {
         unsafe { *self = ark_std::mem::zeroed() }
     }
@@ -61,15 +63,13 @@ mod tests {
     use ark_ff::{One, Zero};
     use zeroize::Zeroize;
 
-    use crate::{
-        big_int,
-        field::{config::ConfigRef, RandomField},
-        field_config, random_field,
-    };
+    use crate::{big_int, define_field_config, field::{config::ConfigRef, RandomField}, field_config, random_field};
+
+    define_field_config!(FC, "23");
 
     #[test]
     fn test_zero_creation() {
-        let zero_elem = RandomField::<1>::zero();
+        let zero_elem = RandomField::<1, FC<1>>::zero();
         assert!(zero_elem.is_zero());
     }
 
@@ -77,14 +77,14 @@ mod tests {
     fn test_set_zero() {
         let config = field_config!(23, 1);
         let config = ConfigRef::from(&config);
-        let mut elem: RandomField<1> = random_field!(7u32, config);
+        let mut elem: RandomField<1, FC<1>> = random_field!(7u32, config);
         elem.set_zero();
         assert!(elem.is_zero());
     }
 
     #[test]
     fn test_one_creation() {
-        let one_elem = RandomField::<1>::one();
+        let one_elem = RandomField::<1, FC<1>>::one();
         assert!(one_elem.is_one());
     }
 
@@ -92,14 +92,14 @@ mod tests {
     fn test_set_one() {
         let config = field_config!(23, 1);
         let config = ConfigRef::from(&config);
-        let mut elem: RandomField<1> = random_field!(5u32, config);
+        let mut elem: RandomField<1, FC<1>> = random_field!(5u32, config);
         elem.set_one();
         assert!(elem.is_one());
     }
 
     #[test]
     fn test_set_one_for_raw() {
-        let mut raw_field = RandomField::<1>::zero();
+        let mut raw_field = RandomField::<1, FC<1>>::zero();
         assert!(raw_field.is_zero());
 
         raw_field.set_one();
@@ -109,25 +109,25 @@ mod tests {
 
     #[test]
     fn test_is_zero_true() {
-        let zero_elem = RandomField::<1>::zero();
+        let zero_elem = RandomField::<1, FC<1>>::zero();
         assert!(zero_elem.is_zero());
     }
 
     #[test]
     fn test_is_zero_false() {
-        let non_zero_elem = RandomField::<1>::one();
+        let non_zero_elem = RandomField::<1, FC<1>>::one();
         assert!(!non_zero_elem.is_zero());
     }
 
     #[test]
     fn test_is_one_true() {
-        let one_elem = RandomField::<1>::one();
+        let one_elem = RandomField::<1, FC<1>>::one();
         assert!(one_elem.is_one());
     }
 
     #[test]
     fn test_is_one_false() {
-        let non_one_elem = RandomField::<1>::from(3u32);
+        let non_one_elem = RandomField::<1, FC<1>>::from(3u32);
         assert!(!non_one_elem.is_one());
     }
 
@@ -135,15 +135,15 @@ mod tests {
     fn test_zeroize() {
         let config = field_config!(23, 1);
         let config = ConfigRef::from(&config);
-        let mut elem: RandomField<1> = random_field!(12, config);
+        let mut elem: RandomField<1, FC<1>> = random_field!(12, config);
         elem.zeroize();
         assert!(elem.is_zero());
     }
 
     #[test]
     fn test_zero_not_equal_one() {
-        let zero_elem = RandomField::<1>::zero();
-        let one_elem = RandomField::<1>::one();
+        let zero_elem = RandomField::<1, FC<1>>::zero();
+        let one_elem = RandomField::<1, FC<1>>::one();
         assert_ne!(zero_elem, one_elem);
     }
 }

--- a/zip-plus/src/field/constant.rs
+++ b/zip-plus/src/field/constant.rs
@@ -1,13 +1,11 @@
-use std::marker::PhantomData;
 use ark_ff::{One, Zero};
+use std::marker::PhantomData;
 use zeroize::Zeroize;
 
 use crate::{
-    field::{biginteger::BigInt, RandomField},
-    traits::Field,
+    field::{RandomField, biginteger::BigInt, config::FieldConfig},
+    traits::{Field, FieldMap},
 };
-use crate::field::config::FieldConfig;
-use crate::traits::{FieldMap};
 
 impl<const N: usize, FC: FieldConfig<BigInt<N>>> Zero for RandomField<N, FC> {
     fn zero() -> Self {
@@ -51,7 +49,7 @@ mod tests {
     use ark_ff::{One, Zero};
     use zeroize::Zeroize;
 
-    use crate::{big_int, define_field_config, field::{RandomField}, random_field};
+    use crate::{big_int, define_field_config, field::RandomField, random_field};
 
     define_field_config!(FC, "23");
 

--- a/zip-plus/src/field/constant.rs
+++ b/zip-plus/src/field/constant.rs
@@ -4,7 +4,7 @@ use zeroize::Zeroize;
 
 use crate::{
     field::{RandomField, biginteger::BigInt, config::FieldConfig},
-    traits::{Field, FieldMap},
+    traits::Field,
 };
 
 impl<const N: usize, FC: FieldConfig<BigInt<N>>> Zero for RandomField<N, FC> {

--- a/zip-plus/src/field/constant.rs
+++ b/zip-plus/src/field/constant.rs
@@ -14,7 +14,7 @@ impl<const N: usize, FC: ConstFieldConfig<N>> Zero for RandomField<'_, N, FC> {
     fn zero() -> Self {
         RandomField {
             value: BigInt::zero(),
-            config: ConfigRef::from(&FC::FIELD_CONFIG),
+            config: unsafe { ConfigRef::new(Box::leak(Box::new(FC::field_config()))) },
             phantom_data: PhantomData,
         }
     }
@@ -30,7 +30,7 @@ impl<const N: usize, FC: ConstFieldConfig<N>> Zero for RandomField<'_, N, FC> {
 
 impl<const N: usize, FC: ConstFieldConfig<N>> One for RandomField<'_, N, FC> {
     fn one() -> Self {
-        BigInt::<N>::one().map_to_field(ConfigRef::from(&FC::FIELD_CONFIG))
+        BigInt::<N>::one().map_to_field(unsafe { ConfigRef::new(Box::leak(Box::new(FC::field_config()))) })
     }
 
     fn set_one(&mut self) {

--- a/zip-plus/src/field/constant.rs
+++ b/zip-plus/src/field/constant.rs
@@ -8,13 +8,13 @@ use crate::{
 };
 use crate::field::config::ConstFieldConfig;
 use crate::field::ConfigRef;
-use crate::traits::FieldMap;
+use crate::traits::{ConfigReference, FieldMap};
 
 impl<const N: usize, FC: ConstFieldConfig<N>> Zero for RandomField<'_, N, FC> {
     fn zero() -> Self {
         RandomField {
             value: BigInt::zero(),
-            config: None,
+            config: ConfigRef::from(&FC::FIELD_CONFIG),
             phantom_data: PhantomData,
         }
     }
@@ -34,21 +34,12 @@ impl<const N: usize, FC: ConstFieldConfig<N>> One for RandomField<'_, N, FC> {
     }
 
     fn set_one(&mut self) {
-        self.with_either_mut(
-            |value| {
-                *value = BigInt::one();
-            },
-            |config, value| {
-                *value = *config.r();
-            },
-        );
+        let config = self.config.reference().expect("Field config cannot be none");
+        *self.value_mut() = *config.r();
     }
 
     fn is_one(&self) -> bool {
-        self.with_either(
-            |value| *value == BigInt::one(),
-            |config, value| *value == *config.r(),
-        )
+        self.value == *self.config.reference().unwrap().r()
     }
 }
 

--- a/zip-plus/src/field/constant.rs
+++ b/zip-plus/src/field/constant.rs
@@ -34,12 +34,11 @@ impl<const N: usize, FC: ConstFieldConfig<N>> One for RandomField<'_, N, FC> {
     }
 
     fn set_one(&mut self) {
-        let config = self.config.reference().expect("Field config cannot be none");
-        *self.value_mut() = *config.r();
+        *self.value_mut() = *self.config().r();
     }
 
     fn is_one(&self) -> bool {
-        self.value == *self.config.reference().unwrap().r()
+        self.value == *self.config().r()
     }
 }
 

--- a/zip-plus/src/field/int.rs
+++ b/zip-plus/src/field/int.rs
@@ -6,8 +6,8 @@ use ark_std::{
     vec::Vec,
 };
 use crypto_bigint::{
-    subtle::{Choice, ConstantTimeEq},
     Int as CryptoInt, NonZero, Random,
+    subtle::{Choice, ConstantTimeEq},
 };
 use num_traits::{ConstOne, ConstZero, One, Zero};
 
@@ -16,8 +16,8 @@ use crate::{
         biginteger::{BigInt, Words},
         uint::Uint,
     },
-    traits::Integer,
     pcs::utils::ToBytes,
+    traits::Integer,
 };
 
 #[derive(Clone, Copy, PartialEq, Eq, Debug)]
@@ -219,9 +219,9 @@ impl<const N: usize> Sum for Int<N> {
 }
 
 impl<const N: usize> Integer for Int<N> {
-    type W = Words<N>;
-    type Uint = Uint<N>;
     type I = BigInt<N>;
+    type Uint = Uint<N>;
+    type W = Words<N>;
 
     fn from_words(words: Words<N>) -> Self {
         Self(CryptoInt::from_words(words.0))
@@ -240,16 +240,18 @@ impl<const N: usize> Integer for Int<N> {
     }
 }
 
-/// Defines a wrapper type suitable for implementing the `ZipTypes` trait with const generics.
+/// Defines a wrapper type suitable for implementing the `ZipTypes` trait with
+/// const generics.
 ///
 /// # Usage
-/// - `define_random_field_zip_types!();`
-///   Expands to `pub struct RandomFieldZipTypes<const N: usize>();`
+/// - `define_random_field_zip_types!();` Expands to `pub struct
+///   RandomFieldZipTypes<const N: usize>();`
 ///
-/// - `define_random_field_zip_types!(CustomName);`
-///   Expands to `pub struct CustomName<const N: usize>();`
+/// - `define_random_field_zip_types!(CustomName);` Expands to `pub struct
+///   CustomName<const N: usize>();`
 ///
-/// This macro allows downstream crates to define their own local wrapper types for implementing traits, in compliance with Rust's orphan rule.
+/// This macro allows downstream crates to define their own local wrapper types
+/// for implementing traits, in compliance with Rust's orphan rule.
 #[macro_export]
 macro_rules! define_random_field_zip_types {
     () => {
@@ -262,16 +264,18 @@ macro_rules! define_random_field_zip_types {
     };
 }
 
-/// Implements the `ZipTypes` trait for a wrapper type and a specific const parameter.
+/// Implements the `ZipTypes` trait for a wrapper type and a specific const
+/// parameter.
 ///
 /// # Usage
-/// - `implement_random_field_zip_types!(N);`
-///   Implements `ZipTypes` for `RandomFieldZipTypes<N>`.
+/// - `implement_random_field_zip_types!(N);` Implements `ZipTypes` for
+///   `RandomFieldZipTypes<N>`.
 ///
-/// - `implement_random_field_zip_types!(TypeName, N);`
-///   Implements `ZipTypes` for `TypeName<N>`.
+/// - `implement_random_field_zip_types!(TypeName, N);` Implements `ZipTypes`
+///   for `TypeName<N>`.
 ///
-/// This macro reduces boilerplate and ensures consistent associated type definitions for each implementation.
+/// This macro reduces boilerplate and ensures consistent associated type
+/// definitions for each implementation.
 #[macro_export]
 macro_rules! implement_random_field_zip_types {
     ($N:expr) => {
@@ -280,10 +284,10 @@ macro_rules! implement_random_field_zip_types {
 
     ($name:ident, $N:expr) => {
         impl $crate::traits::ZipTypes for $name<$N> {
-            type N = $crate::field::Int<$N>;
-            type L = $crate::field::Int<{ 2 * $N }>;
             type K = $crate::field::Int<{ 4 * $N }>;
+            type L = $crate::field::Int<{ 2 * $N }>;
             type M = $crate::field::Int<{ 8 * $N }>;
+            type N = $crate::field::Int<$N>;
         }
     };
 }

--- a/zip-plus/src/field/uint.rs
+++ b/zip-plus/src/field/uint.rs
@@ -4,8 +4,8 @@ use crypto_primes::hazmat::MillerRabin;
 use num_traits::One;
 
 use crate::{
-    field::{biginteger::Words, Int},
-    traits::{types::PrimalityTest, FromBytes, Uinteger},
+    field::{Int, biginteger::Words},
+    traits::{FromBytes, Uinteger, types::PrimalityTest},
 };
 
 #[derive(Clone)]
@@ -32,9 +32,9 @@ impl<'a, const N: usize> SubAssign<&'a Self> for Uint<N> {
 }
 
 impl<const N: usize> Uinteger for Uint<N> {
-    type W = Words<N>;
     type Int = Int<N>;
     type PrimalityTest = MillerRabin<CryptoUint<N>>;
+    type W = Words<N>;
 
     fn from_words(words: Words<N>) -> Self {
         Self(CryptoUint::from_words(words.0))

--- a/zip-plus/src/field/uint.rs
+++ b/zip-plus/src/field/uint.rs
@@ -1,11 +1,10 @@
 use ark_std::ops::{Mul, SubAssign};
-use crypto_bigint::{Integer, Odd, Uint as CryptoUint};
-use crypto_primes::hazmat::MillerRabin;
+use crypto_bigint::{Integer, Uint as CryptoUint};
 use num_traits::One;
 
 use crate::{
     field::{Int, biginteger::Words},
-    traits::{FromBytes, Uinteger, types::PrimalityTest},
+    traits::{FromBytes, Uinteger},
 };
 
 #[derive(Clone)]
@@ -33,7 +32,6 @@ impl<'a, const N: usize> SubAssign<&'a Self> for Uint<N> {
 
 impl<const N: usize> Uinteger for Uint<N> {
     type Int = Int<N>;
-    type PrimalityTest = MillerRabin<CryptoUint<N>>;
     type W = Words<N>;
 
     fn from_words(words: Words<N>) -> Self {
@@ -60,17 +58,5 @@ impl<const N: usize> FromBytes for Uint<N> {
 
     fn from_bytes_be(bytes: &[u8]) -> Option<Self> {
         Some(Self(CryptoUint::from_be_slice(bytes)))
-    }
-}
-
-impl<const N: usize> PrimalityTest<Uint<N>> for MillerRabin<CryptoUint<N>> {
-    type Inner = CryptoUint<N>;
-
-    fn new(candidate: Uint<N>) -> Self {
-        Self::new(Odd::new(candidate.0).unwrap())
-    }
-
-    fn is_probably_prime(&self) -> bool {
-        self.test_base_two().is_probably_prime()
     }
 }

--- a/zip-plus/src/lib.rs
+++ b/zip-plus/src/lib.rs
@@ -1,3 +1,6 @@
+#![feature(adt_const_params)]
+#![feature(const_trait_impl)]
+
 use crypto_primitives::IntRing;
 
 pub mod code;

--- a/zip-plus/src/lib.rs
+++ b/zip-plus/src/lib.rs
@@ -1,6 +1,3 @@
-#![feature(adt_const_params)]
-#![feature(const_trait_impl)]
-
 use crypto_primitives::IntRing;
 
 pub mod code;

--- a/zip-plus/src/lib.rs
+++ b/zip-plus/src/lib.rs
@@ -2,21 +2,21 @@ use crypto_primitives::IntRing;
 
 pub mod code;
 pub mod code_raa;
+mod macros;
 pub mod pcs;
 pub mod pcs_transcript;
-pub mod utils;
 pub mod traits;
-mod macros;
+pub mod utils;
 
-#[cfg(test)]
-mod tests;
-pub mod poly_z;
-mod poly;
-pub mod transcript;
+mod const_helpers;
 mod conversion;
 pub mod field;
-mod const_helpers;
+mod poly;
 mod poly_f;
+pub mod poly_z;
+#[cfg(test)]
+mod tests;
+pub mod transcript;
 
 use ark_std::string::String;
 use thiserror::Error;

--- a/zip-plus/src/macros.rs
+++ b/zip-plus/src/macros.rs
@@ -1,10 +1,12 @@
-/// A macro to construct a `BigInt<N>` from a numeric literal or string literal at compile time.
+/// A macro to construct a `BigInt<N>` from a numeric literal or string literal
+/// at compile time.
 ///
 /// ## Variants
 ///
 /// ### 1. `big_int!(value)`
 /// - Parses a numeric literal using the crate's default `BigInt` type.
-/// - Requires the user to have `use crate::field::BigInt` in scope with a fixed `N`.
+/// - Requires the user to have `use crate::field::BigInt` in scope with a fixed
+///   `N`.
 ///
 /// ### 2. `big_int!(value, N)`
 /// - Parses a numeric literal into a specific `BigInt<N>`.
@@ -54,14 +56,14 @@ macro_rules! big_int {
 /// ## Variants
 ///
 /// ### 1. `random_field!(value, config)`
-/// Converts a numeric literal into a `RandomField` element using a provided field configuration.
+/// Converts a numeric literal into a `RandomField` element using a provided
+/// field configuration.
 ///
 /// - This leverages the `FieldMap` trait’s `.map_to_field()` method.
 /// - The `config` argument must be a valid configuration object of type `F::R`.
 ///
 /// ```rust
-/// use zip_plus::field::{RandomField};
-/// use zip_plus::{big_int, define_field_config, random_field};
+/// use zip_plus::{big_int, define_field_config, field::RandomField, random_field};
 ///
 /// define_field_config!(Fc, 19);
 ///
@@ -69,10 +71,12 @@ macro_rules! big_int {
 /// ```
 ///
 /// ## Notes
-/// - In both cases, the macro uses a closure internally to maintain hygiene and isolate `use` statements.
-/// - The first form (`random_field!(value)`) uses `$crate::field::{BigInt, RandomField}`.
-/// - The second form (`random_field!(value, config)`) uses `$crate::traits::FieldMap`.
-///
+/// - In both cases, the macro uses a closure internally to maintain hygiene and
+///   isolate `use` statements.
+/// - The first form (`random_field!(value)`) uses `$crate::field::{BigInt,
+///   RandomField}`.
+/// - The second form (`random_field!(value, config)`) uses
+///   `$crate::traits::FieldMap`.
 #[macro_export]
 macro_rules! random_field {
     ($v:literal) => {

--- a/zip-plus/src/macros.rs
+++ b/zip-plus/src/macros.rs
@@ -47,62 +47,6 @@ macro_rules! big_int {
     };
 }
 
-/// Constructs a `FieldConfig<N>` from a numeric literal.
-///
-/// This macro provides a shorthand for creating field configuration constants from integer literals,
-/// using the `big_int!` macro internally to produce the modulus.
-///
-/// ## Variants
-///
-/// ### 1. `field_config!(value)`
-/// - Creates a `FieldConfig` using the default `BigInt` type in scope.
-/// - Assumes `BigInt` is imported or aliased appropriately.
-/// - Useful when the generic parameter `N` is inferred or fixed elsewhere.
-///
-/// ```rust
-/// use zip_plus::field::{ConfigRef, RandomField};
-/// use zip_plus::{field_config, random_field};
-/// let config = field_config!(19);
-/// let config_ref = ConfigRef::from(&config);
-/// let f: RandomField<1> = random_field!(1u32, config_ref);
-/// ```
-///
-/// ### 2. `field_config!(value, N)`
-/// - Creates a `FieldConfig<N>` by explicitly specifying the const generic `N`.
-/// - Uses `big_int!(value, N)` internally to construct the modulus.
-///
-/// ```rust
-/// use zip_plus::field_config;
-/// let config = field_config!(123456789, 3);
-/// ```
-///
-/// ## Notes
-/// - The macro expands into a scoped closure to maintain hygiene and allow internal imports.
-/// - Internally uses:
-///   - `$crate::big_int!` to construct the modulus.
-///   - `$crate::field::FieldConfig` for the config struct.
-///   - `$crate::traits::Config` for trait bound resolution.
-///
-/// ## See also
-/// - [`big_int!`] — constructs `BigInt<N>` values from literals
-/// - [`random_field!`] — constructs field elements using configs
-///
-#[macro_export]
-macro_rules! field_config {
-    ($v:literal) => {
-        (|| {
-            use $crate::{big_int, field::FieldConfig, traits::Config};
-            FieldConfig::new(big_int!($v))
-        })()
-    };
-    ($v:literal, $n:expr) => {
-        (|| {
-            use $crate::{big_int, field::FieldConfig, traits::Config};
-            FieldConfig::new(big_int!($v, $n))
-        })()
-    };
-}
-
 /// Constructs a `RandomField` element from a literal value.
 ///
 /// This macro provides two modes:
@@ -116,12 +60,12 @@ macro_rules! field_config {
 /// - The `config` argument must be a valid configuration object of type `F::R`.
 ///
 /// ```rust
-/// use zip_plus::field::{ConfigRef, RandomField};
-/// use zip_plus::{big_int, field_config, random_field};
+/// use zip_plus::field::{RandomField};
+/// use zip_plus::{big_int, define_field_config, random_field};
 ///
-/// let config = field_config!(19);
-/// let config_ref = ConfigRef::from(&config);
-/// let x: RandomField<1> = random_field!(123, config_ref);
+/// define_field_config!(Fc, 19);
+///
+/// let x: RandomField<1, Fc<1>> = random_field!(123);
 /// ```
 ///
 /// ## Notes
@@ -131,17 +75,10 @@ macro_rules! field_config {
 ///
 #[macro_export]
 macro_rules! random_field {
-    ($v:literal, $config:expr) => {
+    ($v:literal) => {
         (|| {
             use $crate::traits::FieldMap;
-            $v.map_to_field($config)
-        })()
-    };
-
-    ($v:expr, $n:literal, $config:expr) => {
-        (|| {
-            use $crate::{big_int, field::BigInt, random_field, traits::FieldMap};
-            <BigInt<$n> as FieldMap<RandomField<$n>>>::map_to_field(&big_int!($v), $config)
+            $v.map_to_field()
         })()
     };
 }

--- a/zip-plus/src/macros.rs
+++ b/zip-plus/src/macros.rs
@@ -24,29 +24,20 @@
 /// ```
 #[macro_export]
 macro_rules! big_int {
-    ($v:literal) => {
-        (|| {
-            use ark_std::str::FromStr;
-            use $crate::field::BigInt;
-            BigInt::from_str(stringify!($v)).unwrap()
-        })()
-    };
+    ($v:literal) => {{
+        use ark_std::str::FromStr;
+        $crate::field::BigInt::from_str(stringify!($v)).unwrap()
+    }};
 
-    ($v:literal, $n:expr) => {
-        (|| {
-            use ark_std::str::FromStr;
-            use $crate::field::BigInt;
-            BigInt::<$n>::from_str(stringify!($v)).unwrap()
-        })()
-    };
+    ($v:literal, $n:expr) => {{
+        use ark_std::str::FromStr;
+        $crate::field::BigInt::<$n>::from_str(stringify!($v)).unwrap()
+    }};
 
-    ($v:literal, $n:expr, $msg:literal) => {
-        (|| {
-            use ark_std::str::FromStr;
-            use $crate::field::BigInt;
-            BigInt::<$n>::from_str(stringify!($v)).expect($msg)
-        })()
-    };
+    ($v:literal, $n:expr, $msg:literal) => {{
+        use ark_std::str::FromStr;
+        $crate::field::BigInt::<$n>::from_str(stringify!($v)).expect($msg)
+    }};
 }
 
 /// Constructs a `RandomField` element from a literal value.
@@ -79,10 +70,8 @@ macro_rules! big_int {
 ///   `$crate::traits::FieldMap`.
 #[macro_export]
 macro_rules! random_field {
-    ($v:literal) => {
-        (|| {
-            use $crate::traits::FieldMap;
-            $v.map_to_field()
-        })()
-    };
+    ($v:literal) => {{
+        use $crate::traits::FieldMap;
+        $v.map_to_field()
+    }};
 }

--- a/zip-plus/src/pcs.rs
+++ b/zip-plus/src/pcs.rs
@@ -2,8 +2,8 @@ mod commit;
 mod error;
 mod open_z;
 pub mod structs;
-pub(crate) mod utils;
 pub(crate) mod tests;
+pub(crate) mod utils;
 mod verify_z;
 
 pub use utils::MerkleTree;

--- a/zip-plus/src/pcs/commit.rs
+++ b/zip-plus/src/pcs/commit.rs
@@ -2,15 +2,15 @@ use ark_std::{vec, vec::Vec};
 
 use super::{
     structs::{MultilinearZip, MultilinearZipCommitment, MultilinearZipData},
-    utils::{validate_input, MerkleTree},
+    utils::{MerkleTree, validate_input},
 };
 use crate::{
-    poly_z::mle::DenseMultilinearExtension,
-    traits::{Field, ZipTypes},
+    Error,
     code::LinearCode,
     pcs::structs::MultilinearZipParams,
+    poly_z::mle::DenseMultilinearExtension,
+    traits::{Field, ZipTypes},
     utils::{div_ceil, num_threads, parallelize_iter},
-    Error,
 };
 
 impl<ZT: ZipTypes, LC: LinearCode<ZT>> MultilinearZip<ZT, LC> {

--- a/zip-plus/src/pcs/open_z.rs
+++ b/zip-plus/src/pcs/open_z.rs
@@ -4,16 +4,16 @@ use itertools::izip;
 
 use super::{
     structs::{MultilinearZip, MultilinearZipData},
-    utils::{left_point_to_tensor, validate_input, ColumnOpening},
+    utils::{ColumnOpening, left_point_to_tensor, validate_input},
 };
 use crate::{
-    poly_z::mle::DenseMultilinearExtension,
-    traits::{Field, FieldMap, ZipTypes},
+    Error,
     code::LinearCode,
     pcs::structs::MultilinearZipParams,
     pcs_transcript::PcsTranscript,
+    poly_z::mle::DenseMultilinearExtension,
+    traits::{Field, FieldMap, ZipTypes},
     utils::{combine_rows, expand},
-    Error,
 };
 
 impl<ZT: ZipTypes, LC: LinearCode<ZT>> MultilinearZip<ZT, LC> {
@@ -67,7 +67,8 @@ impl<ZT: ZipTypes, LC: LinearCode<ZT>> MultilinearZip<ZT, LC> {
         let num_rows = pp.num_rows;
         let row_len = pp.linear_code.row_len();
 
-        // We prove evaluations over the field, so integers need to be mapped to field elements first
+        // We prove evaluations over the field, so integers need to be mapped to field
+        // elements first
         let q_0 = left_point_to_tensor(num_rows, point)?;
 
         let evaluations = poly.evaluations.map_to_field();

--- a/zip-plus/src/pcs/open_z.rs
+++ b/zip-plus/src/pcs/open_z.rs
@@ -22,7 +22,6 @@ impl<ZT: ZipTypes, LC: LinearCode<ZT>> MultilinearZip<ZT, LC> {
         poly: &DenseMultilinearExtension<ZT::N>,
         commit_data: &MultilinearZipData<ZT::K>,
         point: &[F],
-        field: F::R,
         transcript: &mut PcsTranscript<F>,
     ) -> Result<(), Error>
     where
@@ -30,9 +29,9 @@ impl<ZT: ZipTypes, LC: LinearCode<ZT>> MultilinearZip<ZT, LC> {
     {
         validate_input("open", pp.num_vars, [poly], [point])?;
 
-        Self::prove_testing_phase(pp, poly, commit_data, transcript, field)?;
+        Self::prove_testing_phase(pp, poly, commit_data, transcript)?;
 
-        Self::prove_evaluation_phase(pp, transcript, point, poly, field)?;
+        Self::prove_evaluation_phase(pp, transcript, point, poly)?;
 
         Ok(())
     }
@@ -44,13 +43,12 @@ impl<ZT: ZipTypes, LC: LinearCode<ZT>> MultilinearZip<ZT, LC> {
         comms: &[MultilinearZipData<ZT::K>],
         points: &[Vec<F>],
         transcript: &mut PcsTranscript<F>,
-        field: F::R,
     ) -> Result<(), Error>
     where
         ZT::N: FieldMap<F, Output = F>,
     {
         for (poly, comm, point) in izip!(polys.iter(), comms.iter(), points.iter()) {
-            Self::open(pp, poly, comm, point, field, transcript)?;
+            Self::open(pp, poly, comm, point, transcript)?;
         }
         Ok(())
     }
@@ -62,7 +60,6 @@ impl<ZT: ZipTypes, LC: LinearCode<ZT>> MultilinearZip<ZT, LC> {
         transcript: &mut PcsTranscript<F>,
         point: &[F],
         poly: &DenseMultilinearExtension<ZT::N>,
-        field: F::R,
     ) -> Result<(), Error>
     where
         ZT::N: FieldMap<F, Output = F>,
@@ -71,9 +68,9 @@ impl<ZT: ZipTypes, LC: LinearCode<ZT>> MultilinearZip<ZT, LC> {
         let row_len = pp.linear_code.row_len();
 
         // We prove evaluations over the field, so integers need to be mapped to field elements first
-        let q_0 = left_point_to_tensor(num_rows, point, field)?;
+        let q_0 = left_point_to_tensor(num_rows, point)?;
 
-        let evaluations = poly.evaluations.map_to_field(field);
+        let evaluations = poly.evaluations.map_to_field();
 
         let q_0_combined_row = if num_rows > 1 {
             // Return the evaluation row combination
@@ -93,7 +90,6 @@ impl<ZT: ZipTypes, LC: LinearCode<ZT>> MultilinearZip<ZT, LC> {
         poly: &DenseMultilinearExtension<ZT::N>,
         commit_data: &MultilinearZipData<ZT::K>,
         transcript: &mut PcsTranscript<F>,
-        field: F::R, // This is only needed to call the transcript, but we are getting integers not fields
     ) -> Result<(), Error> {
         if pp.num_rows > 1 {
             // If we can take linear combinations
@@ -113,7 +109,7 @@ impl<ZT: ZipTypes, LC: LinearCode<ZT>> MultilinearZip<ZT, LC> {
 
         // Open merkle tree for each column drawn
         for _ in 0..pp.linear_code.num_column_opening() {
-            let column = transcript.squeeze_challenge_idx(field, pp.linear_code.codeword_len());
+            let column = transcript.squeeze_challenge_idx(pp.linear_code.codeword_len());
             Self::open_merkle_trees_for_column(pp, commit_data, column, transcript)?;
         }
         Ok(())

--- a/zip-plus/src/pcs/structs.rs
+++ b/zip-plus/src/pcs/structs.rs
@@ -1,10 +1,10 @@
 use ark_std::{collections::BTreeSet, marker::PhantomData, vec::Vec};
-use sha3::{digest::Output, Keccak256};
+use sha3::{Keccak256, digest::Output};
 
 use super::utils::MerkleTree;
 use crate::{
-    traits::{Integer, ZipTypes},
     code::LinearCode,
+    traits::{Integer, ZipTypes},
 };
 
 pub struct MultilinearZip<ZT: ZipTypes, LC: LinearCode<ZT>>(PhantomData<(ZT, LC)>);
@@ -21,7 +21,8 @@ pub struct MultilinearZipParams<ZT: ZipTypes, LC: LinearCode<ZT>> {
 /// Representantation of a zip commitment to a multilinear polynomial
 #[derive(Clone, Debug, Default)]
 pub struct MultilinearZipData<K: Integer> {
-    /// The encoded rows of the polynomial matrix representation, referred to as "u-hat" in the Zinc paper
+    /// The encoded rows of the polynomial matrix representation, referred to as
+    /// "u-hat" in the Zinc paper
     pub rows: Vec<K>,
     /// Merkle trees of each row
     pub rows_merkle_trees: Vec<MerkleTree>,

--- a/zip-plus/src/pcs/tests.rs
+++ b/zip-plus/src/pcs/tests.rs
@@ -1,24 +1,14 @@
-use ark_std::{collections::BTreeSet, ops::Range, vec::Vec};
-use std::marker::PhantomData;
+use ark_std::{collections::BTreeSet, ops::Range};
 
 use crate::{
-    code::DefaultLinearCodeSpec,
-    code_raa::RaaCode,
-    define_random_field_zip_types,
-    field::Int,
-    implement_random_field_zip_types,
-    pcs::structs::{MultilinearZipParams, ZipTranscript},
-    poly_z::mle::DenseMultilinearExtension,
+    define_random_field_zip_types, implement_random_field_zip_types, pcs::structs::ZipTranscript,
     traits::Integer,
-    utils::div_ceil,
 };
 
 const INT_LIMBS: usize = 1;
 
 define_random_field_zip_types!();
 implement_random_field_zip_types!(INT_LIMBS);
-
-type ZT = RandomFieldZipTypes<INT_LIMBS>;
 
 #[derive(Default)]
 pub struct MockTranscript {
@@ -54,28 +44,4 @@ impl<L: Integer> ZipTranscript<L> for MockTranscript {
         }
         inserted
     }
-}
-
-pub fn setup_test_params(
-    num_vars: usize,
-) -> (
-    MultilinearZipParams<ZT, RaaCode<ZT>>,
-    DenseMultilinearExtension<Int<INT_LIMBS>>,
-) {
-    let poly_size = 1 << num_vars;
-    let num_rows = 1 << div_ceil(num_vars, 2);
-
-    let mut transcript = MockTranscript::default();
-    let linear_code = RaaCode::<ZT>::new(&DefaultLinearCodeSpec, poly_size, &mut transcript);
-    let pp = MultilinearZipParams {
-        num_vars,
-        num_rows,
-        linear_code,
-        phantom_data_zt: PhantomData,
-    };
-
-    let evaluations: Vec<_> = (1..=poly_size).map(|v| Int::from(v as i32)).collect();
-    let poly = DenseMultilinearExtension::from_evaluations_vec(num_vars, evaluations);
-
-    (pp, poly)
 }

--- a/zip-plus/src/pcs/tests.rs
+++ b/zip-plus/src/pcs/tests.rs
@@ -1,17 +1,17 @@
-use std::marker::PhantomData;
 use ark_std::{collections::BTreeSet, ops::Range, vec::Vec};
+use std::marker::PhantomData;
 
 use crate::{
+    code::DefaultLinearCodeSpec,
+    code_raa::RaaCode,
     define_random_field_zip_types,
     field::Int,
     implement_random_field_zip_types,
+    pcs::structs::{MultilinearZipParams, ZipTranscript},
     poly_z::mle::DenseMultilinearExtension,
     traits::Integer,
-    code::DefaultLinearCodeSpec,
-    pcs::structs::{MultilinearZipParams, ZipTranscript},
     utils::div_ceil,
 };
-use crate::code_raa::RaaCode;
 
 const INT_LIMBS: usize = 1;
 
@@ -30,10 +30,12 @@ impl<L: Integer> ZipTranscript<L> for MockTranscript {
         self.counter += 1;
         L::from(self.counter)
     }
+
     fn get_u64(&mut self) -> u64 {
         self.counter += 1;
         self.counter as u64
     }
+
     fn sample_unique_columns(
         &mut self,
         range: Range<usize>,
@@ -65,7 +67,12 @@ pub fn setup_test_params(
 
     let mut transcript = MockTranscript::default();
     let linear_code = RaaCode::<ZT>::new(&DefaultLinearCodeSpec, poly_size, &mut transcript);
-    let pp = MultilinearZipParams { num_vars, num_rows, linear_code, phantom_data_zt: PhantomData };
+    let pp = MultilinearZipParams {
+        num_vars,
+        num_rows,
+        linear_code,
+        phantom_data_zt: PhantomData,
+    };
 
     let evaluations: Vec<_> = (1..=poly_size).map(|v| Int::from(v as i32)).collect();
     let poly = DenseMultilinearExtension::from_evaluations_vec(num_vars, evaluations);

--- a/zip-plus/src/pcs/tests.rs
+++ b/zip-plus/src/pcs/tests.rs
@@ -1,3 +1,9 @@
+#![allow(
+    clippy::arithmetic_side_effects,
+    clippy::cast_lossless,
+    clippy::cast_sign_loss
+)]
+
 use ark_std::{collections::BTreeSet, ops::Range};
 
 use crate::{

--- a/zip-plus/src/pcs/utils.rs
+++ b/zip-plus/src/pcs/utils.rs
@@ -13,6 +13,9 @@ use crate::{
     utils::{div_ceil, num_threads, parallelize, parallelize_iter},
 };
 
+#[cfg(feature = "parallel")]
+use rayon::iter::*;
+
 fn err_too_many_variates(function: &str, upto: usize, got: usize) -> Error {
     Error::InvalidPcsParam(format!(
         "Too many variates of poly to {function} (param supports variates up to {upto} but got {got})"

--- a/zip-plus/src/pcs/utils.rs
+++ b/zip-plus/src/pcs/utils.rs
@@ -1,30 +1,22 @@
 use ark_ff::Zero;
-use ark_std::{
-    cfg_iter_mut, format,
-    iterable::Iterable,
-    vec,
-    vec::Vec,
-};
+use ark_std::{cfg_iter_mut, format, iterable::Iterable, vec, vec::Vec};
 use displaydoc::Display;
-use sha3::{digest::Output, Digest, Keccak256};
+use sha3::{Digest, Keccak256, digest::Output};
 
 use super::{error::MerkleError, structs::MultilinearZipData};
 use crate::{
+    Error,
+    pcs_transcript::PcsTranscript,
     poly_f::mle::DenseMultilinearExtension as MLE_F,
     poly_z::mle::DenseMultilinearExtension as MLE_Z,
     traits::{Field, Integer},
-
-    pcs_transcript::PcsTranscript,
     utils::{div_ceil, num_threads, parallelize, parallelize_iter},
-    Error,
 };
 
 fn err_too_many_variates(function: &str, upto: usize, got: usize) -> Error {
-    Error::InvalidPcsParam(
-        format!(
-            "Too many variates of poly to {function} (param supports variates up to {upto} but got {got})"
-        )
-    )
+    Error::InvalidPcsParam(format!(
+        "Too many variates of poly to {function} (param supports variates up to {upto} but got {got})"
+    ))
 }
 
 // Ensures that polynomials and evaluation points are of appropriate size
@@ -69,7 +61,8 @@ pub trait ToBytes {
     fn to_bytes(&self) -> Vec<u8>;
 }
 
-/// A merkle tree in which its layers are concatenated together in a single vector
+/// A merkle tree in which its layers are concatenated together in a single
+/// vector
 #[derive(Clone, Debug, Default)]
 pub struct MerkleTree {
     pub root: Output<Keccak256>,
@@ -211,9 +204,10 @@ impl MerkleProof {
 }
 
 /// This is a helper struct to open a column in a multilinear polynomial
-/// Opening a column `j` in an `n x m` matrix `u_hat` requires opening `m` Merkle trees,
-/// one for each row at position j
-/// Note that the proof is written to the transcript and the order of the proofs is the same as the order of the columns
+/// Opening a column `j` in an `n x m` matrix `u_hat` requires opening `m`
+/// Merkle trees, one for each row at position j
+/// Note that the proof is written to the transcript and the order of the proofs
+/// is the same as the order of the columns
 #[derive(Clone)]
 pub struct ColumnOpening {}
 
@@ -248,8 +242,9 @@ impl ColumnOpening {
     }
 }
 
-/// For a polynomial arranged in matrix form, this splits the evaluation point into
-/// two vectors, `q_0` multiplying on the left and `q_1` multiplying on the right
+/// For a polynomial arranged in matrix form, this splits the evaluation point
+/// into two vectors, `q_0` multiplying on the left and `q_1` multiplying on the
+/// right
 pub(super) fn point_to_tensor<F: Field>(
     num_rows: usize,
     point: &[F],
@@ -278,9 +273,7 @@ pub(super) fn point_to_tensor<F: Field>(
 ///      eq(x,y) = \prod_i=1^num_var (x_i * y_i + (1-x_i)*(1-y_i))
 /// over r, which is
 ///      eq(x,y) = \prod_i=1^num_var (x_i * r_i + (1-x_i)*(1-r_i))
-pub fn build_eq_x_r_f<F: Field>(
-    r: &[F],
-) -> Result<MLE_F<F>, ArithErrors> {
+pub fn build_eq_x_r_f<F: Field>(r: &[F]) -> Result<MLE_F<F>, ArithErrors> {
     let evals = build_eq_x_r_vec(r)?;
     let mle = MLE_F::from_evaluations_vec(r.len(), evals);
 
@@ -353,9 +346,9 @@ fn build_eq_x_r_helper<F: Field>(r: &[F], buf: &mut Vec<F>) -> Result<(), ArithE
     Ok(())
 }
 
-/// For a polynomial arranged in matrix form, this splits the evaluation point into
-/// two vectors, `q_0` multiplying on the left and `q_1` multiplying on the right
-/// and returns the left vector only
+/// For a polynomial arranged in matrix form, this splits the evaluation point
+/// into two vectors, `q_0` multiplying on the left and `q_1` multiplying on the
+/// right and returns the left vector only
 pub(super) fn left_point_to_tensor<F: Field>(
     num_rows: usize,
     point: &[F],

--- a/zip-plus/src/pcs/utils.rs
+++ b/zip-plus/src/pcs/utils.rs
@@ -368,10 +368,6 @@ pub(super) fn left_point_to_tensor<F: Field>(
 pub enum ArithErrors {
     /// Invalid parameters: {0}
     InvalidParameters(String),
-    /// Should not arrive to this point
-    ShouldNotArrive,
-    /// An error during (de)serialization: {0}
-    SerializationErrors(ark_serialize::SerializationError),
 }
 
 #[cfg(test)]

--- a/zip-plus/src/pcs/utils.rs
+++ b/zip-plus/src/pcs/utils.rs
@@ -253,19 +253,18 @@ impl ColumnOpening {
 pub(super) fn point_to_tensor<F: Field>(
     num_rows: usize,
     point: &[F],
-    config: F::R,
 ) -> Result<(Vec<F>, Vec<F>), Error> {
     assert!(num_rows.is_power_of_two());
     let (hi, lo) = point.split_at(point.len() - num_rows.ilog2() as usize);
     // TODO: get rid of these unwraps.
     let q_0 = if !lo.is_empty() {
-        build_eq_x_r_f(lo, config).unwrap()
+        build_eq_x_r_f(lo).unwrap()
     } else {
         MLE_F::zero()
     };
 
     let q_1 = if !hi.is_empty() {
-        build_eq_x_r_f(hi, config).unwrap()
+        build_eq_x_r_f(hi).unwrap()
     } else {
         MLE_F::zero()
     };
@@ -281,10 +280,9 @@ pub(super) fn point_to_tensor<F: Field>(
 ///      eq(x,y) = \prod_i=1^num_var (x_i * r_i + (1-x_i)*(1-r_i))
 pub fn build_eq_x_r_f<F: Field>(
     r: &[F],
-    config: F::R,
 ) -> Result<MLE_F<F>, ArithErrors> {
     let evals = build_eq_x_r_vec(r)?;
-    let mle = MLE_F::from_evaluations_vec(r.len(), evals, config);
+    let mle = MLE_F::from_evaluations_vec(r.len(), evals);
 
     Ok(mle)
 }
@@ -361,12 +359,11 @@ fn build_eq_x_r_helper<F: Field>(r: &[F], buf: &mut Vec<F>) -> Result<(), ArithE
 pub(super) fn left_point_to_tensor<F: Field>(
     num_rows: usize,
     point: &[F],
-    config: F::R,
 ) -> Result<Vec<F>, Error> {
     let (_, lo) = point.split_at(point.len() - num_rows.ilog2() as usize);
     // TODO: get rid of these unwraps.
     let q_0 = if !lo.is_empty() {
-        build_eq_x_r_f(lo, config).unwrap()
+        build_eq_x_r_f(lo).unwrap()
     } else {
         MLE_F::<F>::zero()
     };

--- a/zip-plus/src/pcs/verify_z.rs
+++ b/zip-plus/src/pcs/verify_z.rs
@@ -21,7 +21,6 @@ impl<ZT: ZipTypes, LC: LinearCode<ZT>> MultilinearZip<ZT, LC> {
         point: &[F],
         eval: F,
         transcript: &mut PcsTranscript<F>,
-        field: F::R,
     ) -> Result<(), Error>
     where
         ZT::L: FieldMap<F, Output = F>,
@@ -29,9 +28,9 @@ impl<ZT: ZipTypes, LC: LinearCode<ZT>> MultilinearZip<ZT, LC> {
     {
         validate_input::<ZT::N, F>("verify", vp.num_vars, [], [point])?;
 
-        let columns_opened = Self::verify_testing(vp, &comm.roots, transcript, field)?;
+        let columns_opened = Self::verify_testing(vp, &comm.roots, transcript)?;
 
-        Self::verify_evaluation_z(vp, point, eval, &columns_opened, transcript, field)?;
+        Self::verify_evaluation_z(vp, point, eval, &columns_opened, transcript)?;
 
         Ok(())
     }
@@ -42,7 +41,6 @@ impl<ZT: ZipTypes, LC: LinearCode<ZT>> MultilinearZip<ZT, LC> {
         points: &[Vec<F>],
         evals: &[F],
         transcript: &mut PcsTranscript<F>,
-        field: F::R,
     ) -> Result<(), Error>
     where
         ZT::L: FieldMap<F, Output = F>,
@@ -50,7 +48,7 @@ impl<ZT: ZipTypes, LC: LinearCode<ZT>> MultilinearZip<ZT, LC> {
         ZT::N: 'a,
     {
         for (i, (eval, comm)) in evals.iter().zip(comms.iter()).enumerate() {
-            Self::verify(vp, comm, &points[i], eval.clone(), transcript, field)?;
+            Self::verify(vp, comm, &points[i], eval.clone(), transcript)?;
         }
         Ok(())
     }
@@ -60,7 +58,6 @@ impl<ZT: ZipTypes, LC: LinearCode<ZT>> MultilinearZip<ZT, LC> {
         vp: &MultilinearZipParams<ZT, LC>,
         roots: &[Output<Keccak256>],
         transcript: &mut PcsTranscript<F>,
-        field: F::R,
     ) -> Result<Vec<(usize, Vec<ZT::K>)>, Error> {
         // Gather the coeffs and encoded combined rows per proximity test
         let mut encoded_combined_rows: Vec<(Vec<ZT::N>, Vec<ZT::M>)> =
@@ -82,7 +79,7 @@ impl<ZT: ZipTypes, LC: LinearCode<ZT>> MultilinearZip<ZT, LC> {
             Vec::with_capacity(vp.linear_code.num_column_opening());
 
         for _ in 0..vp.linear_code.num_column_opening() {
-            let column_idx = transcript.squeeze_challenge_idx(field, vp.linear_code.codeword_len());
+            let column_idx = transcript.squeeze_challenge_idx(vp.linear_code.codeword_len());
             let column_values = transcript.read_integers(vp.num_rows)?;
 
             for (coeffs, encoded_combined_row) in encoded_combined_rows.iter() {
@@ -131,16 +128,15 @@ impl<ZT: ZipTypes, LC: LinearCode<ZT>> MultilinearZip<ZT, LC> {
         eval: F,
         columns_opened: &[(usize, Vec<ZT::K>)],
         transcript: &mut PcsTranscript<F>,
-        field: F::R,
     ) -> Result<(), Error>
     where
         ZT::L: FieldMap<F, Output = F>,
         ZT::K: FieldMap<F, Output = F>,
     {
-        let q_0_combined_row = transcript.read_field_elements(vp.linear_code.row_len(), field)?;
-        let encoded_combined_row = vp.linear_code.encode_f(&q_0_combined_row, field);
+        let q_0_combined_row = transcript.read_field_elements(vp.linear_code.row_len())?;
+        let encoded_combined_row = vp.linear_code.encode_f(&q_0_combined_row);
 
-        let (q_0, q_1) = point_to_tensor(vp.num_rows, point, field)?;
+        let (q_0, q_1) = point_to_tensor(vp.num_rows, point)?;
 
         if inner_product(&q_0_combined_row, &q_1) != eval {
             return Err(Error::InvalidPcsOpen(
@@ -154,7 +150,6 @@ impl<ZT: ZipTypes, LC: LinearCode<ZT>> MultilinearZip<ZT, LC> {
                 column_values,
                 *column_idx,
                 vp.num_rows,
-                field,
             )?;
         }
 
@@ -167,17 +162,16 @@ impl<ZT: ZipTypes, LC: LinearCode<ZT>> MultilinearZip<ZT, LC> {
         column_entries: &[ZT::K],
         column: usize,
         num_rows: usize,
-        field: F::R,
     ) -> Result<(), Error>
     where
         ZT::K: FieldMap<F, Output = F>,
     {
         let column_entries_comb = if num_rows > 1 {
-            let column_entries = column_entries.map_to_field(field);
+            let column_entries = column_entries.map_to_field();
             inner_product(q_0, &column_entries)
             // TODO: this inner product is taking a long time.
         } else {
-            column_entries.first().unwrap().map_to_field(field)
+            column_entries.first().unwrap().map_to_field()
         };
         if column_entries_comb != encoded_q_0_combined_row[column] {
             return Err(Error::InvalidPcsOpen("Proximity failure".into()));

--- a/zip-plus/src/pcs/verify_z.rs
+++ b/zip-plus/src/pcs/verify_z.rs
@@ -1,17 +1,17 @@
 use ark_std::{iterable::Iterable, vec::Vec};
-use sha3::{digest::Output, Keccak256};
+use sha3::{Keccak256, digest::Output};
 
 use super::{
     structs::{MultilinearZip, MultilinearZipCommitment},
-    utils::{point_to_tensor, validate_input, ColumnOpening},
+    utils::{ColumnOpening, point_to_tensor, validate_input},
 };
 use crate::{
-    traits::{Field, FieldMap, ZipTypes},
+    Error,
     code::LinearCode,
     pcs::structs::MultilinearZipParams,
     pcs_transcript::PcsTranscript,
+    traits::{Field, FieldMap, ZipTypes},
     utils::{expand, inner_product},
-    Error,
 };
 
 impl<ZT: ZipTypes, LC: LinearCode<ZT>> MultilinearZip<ZT, LC> {

--- a/zip-plus/src/pcs_transcript.rs
+++ b/zip-plus/src/pcs_transcript.rs
@@ -82,22 +82,22 @@ impl<F: Field> PcsTranscript<F> {
         Ok(())
     }
 
-    pub fn read_field_elements(&mut self, n: usize, config: F::R) -> Result<Vec<F>, Error> {
+    pub fn read_field_elements(&mut self, n: usize) -> Result<Vec<F>, Error> {
         (0..n)
-            .map(|_| self.read_field_element(config))
+            .map(|_| self.read_field_element())
             .collect::<Result<Vec<_>, _>>()
     }
 
     /// Reads a field element from the proof stream and absorbs it into the transcript.
     /// Used during proof verification to retrieve and process field elements.
-    pub fn read_field_element(&mut self, config: F::R) -> Result<F, Error> {
+    pub fn read_field_element(&mut self) -> Result<F, Error> {
         let mut bytes: Vec<u8> = vec![0; F::W::num_words() * 8];
 
         self.stream
             .read_exact(&mut bytes)
             .map_err(|err| Error::Transcript(err.kind(), err.to_string()))?;
 
-        let fe = F::new_unchecked(config, F::B::from_bytes_be(&bytes).unwrap());
+        let fe = F::new_unchecked(F::B::from_bytes_be(&bytes).unwrap());
 
         self.common_field_element(&fe);
         Ok(fe)
@@ -179,8 +179,8 @@ impl<F: Field> PcsTranscript<F> {
     /// Generates a pseudorandom index based on the current transcript state.
     /// Used to create deterministic challenges for zero-knowledge protocols.
     /// Returns an index between 0 and cap-1.
-    pub fn squeeze_challenge_idx(&mut self, config: F::R, cap: usize) -> usize {
-        let challenge: F = self.fs_transcript.get_challenge(config);
+    pub fn squeeze_challenge_idx(&mut self, cap: usize) -> usize {
+        let challenge: F = self.fs_transcript.get_challenge();
         let bytes = challenge.value().clone().to_bytes_le();
         let num = u32::from_le_bytes(bytes[..4].try_into().unwrap()) as usize;
         num % cap

--- a/zip-plus/src/pcs_transcript.rs
+++ b/zip-plus/src/pcs_transcript.rs
@@ -6,9 +6,9 @@ use ark_std::{
     vec,
     vec::Vec,
 };
-use sha3::{digest::Output, Keccak256};
+use sha3::{Keccak256, digest::Output};
 
-use super::{define_field_config, pcs::utils::MerkleProof, Error};
+use super::{Error, define_field_config, pcs::utils::MerkleProof};
 use crate::{
     poly::alloc::string::ToString,
     traits::{BigInteger, Field, FromBytes, Integer, PrimitiveConversion, Words},
@@ -16,14 +16,17 @@ use crate::{
 };
 
 /// A transcript for Polynomial Commitment Scheme (PCS) operations.
-/// Manages both Fiat-Shamir transformations and serialization/deserialization of proof data.
+/// Manages both Fiat-Shamir transformations and serialization/deserialization
+/// of proof data.
 #[derive(Default, Clone)]
 pub struct PcsTranscript<F: Field> {
-    /// Handles Fiat-Shamir transformations for non-interactive zero-knowledge proofs.
-    /// Used to absorb field elements and generate cryptographic challenges.
+    /// Handles Fiat-Shamir transformations for non-interactive zero-knowledge
+    /// proofs. Used to absorb field elements and generate cryptographic
+    /// challenges.
     pub fs_transcript: KeccakTranscript,
 
-    /// Manages serialization and deserialization of proof data as a byte stream.
+    /// Manages serialization and deserialization of proof data as a byte
+    /// stream.
     pub stream: Cursor<Vec<u8>>,
 
     _phantom: PhantomData<F>,
@@ -49,7 +52,8 @@ impl<F: Field> PcsTranscript<F> {
     }
 
     /// Absorbs a field element into the Fiat-Shamir transcript.
-    /// This is used to incorporate public values into the transcript for challenge generation.
+    /// This is used to incorporate public values into the transcript for
+    /// challenge generation.
     pub fn common_field_element(&mut self, fe: &F) {
         self.fs_transcript.absorb_random_field(fe);
     }
@@ -65,7 +69,8 @@ impl<F: Field> PcsTranscript<F> {
     }
 
     /// Writes a cryptographic commitment to the proof stream.
-    /// Used during proof generation to store commitments for later verification.
+    /// Used during proof generation to store commitments for later
+    /// verification.
     pub fn write_commitment(&mut self, comm: &Output<Keccak256>) -> Result<(), Error> {
         self.stream
             .write_all(comm)
@@ -88,8 +93,9 @@ impl<F: Field> PcsTranscript<F> {
             .collect::<Result<Vec<_>, _>>()
     }
 
-    /// Reads a field element from the proof stream and absorbs it into the transcript.
-    /// Used during proof verification to retrieve and process field elements.
+    /// Reads a field element from the proof stream and absorbs it into the
+    /// transcript. Used during proof verification to retrieve and process
+    /// field elements.
     pub fn read_field_element(&mut self) -> Result<F, Error> {
         let mut bytes: Vec<u8> = vec![0; F::W::num_words() * 8];
 
@@ -103,8 +109,9 @@ impl<F: Field> PcsTranscript<F> {
         Ok(fe)
     }
 
-    /// Writes a field element to the proof stream and absorbs it into the transcript.
-    /// Used during proof generation to store field elements for later verification.
+    /// Writes a field element to the proof stream and absorbs it into the
+    /// transcript. Used during proof generation to store field elements for
+    /// later verification.
     pub fn write_field_element(&mut self, fe: &F) -> Result<(), Error> {
         self.common_field_element(fe);
         let repr = fe.value().clone().to_bytes_be();
@@ -123,8 +130,8 @@ impl<F: Field> PcsTranscript<F> {
         Ok(())
     }
 
-    // pub fn write_integers<M: CryptoInt>(&mut self, ints: &[M]) -> Result<(), Error> {
-    //     for int in ints {
+    // pub fn write_integers<M: CryptoInt>(&mut self, ints: &[M]) -> Result<(),
+    // Error> {     for int in ints {
     //         self.write_integer(int)?;
     //     }
     //     Ok(())

--- a/zip-plus/src/pcs_transcript.rs
+++ b/zip-plus/src/pcs_transcript.rs
@@ -8,7 +8,7 @@ use ark_std::{
 };
 use sha3::{digest::Output, Keccak256};
 
-use super::{pcs::utils::MerkleProof, Error};
+use super::{define_field_config, pcs::utils::MerkleProof, Error};
 use crate::{
     poly::alloc::string::ToString,
     traits::{BigInteger, Field, FromBytes, Integer, PrimitiveConversion, Words},
@@ -219,17 +219,19 @@ impl<F: Field> PcsTranscript<F> {
     }
 }
 
+define_field_config!(FC, "57316695564490278656402085503");
+
 #[allow(unused_macros)]
 macro_rules! test_read_write {
     // TODO: N is magic
     ($write_fn:ident, $read_fn:ident, $original_value:expr, $assert_msg:expr) => {{
         use ark_std::format;
-        let mut transcript = PcsTranscript::<RandomField<N>>::new();
+        let mut transcript = PcsTranscript::<RandomField<N, FC<N>>>::new();
         transcript
             .$write_fn(&$original_value)
             .expect(&format!("Failed to write {}", $assert_msg));
         let proof = transcript.into_proof();
-        let mut transcript = PcsTranscript::<RandomField<N>>::from_proof(&proof);
+        let mut transcript = PcsTranscript::<RandomField<N, FC<N>>>::from_proof(&proof);
         let read_value = transcript
             .$read_fn()
             .expect(&format!("Failed to read {}", $assert_msg));
@@ -246,12 +248,12 @@ macro_rules! test_read_write_vec {
     // TODO: N is magic
     ($write_fn:ident, $read_fn:ident, $original_values:expr, $assert_msg:expr) => {{
         use ark_std::format;
-        let mut transcript = PcsTranscript::<RandomField<N>>::new();
+        let mut transcript = PcsTranscript::<RandomField<N, FC<N>>>::new();
         transcript
             .$write_fn(&$original_values)
             .expect(&format!("Failed to write {}", $assert_msg));
         let proof = transcript.into_proof();
-        let mut transcript = PcsTranscript::<RandomField<N>>::from_proof(&proof);
+        let mut transcript = PcsTranscript::<RandomField<N, FC<N>>>::from_proof(&proof);
         let read_values = transcript
             .$read_fn($original_values.len())
             .expect(&format!("Failed to read {}", $assert_msg));

--- a/zip-plus/src/poly.rs
+++ b/zip-plus/src/poly.rs
@@ -1,12 +1,10 @@
 pub mod errors;
 
-
 pub(crate) extern crate alloc;
 
 // ark-std v0.5 should re-export alloc/std::sync.
-// While already released on crates.io, related versioning changes were reverted on the GitHub repo.
-// Let's wait for this issue to stabilize.
-
+// While already released on crates.io, related versioning changes were reverted
+// on the GitHub repo. Let's wait for this issue to stabilize.
 
 #[cfg(not(target_has_atomic = "ptr"))]
 pub use ark_std::rc::Rc as RefCounter;

--- a/zip-plus/src/poly/errors.rs
+++ b/zip-plus/src/poly/errors.rs
@@ -5,7 +5,6 @@
 
 //! Error module.
 
-
 use displaydoc::Display;
 use thiserror::Error;
 

--- a/zip-plus/src/poly_f/mle.rs
+++ b/zip-plus/src/poly_f/mle.rs
@@ -1,9 +1,9 @@
 mod dense;
 
 use ark_std::{
+    Zero,
     fmt::Debug,
     ops::{Add, AddAssign, Index, Neg, SubAssign},
-    Zero,
 };
 
 /// This trait describes an interface for the multilinear extension
@@ -31,11 +31,12 @@ pub trait MultilinearExtension<F: Field>:
     /// `partial_point.len()` variables at `partial_point`.
     fn fix_variables(&mut self, partial_point: &[F]);
 
-    /// Creates a new object with the number of variables of `self` reduced by fixing the
-    /// `partial_point.len()` variables at `partial_point`.
+    /// Creates a new object with the number of variables of `self` reduced by
+    /// fixing the `partial_point.len()` variables at `partial_point`.
     fn fixed_variables(&self, partial_point: &[F]) -> Self;
 }
-/// swap the bits of `x` from position `a..a+n` to `b..b+n` and from `b..b+n` to `a..a+n` in little endian order
+/// swap the bits of `x` from position `a..a+n` to `b..b+n` and from `b..b+n` to
+/// `a..a+n` in little endian order
 pub(crate) fn swap_bits(x: usize, a: usize, b: usize, n: usize) -> usize {
     let a_bits = (x >> a) & ((1usize << n) - 1);
     let b_bits = (x >> b) & ((1usize << n) - 1);

--- a/zip-plus/src/poly_f/mle.rs
+++ b/zip-plus/src/poly_f/mle.rs
@@ -29,11 +29,11 @@ pub trait MultilinearExtension<F: Field>:
 {
     /// Reduce the number of variables of `self` by fixing the
     /// `partial_point.len()` variables at `partial_point`.
-    fn fix_variables(&mut self, partial_point: &[F], config: F::R);
+    fn fix_variables(&mut self, partial_point: &[F]);
 
     /// Creates a new object with the number of variables of `self` reduced by fixing the
     /// `partial_point.len()` variables at `partial_point`.
-    fn fixed_variables(&self, partial_point: &[F], config: F::R) -> Self;
+    fn fixed_variables(&self, partial_point: &[F]) -> Self;
 }
 /// swap the bits of `x` from position `a..a+n` to `b..b+n` and from `b..b+n` to `a..a+n` in little endian order
 pub(crate) fn swap_bits(x: usize, a: usize, b: usize, n: usize) -> usize {

--- a/zip-plus/src/poly_f/mle/dense.rs
+++ b/zip-plus/src/poly_f/mle/dense.rs
@@ -11,8 +11,8 @@ use ark_std::{
 #[cfg(feature = "parallel")]
 use rayon::iter::*;
 
-use super::{swap_bits, MultilinearExtension};
-use crate::traits::{Field};
+use super::{MultilinearExtension, swap_bits};
+use crate::traits::Field;
 use crypto_primitives::Matrix;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -40,7 +40,8 @@ impl<F: Field> DenseMultilinearExtension<F> {
         // assert that the number of variables matches the size of evaluations
         assert!(
             evaluations.len() <= 1 << num_vars,
-            "The size of evaluations should not exceed 2^num_vars. \n eval len: {:?}. num vars: {num_vars}", evaluations.len()
+            "The size of evaluations should not exceed 2^num_vars. \n eval len: {:?}. num vars: {num_vars}",
+            evaluations.len()
         );
 
         if evaluations.len() != 1 << num_vars {
@@ -58,7 +59,8 @@ impl<F: Field> DenseMultilinearExtension<F> {
         }
     }
 
-    /// Returns the dense MLE from the given matrix, without modifying the original matrix.
+    /// Returns the dense MLE from the given matrix, without modifying the
+    /// original matrix.
     pub fn from_matrix<M: Matrix<F>>(matrix: &M) -> Self {
         let n_vars: usize = (log2(matrix.num_rows()) + log2(matrix.num_cols())) as usize; // n_vars = s + s'
 

--- a/zip-plus/src/poly_f/mle/dense.rs
+++ b/zip-plus/src/poly_f/mle/dense.rs
@@ -12,7 +12,7 @@ use ark_std::{
 use rayon::iter::*;
 
 use super::{swap_bits, MultilinearExtension};
-use crate::traits::{ConfigReference, Field};
+use crate::traits::{Field};
 use crypto_primitives::Matrix;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -21,24 +21,22 @@ pub struct DenseMultilinearExtension<F: Field> {
     pub evaluations: Vec<F>,
     /// Number of variables
     pub num_vars: usize,
-    /// Field in which the MLE is operating
-    pub config: F::R,
 }
 
 impl<F: Field> DenseMultilinearExtension<F> {
-    pub fn from_evaluations_slice(num_vars: usize, evaluations: &[F], config: F::R) -> Self {
-        Self::from_evaluations_vec(num_vars, evaluations.to_vec(), config)
+    pub fn from_evaluations_slice(num_vars: usize, evaluations: &[F]) -> Self {
+        Self::from_evaluations_vec(num_vars, evaluations.to_vec())
     }
 
-    pub fn evaluate(&self, point: &[F], config: F::R) -> Option<F> {
+    pub fn evaluate(&self, point: &[F]) -> Option<F> {
         if point.len() == self.num_vars {
-            Some(self.fixed_variables(point, config)[0].clone())
+            Some(self.fixed_variables(point)[0].clone())
         } else {
             None
         }
     }
 
-    pub fn from_evaluations_vec(num_vars: usize, evaluations: Vec<F>, config: F::R) -> Self {
+    pub fn from_evaluations_vec(num_vars: usize, evaluations: Vec<F>) -> Self {
         // assert that the number of variables matches the size of evaluations
         assert!(
             evaluations.len() <= 1 << num_vars,
@@ -47,23 +45,21 @@ impl<F: Field> DenseMultilinearExtension<F> {
 
         if evaluations.len() != 1 << num_vars {
             let mut evaluations = evaluations;
-            evaluations.resize(1 << num_vars, F::new_unchecked(config, 0u32.into()));
+            evaluations.resize(1 << num_vars, F::zero());
             return Self {
                 num_vars,
                 evaluations,
-                config,
             };
         }
 
         Self {
             num_vars,
             evaluations,
-            config,
         }
     }
 
     /// Returns the dense MLE from the given matrix, without modifying the original matrix.
-    pub fn from_matrix<M: Matrix<F>>(matrix: &M, config: F::R) -> Self {
+    pub fn from_matrix<M: Matrix<F>>(matrix: &M) -> Self {
         let n_vars: usize = (log2(matrix.num_rows()) + log2(matrix.num_cols())) as usize; // n_vars = s + s'
 
         // Matrices might need to get padded before turned into an MLE
@@ -80,11 +76,11 @@ impl<F: Field> DenseMultilinearExtension<F> {
         }
 
         // convert the dense vector into a mle
-        Self::from_slice(n_vars, &v, config)
+        Self::from_slice(n_vars, &v)
     }
 
     /// Takes n_vars and a dense slice and returns its dense MLE.
-    pub fn from_slice(n_vars: usize, v: &[F], config: F::R) -> Self {
+    pub fn from_slice(n_vars: usize, v: &[F]) -> Self {
         let v_padded: Vec<F> = if v.len() != (1 << n_vars) {
             // pad to 2^n_vars
             [
@@ -95,7 +91,7 @@ impl<F: Field> DenseMultilinearExtension<F> {
         } else {
             v.to_owned()
         };
-        Self::from_evaluations_vec(n_vars, v_padded, config)
+        Self::from_evaluations_vec(n_vars, v_padded)
     }
 
     pub fn relabel_in_place(&mut self, mut a: usize, mut b: usize, k: usize) {
@@ -118,7 +114,7 @@ impl<F: Field> DenseMultilinearExtension<F> {
 }
 
 impl<F: Field> MultilinearExtension<F> for DenseMultilinearExtension<F> {
-    fn fix_variables(&mut self, partial_point: &[F], _config: F::R) {
+    fn fix_variables(&mut self, partial_point: &[F]) {
         assert!(
             partial_point.len() <= self.num_vars,
             "too many partial points"
@@ -146,9 +142,9 @@ impl<F: Field> MultilinearExtension<F> for DenseMultilinearExtension<F> {
         self.num_vars = nv - dim;
     }
 
-    fn fixed_variables(&self, partial_point: &[F], config: F::R) -> Self {
+    fn fixed_variables(&self, partial_point: &[F]) -> Self {
         let mut res = self.clone();
-        res.fix_variables(partial_point, config);
+        res.fix_variables(partial_point);
         res
     }
 }
@@ -158,7 +154,6 @@ impl<F: Field> Zero for DenseMultilinearExtension<F> {
         Self {
             num_vars: 0,
             evaluations: vec![F::zero()],
-            config: F::R::NONE,
         }
     }
 
@@ -191,17 +186,13 @@ impl<F: Field> Add for &DenseMultilinearExtension<F> {
             self.num_vars, rhs.num_vars,
             "trying to add two dense MLEs with different numbers of variables"
         );
-        assert_eq!(
-            self.config, rhs.config,
-            "trying to add two dense MLEs in different fields"
-        );
 
         let result = cfg_iter!(self.evaluations)
             .zip(cfg_iter!(rhs.evaluations))
             .map(|(a, b)| a.clone() + b.clone())
             .collect();
 
-        Self::Output::from_evaluations_vec(self.num_vars, result, self.config)
+        Self::Output::from_evaluations_vec(self.num_vars, result)
     }
 }
 
@@ -225,10 +216,6 @@ impl<F: Field> AddAssign<&Self> for DenseMultilinearExtension<F> {
         assert_eq!(
             self.num_vars, other.num_vars,
             "trying to add two dense MLEs with different numbers of variables"
-        );
-        assert_eq!(
-            self.config, other.config,
-            "trying to add two dense MLEs in different fields"
         );
 
         cfg_iter_mut!(self.evaluations)
@@ -254,11 +241,6 @@ impl<F: Field> AddAssign<(F, &Self)> for DenseMultilinearExtension<F> {
         assert_eq!(
             self.num_vars, other.num_vars,
             "trying to add two dense MLEs with different numbers of variables"
-        );
-
-        assert_eq!(
-            self.config, other.config,
-            "trying to add two dense MLEs in different fields"
         );
 
         cfg_iter_mut!(self.evaluations)
@@ -301,16 +283,12 @@ impl<F: Field> Sub for &DenseMultilinearExtension<F> {
             self.num_vars, rhs.num_vars,
             "trying to subtract two dense MLEs with different numbers of variables"
         );
-        assert_eq!(
-            self.config, rhs.config,
-            "trying to add two dense MLEs in different fields"
-        );
         let result = cfg_iter!(self.evaluations)
             .zip(cfg_iter!(rhs.evaluations))
             .map(|(a, b)| a.clone() - b.clone())
             .collect();
 
-        Self::Output::from_evaluations_vec(self.num_vars, result, self.config)
+        Self::Output::from_evaluations_vec(self.num_vars, result)
     }
 }
 

--- a/zip-plus/src/poly_z/mle.rs
+++ b/zip-plus/src/poly_z/mle.rs
@@ -1,11 +1,11 @@
 mod dense;
 
 use ark_std::{
+    Zero,
     fmt::Debug,
     ops::{Add, AddAssign, Index, Neg, SubAssign},
     rand::Rng,
     vec::Vec,
-    Zero,
 };
 
 /// This trait describes an interface for the multilinear extension
@@ -40,23 +40,25 @@ pub trait MultilinearExtension<I: Integer>:
     /// positions `b..b+k`, and from position `b..b+k` to position `a..a+k`
     /// in vector.
     ///
-    /// This function turns `P(x_1,...,x_a,...,x_{a+k - 1},...,x_b,...,x_{b+k - 1},...,x_n)`
-    /// to `P(x_1,...,x_b,...,x_{b+k - 1},...,x_a,...,x_{a+k - 1},...,x_n)`
+    /// This function turns `P(x_1,...,x_a,...,x_{a+k - 1},...,x_b,...,x_{b+k -
+    /// 1},...,x_n)` to `P(x_1,...,x_b,...,x_{b+k - 1},...,x_a,...,x_{a+k -
+    /// 1},...,x_n)`
     fn relabel(&self, a: usize, b: usize, k: usize) -> Self;
 
     /// Reduce the number of variables of `self` by fixing the
     /// `partial_point.len()` variables at `partial_point`.
     fn fix_variables(&mut self, partial_point: &[I]);
 
-    /// Creates a new object with the number of variables of `self` reduced by fixing the
-    /// `partial_point.len()` variables at `partial_point`.
+    /// Creates a new object with the number of variables of `self` reduced by
+    /// fixing the `partial_point.len()` variables at `partial_point`.
     fn fixed_variables(&self, partial_point: &[I]) -> Self;
 
     /// Returns a list of evaluations over the domain, which is the boolean
     /// hypercube. The evaluations are in little-endian order.
     fn to_evaluations(&self) -> Vec<I>;
 }
-/// swap the bits of `x` from position `a..a+n` to `b..b+n` and from `b..b+n` to `a..a+n` in little endian order
+/// swap the bits of `x` from position `a..a+n` to `b..b+n` and from `b..b+n` to
+/// `a..a+n` in little endian order
 pub(crate) fn swap_bits(x: usize, a: usize, b: usize, n: usize) -> usize {
     let a_bits = (x >> a) & ((1usize << n) - 1);
     let b_bits = (x >> b) & ((1usize << n) - 1);

--- a/zip-plus/src/poly_z/mle/dense.rs
+++ b/zip-plus/src/poly_z/mle/dense.rs
@@ -59,7 +59,8 @@ impl<I: Integer> DenseMultilinearExtension<I> {
         }
     }
 
-    /// Returns the dense MLE from the given matrix, without modifying the original matrix.
+    /// Returns the dense MLE from the given matrix, without modifying the
+    /// original matrix.
     pub fn from_matrix<M: Matrix<I>>(matrix: &M) -> Self {
         let n_vars: usize = (log2(matrix.num_rows()) + log2(matrix.num_cols())) as usize; // n_vars = s + s'
 

--- a/zip-plus/src/tests.rs
+++ b/zip-plus/src/tests.rs
@@ -1,16 +1,6 @@
 use ark_std::{vec, vec::Vec, UniformRand};
 
-use crate::{
-    define_random_field_zip_types,
-    field::{ConfigRef, Int, RandomField},
-    field_config, implement_random_field_zip_types,
-    poly_z::mle::DenseMultilinearExtension,
-    traits::{ConfigReference, FieldMap},
-    transcript::KeccakTranscript,
-    
-    code::DefaultLinearCodeSpec, code_raa::RaaCode, pcs::structs::MultilinearZip,
-    pcs_transcript::PcsTranscript,
-};
+use crate::{define_random_field_zip_types, field::{ConfigRef, Int, RandomField}, field_config, implement_random_field_zip_types, poly_z::mle::DenseMultilinearExtension, traits::{ConfigReference, FieldMap}, transcript::KeccakTranscript, code::DefaultLinearCodeSpec, code_raa::RaaCode, pcs::structs::MultilinearZip, pcs_transcript::PcsTranscript, big_int, define_field_config};
 
 const I: usize = 1;
 const N: usize = 2;
@@ -21,6 +11,8 @@ implement_random_field_zip_types!(I);
 type ZT = RandomFieldZipTypes<I>;
 type LC = RaaCode<ZT>;
 type TestZip<LC> = MultilinearZip<ZT, LC>;
+
+define_field_config!(FC, "57316695564490278656402085503");
 
 #[test]
 fn test_zip_commitment() {
@@ -34,7 +26,7 @@ fn test_zip_commitment() {
     let n = 3;
     let mle = DenseMultilinearExtension::from_evaluations_slice(n, &evaluations);
 
-    let res = TestZip::commit::<RandomField<N>>(&param, &mle);
+    let res = TestZip::commit::<RandomField<N, FC<N>>>(&param, &mle);
 
     assert!(res.is_ok())
 }
@@ -50,7 +42,7 @@ fn test_failing_zip_commitment() {
     let n = 4;
     let mle = DenseMultilinearExtension::from_evaluations_slice(n, &evaluations);
 
-    let res = TestZip::commit::<RandomField<N>>(&param, &mle);
+    let res = TestZip::commit::<RandomField<N, FC<N>>>(&param, &mle);
 
     assert!(res.is_err())
 }
@@ -65,13 +57,13 @@ fn test_zip_opening() {
     let linear_code: LC = LC::new(&DefaultLinearCodeSpec, poly_size, &mut keccak_transcript);
     let param = TestZip::setup(poly_size, linear_code);
 
-    let mut transcript = PcsTranscript::<RandomField<N>>::new();
+    let mut transcript = PcsTranscript::<RandomField<N, FC<N>>>::new();
 
     let evaluations: Vec<_> = (0..8).map(Int::<I>::from).collect();
     let n = 3;
     let mle = DenseMultilinearExtension::from_evaluations_slice(n, &evaluations);
 
-    let (data, _) = TestZip::commit::<RandomField<N>>(&param, &mle).unwrap();
+    let (data, _) = TestZip::commit::<RandomField<N, FC<N>>>(&param, &mle).unwrap();
 
     let point = vec![0i64, 0i64, 0i64].map_to_field(config);
 
@@ -82,7 +74,7 @@ fn test_zip_opening() {
 
 #[test]
 fn test_failing_zip_evaluation() {
-    type F<'cfg> = RandomField<'cfg, N>;
+    type F<'cfg> = RandomField<'cfg, N, FC<N>>;
     let config = field_config!(57316695564490278656402085503, N);
     let config = ConfigRef::from(&config);
 
@@ -95,7 +87,7 @@ fn test_failing_zip_evaluation() {
     let n = 3;
     let mle = DenseMultilinearExtension::from_evaluations_slice(n, &evaluations);
 
-    let (data, comm) = TestZip::commit::<RandomField<N>>(&param, &mle).unwrap();
+    let (data, comm) = TestZip::commit::<RandomField<N, FC<N>>>(&param, &mle).unwrap();
 
     let point = vec![0i64, 0i64, 0i64].map_to_field(config);
     let eval: F = 7i64.map_to_field(config);
@@ -113,7 +105,7 @@ fn test_failing_zip_evaluation() {
 
 #[test]
 fn test_zip_evaluation() {
-    type F<'cfg> = RandomField<'cfg, N>;
+    type F<'cfg> = RandomField<'cfg, N, FC<N>>;
     let config = field_config!(57316695564490278656402085503, N);
     let config = ConfigRef::from(&config);
     let mut rng = ark_std::test_rng();
@@ -128,7 +120,7 @@ fn test_zip_evaluation() {
         .collect();
     let mle = DenseMultilinearExtension::from_evaluations_slice(n, &evaluations);
 
-    let (data, comm) = TestZip::commit::<RandomField<N>>(&param, &mle).unwrap();
+    let (data, comm) = TestZip::commit::<RandomField<N, FC<N>>>(&param, &mle).unwrap();
 
     let point: Vec<_> = (0..n).map(|_| Int::<I>::from(i8::rand(&mut rng))).collect();
     let eval: F = mle.evaluate(&point).unwrap().map_to_field(config);
@@ -145,7 +137,7 @@ fn test_zip_evaluation() {
 }
 #[test]
 fn test_zip_batch_evaluation() {
-    type F<'cfg> = RandomField<'cfg, N>;
+    type F<'cfg> = RandomField<'cfg, N, FC<N>>;
     let config = field_config!(57316695564490278656402085503, N);
     let config = ConfigRef::from(&config);
     let mut rng = ark_std::test_rng();
@@ -170,7 +162,7 @@ fn test_zip_batch_evaluation() {
         .map(|evaluations| DenseMultilinearExtension::from_evaluations_slice(n, evaluations))
         .collect();
 
-    let commitments: Vec<_> = TestZip::batch_commit::<RandomField<N>>(&param, &mles).unwrap();
+    let commitments: Vec<_> = TestZip::batch_commit::<RandomField<N, FC<N>>>(&param, &mles).unwrap();
     let (data, commitments): (Vec<_>, Vec<_>) = commitments.into_iter().unzip();
     let point: Vec<_> = (0..n).map(|_| Int::<I>::from(i8::rand(&mut rng))).collect();
     let eval: Vec<_> = mles

--- a/zip-plus/src/tests.rs
+++ b/zip-plus/src/tests.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::unwrap_used)]
+
 use ark_std::{UniformRand, vec, vec::Vec};
 
 use crate::{

--- a/zip-plus/src/tests.rs
+++ b/zip-plus/src/tests.rs
@@ -1,6 +1,6 @@
 use ark_std::{vec, vec::Vec, UniformRand};
 
-use crate::{define_random_field_zip_types, field::{ConfigRef, Int, RandomField}, field_config, implement_random_field_zip_types, poly_z::mle::DenseMultilinearExtension, traits::{ConfigReference, FieldMap}, transcript::KeccakTranscript, code::DefaultLinearCodeSpec, code_raa::RaaCode, pcs::structs::MultilinearZip, pcs_transcript::PcsTranscript, big_int, define_field_config};
+use crate::{define_random_field_zip_types, field::{Int, RandomField}, implement_random_field_zip_types, poly_z::mle::DenseMultilinearExtension, traits::{FieldMap}, transcript::KeccakTranscript, code::DefaultLinearCodeSpec, code_raa::RaaCode, pcs::structs::MultilinearZip, pcs_transcript::PcsTranscript, define_field_config};
 
 const I: usize = 1;
 const N: usize = 2;
@@ -49,9 +49,6 @@ fn test_failing_zip_commitment() {
 
 #[test]
 fn test_zip_opening() {
-    let config = field_config!(57316695564490278656402085503, N);
-    let config = ConfigRef::from(&config);
-
     let poly_size = 8;
     let mut keccak_transcript = KeccakTranscript::new();
     let linear_code: LC = LC::new(&DefaultLinearCodeSpec, poly_size, &mut keccak_transcript);
@@ -65,18 +62,16 @@ fn test_zip_opening() {
 
     let (data, _) = TestZip::commit::<RandomField<N, FC<N>>>(&param, &mle).unwrap();
 
-    let point = vec![0i64, 0i64, 0i64].map_to_field(config);
+    let point = vec![0i64, 0i64, 0i64].map_to_field();
 
-    let res = TestZip::open(&param, &mle, &data, &point, config, &mut transcript);
+    let res = TestZip::open(&param, &mle, &data, &point, &mut transcript);
 
     assert!(res.is_ok())
 }
 
 #[test]
 fn test_failing_zip_evaluation() {
-    type F<'cfg> = RandomField<'cfg, N, FC<N>>;
-    let config = field_config!(57316695564490278656402085503, N);
-    let config = ConfigRef::from(&config);
+    type F = RandomField<N, FC<N>>;
 
     let poly_size = 8;
     let mut keccak_transcript = KeccakTranscript::new();
@@ -89,25 +84,22 @@ fn test_failing_zip_evaluation() {
 
     let (data, comm) = TestZip::commit::<RandomField<N, FC<N>>>(&param, &mle).unwrap();
 
-    let point = vec![0i64, 0i64, 0i64].map_to_field(config);
-    let eval: F = 7i64.map_to_field(config);
+    let point = vec![0i64, 0i64, 0i64].map_to_field();
+    let eval: F = 7i64.map_to_field();
 
     let mut transcript = PcsTranscript::new();
-    let _ = TestZip::open(&param, &mle, &data, &point, config, &mut transcript);
+    let _ = TestZip::open(&param, &mle, &data, &point, &mut transcript);
 
     let proof = transcript.into_proof();
     let mut transcript = PcsTranscript::from_proof(&proof);
-    config.reference().expect("Field config cannot be none");
-    let res = TestZip::verify(&param, &comm, &point, eval, &mut transcript, config);
+    let res = TestZip::verify(&param, &comm, &point, eval, &mut transcript);
 
     assert!(res.is_err())
 }
 
 #[test]
 fn test_zip_evaluation() {
-    type F<'cfg> = RandomField<'cfg, N, FC<N>>;
-    let config = field_config!(57316695564490278656402085503, N);
-    let config = ConfigRef::from(&config);
+    type F<'cfg> = RandomField<N, FC<N>>;
     let mut rng = ark_std::test_rng();
 
     let n = 8;
@@ -123,23 +115,20 @@ fn test_zip_evaluation() {
     let (data, comm) = TestZip::commit::<RandomField<N, FC<N>>>(&param, &mle).unwrap();
 
     let point: Vec<_> = (0..n).map(|_| Int::<I>::from(i8::rand(&mut rng))).collect();
-    let eval: F = mle.evaluate(&point).unwrap().map_to_field(config);
+    let eval: F = mle.evaluate(&point).unwrap().map_to_field();
 
-    let point = point.map_to_field(config);
+    let point = point.map_to_field();
     let mut transcript = PcsTranscript::new();
-    let _ = TestZip::open(&param, &mle, &data, &point, config, &mut transcript);
+    let _ = TestZip::open(&param, &mle, &data, &point, &mut transcript);
 
     let proof = transcript.into_proof();
     let mut transcript = PcsTranscript::from_proof(&proof);
-    config.reference().expect("Field config cannot be none");
-    TestZip::verify(&param, &comm, &point, eval, &mut transcript, config)
+    TestZip::verify(&param, &comm, &point, eval, &mut transcript)
         .expect("Failed to verify");
 }
 #[test]
 fn test_zip_batch_evaluation() {
-    type F<'cfg> = RandomField<'cfg, N, FC<N>>;
-    let config = field_config!(57316695564490278656402085503, N);
-    let config = ConfigRef::from(&config);
+    type F<'cfg> = RandomField<N, FC<N>>;
     let mut rng = ark_std::test_rng();
 
     let n = 8;
@@ -167,24 +156,22 @@ fn test_zip_batch_evaluation() {
     let point: Vec<_> = (0..n).map(|_| Int::<I>::from(i8::rand(&mut rng))).collect();
     let eval: Vec<_> = mles
         .iter()
-        .map(|mle| mle.evaluate(&point).unwrap().map_to_field(config))
+        .map(|mle| mle.evaluate(&point).unwrap().map_to_field())
         .collect();
 
-    let point: Vec<F> = point.map_to_field(config);
+    let point: Vec<F> = point.map_to_field();
     let points: Vec<_> = (0..m).map(|_| point.clone()).collect();
     let mut transcript = PcsTranscript::new();
-    let _ = TestZip::batch_open(&param, &mles, &data, &points, &mut transcript, config);
+    let _ = TestZip::batch_open(&param, &mles, &data, &points, &mut transcript);
 
     let proof = transcript.into_proof();
     let mut transcript = PcsTranscript::from_proof(&proof);
-    config.reference().expect("Field config cannot be none");
     TestZip::batch_verify_z(
         &param,
         &commitments,
         &points,
         &eval,
         &mut transcript,
-        config,
     )
     .expect("Failed to verify");
 }

--- a/zip-plus/src/tests.rs
+++ b/zip-plus/src/tests.rs
@@ -1,6 +1,17 @@
-use ark_std::{vec, vec::Vec, UniformRand};
+use ark_std::{UniformRand, vec, vec::Vec};
 
-use crate::{define_random_field_zip_types, field::{Int, RandomField}, implement_random_field_zip_types, poly_z::mle::DenseMultilinearExtension, traits::{FieldMap}, transcript::KeccakTranscript, code::DefaultLinearCodeSpec, code_raa::RaaCode, pcs::structs::MultilinearZip, pcs_transcript::PcsTranscript, define_field_config};
+use crate::{
+    code::DefaultLinearCodeSpec,
+    code_raa::RaaCode,
+    define_field_config, define_random_field_zip_types,
+    field::{Int, RandomField},
+    implement_random_field_zip_types,
+    pcs::structs::MultilinearZip,
+    pcs_transcript::PcsTranscript,
+    poly_z::mle::DenseMultilinearExtension,
+    traits::FieldMap,
+    transcript::KeccakTranscript,
+};
 
 const I: usize = 1;
 const N: usize = 2;
@@ -123,8 +134,7 @@ fn test_zip_evaluation() {
 
     let proof = transcript.into_proof();
     let mut transcript = PcsTranscript::from_proof(&proof);
-    TestZip::verify(&param, &comm, &point, eval, &mut transcript)
-        .expect("Failed to verify");
+    TestZip::verify(&param, &comm, &point, eval, &mut transcript).expect("Failed to verify");
 }
 #[test]
 fn test_zip_batch_evaluation() {
@@ -151,7 +161,8 @@ fn test_zip_batch_evaluation() {
         .map(|evaluations| DenseMultilinearExtension::from_evaluations_slice(n, evaluations))
         .collect();
 
-    let commitments: Vec<_> = TestZip::batch_commit::<RandomField<N, FC<N>>>(&param, &mles).unwrap();
+    let commitments: Vec<_> =
+        TestZip::batch_commit::<RandomField<N, FC<N>>>(&param, &mles).unwrap();
     let (data, commitments): (Vec<_>, Vec<_>) = commitments.into_iter().unzip();
     let point: Vec<_> = (0..n).map(|_| Int::<I>::from(i8::rand(&mut rng))).collect();
     let eval: Vec<_> = mles
@@ -166,12 +177,6 @@ fn test_zip_batch_evaluation() {
 
     let proof = transcript.into_proof();
     let mut transcript = PcsTranscript::from_proof(&proof);
-    TestZip::batch_verify_z(
-        &param,
-        &commitments,
-        &points,
-        &eval,
-        &mut transcript,
-    )
-    .expect("Failed to verify");
+    TestZip::batch_verify_z(&param, &commitments, &points, &eval, &mut transcript)
+        .expect("Failed to verify");
 }

--- a/zip-plus/src/traits.rs
+++ b/zip-plus/src/traits.rs
@@ -2,7 +2,4 @@ pub(crate) mod conversion;
 pub(crate) mod types;
 
 pub use conversion::{FieldMap, FromBytes};
-pub use types::{
-    BigInteger, Field, Integer, PrimitiveConversion,
-    Uinteger, Words, ZipTypes,
-};
+pub use types::{BigInteger, Field, Integer, PrimitiveConversion, Uinteger, Words, ZipTypes};

--- a/zip-plus/src/traits.rs
+++ b/zip-plus/src/traits.rs
@@ -3,6 +3,6 @@ pub(crate) mod types;
 
 pub use conversion::{FieldMap, FromBytes};
 pub use types::{
-    BigInteger, Config, ConfigReference, Field, Integer, PrimitiveConversion,
+    BigInteger, Field, Integer, PrimitiveConversion,
     Uinteger, Words, ZipTypes,
 };

--- a/zip-plus/src/traits/conversion.rs
+++ b/zip-plus/src/traits/conversion.rs
@@ -11,5 +11,5 @@ pub trait FromBytes: Sized {
 
 pub trait FieldMap<F: Field> {
     type Output;
-    fn map_to_field(&self, config_ref: F::R) -> Self::Output;
+    fn map_to_field(&self) -> Self::Output;
 }

--- a/zip-plus/src/traits/conversion.rs
+++ b/zip-plus/src/traits/conversion.rs
@@ -1,6 +1,7 @@
 use crate::traits::Field;
 
-/// A trait for converting from little-endian and big-endian byte slices into a concrete type.
+/// A trait for converting from little-endian and big-endian byte slices into a
+/// concrete type.
 pub trait FromBytes: Sized {
     /// Constructs an instance from a little-endian byte slice.
     fn from_bytes_le(bytes: &[u8]) -> Option<Self>;

--- a/zip-plus/src/traits/types.rs
+++ b/zip-plus/src/traits/types.rs
@@ -56,8 +56,6 @@ pub trait Field:
     /// Cryptographic unsigned integer type.
     type U: Uinteger<W = Self::W, Int = Self::I>;
 
-    fn modulus() -> Self::B;
-
     /// Creates a new field element from config and value, without checking.
     fn new_unchecked(value: Self::B) -> Self;
 

--- a/zip-plus/src/traits/types.rs
+++ b/zip-plus/src/traits/types.rs
@@ -60,9 +60,6 @@ pub trait Field:
     /// Creates a new field element from config and value, without checking.
     fn new_unchecked(value: Self::B) -> Self;
 
-    /// Generates a random field element with the given config.
-    fn rand<R: ark_std::rand::Rng + ?Sized>(rng: &mut R) -> Self;
-
     /// Returns a reference to the integer value.
     fn value(&self) -> &Self::B;
 

--- a/zip-plus/src/traits/types.rs
+++ b/zip-plus/src/traits/types.rs
@@ -11,14 +11,15 @@ use crypto_bigint::Random;
 use num_traits::{ConstOne, ConstZero, One, Zero};
 
 use crate::{
+    field::FieldConfig,
+    pcs::utils::ToBytes,
     traits::{FieldMap, FromBytes},
     transcript::KeccakTranscript,
-    pcs::utils::ToBytes,
 };
-use crate::field::FieldConfig;
 
-/// Trait for field elements, requiring arithmetic, assignment, random generation, and conversion traits.
-/// Used as a bound for generic code over finite fields.
+/// Trait for field elements, requiring arithmetic, assignment, random
+/// generation, and conversion traits. Used as a bound for generic code over
+/// finite fields.
 pub trait Field:
     Debug
     + Clone

--- a/zip-plus/src/traits/types.rs
+++ b/zip-plus/src/traits/types.rs
@@ -162,7 +162,6 @@ pub trait Integer:
 pub trait Uinteger: Clone + FromBytes + One + for<'a> SubAssign<&'a Self> {
     type W: Words;
     type Int: Integer<W = Self::W>;
-    type PrimalityTest: PrimalityTest<Self>;
     /// Constructs from words.
     fn from_words(words: Self::W) -> Self;
     /// Converts to the signed integer type.
@@ -187,12 +186,6 @@ pub trait ZipTypes: Send + Sync {
         + for<'a> From<&'a Self::N>
         + for<'a> From<&'a Self::L>
         + for<'a> From<&'a Self::K>;
-}
-
-pub trait PrimalityTest<U: Uinteger> {
-    type Inner;
-    fn new(candidate: U) -> Self;
-    fn is_probably_prime(&self) -> bool;
 }
 
 pub trait PrimitiveConversion<T> {

--- a/zip-plus/src/traits/types.rs
+++ b/zip-plus/src/traits/types.rs
@@ -60,12 +60,8 @@ pub trait Field:
     type DebugField: Debug + From<Self> + Send + Sync;
     /// Creates a new field element from config and value, without checking.
     fn new_unchecked(config: Self::R, value: Self::B) -> Self;
-    /// Creates a new field element from value, without config.
-    fn without_config(value: Self::B) -> Self;
     /// Generates a random field element with the given config.
     fn rand_with_config<R: ark_std::rand::Rng + ?Sized>(rng: &mut R, config: Self::R) -> Self;
-    /// Sets the field configuration on the returned value.
-    fn with_config(self, config: Self::R) -> Self;
     /// Returns a reference to the integer value.
     fn value(&self) -> &Self::B;
     /// Returns a mutable reference to the integer value.

--- a/zip-plus/src/traits/types.rs
+++ b/zip-plus/src/traits/types.rs
@@ -15,6 +15,7 @@ use crate::{
     transcript::KeccakTranscript,
     pcs::utils::ToBytes,
 };
+use crate::field::FieldConfig;
 
 /// Trait for field elements, requiring arithmetic, assignment, random generation, and conversion traits.
 /// Used as a bound for generic code over finite fields.
@@ -47,25 +48,28 @@ pub trait Field:
     /// Integer representation type for the field element.
     type B: BigInteger<W = Self::W> + From<Self::I> + FieldMap<Self, Output = Self>;
     /// Field configuration type.
-    type C: Config<B = Self::B>;
-    /// Reference to field configuration.
-    type R: ConfigReference<C = Self::C>;
+    type C: FieldConfig<Self::B>;
     /// Word representation type.
     type W: Words;
     /// Cryptographic integer type.
     type I: Integer<W = Self::W, Uint = Self::U> + for<'a> From<&'a Self::B>;
     /// Cryptographic unsigned integer type.
     type U: Uinteger<W = Self::W, Int = Self::I>;
-    /// Debug representation for the field.
-    type DebugField: Debug + From<Self> + Send + Sync;
+
+    fn modulus() -> Self::B;
+
     /// Creates a new field element from config and value, without checking.
-    fn new_unchecked(config: Self::R, value: Self::B) -> Self;
+    fn new_unchecked(value: Self::B) -> Self;
+
     /// Generates a random field element with the given config.
-    fn rand_with_config<R: ark_std::rand::Rng + ?Sized>(rng: &mut R, config: Self::R) -> Self;
+    fn rand<R: ark_std::rand::Rng + ?Sized>(rng: &mut R) -> Self;
+
     /// Returns a reference to the integer value.
     fn value(&self) -> &Self::B;
+
     /// Returns a mutable reference to the integer value.
     fn value_mut(&mut self) -> &mut Self::B;
+
     /// Absorbs the field element into a Keccak transcript.
     fn absorb_into_transcript(&self, transcript: &mut KeccakTranscript);
 }
@@ -89,33 +93,6 @@ pub trait BigInteger: From<u64> + From<u32> + Debug + FromBytes + Clone {
     fn to_bytes_be(self) -> Vec<u8>;
     /// Converts to little-endian bytes.
     fn to_bytes_le(self) -> Vec<u8>;
-}
-
-/// Trait for field configuration types.
-pub trait Config: PartialEq + Eq {
-    type B: BigInteger;
-    /// Returns the modulus for the field.
-    fn modulus(&self) -> &Self::B;
-    /// Multiplies two integers in the field.
-    fn mul_assign(&self, a: &mut Self::B, b: &Self::B);
-    /// Returns the R^2 value for Montgomery reduction.
-    fn r2(&self) -> &Self::B;
-    /// Constructs a new config from a modulus.
-    fn new(modulus: Self::B) -> Self;
-}
-
-/// Trait for references to field configuration.
-pub trait ConfigReference: Copy + Clone + PartialEq + Eq + Debug + Send + Sync {
-    type C: Config;
-    /// Returns a reference to the config, if available.
-    fn reference(&self) -> Option<&Self::C>;
-    /// Creates a new config reference from a pointer.
-    #[allow(clippy::missing_safety_doc)] // TODO Should be documented.
-    unsafe fn new(config_ptr: *mut Self::C) -> Self;
-    /// Returns a pointer to the config, if available.
-    fn pointer(&self) -> Option<*mut Self::C>;
-    /// Constant representing no config reference.
-    const NONE: Self;
 }
 
 /// Trait for word-based representations of integers.

--- a/zip-plus/src/transcript.rs
+++ b/zip-plus/src/transcript.rs
@@ -4,10 +4,11 @@ use sha3::{Digest, Keccak256};
 use crate::{
     field::Int,
     traits::{
-        BigInteger, Config, ConfigReference, Field, FieldMap, Integer, PrimitiveConversion, Words,
+        BigInteger, Field, FieldMap, Integer, PrimitiveConversion, Words,
     },
     pcs::structs::ZipTranscript,
 };
+use crate::field::FieldConfig;
 
 /// A cryptographic transcript implementation using the Keccak-256 hash function.
 /// Used for Fiat-Shamir transformations in zero-knowledge proof systems.
@@ -85,17 +86,16 @@ impl KeccakTranscript {
 
     /// Generates a pseudorandom field element as a challenge based on the current transcript state.
     #[allow(clippy::not_unsafe_ptr_arg_deref)]
-    pub fn get_challenge<F: Field>(&mut self, config_ref: F::R) -> F {
+    pub fn get_challenge<F: Field>(&mut self) -> F {
         let (lo, hi) = self.get_challenge_limbs();
-        let config = config_ref.reference().expect("Field config cannot be none");
-        let modulus = config.modulus();
+        let modulus = F::modulus();
         let challenge_num_bits = modulus.num_bits() - 1;
         if F::W::num_words() == 1 {
             let lo_mask = (1u64 << challenge_num_bits) - 1;
 
             let truncated_lo = lo as u64 & lo_mask;
 
-            let mut challenge: F = truncated_lo.map_to_field(config_ref);
+            let challenge: F = truncated_lo.map_to_field();
             return challenge;
         }
         if challenge_num_bits < 128 {
@@ -103,14 +103,14 @@ impl KeccakTranscript {
 
             let truncated_lo = lo & lo_mask;
 
-            let mut challenge: F = truncated_lo.map_to_field(config_ref);
+            let mut challenge: F = truncated_lo.map_to_field();
             challenge
         } else if challenge_num_bits >= 256 {
             let two_to_128 = F::B::from_bits_le(&(0..196).map(|i| i == 128).collect::<Vec<bool>>())
-                .map_to_field(config_ref);
+                .map_to_field();
 
-            let mut challenge: F = <u128 as FieldMap<F>>::map_to_field(&lo, config_ref)
-                + two_to_128 * <u128 as FieldMap<F>>::map_to_field(&hi, config_ref);
+            let mut challenge: F = <u128 as FieldMap<F>>::map_to_field(&lo)
+                + two_to_128 * <u128 as FieldMap<F>>::map_to_field(&hi);
             challenge
         } else {
             let hi_bits_to_keep = challenge_num_bits - 128;
@@ -119,18 +119,18 @@ impl KeccakTranscript {
             let truncated_hi = hi & hi_mask;
 
             let two_to_128 = F::B::from_bits_le(&(0..196).map(|i| i == 128).collect::<Vec<bool>>())
-                .map_to_field(config_ref);
+                .map_to_field();
 
-            let mut ret: F = <u128 as FieldMap<F>>::map_to_field(&lo, config_ref)
-                + two_to_128 * <u128 as FieldMap<F>>::map_to_field(&truncated_hi, config_ref);
+            let mut ret: F = <u128 as FieldMap<F>>::map_to_field(&lo)
+                + two_to_128 * <u128 as FieldMap<F>>::map_to_field(&truncated_hi);
             ret
         }
     }
 
     /// Generates pseudorandom field elements as challenges based on the current transcript state.
-    pub fn get_challenges<F: Field>(&mut self, n: usize, config: F::R) -> Vec<F> {
+    pub fn get_challenges<F: Field>(&mut self, n: usize) -> Vec<F> {
         let mut challenges = Vec::with_capacity(n);
-        challenges.extend((0..n).map(|_| self.get_challenge::<F>(config)));
+        challenges.extend((0..n).map(|_| self.get_challenge::<F>()));
         challenges
     }
 
@@ -201,25 +201,22 @@ mod tests {
     use ark_std::str::FromStr;
 
     use super::KeccakTranscript;
-    use crate::{define_field_config, field::{BigInt, ConfigRef, FieldConfig, RandomField}, traits::{Config, FieldMap}};
-    use crate::field::config::ConstFieldConfig;
+    use crate::{define_field_config, field::{BigInt, FieldConfig, RandomField}, traits::{FieldMap}};
 
     define_field_config!(FC, "3618502788666131213697322783095070105623107215331596699973092056135872020481");
 
     #[test]
     fn test_keccak_transcript() {
         let mut transcript = KeccakTranscript::new();
-        let config = FieldConfig::new(FC::<32>::modulus());
-        let field_config = ConfigRef::from(&config);
 
         transcript.absorb(b"This is a test string!");
-        let challenge: RandomField<32, FC<32>> = transcript.get_challenge(field_config);
+        let challenge: RandomField<32, FC<32>> = transcript.get_challenge();
 
         let expected_bigint = BigInt::<32>::from_str(
             "693058076479703886486101269644733982722902192016595549603371045888466087870",
         )
         .unwrap();
-        let expected_field = expected_bigint.map_to_field(field_config);
+        let expected_field = expected_bigint.map_to_field();
 
         assert_eq!(challenge, expected_field);
     }

--- a/zip-plus/src/transcript.rs
+++ b/zip-plus/src/transcript.rs
@@ -8,7 +8,7 @@ use crate::{
     },
     pcs::structs::ZipTranscript,
 };
-use crate::field::FieldConfig;
+use crate::field::config::FieldConfigBase;
 
 /// A cryptographic transcript implementation using the Keccak-256 hash function.
 /// Used for Fiat-Shamir transformations in zero-knowledge proof systems.
@@ -88,7 +88,7 @@ impl KeccakTranscript {
     #[allow(clippy::not_unsafe_ptr_arg_deref)]
     pub fn get_challenge<F: Field>(&mut self) -> F {
         let (lo, hi) = self.get_challenge_limbs();
-        let modulus = F::modulus();
+        let modulus = F::C::modulus();
         let challenge_num_bits = modulus.num_bits() - 1;
         if F::W::num_words() == 1 {
             let lo_mask = (1u64 << challenge_num_bits) - 1;
@@ -103,13 +103,13 @@ impl KeccakTranscript {
 
             let truncated_lo = lo & lo_mask;
 
-            let mut challenge: F = truncated_lo.map_to_field();
+            let challenge: F = truncated_lo.map_to_field();
             challenge
         } else if challenge_num_bits >= 256 {
             let two_to_128 = F::B::from_bits_le(&(0..196).map(|i| i == 128).collect::<Vec<bool>>())
                 .map_to_field();
 
-            let mut challenge: F = <u128 as FieldMap<F>>::map_to_field(&lo)
+            let challenge: F = <u128 as FieldMap<F>>::map_to_field(&lo)
                 + two_to_128 * <u128 as FieldMap<F>>::map_to_field(&hi);
             challenge
         } else {
@@ -121,7 +121,7 @@ impl KeccakTranscript {
             let two_to_128 = F::B::from_bits_le(&(0..196).map(|i| i == 128).collect::<Vec<bool>>())
                 .map_to_field();
 
-            let mut ret: F = <u128 as FieldMap<F>>::map_to_field(&lo)
+            let ret: F = <u128 as FieldMap<F>>::map_to_field(&lo)
                 + two_to_128 * <u128 as FieldMap<F>>::map_to_field(&truncated_hi);
             ret
         }
@@ -201,7 +201,7 @@ mod tests {
     use ark_std::str::FromStr;
 
     use super::KeccakTranscript;
-    use crate::{define_field_config, field::{BigInt, FieldConfig, RandomField}, traits::{FieldMap}};
+    use crate::{define_field_config, field::{BigInt, RandomField}, traits::{FieldMap}};
 
     define_field_config!(FC, "3618502788666131213697322783095070105623107215331596699973092056135872020481");
 

--- a/zip-plus/src/transcript.rs
+++ b/zip-plus/src/transcript.rs
@@ -2,16 +2,14 @@ use ark_std::vec::Vec;
 use sha3::{Digest, Keccak256};
 
 use crate::{
-    field::Int,
-    traits::{
-        BigInteger, Field, FieldMap, Integer, PrimitiveConversion, Words,
-    },
+    field::{Int, config::FieldConfigBase},
     pcs::structs::ZipTranscript,
+    traits::{BigInteger, Field, FieldMap, Integer, PrimitiveConversion, Words},
 };
-use crate::field::config::FieldConfigBase;
 
-/// A cryptographic transcript implementation using the Keccak-256 hash function.
-/// Used for Fiat-Shamir transformations in zero-knowledge proof systems.
+/// A cryptographic transcript implementation using the Keccak-256 hash
+/// function. Used for Fiat-Shamir transformations in zero-knowledge proof
+/// systems.
 #[derive(Clone)]
 pub struct KeccakTranscript {
     /// The underlying Keccak-256 hasher that maintains the transcript state.
@@ -37,8 +35,9 @@ impl KeccakTranscript {
         self.hasher.update(v);
     }
 
-    /// Generates a specified number of pseudorandom bytes based on the current transcript state.
-    /// Uses a counter-based approach to generate enough bytes from the hasher.
+    /// Generates a specified number of pseudorandom bytes based on the current
+    /// transcript state. Uses a counter-based approach to generate enough
+    /// bytes from the hasher.
     pub fn get_random_bytes(&mut self, length: usize) -> Vec<u8> {
         let mut result = Vec::with_capacity(length);
         let mut counter = 0;
@@ -56,7 +55,8 @@ impl KeccakTranscript {
     }
 
     /// Absorbs a field element into the transcript.
-    /// Delegates to the field element's implementation of absorb_into_transcript.
+    /// Delegates to the field element's implementation of
+    /// absorb_into_transcript.
     pub fn absorb_random_field<F: Field>(&mut self, v: &F) {
         v.absorb_into_transcript(self)
     }
@@ -69,8 +69,8 @@ impl KeccakTranscript {
         }
     }
 
-    /// Internal helper that generates two 128-bit limbs from the current transcript state.
-    /// Updates the transcript state.
+    /// Internal helper that generates two 128-bit limbs from the current
+    /// transcript state. Updates the transcript state.
     fn get_challenge_limbs(&mut self) -> (u128, u128) {
         let challenge = self.hasher.clone().finalize();
 
@@ -84,7 +84,8 @@ impl KeccakTranscript {
         (lo, hi)
     }
 
-    /// Generates a pseudorandom field element as a challenge based on the current transcript state.
+    /// Generates a pseudorandom field element as a challenge based on the
+    /// current transcript state.
     #[allow(clippy::not_unsafe_ptr_arg_deref)]
     pub fn get_challenge<F: Field>(&mut self) -> F {
         let (lo, hi) = self.get_challenge_limbs();
@@ -127,14 +128,16 @@ impl KeccakTranscript {
         }
     }
 
-    /// Generates pseudorandom field elements as challenges based on the current transcript state.
+    /// Generates pseudorandom field elements as challenges based on the current
+    /// transcript state.
     pub fn get_challenges<F: Field>(&mut self, n: usize) -> Vec<F> {
         let mut challenges = Vec::with_capacity(n);
         challenges.extend((0..n).map(|_| self.get_challenge::<F>()));
         challenges
     }
 
-    /// Generates a pseudorandom [Integer] as a challenge based on the current transcript state.
+    /// Generates a pseudorandom [Integer] as a challenge based on the current
+    /// transcript state.
     pub fn get_integer_challenge<I: Integer>(&mut self) -> I {
         let mut words = I::W::default();
 
@@ -150,12 +153,14 @@ impl KeccakTranscript {
         I::from_words(words)
     }
 
-    /// Generates pseudorandom [CryptoInt]s as challenges based on the current transcript state.
+    /// Generates pseudorandom [CryptoInt]s as challenges based on the current
+    /// transcript state.
     pub fn get_integer_challenges<I: Integer>(&mut self, n: usize) -> Vec<I> {
         (0..n).map(|_| self.get_integer_challenge()).collect()
     }
 
-    /// Generates a pseudorandom `usize` within the given range bounds based on the current transcript state.
+    /// Generates a pseudorandom `usize` within the given range bounds based on
+    /// the current transcript state.
     fn get_usize_in_range(&mut self, range: &ark_std::ops::Range<usize>) -> usize {
         let challenge = self.hasher.clone().finalize();
 
@@ -201,9 +206,16 @@ mod tests {
     use ark_std::str::FromStr;
 
     use super::KeccakTranscript;
-    use crate::{define_field_config, field::{BigInt, RandomField}, traits::{FieldMap}};
+    use crate::{
+        define_field_config,
+        field::{BigInt, RandomField},
+        traits::FieldMap,
+    };
 
-    define_field_config!(FC, "3618502788666131213697322783095070105623107215331596699973092056135872020481");
+    define_field_config!(
+        FC,
+        "3618502788666131213697322783095070105623107215331596699973092056135872020481"
+    );
 
     #[test]
     fn test_keccak_transcript() {

--- a/zip-plus/src/transcript.rs
+++ b/zip-plus/src/transcript.rs
@@ -201,24 +201,19 @@ mod tests {
     use ark_std::str::FromStr;
 
     use super::KeccakTranscript;
-    use crate::{
-        field::{BigInt, ConfigRef, FieldConfig, RandomField},
-        traits::{Config, FieldMap},
-    };
+    use crate::{define_field_config, field::{BigInt, ConfigRef, FieldConfig, RandomField}, traits::{Config, FieldMap}};
+    use crate::field::config::ConstFieldConfig;
+
+    define_field_config!(FC, "3618502788666131213697322783095070105623107215331596699973092056135872020481");
 
     #[test]
     fn test_keccak_transcript() {
         let mut transcript = KeccakTranscript::new();
-        let config = FieldConfig::new(
-            BigInt::<32>::from_str(
-                "3618502788666131213697322783095070105623107215331596699973092056135872020481",
-            )
-            .unwrap(),
-        );
+        let config = FieldConfig::new(FC::<32>::MODULUS);
         let field_config = ConfigRef::from(&config);
 
         transcript.absorb(b"This is a test string!");
-        let challenge: RandomField<32> = transcript.get_challenge(field_config);
+        let challenge: RandomField<32, FC<32>> = transcript.get_challenge(field_config);
 
         let expected_bigint = BigInt::<32>::from_str(
             "693058076479703886486101269644733982722902192016595549603371045888466087870",

--- a/zip-plus/src/transcript.rs
+++ b/zip-plus/src/transcript.rs
@@ -209,7 +209,7 @@ mod tests {
     #[test]
     fn test_keccak_transcript() {
         let mut transcript = KeccakTranscript::new();
-        let config = FieldConfig::new(FC::<32>::MODULUS);
+        let config = FieldConfig::new(FC::<32>::modulus());
         let field_config = ConfigRef::from(&config);
 
         transcript.absorb(b"This is a test string!");

--- a/zip-plus/src/utils.rs
+++ b/zip-plus/src/utils.rs
@@ -4,7 +4,7 @@ use ark_std::{
     vec::Vec,
 };
 use num_integer::Integer as NumInteger;
-use rand::{rngs::StdRng, seq::SliceRandom, SeedableRng};
+use rand::{SeedableRng, rngs::StdRng, seq::SliceRandom};
 
 use crate::traits::{Integer, Words};
 
@@ -72,15 +72,18 @@ where
     f((v, 0));
 }
 
-/// Computes a linear combination of multiple evaluation rows into a single combined row.
+/// Computes a linear combination of multiple evaluation rows into a single
+/// combined row.
 ///
-/// Given a flat `evaluations` vector, interpreted as a matrix with `row_len` columns,
-/// this function treats each consecutive `row_len` values as one row. The output is a single row,
-/// computed by multiplying each input row by the corresponding coefficient from `coeffs`,
-/// and summing these scaled rows column-wise.
+/// Given a flat `evaluations` vector, interpreted as a matrix with `row_len`
+/// columns, this function treats each consecutive `row_len` values as one row.
+/// The output is a single row, computed by multiplying each input row by the
+/// corresponding coefficient from `coeffs`, and summing these scaled rows
+/// column-wise.
 ///
-/// This is equivalent to performing a matrix-vector multiplication where the matrix is formed by
-/// the evaluations and the vector is formed by the coefficients.
+/// This is equivalent to performing a matrix-vector multiplication where the
+/// matrix is formed by the evaluations and the vector is formed by the
+/// coefficients.
 ///
 /// # Arguments
 ///

--- a/zip-plus/src/utils.rs
+++ b/zip-plus/src/utils.rs
@@ -58,7 +58,7 @@ where
 {
     #[cfg(feature = "parallel")]
     {
-        use crate::zip::utils::div_ceil;
+        use crate::utils::div_ceil;
         let num_threads = num_threads();
         let chunk_size = div_ceil(v.len(), num_threads);
         if chunk_size < num_threads {


### PR DESCRIPTION
Previous implementation of `RandomField` stored `ConfigRef` that described field modulus and precomputed values for Montgomery representation. Moreover, it allowed having `RandomField` with no config at all.
This approach introduced a lot of unnecessary complexity, and wasn't actually useful in any meaningful way.

This PR introduces a static `FieldConfig` that is passed to `RandomField` as a parameter. This also allowed us to get rid of lifetimes in  `RandomField` definition.

The resulting code is shorter, simpler and more performant: as per `RandomFieldArithmetic` benchmark:
```
RandomFieldArithmetic/Multiply/Random128BitFieldElement
                        time:   [3.2569 µs 3.2817 µs 3.3152 µs]
                        change: [−98.302% −98.222% −98.164%] (p = 0.00 < 0.05)

RandomFieldArithmetic/Addition/Random128BitFieldElement
                        time:   [3.2753 µs 3.3093 µs 3.3523 µs]
                        change: [−92.487% −92.357% −92.233%] (p = 0.00 < 0.05)

RandomFieldArithmetic/Division/Random128BitFieldElement
                        time:   [7.2005 ms 7.2498 ms 7.3118 ms]
                        change: [−3.4696% −2.3770% −1.2831%] (p = 0.00 < 0.05)

RandomFieldArithmetic/Negation/Random128BitFieldElement
                        time:   [3.2196 µs 3.2870 µs 3.4107 µs]
                        change: [−79.418% −79.216% −78.937%] (p = 0.00 < 0.05)

RandomFieldArithmetic/Sum/Random128BitFieldElement
                        time:   [167.74 µs 169.54 µs 171.99 µs]
                        change: [−86.156% −86.031% −85.891%] (p = 0.00 < 0.05)

RandomFieldArithmetic/Product/Random128BitFieldElement
                        time:   [1.6908 ms 1.7224 ms 1.7742 ms]
                        change: [−37.438% −36.880% −36.091%] (p = 0.00 < 0.05)
```