### PR TITLE
Separate linear code and adjust benchmark parameters

### DIFF
--- a/zip-plus/benches/zip_benches.rs
+++ b/zip-plus/benches/zip_benches.rs
@@ -13,13 +13,13 @@ const INT_LIMBS: usize = WORD_FACTOR;
 
 struct BenchZipTypes {}
 impl ZipTypes for BenchZipTypes {
-    type EvalR = Int<{ INT_LIMBS }>;
+    type EvalR = i32;
     type Eval = Self::EvalR;
-    type CwR = Int<{ INT_LIMBS * 4 }>;
+    type CwR = i64;
     type Cw = Self::CwR;
-    type Chal = Int<{ INT_LIMBS }>;
-    type Pt = Int<{ INT_LIMBS }>;
-    type CombR = Int<{ INT_LIMBS * 8 }>;
+    type Chal = i128;
+    type Pt = i128;
+    type CombR = Int<{ INT_LIMBS * 4 }>;
     type Comb = Self::CombR;
     type Code = RaaCode<Self::Eval, Self::Cw, Self::Comb>;
 }

--- a/zip-plus/benches/zip_benches.rs
+++ b/zip-plus/benches/zip_benches.rs
@@ -22,12 +22,12 @@ impl ZipTypes for BenchZipTypes {
     type Pt = i128;
     type CombR = Int<{ INT_LIMBS * 3 }>;
     type Comb = Self::CombR;
-    type Code = RaaCode<Self::Eval, Self::Cw, Self::Comb, 4>;
 }
+type Code = RaaCode<BenchZipTypes, 4>;
 
 fn zip_benchmarks(c: &mut Criterion) {
     let mut group = c.benchmark_group("Zip+");
-    do_bench::<BenchZipTypes>(&mut group);
+    do_bench::<BenchZipTypes, Code>(&mut group);
     group.finish();
 }
 

--- a/zip-plus/benches/zip_benches.rs
+++ b/zip-plus/benches/zip_benches.rs
@@ -13,15 +13,16 @@ const INT_LIMBS: usize = WORD_FACTOR;
 
 struct BenchZipTypes {}
 impl ZipTypes for BenchZipTypes {
+    const NUM_COLUMN_OPENINGS: usize = 650;
     type EvalR = i32;
     type Eval = Self::EvalR;
     type CwR = i64;
     type Cw = Self::CwR;
     type Chal = i128;
     type Pt = i128;
-    type CombR = Int<{ INT_LIMBS * 4 }>;
+    type CombR = Int<{ INT_LIMBS * 3 }>;
     type Comb = Self::CombR;
-    type Code = RaaCode<Self::Eval, Self::Cw, Self::Comb>;
+    type Code = RaaCode<Self::Eval, Self::Cw, Self::Comb, 4>;
 }
 
 fn zip_benchmarks(c: &mut Criterion) {

--- a/zip-plus/benches/zip_common.rs
+++ b/zip-plus/benches/zip_common.rs
@@ -48,8 +48,6 @@ where
     encode_single_row::<Zt, Lc, 256>(group);
     encode_single_row::<Zt, Lc, 512>(group);
     encode_single_row::<Zt, Lc, 1024>(group);
-    encode_single_row::<Zt, Lc, 2048>(group);
-    encode_single_row::<Zt, Lc, 4096>(group);
 
     merkle_root::<Zt, 12>(group);
     merkle_root::<Zt, 13>(group);

--- a/zip-plus/benches/zip_common.rs
+++ b/zip-plus/benches/zip_common.rs
@@ -167,7 +167,7 @@ pub fn commit<Zt: ZipTypes, Lc: LinearCode<Zt>, const P: usize>(
 
     group.bench_function(
         format!(
-            "Commit: Eval={}, Codeword={}, Combination={}, poly_size=2^{P}",
+            "Commit: Eval={}, Cw={}, Comb={}, poly_size=2^{P}",
             Zt::Eval::type_name(),
             Zt::Cw::type_name(),
             Zt::Comb::type_name()
@@ -209,7 +209,7 @@ where
 
     group.bench_function(
         format!(
-            "Open: Eval={}, Codeword={}, Combination={}, poly_size=2^{P}, modulus={}",
+            "Open: Eval={}, Cw={}, Comb={}, poly_size=2^{P}, modulus={}",
             Zt::Eval::type_name(),
             Zt::Cw::type_name(),
             Zt::Comb::type_name(),
@@ -259,7 +259,7 @@ pub fn verify<Zt: ZipTypes, Lc: LinearCode<Zt>, const P: usize>(
 
     group.bench_function(
         format!(
-            "Verify: Eval={}, Codeword={}, Combination={}, poly_size=2^{P}, modulus={}",
+            "Verify: Eval={}, Cw={}, Comb={}, poly_size=2^{P}, modulus={}",
             Zt::Eval::type_name(),
             Zt::Cw::type_name(),
             Zt::Comb::type_name(),

--- a/zip-plus/benches/zip_common.rs
+++ b/zip-plus/benches/zip_common.rs
@@ -31,27 +31,25 @@ const_monty_params!(
 );
 type F = F256<ModP>;
 
-pub fn do_bench<Zt: ZipTypes>(group: &mut BenchmarkGroup<WallTime>)
+pub fn do_bench<Zt: ZipTypes, Lc: LinearCode<Zt>>(group: &mut BenchmarkGroup<WallTime>)
 where
     StandardUniform: Distribution<Zt::Eval> + Distribution<Zt::Cw>,
-    F: FromRef<Zt::Chal>
-        + FromRef<Zt::Pt>
-        + FromRef<<Zt::Code as LinearCode<Zt::Eval, Zt::Cw, Zt::CombR>>::Inner>,
+    F: FromRef<Zt::Chal> + FromRef<Zt::Pt> + FromRef<Lc::Inner>,
     Zt::Eval: ProjectableToField<F>,
     Zt::Cw: ProjectableToField<F>,
 {
-    encode_rows::<Zt, 12>(group);
-    encode_rows::<Zt, 13>(group);
-    encode_rows::<Zt, 14>(group);
-    encode_rows::<Zt, 15>(group);
-    encode_rows::<Zt, 16>(group);
+    encode_rows::<Zt, Lc, 12>(group);
+    encode_rows::<Zt, Lc, 13>(group);
+    encode_rows::<Zt, Lc, 14>(group);
+    encode_rows::<Zt, Lc, 15>(group);
+    encode_rows::<Zt, Lc, 16>(group);
 
-    encode_single_row::<Zt, 128>(group);
-    encode_single_row::<Zt, 256>(group);
-    encode_single_row::<Zt, 512>(group);
-    encode_single_row::<Zt, 1024>(group);
-    encode_single_row::<Zt, 2048>(group);
-    encode_single_row::<Zt, 4096>(group);
+    encode_single_row::<Zt, Lc, 128>(group);
+    encode_single_row::<Zt, Lc, 256>(group);
+    encode_single_row::<Zt, Lc, 512>(group);
+    encode_single_row::<Zt, Lc, 1024>(group);
+    encode_single_row::<Zt, Lc, 2048>(group);
+    encode_single_row::<Zt, Lc, 4096>(group);
 
     merkle_root::<Zt, 12>(group);
     merkle_root::<Zt, 13>(group);
@@ -59,27 +57,28 @@ where
     merkle_root::<Zt, 15>(group);
     merkle_root::<Zt, 16>(group);
 
-    commit::<Zt, 12>(group);
-    commit::<Zt, 13>(group);
-    commit::<Zt, 14>(group);
-    commit::<Zt, 15>(group);
-    commit::<Zt, 16>(group);
+    commit::<Zt, Lc, 12>(group);
+    commit::<Zt, Lc, 13>(group);
+    commit::<Zt, Lc, 14>(group);
+    commit::<Zt, Lc, 15>(group);
+    commit::<Zt, Lc, 16>(group);
 
-    open::<Zt, 12>(group);
-    open::<Zt, 13>(group);
-    open::<Zt, 14>(group);
-    open::<Zt, 15>(group);
-    open::<Zt, 16>(group);
+    open::<Zt, Lc, 12>(group);
+    open::<Zt, Lc, 13>(group);
+    open::<Zt, Lc, 14>(group);
+    open::<Zt, Lc, 15>(group);
+    open::<Zt, Lc, 16>(group);
 
-    verify::<Zt, 12>(group);
-    verify::<Zt, 13>(group);
-    verify::<Zt, 14>(group);
-    verify::<Zt, 15>(group);
-    verify::<Zt, 16>(group);
+    verify::<Zt, Lc, 12>(group);
+    verify::<Zt, Lc, 13>(group);
+    verify::<Zt, Lc, 14>(group);
+    verify::<Zt, Lc, 15>(group);
+    verify::<Zt, Lc, 16>(group);
 }
 
-pub fn encode_rows<Zt: ZipTypes, const P: usize>(group: &mut BenchmarkGroup<WallTime>)
-where
+pub fn encode_rows<Zt: ZipTypes, Lc: LinearCode<Zt>, const P: usize>(
+    group: &mut BenchmarkGroup<WallTime>,
+) where
     StandardUniform: Distribution<Zt::Eval>,
 {
     group.bench_function(
@@ -93,8 +92,8 @@ where
             type T = KeccakTranscript;
             let mut keccak_transcript = T::new();
             let poly_size = 1 << P;
-            let linear_code = Zt::Code::new(poly_size, false, &mut keccak_transcript);
-            let params = ZipPlus::<Zt>::setup(poly_size, linear_code);
+            let linear_code = Lc::new(poly_size, false, &mut keccak_transcript);
+            let params = ZipPlus::setup(poly_size, linear_code);
             let row_len = params.linear_code.row_len();
             let codeword_len = params.linear_code.codeword_len();
             let poly = DenseMultilinearExtension::<<Zt as ZipTypes>::Eval>::rand(P, &mut rng);
@@ -105,8 +104,9 @@ where
     );
 }
 
-pub fn encode_single_row<Zt: ZipTypes, const ROW_LEN: usize>(group: &mut BenchmarkGroup<WallTime>)
-where
+pub fn encode_single_row<Zt: ZipTypes, Lc: LinearCode<Zt>, const ROW_LEN: usize>(
+    group: &mut BenchmarkGroup<WallTime>,
+) where
     StandardUniform: Distribution<Zt::Eval>,
 {
     group.bench_function(
@@ -119,7 +119,7 @@ where
             let mut rng = ThreadRng::default();
             let mut keccak_transcript = KeccakTranscript::new();
             let poly_size = ROW_LEN * ROW_LEN;
-            let linear_code = <Zt as ZipTypes>::Code::new(poly_size, false, &mut keccak_transcript);
+            let linear_code = Lc::new(poly_size, false, &mut keccak_transcript);
             assert_eq!(linear_code.row_len(), ROW_LEN, "Unexpected row_len");
             let message: Vec<<Zt as ZipTypes>::Eval> =
                 (0..ROW_LEN).map(|_i| rng.random()).collect();
@@ -153,16 +153,17 @@ where
     );
 }
 
-pub fn commit<Zt: ZipTypes, const P: usize>(group: &mut BenchmarkGroup<WallTime>)
-where
+pub fn commit<Zt: ZipTypes, Lc: LinearCode<Zt>, const P: usize>(
+    group: &mut BenchmarkGroup<WallTime>,
+) where
     StandardUniform: Distribution<Zt::Eval>,
 {
     let mut rng = ThreadRng::default();
     type T = KeccakTranscript;
     let mut keccak_transcript = T::new();
     let poly_size = 1 << P;
-    let linear_code = <Zt as ZipTypes>::Code::new(poly_size, false, &mut keccak_transcript);
-    let params = ZipPlus::<Zt>::setup(poly_size, linear_code);
+    let linear_code = Lc::new(poly_size, false, &mut keccak_transcript);
+    let params = ZipPlus::setup(poly_size, linear_code);
 
     group.bench_function(
         format!(
@@ -188,7 +189,7 @@ where
     );
 }
 
-pub fn open<Zt: ZipTypes, const P: usize>(group: &mut BenchmarkGroup<WallTime>)
+pub fn open<Zt: ZipTypes, Lc: LinearCode<Zt>, const P: usize>(group: &mut BenchmarkGroup<WallTime>)
 where
     StandardUniform: Distribution<Zt::Eval>,
     Zt::Eval: ProjectableToField<F>,
@@ -199,8 +200,8 @@ where
     type T = KeccakTranscript;
     let mut keccak_transcript = T::new();
     let poly_size = 1 << P;
-    let linear_code = <Zt as ZipTypes>::Code::new(poly_size, false, &mut keccak_transcript);
-    let params = ZipPlus::<Zt>::setup(poly_size, linear_code);
+    let linear_code = Lc::new(poly_size, false, &mut keccak_transcript);
+    let params = ZipPlus::setup(poly_size, linear_code);
 
     let poly = DenseMultilinearExtension::rand(P, &mut rng);
     let (data, _) = ZipPlus::commit(&params, &poly).unwrap();
@@ -231,12 +232,11 @@ where
     );
 }
 
-pub fn verify<Zt: ZipTypes, const P: usize>(group: &mut BenchmarkGroup<WallTime>)
-where
+pub fn verify<Zt: ZipTypes, Lc: LinearCode<Zt>, const P: usize>(
+    group: &mut BenchmarkGroup<WallTime>,
+) where
     StandardUniform: Distribution<Zt::Eval>,
-    F: FromRef<Zt::Chal>
-        + FromRef<Zt::Pt>
-        + FromRef<<Zt::Code as LinearCode<Zt::Eval, Zt::Cw, Zt::CombR>>::Inner>,
+    F: FromRef<Zt::Chal> + FromRef<Zt::Pt> + FromRef<Lc::Inner>,
     Zt::Eval: ProjectableToField<F>,
     Zt::Cw: ProjectableToField<F>,
 {
@@ -244,8 +244,8 @@ where
     type T = KeccakTranscript;
     let mut keccak_transcript = T::new();
     let poly_size = 1 << P;
-    let linear_code = <Zt as ZipTypes>::Code::new(poly_size, false, &mut keccak_transcript);
-    let params = ZipPlus::<Zt>::setup(poly_size, linear_code);
+    let linear_code = Lc::new(poly_size, true, &mut keccak_transcript);
+    let params = ZipPlus::setup(poly_size, linear_code);
 
     let poly = DenseMultilinearExtension::rand(P, &mut rng);
     let (data, commitment) = ZipPlus::commit(&params, &poly).unwrap();

--- a/zip-plus/benches/zip_common.rs
+++ b/zip-plus/benches/zip_common.rs
@@ -242,7 +242,7 @@ pub fn verify<Zt: ZipTypes, Lc: LinearCode<Zt>, const P: usize>(
     type T = KeccakTranscript;
     let mut keccak_transcript = T::new();
     let poly_size = 1 << P;
-    let linear_code = Lc::new(poly_size, true, &mut keccak_transcript);
+    let linear_code = Lc::new(poly_size, false, &mut keccak_transcript);
     let params = ZipPlus::setup(poly_size, linear_code);
 
     let poly = DenseMultilinearExtension::rand(P, &mut rng);

--- a/zip-plus/benches/zip_common.rs
+++ b/zip-plus/benches/zip_common.rs
@@ -14,7 +14,7 @@ use itertools::Itertools;
 use num_traits::ConstOne;
 use rand::{distr::StandardUniform, prelude::*};
 use zip_plus::{
-    code::{DefaultLinearCodeSpec, LinearCode},
+    code::LinearCode,
     field::F256,
     merkle::MerkleTree,
     pcs::structs::{ProjectableToField, ZipPlus, ZipTypes},
@@ -93,12 +93,7 @@ where
             type T = KeccakTranscript;
             let mut keccak_transcript = T::new();
             let poly_size = 1 << P;
-            let linear_code = Zt::Code::new(
-                &DefaultLinearCodeSpec,
-                poly_size,
-                false,
-                &mut keccak_transcript,
-            );
+            let linear_code = Zt::Code::new(poly_size, false, &mut keccak_transcript);
             let params = ZipPlus::<Zt>::setup(poly_size, linear_code);
             let row_len = params.linear_code.row_len();
             let codeword_len = params.linear_code.codeword_len();
@@ -124,12 +119,7 @@ where
             let mut rng = ThreadRng::default();
             let mut keccak_transcript = KeccakTranscript::new();
             let poly_size = ROW_LEN * ROW_LEN;
-            let linear_code = <Zt as ZipTypes>::Code::new(
-                &DefaultLinearCodeSpec,
-                poly_size,
-                false,
-                &mut keccak_transcript,
-            );
+            let linear_code = <Zt as ZipTypes>::Code::new(poly_size, false, &mut keccak_transcript);
             assert_eq!(linear_code.row_len(), ROW_LEN, "Unexpected row_len");
             let message: Vec<<Zt as ZipTypes>::Eval> =
                 (0..ROW_LEN).map(|_i| rng.random()).collect();
@@ -171,12 +161,7 @@ where
     type T = KeccakTranscript;
     let mut keccak_transcript = T::new();
     let poly_size = 1 << P;
-    let linear_code = <Zt as ZipTypes>::Code::new(
-        &DefaultLinearCodeSpec,
-        poly_size,
-        false,
-        &mut keccak_transcript,
-    );
+    let linear_code = <Zt as ZipTypes>::Code::new(poly_size, false, &mut keccak_transcript);
     let params = ZipPlus::<Zt>::setup(poly_size, linear_code);
 
     group.bench_function(
@@ -214,12 +199,7 @@ where
     type T = KeccakTranscript;
     let mut keccak_transcript = T::new();
     let poly_size = 1 << P;
-    let linear_code = <Zt as ZipTypes>::Code::new(
-        &DefaultLinearCodeSpec,
-        poly_size,
-        false,
-        &mut keccak_transcript,
-    );
+    let linear_code = <Zt as ZipTypes>::Code::new(poly_size, false, &mut keccak_transcript);
     let params = ZipPlus::<Zt>::setup(poly_size, linear_code);
 
     let poly = DenseMultilinearExtension::rand(P, &mut rng);
@@ -264,12 +244,7 @@ where
     type T = KeccakTranscript;
     let mut keccak_transcript = T::new();
     let poly_size = 1 << P;
-    let linear_code = <Zt as ZipTypes>::Code::new(
-        &DefaultLinearCodeSpec,
-        poly_size,
-        false,
-        &mut keccak_transcript,
-    );
+    let linear_code = <Zt as ZipTypes>::Code::new(poly_size, false, &mut keccak_transcript);
     let params = ZipPlus::<Zt>::setup(poly_size, linear_code);
 
     let poly = DenseMultilinearExtension::rand(P, &mut rng);

--- a/zip-plus/benches/zip_common.rs
+++ b/zip-plus/benches/zip_common.rs
@@ -81,7 +81,7 @@ pub fn encode_rows<Zt: ZipTypes, Lc: LinearCode<Zt>, const P: usize>(
 {
     group.bench_function(
         format!(
-            "EncodeRows: {} -> {}, poly_size = 2^{P})",
+            "EncodeRows: {} -> {}, poly_size = 2^{P}",
             Zt::Eval::type_name(),
             Zt::Cw::type_name()
         ),

--- a/zip-plus/benches/zip_common.rs
+++ b/zip-plus/benches/zip_common.rs
@@ -34,7 +34,7 @@ type F = F256<ModP>;
 pub fn do_bench<Zt: ZipTypes, Lc: LinearCode<Zt>>(group: &mut BenchmarkGroup<WallTime>)
 where
     StandardUniform: Distribution<Zt::Eval> + Distribution<Zt::Cw>,
-    F: FromRef<Zt::Chal> + FromRef<Zt::Pt> + FromRef<Lc::Inner>,
+    F: FromRef<Zt::Chal> + FromRef<Zt::Pt>,
     Zt::Eval: ProjectableToField<F>,
     Zt::Cw: ProjectableToField<F>,
 {
@@ -236,7 +236,7 @@ pub fn verify<Zt: ZipTypes, Lc: LinearCode<Zt>, const P: usize>(
     group: &mut BenchmarkGroup<WallTime>,
 ) where
     StandardUniform: Distribution<Zt::Eval>,
-    F: FromRef<Zt::Chal> + FromRef<Zt::Pt> + FromRef<Lc::Inner>,
+    F: FromRef<Zt::Chal> + FromRef<Zt::Pt>,
     Zt::Eval: ProjectableToField<F>,
     Zt::Cw: ProjectableToField<F>,
 {

--- a/zip-plus/benches/zip_plus_benches.rs
+++ b/zip-plus/benches/zip_plus_benches.rs
@@ -18,20 +18,20 @@ impl<const D: usize> ZipTypes for BenchZipPlusTypes<D> {
     const NUM_COLUMN_OPENINGS: usize = 650;
     type EvalR = i8; // TODO: Use binary polynomials for evaluations
     type Eval = DensePolynomial<Self::EvalR, D>;
-    type CwR = i16;
+    type CwR = i32;
     type Cw = DensePolynomial<Self::CwR, D>;
     type Chal = i128;
     type Pt = i128;
     type CombR = Int<{ INT_LIMBS * 5 }>;
     type Comb = DensePolynomial<Self::CombR, D>;
-    type Code = RaaCode<Self::Eval, Self::Cw, Self::CombR, 4>;
 }
+type Code<const D: usize> = RaaCode<BenchZipPlusTypes<D>, 4>;
 
 fn zip_plus_benchmarks(c: &mut Criterion) {
     let mut group = c.benchmark_group("Zip+");
 
-    do_bench::<BenchZipPlusTypes<31>>(&mut group);
-    do_bench::<BenchZipPlusTypes<63>>(&mut group);
+    do_bench::<BenchZipPlusTypes<31>, Code<31>>(&mut group);
+    do_bench::<BenchZipPlusTypes<63>, Code<63>>(&mut group);
 
     group.finish();
 }

--- a/zip-plus/benches/zip_plus_benches.rs
+++ b/zip-plus/benches/zip_plus_benches.rs
@@ -15,15 +15,16 @@ const INT_LIMBS: usize = WORD_FACTOR;
 
 struct BenchZipPlusTypes<const D: usize> {}
 impl<const D: usize> ZipTypes for BenchZipPlusTypes<D> {
-    type EvalR = i32;
+    const NUM_COLUMN_OPENINGS: usize = 650;
+    type EvalR = i8; // TODO: Use binary polynomials for evaluations
     type Eval = DensePolynomial<Self::EvalR, D>;
-    type CwR = i64;
+    type CwR = i16;
     type Cw = DensePolynomial<Self::CwR, D>;
     type Chal = i128;
     type Pt = i128;
-    type CombR = Int<{ INT_LIMBS * 4 }>;
+    type CombR = Int<{ INT_LIMBS * 5 }>;
     type Comb = DensePolynomial<Self::CombR, D>;
-    type Code = RaaCode<Self::Eval, Self::Cw, Self::CombR>;
+    type Code = RaaCode<Self::Eval, Self::Cw, Self::CombR, 4>;
 }
 
 fn zip_plus_benchmarks(c: &mut Criterion) {

--- a/zip-plus/benches/zip_plus_benches.rs
+++ b/zip-plus/benches/zip_plus_benches.rs
@@ -15,13 +15,13 @@ const INT_LIMBS: usize = WORD_FACTOR;
 
 struct BenchZipPlusTypes<const D: usize> {}
 impl<const D: usize> ZipTypes for BenchZipPlusTypes<D> {
-    type EvalR = Int<{ INT_LIMBS }>;
+    type EvalR = i32;
     type Eval = DensePolynomial<Self::EvalR, D>;
-    type CwR = Int<{ INT_LIMBS * 4 }>;
+    type CwR = i64;
     type Cw = DensePolynomial<Self::CwR, D>;
-    type Chal = Int<{ INT_LIMBS }>;
-    type Pt = Int<{ INT_LIMBS }>;
-    type CombR = Int<{ INT_LIMBS * 8 }>;
+    type Chal = i128;
+    type Pt = i128;
+    type CombR = Int<{ INT_LIMBS * 4 }>;
     type Comb = DensePolynomial<Self::CombR, D>;
     type Code = RaaCode<Self::Eval, Self::Cw, Self::CombR>;
 }

--- a/zip-plus/src/code.rs
+++ b/zip-plus/src/code.rs
@@ -24,9 +24,6 @@ pub trait LinearCode<Eval: Ring, Cw: Ring, Comb: Ring>: Sync + Send {
     /// Number of columns to open during verification (security parameter)
     fn num_column_opening(&self) -> usize;
 
-    /// Number of proximity tests to perform (security parameter)
-    fn num_proximity_testing(&self) -> usize;
-
     /// Encodes a row of cryptographic integers using this linear encoding
     /// scheme.
     ///
@@ -78,8 +75,6 @@ pub trait LinearCodeSpec: Debug {
     /// A.k.a. inverse rate, the ratio of codeword length to input row length.
     /// Has to be at a power of 2.
     fn repetition_factor(&self) -> usize;
-
-    fn num_proximity_testing(&self, _n: usize, _n_0: usize) -> usize;
 }
 
 // Figure 2 in [GLSTW21](https://eprint.iacr.org/2021/1043.pdf).
@@ -87,14 +82,10 @@ pub trait LinearCodeSpec: Debug {
 pub struct DefaultLinearCodeSpec;
 impl LinearCodeSpec for DefaultLinearCodeSpec {
     fn num_column_opening(&self) -> usize {
-        1000
+        650
     }
 
     fn repetition_factor(&self) -> usize {
-        2
-    }
-
-    fn num_proximity_testing(&self, _n: usize, _n_0: usize) -> usize {
-        1
+        4
     }
 }

--- a/zip-plus/src/code.rs
+++ b/zip-plus/src/code.rs
@@ -1,9 +1,12 @@
 pub mod raa;
 
-use crate::traits::{FromRef, Transcript};
-use crypto_primitives::{PrimeField, Ring};
+use crate::{
+    pcs::structs::ZipTypes,
+    traits::{FromRef, Transcript},
+};
+use crypto_primitives::PrimeField;
 
-pub trait LinearCode<Eval: Ring, Cw: Ring, Comb: Ring>: Sync + Send {
+pub trait LinearCode<Zt: ZipTypes>: Sync + Send {
     /// Repetition factor, a.k.a. inverse rate, the ratio of codeword length to
     /// input row length. Has to be at a power of 2.
     ///
@@ -34,7 +37,7 @@ pub trait LinearCode<Eval: Ring, Cw: Ring, Comb: Ring>: Sync + Send {
     ///
     /// # Returns
     /// A vector of cryptographic integers representing the encoded row
-    fn encode(&self, row: &[Eval]) -> Vec<Cw>;
+    fn encode(&self, row: &[Zt::Eval]) -> Vec<Zt::Cw>;
 
     /// Encodes a row of cryptographic integers using this linear encoding
     /// scheme.
@@ -48,7 +51,7 @@ pub trait LinearCode<Eval: Ring, Cw: Ring, Comb: Ring>: Sync + Send {
     ///
     /// # Returns
     /// A vector of cryptographic integers representing the encoded row
-    fn encode_wide(&self, row: &[Comb]) -> Vec<Comb>;
+    fn encode_wide(&self, row: &[Zt::CombR]) -> Vec<Zt::CombR>;
 
     /// Encodes a row of field elements using this linear encoding scheme.
     ///

--- a/zip-plus/src/code.rs
+++ b/zip-plus/src/code.rs
@@ -15,8 +15,6 @@ pub trait LinearCode<Zt: ZipTypes>: Sync + Send {
     /// makes using it too much of a hassle.
     const REPETITION_FACTOR: usize;
 
-    type Inner;
-
     fn new<T: Transcript>(poly_size: usize, check_for_overflows: bool, transcript: &mut T) -> Self;
 
     /// Length of each input row before encoding
@@ -67,5 +65,5 @@ pub trait LinearCode<Zt: ZipTypes>: Sync + Send {
     /// A vector of field elements representing the encoded row
     fn encode_f<F>(&self, row: &[F]) -> Vec<F>
     where
-        F: PrimeField + FromRef<F> + FromRef<Self::Inner>;
+        F: PrimeField + FromRef<F>;
 }

--- a/zip-plus/src/code.rs
+++ b/zip-plus/src/code.rs
@@ -1,28 +1,26 @@
 pub mod raa;
 
-use std::fmt::Debug;
-
 use crate::traits::{FromRef, Transcript};
 use crypto_primitives::{PrimeField, Ring};
 
 pub trait LinearCode<Eval: Ring, Cw: Ring, Comb: Ring>: Sync + Send {
+    /// Repetition factor, a.k.a. inverse rate, the ratio of codeword length to
+    /// input row length. Has to be at a power of 2.
+    ///
+    /// Note: Ideally, this should be a generic constant, but due to the fact
+    /// that generic parameters may not be used in const operations, this
+    /// makes using it too much of a hassle.
+    const REPETITION_FACTOR: usize;
+
     type Inner;
 
-    fn new<S: LinearCodeSpec, T: Transcript>(
-        spec: &S,
-        poly_size: usize,
-        check_for_overflows: bool,
-        transcript: &mut T,
-    ) -> Self;
+    fn new<T: Transcript>(poly_size: usize, check_for_overflows: bool, transcript: &mut T) -> Self;
 
     /// Length of each input row before encoding
     fn row_len(&self) -> usize;
 
     /// Length of each encoded codeword (output length after encoding)
     fn codeword_len(&self) -> usize;
-
-    /// Number of columns to open during verification (security parameter)
-    fn num_column_opening(&self) -> usize;
 
     /// Encodes a row of cryptographic integers using this linear encoding
     /// scheme.
@@ -67,25 +65,4 @@ pub trait LinearCode<Eval: Ring, Cw: Ring, Comb: Ring>: Sync + Send {
     fn encode_f<F>(&self, row: &[F]) -> Vec<F>
     where
         F: PrimeField + FromRef<F> + FromRef<Self::Inner>;
-}
-
-pub trait LinearCodeSpec: Debug {
-    fn num_column_opening(&self) -> usize;
-
-    /// A.k.a. inverse rate, the ratio of codeword length to input row length.
-    /// Has to be at a power of 2.
-    fn repetition_factor(&self) -> usize;
-}
-
-// Figure 2 in [GLSTW21](https://eprint.iacr.org/2021/1043.pdf).
-#[derive(Debug)]
-pub struct DefaultLinearCodeSpec;
-impl LinearCodeSpec for DefaultLinearCodeSpec {
-    fn num_column_opening(&self) -> usize {
-        650
-    }
-
-    fn repetition_factor(&self) -> usize {
-        4
-    }
 }

--- a/zip-plus/src/code/raa.rs
+++ b/zip-plus/src/code/raa.rs
@@ -1,4 +1,4 @@
-use crypto_primitives::{PrimeField, Ring};
+use crypto_primitives::PrimeField;
 use num_traits::{CheckedAdd, Zero};
 use std::{marker::PhantomData, ops::AddAssign};
 
@@ -6,6 +6,7 @@ use crate::{
     add,
     code::LinearCode,
     mul,
+    pcs::structs::ZipTypes,
     traits::{FromRef, Transcript},
     utils::shuffle_seeded,
 };
@@ -13,7 +14,7 @@ use crate::{
 /// Implementation of a repeat-accumulate-accumulate (RAA) codes over the binary
 /// field, as defined by the Blaze paper (https://eprint.iacr.org/2024/1609)
 #[derive(Debug, Clone)]
-pub struct RaaCode<Eval: Ring, Cw: Ring, Comb: Ring, const REP: usize> {
+pub struct RaaCode<Zt: ZipTypes, const REP: usize> {
     /// Whether to check for overflows during encoding
     check_for_overflows: bool,
 
@@ -25,15 +26,10 @@ pub struct RaaCode<Eval: Ring, Cw: Ring, Comb: Ring, const REP: usize> {
     /// Randomness seed for the second permutation
     perm_2_seed: u64,
 
-    phantom: PhantomData<(Eval, Cw, Comb)>,
+    phantom: PhantomData<Zt>,
 }
 
-impl<Eval, Cw, Comb, const REP: usize> RaaCode<Eval, Cw, Comb, REP>
-where
-    Eval: Ring,
-    Cw: Ring + FromRef<Eval>,
-    Comb: Ring + FromRef<Comb>,
-{
+impl<Zt: ZipTypes, const REP: usize> RaaCode<Zt, REP> {
     /// Do the actual encoding, as per RAA spec
     fn encode_inner<In, Out>(&self, row: &[In]) -> Vec<Out>
     where
@@ -62,12 +58,7 @@ where
     }
 }
 
-impl<Eval, Cw, Comb, const REP: usize> LinearCode<Eval, Cw, Comb> for RaaCode<Eval, Cw, Comb, REP>
-where
-    Eval: Ring,
-    Cw: Ring + FromRef<Eval>,
-    Comb: Ring + FromRef<Comb>,
-{
+impl<Zt: ZipTypes, const REP: usize> LinearCode<Zt> for RaaCode<Zt, REP> {
     const REPETITION_FACTOR: usize = REP;
 
     type Inner = u64; // Doesn't really matter, we don't use it
@@ -93,7 +84,7 @@ where
         let codeword_width_bits = {
             // let initial_bits = crypto_bigint::Int::<N>::BITS;
 
-            let initial_bits = u32::try_from(size_of::<Eval>())
+            let initial_bits = u32::try_from(size_of::<Zt::EvalR>())
                 .ok()
                 .and_then(|b| b.checked_mul(8))
                 .expect("Size of Eval type is too large");
@@ -106,7 +97,7 @@ where
             };
             add!(initial_bits, add!(num_vars_even, mul!(rep_factor_log, 2)))
         };
-        let codeword_type_bits = u32::try_from(size_of::<Cw>())
+        let codeword_type_bits = u32::try_from(size_of::<Zt::CwR>())
             .ok()
             .and_then(|b| b.checked_mul(8))
             .expect("Size of Cw type is too large");
@@ -137,11 +128,11 @@ where
         self.row_len * REP
     }
 
-    fn encode(&self, row: &[Eval]) -> Vec<Cw> {
+    fn encode(&self, row: &[Zt::Eval]) -> Vec<Zt::Cw> {
         self.encode_inner(row)
     }
 
-    fn encode_wide(&self, row: &[Comb]) -> Vec<Comb> {
+    fn encode_wide(&self, row: &[Zt::CombR]) -> Vec<Zt::CombR> {
         self.encode_inner(row)
     }
 
@@ -209,7 +200,11 @@ mod tests {
     use num_traits::Zero;
 
     use super::*;
-    use crate::{code::LinearCode, pcs::test_utils::MockTranscript, utils::shuffle_seeded};
+    use crate::{
+        code::LinearCode,
+        pcs::test_utils::{MockTranscript, TestZipTypes},
+        utils::shuffle_seeded,
+    };
 
     const REPETITION_FACTOR: usize = 4;
 
@@ -220,16 +215,14 @@ mod tests {
     const K: usize = INT_LIMBS * 4;
     const M: usize = INT_LIMBS * 8;
 
-    fn test_raa<Eval, Cw, Comb, F>(poly_size: usize, f: F)
+    fn test_raa<Zt, F>(poly_size: usize, f: F)
     where
-        Eval: Ring,
-        Cw: Ring + FromRef<Eval>,
-        Comb: Ring + FromRef<Comb>,
-        F: Fn(&RaaCode<Eval, Cw, Comb, 4>),
+        Zt: ZipTypes,
+        F: Fn(&RaaCode<Zt, REPETITION_FACTOR>),
     {
         for check_for_overflows in [true, false] {
             let mut transcript = MockTranscript::default();
-            let code = RaaCode::<Eval, Cw, Comb, REPETITION_FACTOR>::new(
+            let code = RaaCode::<Zt, REPETITION_FACTOR>::new(
                 poly_size,
                 check_for_overflows,
                 &mut transcript,
@@ -324,7 +317,7 @@ mod tests {
 
     #[test]
     fn encoding_preserves_linearity() {
-        test_raa::<Int<N>, Int<K>, Int<M>, _>(16, |code| {
+        test_raa::<TestZipTypes<N, K, M>, _>(16, |code| {
             let a: Vec<Int<N>> = (1..=4).map(Int::<N>::from).collect();
             let b: Vec<Int<N>> = (5..=8).map(Int::<N>::from).collect();
             let sum_ab: Vec<Int<N>> = a.iter().zip(b.iter()).map(|(x, y)| *x + y).collect();
@@ -347,7 +340,7 @@ mod tests {
     /// against a known output.
     #[test]
     fn encoding_produces_predictable_results() {
-        test_raa::<Int<N>, Int<K>, Int<M>, _>(16, |code| {
+        test_raa::<TestZipTypes<N, K, M>, _>(16, |code| {
             let a: Vec<Int<N>> = (1..=4).map(Int::<N>::from).collect();
 
             let encode_a: Vec<Int<K>> = code.encode(&a);
@@ -364,7 +357,7 @@ mod tests {
 
     #[test]
     fn encoding_zero_vector_results_in_zero_codeword() {
-        test_raa::<Int<N>, Int<K>, Int<M>, _>(16, |code| {
+        test_raa::<TestZipTypes<N, K, M>, _>(16, |code| {
             let zero_vector: Vec<_> = vec![Int::<N>::zero(); code.row_len()];
             let encoded_vector: Vec<Int<K>> = code.encode(&zero_vector);
 
@@ -384,7 +377,7 @@ mod tests {
         const K: usize = 1;
 
         let mut transcript = MockTranscript::default();
-        let _code = RaaCode::<Int<N>, Int<K>, Int<M>, REPETITION_FACTOR>::new(
+        let _code = RaaCode::<TestZipTypes<N, K, N>, REPETITION_FACTOR>::new(
             1 << 30,
             true,
             &mut transcript,
@@ -395,7 +388,7 @@ mod tests {
     #[should_panic(expected = "Row length must match the code's row length")]
     #[cfg(debug_assertions)]
     fn encode_panics_on_mismatched_row_length() {
-        test_raa::<Int<N>, Int<K>, Int<M>, _>(16, |code| {
+        test_raa::<TestZipTypes<N, K, M>, _>(16, |code| {
             let incorrect_row = vec![Int::<N>::from(1), Int::<N>::from(2), Int::<N>::from(3)];
             let _: Vec<Int<K>> = code.encode(&incorrect_row);
         })

--- a/zip-plus/src/code/raa.rs
+++ b/zip-plus/src/code/raa.rs
@@ -61,8 +61,6 @@ impl<Zt: ZipTypes, const REP: usize> RaaCode<Zt, REP> {
 impl<Zt: ZipTypes, const REP: usize> LinearCode<Zt> for RaaCode<Zt, REP> {
     const REPETITION_FACTOR: usize = REP;
 
-    type Inner = u64; // Doesn't really matter, we don't use it
-
     fn new<T: Transcript>(poly_size: usize, check_for_overflows: bool, transcript: &mut T) -> Self {
         assert!(
             REP.is_power_of_two(),
@@ -138,7 +136,7 @@ impl<Zt: ZipTypes, const REP: usize> LinearCode<Zt> for RaaCode<Zt, REP> {
 
     fn encode_f<F>(&self, row: &[F]) -> Vec<F>
     where
-        F: PrimeField + FromRef<F> + FromRef<Self::Inner>,
+        F: PrimeField + FromRef<F>,
     {
         self.encode_inner(row)
     }

--- a/zip-plus/src/code/raa.rs
+++ b/zip-plus/src/code/raa.rs
@@ -4,7 +4,7 @@ use std::{marker::PhantomData, ops::AddAssign};
 
 use crate::{
     add,
-    code::{LinearCode, LinearCodeSpec},
+    code::LinearCode,
     mul,
     traits::{FromRef, Transcript},
     utils::shuffle_seeded,
@@ -13,15 +13,11 @@ use crate::{
 /// Implementation of a repeat-accumulate-accumulate (RAA) codes over the binary
 /// field, as defined by the Blaze paper (https://eprint.iacr.org/2024/1609)
 #[derive(Debug, Clone)]
-pub struct RaaCode<Eval: Ring, Cw: Ring, Comb: Ring> {
+pub struct RaaCode<Eval: Ring, Cw: Ring, Comb: Ring, const REP: usize> {
     /// Whether to check for overflows during encoding
     check_for_overflows: bool,
 
     row_len: usize,
-
-    repetition_factor: usize,
-
-    num_column_opening: usize,
 
     /// Randomness seed for the first permutation
     perm_1_seed: u64,
@@ -32,7 +28,7 @@ pub struct RaaCode<Eval: Ring, Cw: Ring, Comb: Ring> {
     phantom: PhantomData<(Eval, Cw, Comb)>,
 }
 
-impl<Eval, Cw, Comb> RaaCode<Eval, Cw, Comb>
+impl<Eval, Cw, Comb, const REP: usize> RaaCode<Eval, Cw, Comb, REP>
 where
     Eval: Ring,
     Cw: Ring + FromRef<Eval>,
@@ -48,7 +44,7 @@ where
             self.row_len,
             "Row length must match the code's row length"
         );
-        let mut result: Vec<Out> = repeat(row, self.repetition_factor);
+        let mut result: Vec<Out> = repeat(row, REP);
         shuffle_seeded(&mut result, self.perm_1_seed);
         if self.check_for_overflows {
             accumulate(&mut result);
@@ -66,22 +62,23 @@ where
     }
 }
 
-impl<Eval, Cw, Comb> LinearCode<Eval, Cw, Comb> for RaaCode<Eval, Cw, Comb>
+impl<Eval, Cw, Comb, const REP: usize> LinearCode<Eval, Cw, Comb> for RaaCode<Eval, Cw, Comb, REP>
 where
     Eval: Ring,
     Cw: Ring + FromRef<Eval>,
     Comb: Ring + FromRef<Comb>,
 {
+    const REPETITION_FACTOR: usize = REP;
+
     type Inner = u64; // Doesn't really matter, we don't use it
 
-    fn new<S: LinearCodeSpec, T: Transcript>(
-        spec: &S,
-        poly_size: usize,
-        check_for_overflows: bool,
-        transcript: &mut T,
-    ) -> Self {
-        // Taken from original Zip codes
+    fn new<T: Transcript>(poly_size: usize, check_for_overflows: bool, transcript: &mut T) -> Self {
+        assert!(
+            REP.is_power_of_two(),
+            "Repetition factor must be a power of two"
+        );
 
+        // Taken from original Zip codes
         let num_vars = poly_size.ilog2();
         let two_pow_num_vars = 1_usize
             .checked_shl(num_vars)
@@ -90,9 +87,6 @@ where
             .isqrt()
             .checked_next_power_of_two()
             .expect("row_len overflow");
-        let repetition_factor = spec.repetition_factor();
-
-        let num_column_opening = spec.num_column_opening();
 
         // Width of each entry in codeword vector, in bits.
         // For RAA it's initial_bits + 2*log(repetition_factor) + num_variables
@@ -104,10 +98,7 @@ where
                 .and_then(|b| b.checked_mul(8))
                 .expect("Size of Eval type is too large");
 
-            let rep_factor_log = repetition_factor
-                .checked_next_power_of_two()
-                .expect("Repetition factor is too large")
-                .ilog2();
+            let rep_factor_log = REP.ilog2();
             let num_vars_even = if num_vars.is_multiple_of(2) {
                 num_vars
             } else {
@@ -131,8 +122,6 @@ where
         Self {
             check_for_overflows,
             row_len,
-            repetition_factor,
-            num_column_opening,
             perm_1_seed,
             perm_2_seed,
             phantom: PhantomData,
@@ -145,11 +134,7 @@ where
 
     #[allow(clippy::arithmetic_side_effects)]
     fn codeword_len(&self) -> usize {
-        self.row_len * self.repetition_factor
-    }
-
-    fn num_column_opening(&self) -> usize {
-        self.num_column_opening
+        self.row_len * REP
     }
 
     fn encode(&self, row: &[Eval]) -> Vec<Cw> {
@@ -224,11 +209,9 @@ mod tests {
     use num_traits::Zero;
 
     use super::*;
-    use crate::{
-        code::{DefaultLinearCodeSpec, LinearCode},
-        pcs::test_utils::MockTranscript,
-        utils::shuffle_seeded,
-    };
+    use crate::{code::LinearCode, pcs::test_utils::MockTranscript, utils::shuffle_seeded};
+
+    const REPETITION_FACTOR: usize = 4;
 
     // Define common types for testing
     const INT_LIMBS: usize = 1;
@@ -242,12 +225,11 @@ mod tests {
         Eval: Ring,
         Cw: Ring + FromRef<Eval>,
         Comb: Ring + FromRef<Comb>,
-        F: Fn(&RaaCode<Eval, Cw, Comb>),
+        F: Fn(&RaaCode<Eval, Cw, Comb, 4>),
     {
         for check_for_overflows in [true, false] {
             let mut transcript = MockTranscript::default();
-            let code = RaaCode::<Eval, Cw, Comb>::new(
-                &DefaultLinearCodeSpec,
+            let code = RaaCode::<Eval, Cw, Comb, REPETITION_FACTOR>::new(
                 poly_size,
                 check_for_overflows,
                 &mut transcript,
@@ -369,10 +351,13 @@ mod tests {
             let a: Vec<Int<N>> = (1..=4).map(Int::<N>::from).collect();
 
             let encode_a: Vec<Int<K>> = code.encode(&a);
-
             assert_eq!(
                 encode_a,
-                [0x11, 0x1C, 0x21, 0x28, 0x3C, 0x48, 0x49, 0x58].map(Int::<K>::from)
+                [
+                    0x1E, 0x36, 0x39, 0x5A, 0x70, 0x7E, 0xA5, 0xC1, 0xCB, 0xDC, 0xF9, 0x11E, 0x124,
+                    0x14C, 0x14D, 0x160
+                ]
+                .map(Int::<K>::from)
             );
         })
     }
@@ -399,8 +384,7 @@ mod tests {
         const K: usize = 1;
 
         let mut transcript = MockTranscript::default();
-        let _code = RaaCode::<Int<N>, Int<K>, Int<M>>::new(
-            &DefaultLinearCodeSpec,
+        let _code = RaaCode::<Int<N>, Int<K>, Int<M>, REPETITION_FACTOR>::new(
             1 << 30,
             true,
             &mut transcript,

--- a/zip-plus/src/code/raa.rs
+++ b/zip-plus/src/code/raa.rs
@@ -7,7 +7,7 @@ use crate::{
     code::LinearCode,
     mul,
     pcs::structs::ZipTypes,
-    traits::{FromRef, Transcript},
+    traits::{FromRef, Transcribable, Transcript},
     utils::shuffle_seeded,
 };
 
@@ -82,10 +82,10 @@ impl<Zt: ZipTypes, const REP: usize> LinearCode<Zt> for RaaCode<Zt, REP> {
         let codeword_width_bits = {
             // let initial_bits = crypto_bigint::Int::<N>::BITS;
 
-            let initial_bits = u32::try_from(size_of::<Zt::EvalR>())
+            let initial_bits = u32::try_from(Zt::EvalR::NUM_BYTES)
                 .ok()
                 .and_then(|b| b.checked_mul(8))
-                .expect("Size of Eval type is too large");
+                .expect("Size of EvalR type is too large");
 
             let rep_factor_log = REP.ilog2();
             let num_vars_even = if num_vars.is_multiple_of(2) {
@@ -95,10 +95,10 @@ impl<Zt: ZipTypes, const REP: usize> LinearCode<Zt> for RaaCode<Zt, REP> {
             };
             add!(initial_bits, add!(num_vars_even, mul!(rep_factor_log, 2)))
         };
-        let codeword_type_bits = u32::try_from(size_of::<Zt::CwR>())
+        let codeword_type_bits = u32::try_from(Zt::CwR::NUM_BYTES)
             .ok()
             .and_then(|b| b.checked_mul(8))
-            .expect("Size of Cw type is too large");
+            .expect("Size of CwR type is too large");
         assert!(
             codeword_type_bits >= codeword_width_bits,
             "Cannot fit {codeword_width_bits}-bit wide codeword entries in {} bits entries",

--- a/zip-plus/src/code/raa.rs
+++ b/zip-plus/src/code/raa.rs
@@ -5,7 +5,7 @@ use std::{marker::PhantomData, ops::AddAssign};
 use crate::{
     add,
     code::{LinearCode, LinearCodeSpec},
-    mul, sub,
+    mul,
     traits::{FromRef, Transcript},
     utils::shuffle_seeded,
 };
@@ -22,8 +22,6 @@ pub struct RaaCode<Eval: Ring, Cw: Ring, Comb: Ring> {
     repetition_factor: usize,
 
     num_column_opening: usize,
-
-    num_proximity_testing: usize,
 
     /// Randomness seed for the first permutation
     perm_1_seed: u64,
@@ -95,8 +93,6 @@ where
         let repetition_factor = spec.repetition_factor();
 
         let num_column_opening = spec.num_column_opening();
-        let n_0 = sub!(two_pow_num_vars, 1).min(20);
-        let num_proximity_testing = spec.num_proximity_testing(row_len, n_0);
 
         // Width of each entry in codeword vector, in bits.
         // For RAA it's initial_bits + 2*log(repetition_factor) + num_variables
@@ -137,7 +133,6 @@ where
             row_len,
             repetition_factor,
             num_column_opening,
-            num_proximity_testing,
             perm_1_seed,
             perm_2_seed,
             phantom: PhantomData,
@@ -155,10 +150,6 @@ where
 
     fn num_column_opening(&self) -> usize {
         self.num_column_opening
-    }
-
-    fn num_proximity_testing(&self) -> usize {
-        self.num_proximity_testing
     }
 
     fn encode(&self, row: &[Eval]) -> Vec<Cw> {

--- a/zip-plus/src/code/raa.rs
+++ b/zip-plus/src/code/raa.rs
@@ -80,12 +80,8 @@ impl<Zt: ZipTypes, const REP: usize> LinearCode<Zt> for RaaCode<Zt, REP> {
         // Width of each entry in codeword vector, in bits.
         // For RAA it's initial_bits + 2*log(repetition_factor) + num_variables
         let codeword_width_bits = {
-            // let initial_bits = crypto_bigint::Int::<N>::BITS;
-
-            let initial_bits = u32::try_from(Zt::EvalR::NUM_BYTES)
-                .ok()
-                .and_then(|b| b.checked_mul(8))
-                .expect("Size of EvalR type is too large");
+            let initial_bits =
+                u32::try_from(Zt::EvalR::NUM_BITS).expect("Size of EvalR type is too large");
 
             let rep_factor_log = REP.ilog2();
             let num_vars_even = if num_vars.is_multiple_of(2) {
@@ -95,10 +91,8 @@ impl<Zt: ZipTypes, const REP: usize> LinearCode<Zt> for RaaCode<Zt, REP> {
             };
             add!(initial_bits, add!(num_vars_even, mul!(rep_factor_log, 2)))
         };
-        let codeword_type_bits = u32::try_from(Zt::CwR::NUM_BYTES)
-            .ok()
-            .and_then(|b| b.checked_mul(8))
-            .expect("Size of CwR type is too large");
+        let codeword_type_bits =
+            u32::try_from(Zt::CwR::NUM_BITS).expect("Size of CwR type is too large");
         assert!(
             codeword_type_bits >= codeword_width_bits,
             "Cannot fit {codeword_width_bits}-bit wide codeword entries in {} bits entries",

--- a/zip-plus/src/pcs/commit.rs
+++ b/zip-plus/src/pcs/commit.rs
@@ -206,7 +206,7 @@ mod tests {
     use rand::{Rng, rng};
 
     use crate::{
-        code::{DefaultLinearCodeSpec, LinearCode},
+        code::LinearCode,
         field::F256,
         merkle::{MerkleTree, MtHash},
         pcs::{
@@ -274,7 +274,7 @@ mod tests {
     #[test]
     fn commit_succeeds_for_small_polynomial() {
         let mut transcript = MockTranscript::default();
-        let code = C::new(&DefaultLinearCodeSpec, 16, true, &mut transcript);
+        let code = C::new(16, true, &mut transcript);
         let pp = ZipPlusParams::new(4, 4, code);
 
         let evaluations = vec![Int::from(42); 16];
@@ -287,7 +287,7 @@ mod tests {
     #[test]
     fn commit_succeeds_for_two_variables() {
         let mut transcript = MockTranscript::default();
-        let code = C::new(&DefaultLinearCodeSpec, 4, true, &mut transcript);
+        let code = C::new(4, true, &mut transcript);
         let pp = ZipPlusParams::new(2, 2, code);
 
         let evaluations = vec![Int::from(1), Int::from(2), Int::from(3), Int::from(4)];
@@ -427,7 +427,7 @@ mod tests {
             .into_par_iter()
             .map(|_| {
                 let mut transcript = MockTranscript::default();
-                let code = C::new(&DefaultLinearCodeSpec, poly_size, true, &mut transcript);
+                let code = C::new(poly_size, true, &mut transcript);
                 let pp = ZipPlusParams::new(num_vars, 8, code);
 
                 TestZip::encode_rows(
@@ -476,7 +476,7 @@ mod tests {
     #[test]
     fn encode_rows_succeeds_for_single_row() {
         let mut transcript = MockTranscript::default();
-        let code = C::new(&DefaultLinearCodeSpec, 4, true, &mut transcript);
+        let code = C::new(4, true, &mut transcript);
         let pp = ZipPlusParams::new(2, 1, code);
 
         // Create a polynomial with 2 variables and 4 evaluations
@@ -494,7 +494,7 @@ mod tests {
     #[test]
     fn encode_rows_succeeds_for_single_poly_row() {
         let mut transcript = MockTranscript::default();
-        let code = PolyC::new(&DefaultLinearCodeSpec, 4, true, &mut transcript);
+        let code = PolyC::new(4, true, &mut transcript);
         let pp = ZipPlusParams::new(2, 1, code);
 
         // Create a polynomial with 2 variables and 4 evaluations
@@ -630,8 +630,8 @@ mod tests {
             let column_values_size = pp.num_rows * size_of_zt_k;
             let single_merkle_proof_size =
                 size_of_dimension * 2 + size_of_path_len + merkle_depth * size_of_path_elem;
-            let column_opening_phase_size = pp.linear_code.num_column_opening()
-                * (column_values_size + single_merkle_proof_size);
+            let column_opening_phase_size =
+                Zt::NUM_COLUMN_OPENINGS * (column_values_size + single_merkle_proof_size);
 
             let evaluation_phase_size = pp.linear_code.row_len() * size_of_f_b;
 
@@ -649,12 +649,7 @@ mod tests {
         let num_vars = 4;
         let poly_size = 1 << num_vars;
         let mut keccak_transcript = KeccakTranscript::new();
-        let linear_code = C::new(
-            &DefaultLinearCodeSpec,
-            poly_size,
-            true,
-            &mut keccak_transcript,
-        );
+        let linear_code = C::new(poly_size, true, &mut keccak_transcript);
         let param = TestZip::setup(poly_size, linear_code);
         let evaluations: Vec<_> = (0..poly_size)
             .map(|_| <Zt as ZipTypes>::Eval::from(rng.random::<i8>()))

--- a/zip-plus/src/pcs/commit.rs
+++ b/zip-plus/src/pcs/commit.rs
@@ -63,7 +63,7 @@ impl<Zt: ZipTypes> ZipPlus<Zt> {
         pp: &ZipPlusParams<Zt>,
         poly: &DenseMultilinearExtension<Zt::Eval>,
     ) -> Result<(ZipPlusHint<Zt::Cw>, ZipPlusCommitment), ZipError> {
-        validate_input("commit", pp.num_vars, [poly], None::<&[bool]>)?;
+        validate_input::<Zt, bool>("commit", pp.num_vars, [poly], None)?;
 
         let expected_num_evals = pp.num_rows * pp.linear_code.row_len();
         assert_eq!(
@@ -108,7 +108,7 @@ impl<Zt: ZipTypes> ZipPlus<Zt> {
         pp: &ZipPlusParams<Zt>,
         poly: &DenseMultilinearExtension<Zt::Eval>,
     ) -> Result<Vec<Zt::Cw>, ZipError> {
-        validate_input("commit", pp.num_vars, [poly], None::<&[bool]>)?;
+        validate_input::<Zt, bool>("commit", pp.num_vars, [poly], None)?;
 
         let row_len = pp.linear_code.row_len();
         let codeword_len = pp.linear_code.codeword_len();
@@ -625,8 +625,7 @@ mod tests {
             let codeword_len = pp.linear_code.codeword_len();
             let merkle_depth = codeword_len.next_power_of_two().ilog2() as usize;
 
-            let proximity_phase_size =
-                pp.linear_code.num_proximity_testing() * pp.linear_code.row_len() * size_of_zt_m;
+            let proximity_phase_size = pp.linear_code.row_len() * size_of_zt_m;
 
             let column_values_size = pp.num_rows * size_of_zt_k;
             let single_merkle_proof_size =

--- a/zip-plus/src/pcs/commit.rs
+++ b/zip-plus/src/pcs/commit.rs
@@ -11,7 +11,7 @@ use crate::{
 };
 use uninit::out_ref::Out;
 
-impl<Zt: ZipTypes> ZipPlus<Zt> {
+impl<Zt: ZipTypes, Lc: LinearCode<Zt>> ZipPlus<Zt, Lc> {
     /// Creates a commitment to a multilinear polynomial using the ZIP PCS
     /// scheme.
     ///
@@ -60,10 +60,10 @@ impl<Zt: ZipTypes> ZipPlus<Zt> {
     ///   `pp.num_rows`, indicating an internal logic error.
     #[allow(clippy::arithmetic_side_effects)]
     pub fn commit(
-        pp: &ZipPlusParams<Zt>,
+        pp: &ZipPlusParams<Zt, Lc>,
         poly: &DenseMultilinearExtension<Zt::Eval>,
     ) -> Result<(ZipPlusHint<Zt::Cw>, ZipPlusCommitment), ZipError> {
-        validate_input::<Zt, bool>("commit", pp.num_vars, [poly], None)?;
+        validate_input::<Zt, Lc, bool>("commit", pp.num_vars, [poly], None)?;
 
         let expected_num_evals = pp.num_rows * pp.linear_code.row_len();
         assert_eq!(
@@ -105,10 +105,10 @@ impl<Zt: ZipTypes> ZipPlus<Zt> {
     /// vector of roots.
     #[allow(dead_code)]
     pub fn commit_no_merkle(
-        pp: &ZipPlusParams<Zt>,
+        pp: &ZipPlusParams<Zt, Lc>,
         poly: &DenseMultilinearExtension<Zt::Eval>,
     ) -> Result<Vec<Zt::Cw>, ZipError> {
-        validate_input::<Zt, bool>("commit", pp.num_vars, [poly], None)?;
+        validate_input::<Zt, Lc, bool>("commit", pp.num_vars, [poly], None)?;
 
         let row_len = pp.linear_code.row_len();
         let codeword_len = pp.linear_code.codeword_len();
@@ -134,7 +134,7 @@ impl<Zt: ZipTypes> ZipPlus<Zt> {
     /// corresponds to a polynomial in the input slice.
     #[allow(clippy::type_complexity)]
     pub fn batch_commit(
-        pp: &ZipPlusParams<Zt>,
+        pp: &ZipPlusParams<Zt, Lc>,
         polys: &[DenseMultilinearExtension<Zt::Eval>],
     ) -> Result<Vec<(ZipPlusHint<Zt::Cw>, ZipPlusCommitment)>, ZipError> {
         polys.iter().map(|poly| Self::commit(pp, poly)).collect()
@@ -159,7 +159,7 @@ impl<Zt: ZipTypes> ZipPlus<Zt> {
     /// A `Vec<Int<K>>` containing all the encoded rows concatenated together.
     #[allow(clippy::arithmetic_side_effects)]
     pub fn encode_rows(
-        pp: &ZipPlusParams<Zt>,
+        pp: &ZipPlusParams<Zt, Lc>,
         codeword_len: usize,
         row_len: usize,
         evals: &[Zt::Eval],
@@ -206,7 +206,7 @@ mod tests {
     use rand::{Rng, rng};
 
     use crate::{
-        code::LinearCode,
+        code::{LinearCode, raa::RaaCode},
         field::F256,
         merkle::{MerkleTree, MtHash},
         pcs::{
@@ -228,13 +228,13 @@ mod tests {
     const DEGREE: usize = 2;
 
     type Zt = TestZipTypes<N, K, M>;
-    type C = <Zt as ZipTypes>::Code;
+    type C = RaaCode<Zt, 4>;
 
     type PolyZt = TestPolyZipTypes<N, K, M, DEGREE>;
-    type PolyC = <PolyZt as ZipTypes>::Code;
+    type PolyC = RaaCode<PolyZt, 4>;
 
-    type TestZip = ZipPlus<Zt>;
-    type TestPolyZip = ZipPlus<PolyZt>;
+    type TestZip = ZipPlus<Zt, C>;
+    type TestPolyZip = ZipPlus<PolyZt, PolyC>;
 
     #[test]
     fn commit_rejects_too_many_variables() {
@@ -614,7 +614,7 @@ mod tests {
 
     #[test]
     fn proof_size_is_correct_for_parameters() {
-        fn calculate_expected_proof_size_bytes(pp: &ZipPlusParams<Zt>) -> usize {
+        fn calculate_expected_proof_size_bytes(pp: &ZipPlusParams<Zt, C>) -> usize {
             let size_of_zt_k = K * size_of::<Word>();
             let size_of_zt_m = M * size_of::<Word>();
             let size_of_f_b = FIELD_LIMBS * size_of::<Word>();

--- a/zip-plus/src/pcs/open_z.rs
+++ b/zip-plus/src/pcs/open_z.rs
@@ -16,9 +16,9 @@ use crypto_primitives::PrimeField;
 use itertools::{Itertools, izip};
 
 // TODO: Split onto test and open(aka eval)
-impl<Zt: ZipTypes> ZipPlus<Zt> {
+impl<Zt: ZipTypes, Lc: LinearCode<Zt>> ZipPlus<Zt, Lc> {
     pub fn open<F>(
-        pp: &ZipPlusParams<Zt>,
+        pp: &ZipPlusParams<Zt, Lc>,
         poly: &DenseMultilinearExtension<Zt::Eval>,
         commit_hint: &ZipPlusHint<Zt::Cw>,
         point: &[Zt::Pt],
@@ -29,7 +29,7 @@ impl<Zt: ZipTypes> ZipPlus<Zt> {
         F::Inner: Transcribable,
         Zt::Eval: ProjectableToField<F>,
     {
-        validate_input::<Zt, _>("open", pp.num_vars, [poly], [point])?;
+        validate_input::<Zt, Lc, _>("open", pp.num_vars, [poly], [point])?;
 
         Self::prove_testing_phase(pp, poly, commit_hint, transcript)?;
 
@@ -41,7 +41,7 @@ impl<Zt: ZipTypes> ZipPlus<Zt> {
 
     // TODO Apply 2022/1355 https://eprint.iacr.org/2022/1355.pdf#page=30
     pub fn batch_open<F>(
-        pp: &ZipPlusParams<Zt>,
+        pp: &ZipPlusParams<Zt, Lc>,
         polys: &[DenseMultilinearExtension<Zt::Eval>],
         comms: &[ZipPlusHint<Zt::Cw>],
         points: &[Vec<Zt::Pt>],
@@ -61,7 +61,7 @@ impl<Zt: ZipTypes> ZipPlus<Zt> {
     // Subprotocol functions
 
     fn prove_evaluation_phase<F>(
-        pp: &ZipPlusParams<Zt>,
+        pp: &ZipPlusParams<Zt, Lc>,
         transcript: &mut PcsTranscript,
         point: &[Zt::Pt],
         poly: &DenseMultilinearExtension<Zt::Eval>,
@@ -98,7 +98,7 @@ impl<Zt: ZipTypes> ZipPlus<Zt> {
     }
 
     pub(super) fn prove_testing_phase(
-        pp: &ZipPlusParams<Zt>,
+        pp: &ZipPlusParams<Zt, Lc>,
         poly: &DenseMultilinearExtension<Zt::Eval>,
         commit_hint: &ZipPlusHint<Zt::Cw>,
         transcript: &mut PcsTranscript,
@@ -141,7 +141,7 @@ impl<Zt: ZipTypes> ZipPlus<Zt> {
     }
 
     pub(super) fn open_merkle_trees_for_column(
-        pp: &ZipPlusParams<Zt>,
+        pp: &ZipPlusParams<Zt, Lc>,
         commit_hint: &ZipPlusHint<Zt::Cw>,
         column: usize,
         transcript: &mut PcsTranscript,
@@ -170,7 +170,7 @@ impl<Zt: ZipTypes> ZipPlus<Zt> {
 )]
 mod tests {
     use crate::{
-        code::LinearCode,
+        code::{LinearCode, raa::RaaCode},
         field::ConstMontyField,
         merkle::MerkleTree,
         pcs::{
@@ -202,10 +202,13 @@ mod tests {
     type F = ConstMontyField<ModP, FIELD_LIMBS>;
 
     type Zt = TestZipTypes<N, K, M>;
-    type PolyZt = TestPolyZipTypes<N, K, M, DEGREE>;
+    type C = RaaCode<Zt, 4>;
 
-    type TestZip = ZipPlus<Zt>;
-    type TestPolyZip = ZipPlus<PolyZt>;
+    type PolyZt = TestPolyZipTypes<N, K, M, DEGREE>;
+    type PolyC = RaaCode<PolyZt, 4>;
+
+    type TestZip = ZipPlus<Zt, C>;
+    type TestPolyZip = ZipPlus<PolyZt, PolyC>;
 
     fn random_point<R: Ring>(num_vars: usize, rng: &mut impl RngCore) -> Vec<R>
     where

--- a/zip-plus/src/pcs/open_z.rs
+++ b/zip-plus/src/pcs/open_z.rs
@@ -133,7 +133,7 @@ impl<Zt: ZipTypes> ZipPlus<Zt> {
         }
 
         // Open merkle tree for each column drawn
-        for _ in 0..pp.linear_code.num_column_opening() {
+        for _ in 0..Zt::NUM_COLUMN_OPENINGS {
             let column = transcript.squeeze_challenge_idx(pp.linear_code.codeword_len());
             Self::open_merkle_trees_for_column(pp, commit_hint, column, transcript)?;
         }

--- a/zip-plus/src/pcs/open_z.rs
+++ b/zip-plus/src/pcs/open_z.rs
@@ -29,7 +29,7 @@ impl<Zt: ZipTypes> ZipPlus<Zt> {
         F::Inner: Transcribable,
         Zt::Eval: ProjectableToField<F>,
     {
-        validate_input("open", pp.num_vars, [poly], [point])?;
+        validate_input::<Zt, _>("open", pp.num_vars, [poly], [point])?;
 
         Self::prove_testing_phase(pp, poly, commit_hint, transcript)?;
 
@@ -103,36 +103,33 @@ impl<Zt: ZipTypes> ZipPlus<Zt> {
         commit_hint: &ZipPlusHint<Zt::Cw>,
         transcript: &mut PcsTranscript,
     ) -> Result<(), ZipError> {
+        // If we can take linear combinations, perform the proximity test
         if pp.num_rows > 1 {
-            // If we can take linear combinations
-            // perform the proximity test an arbitrary number of times
-            for _ in 0..pp.linear_code.num_proximity_testing() {
-                // Values to evaluate the coefficients at
-                let alphas = transcript
-                    .fs_transcript
-                    .get_challenges::<Zt::Chal>(Zt::Comb::DEGREE_BOUND);
+            // Values to evaluate the coefficients at
+            let alphas = transcript
+                .fs_transcript
+                .get_challenges::<Zt::Chal>(Zt::Comb::DEGREE_BOUND);
 
-                // Coefficients for the linear combination of polynomial with evaluated
-                // coefficients
-                let coeffs = transcript
-                    .fs_transcript
-                    .get_challenges::<Zt::Chal>(pp.num_rows);
+            // Coefficients for the linear combination of polynomial with evaluated
+            // coefficients
+            let coeffs = transcript
+                .fs_transcript
+                .get_challenges::<Zt::Chal>(pp.num_rows);
 
-                let evals = poly
-                    .evaluations
-                    .iter()
-                    .map(Zt::Comb::from_ref)
-                    .map(|p| {
-                        p.evaluate_at_point(&alphas)
-                            .expect("Failed to evaluate polynomial")
-                    })
-                    .collect_vec();
+            let evals = poly
+                .evaluations
+                .iter()
+                .map(Zt::Comb::from_ref)
+                .map(|p| {
+                    p.evaluate_at_point(&alphas)
+                        .expect("Failed to evaluate polynomial")
+                })
+                .collect_vec();
 
-                // u' in the Zinc paper
-                let combined_row = combine_rows(&coeffs, &evals, pp.linear_code.row_len());
+            // u' in the Zinc paper
+            let combined_row = combine_rows(&coeffs, &evals, pp.linear_code.row_len());
 
-                transcript.write_many(&combined_row)?;
-            }
+            transcript.write_many(&combined_row)?;
         }
 
         // Open merkle tree for each column drawn

--- a/zip-plus/src/pcs/structs.rs
+++ b/zip-plus/src/pcs/structs.rs
@@ -11,6 +11,8 @@ use p3_field::Packable;
 use std::marker::PhantomData;
 
 pub trait ZipTypes: Send + Sync {
+    const NUM_COLUMN_OPENINGS: usize;
+
     /// Coefficient ring of evaluation polynomial [Self::Eval]
     type EvalR: IntRing + Named + Transcribable;
     /// Ring of witness/polynomial evaluations on boolean hypercube

--- a/zip-plus/src/pcs/structs.rs
+++ b/zip-plus/src/pcs/structs.rs
@@ -12,12 +12,12 @@ use std::marker::PhantomData;
 
 pub trait ZipTypes: Send + Sync {
     /// Coefficient ring of evaluation polynomial [Self::Eval]
-    type EvalR: Ring + Named;
+    type EvalR: IntRing + Named + Transcribable;
     /// Ring of witness/polynomial evaluations on boolean hypercube
     type Eval: Ring + Named + Polynomial<Self::EvalR>;
 
     /// Coefficient ring of codeword polynomial [Self::Cw]
-    type CwR: Ring + Named;
+    type CwR: IntRing + Named;
     /// Ring of codeword elements, at least as wide as the evaluation ring
     type Cw: Ring + Named + Polynomial<Self::CwR> + Transcribable + AsPackable + Copy;
 
@@ -197,3 +197,17 @@ pub trait ProjectableToField<F: PrimeField> {
     /// to a prime field using the given sampled value.
     fn prepare_projection(sampled_value: &F) -> impl Fn(&Self) -> F + 'static;
 }
+
+macro_rules! impl_projectable_to_field_for_primitives {
+    ($($t:ty),*) => {
+        $(
+            impl<F: PrimeField + From<$t>> ProjectableToField<F> for $t {
+                fn prepare_projection(_sampled_value: &F) -> impl Fn(&Self) -> F + 'static {
+                    move |x: &Self| F::from(*x)
+                }
+            }
+        )*
+    };
+}
+
+impl_projectable_to_field_for_primitives!(i8, i16, i32, i64, i128);

--- a/zip-plus/src/pcs/structs.rs
+++ b/zip-plus/src/pcs/structs.rs
@@ -21,35 +21,39 @@ pub trait ZipTypes: Send + Sync {
     /// Coefficient ring of codeword polynomial [Self::Cw]
     type CwR: IntRing + Named;
     /// Ring of codeword elements, at least as wide as the evaluation ring
-    type Cw: Ring + Named + Polynomial<Self::CwR> + Transcribable + AsPackable + Copy;
+    type Cw: Ring
+        + Polynomial<Self::CwR>
+        + FromRef<Self::Eval>
+        + Transcribable
+        + AsPackable
+        + Named
+        + Copy;
 
     /// Ring of challenge elements (coefficients) to perform a random linear
     /// combination of codewords
-    type Chal: IntRing + Named + Transcribable;
+    type Chal: IntRing + Transcribable + Named;
 
     /// Ring of point coordinates to evaluate the multilinear polynomial
     type Pt: IntRing;
 
     /// Coefficient ring of linear combination polynomial [Self::Comb]
-    type CombR: Ring + Transcribable + for<'a> MulByScalar<&'a Self::Chal>;
+    type CombR: Ring + FromRef<Self::CombR> + Transcribable + for<'a> MulByScalar<&'a Self::Chal>;
     /// Ring of elements in the linear combination of codewords, at least as
     /// wide as the evaluation, codeword, and challenge rings.
-    type Comb: Ring + Named + Polynomial<Self::CombR> + FromRef<Self::Eval> + FromRef<Self::Cw>;
-
-    /// Linear code used to encode the polynomial matrix representation
-    type Code: LinearCode<Self::Eval, Self::Cw, Self::CombR>;
+    type Comb: Ring + Polynomial<Self::CombR> + FromRef<Self::Eval> + FromRef<Self::Cw> + Named;
 }
 
 /// Zip is a Polynomial Commitment Scheme (PCS) that supports committing to
 /// multilinear polynomials.
-pub struct ZipPlus<Zt: ZipTypes>(PhantomData<Zt>);
+pub struct ZipPlus<Zt: ZipTypes, Lc: LinearCode<Zt>>(PhantomData<(Zt, Lc)>);
 
-impl<Zt> ZipPlus<Zt>
+impl<Zt, Lc> ZipPlus<Zt, Lc>
 where
     Zt: ZipTypes,
+    Lc: LinearCode<Zt>,
 {
     #[allow(clippy::arithmetic_side_effects)]
-    pub fn setup(poly_size: usize, linear_code: Zt::Code) -> ZipPlusParams<Zt> {
+    pub fn setup(poly_size: usize, linear_code: Lc) -> ZipPlusParams<Zt, Lc> {
         assert!(poly_size.is_power_of_two());
         let num_vars = poly_size.ilog2() as usize;
         let num_rows = ((1 << num_vars) / linear_code.row_len()).next_power_of_two();
@@ -59,15 +63,15 @@ where
 
 /// Parameters for the Zip+ PCS.
 #[derive(Clone, Debug)]
-pub struct ZipPlusParams<Zt: ZipTypes> {
+pub struct ZipPlusParams<Zt: ZipTypes, Lc: LinearCode<Zt>> {
     pub num_vars: usize,
     pub num_rows: usize,
-    pub linear_code: Zt::Code,
+    pub linear_code: Lc,
     phantom_data: PhantomData<Zt>,
 }
 
-impl<Zt: ZipTypes> ZipPlusParams<Zt> {
-    pub fn new(num_vars: usize, num_rows: usize, linear_code: Zt::Code) -> Self {
+impl<Zt: ZipTypes, Lc: LinearCode<Zt>> ZipPlusParams<Zt, Lc> {
+    pub fn new(num_vars: usize, num_rows: usize, linear_code: Lc) -> Self {
         Self {
             num_vars,
             num_rows,

--- a/zip-plus/src/pcs/structs.rs
+++ b/zip-plus/src/pcs/structs.rs
@@ -14,12 +14,12 @@ pub trait ZipTypes: Send + Sync {
     const NUM_COLUMN_OPENINGS: usize;
 
     /// Coefficient ring of evaluation polynomial [Self::Eval]
-    type EvalR: IntRing + Named + Transcribable;
+    type EvalR: IntRing + Transcribable + Named;
     /// Ring of witness/polynomial evaluations on boolean hypercube
     type Eval: Ring + Named + Polynomial<Self::EvalR>;
 
     /// Coefficient ring of codeword polynomial [Self::Cw]
-    type CwR: IntRing + Named;
+    type CwR: IntRing + Transcribable + Named;
     /// Ring of codeword elements, at least as wide as the evaluation ring
     type Cw: Ring
         + Polynomial<Self::CwR>

--- a/zip-plus/src/pcs/test_utils.rs
+++ b/zip-plus/src/pcs/test_utils.rs
@@ -7,7 +7,7 @@
 )]
 
 use crate::{
-    code::{DefaultLinearCodeSpec, LinearCode, raa::RaaCode},
+    code::{LinearCode, raa::RaaCode},
     pcs::structs::{
         AsPackable, MulByScalar, ProjectableToField, ZipPlus, ZipPlusCommitment, ZipPlusParams,
         ZipTypes,
@@ -19,8 +19,11 @@ use crate::{
 use crypto_primitives::{PrimeField, Ring, crypto_bigint_int::Int};
 use itertools::Itertools;
 
+const REPETITION_FACTOR: usize = 4;
+
 pub struct TestZipTypes<const N: usize, const K: usize, const M: usize> {}
 impl<const N: usize, const K: usize, const M: usize> ZipTypes for TestZipTypes<N, K, M> {
+    const NUM_COLUMN_OPENINGS: usize = 650;
     type EvalR = Int<N>;
     type Eval = Int<N>;
     type CwR = Int<K>;
@@ -29,7 +32,7 @@ impl<const N: usize, const K: usize, const M: usize> ZipTypes for TestZipTypes<N
     type Pt = Int<N>;
     type CombR = Int<M>;
     type Comb = Int<M>;
-    type Code = RaaCode<Int<N>, Int<K>, Int<M>>;
+    type Code = RaaCode<Int<N>, Int<K>, Int<M>, REPETITION_FACTOR>;
 }
 
 pub struct TestPolyZipTypes<const N: usize, const K: usize, const M: usize, const DEGREE: usize> {
@@ -37,6 +40,7 @@ pub struct TestPolyZipTypes<const N: usize, const K: usize, const M: usize, cons
 impl<const N: usize, const K: usize, const M: usize, const DEGREE: usize> ZipTypes
     for TestPolyZipTypes<N, K, M, DEGREE>
 {
+    const NUM_COLUMN_OPENINGS: usize = 650;
     type EvalR = Int<N>;
     type Eval = DensePolynomial<Int<N>, DEGREE>;
     type CwR = Int<K>;
@@ -45,7 +49,12 @@ impl<const N: usize, const K: usize, const M: usize, const DEGREE: usize> ZipTyp
     type Pt = Int<N>;
     type CombR = Int<M>;
     type Comb = DensePolynomial<Int<M>, DEGREE>;
-    type Code = RaaCode<DensePolynomial<Int<N>, DEGREE>, DensePolynomial<Int<K>, DEGREE>, Int<M>>;
+    type Code = RaaCode<
+        DensePolynomial<Int<N>, DEGREE>,
+        DensePolynomial<Int<K>, DEGREE>,
+        Int<M>,
+        REPETITION_FACTOR,
+    >;
 }
 
 /// Helper function to set up common parameters for tests.
@@ -91,8 +100,7 @@ fn setup_test_params_inner<Zt: ZipTypes>(
     let num_rows = 1 << num_vars.div_ceil(2);
 
     let mut transcript = MockTranscript::default();
-    let code =
-        <Zt as ZipTypes>::Code::new(&DefaultLinearCodeSpec, poly_size, true, &mut transcript);
+    let code = <Zt as ZipTypes>::Code::new(poly_size, true, &mut transcript);
     let pp = ZipPlusParams::new(num_vars, num_rows, code);
 
     let evaluations = prepare_evaluations(poly_size);
@@ -154,7 +162,13 @@ where
     Eval: Ring + for<'a> MulByScalar<&'a Pt>,
     Cw: Ring + FromRef<Eval> + AsPackable + Transcribable,
     CombR: Ring + FromRef<CombR> + Transcribable,
-    Zt: ZipTypes<Eval = Eval, Cw = Cw, Pt = Pt, CombR = CombR, Code = RaaCode<Eval, Cw, CombR>>,
+    Zt: ZipTypes<
+            Eval = Eval,
+            Cw = Cw,
+            Pt = Pt,
+            CombR = CombR,
+            Code = RaaCode<Eval, Cw, CombR, REPETITION_FACTOR>,
+        >,
     F: PrimeField + FromRef<Zt::Chal> + FromRef<Zt::Pt> + for<'a> MulByScalar<&'a F>,
     F::Inner: Transcribable,
     Eval: ProjectableToField<F>,
@@ -205,7 +219,7 @@ where
             .fs_transcript
             .get_challenges::<Zt::Chal>(pp.num_rows);
     }
-    for _ in 0..pp.linear_code.num_column_opening() {
+    for _ in 0..Zt::NUM_COLUMN_OPENINGS {
         let _ = transcript.squeeze_challenge_idx(pp.linear_code.codeword_len());
         let _ = transcript.read_many::<Zt::Cw>(pp.num_rows).unwrap();
         let _ = transcript.read_merkle_proof().unwrap();

--- a/zip-plus/src/pcs/test_utils.rs
+++ b/zip-plus/src/pcs/test_utils.rs
@@ -9,14 +9,13 @@
 use crate::{
     code::{LinearCode, raa::RaaCode},
     pcs::structs::{
-        AsPackable, MulByScalar, ProjectableToField, ZipPlus, ZipPlusCommitment, ZipPlusParams,
-        ZipTypes,
+        MulByScalar, ProjectableToField, ZipPlus, ZipPlusCommitment, ZipPlusParams, ZipTypes,
     },
     pcs_transcript::PcsTranscript,
     poly::{Polynomial, dense::DensePolynomial, mle::DenseMultilinearExtension},
     traits::{FromRef, Transcribable, Transcript},
 };
-use crypto_primitives::{PrimeField, Ring, crypto_bigint_int::Int};
+use crypto_primitives::{PrimeField, crypto_bigint_int::Int};
 use itertools::Itertools;
 
 const REPETITION_FACTOR: usize = 4;
@@ -32,7 +31,6 @@ impl<const N: usize, const K: usize, const M: usize> ZipTypes for TestZipTypes<N
     type Pt = Int<N>;
     type CombR = Int<M>;
     type Comb = Int<M>;
-    type Code = RaaCode<Int<N>, Int<K>, Int<M>, REPETITION_FACTOR>;
 }
 
 pub struct TestPolyZipTypes<const N: usize, const K: usize, const M: usize, const DEGREE: usize> {
@@ -49,19 +47,13 @@ impl<const N: usize, const K: usize, const M: usize, const DEGREE: usize> ZipTyp
     type Pt = Int<N>;
     type CombR = Int<M>;
     type Comb = DensePolynomial<Int<M>, DEGREE>;
-    type Code = RaaCode<
-        DensePolynomial<Int<N>, DEGREE>,
-        DensePolynomial<Int<K>, DEGREE>,
-        Int<M>,
-        REPETITION_FACTOR,
-    >;
 }
 
 /// Helper function to set up common parameters for tests.
 pub fn setup_test_params<const N: usize, const K: usize, const M: usize>(
     num_vars: usize,
 ) -> (
-    ZipPlusParams<TestZipTypes<N, K, M>>,
+    ZipPlusParams<TestZipTypes<N, K, M>, RaaCode<TestZipTypes<N, K, M>, REPETITION_FACTOR>>,
     DenseMultilinearExtension<Int<N>>,
 ) {
     setup_test_params_inner(num_vars, |poly_size| {
@@ -78,7 +70,10 @@ pub fn setup_poly_test_params<
 >(
     num_vars: usize,
 ) -> (
-    ZipPlusParams<TestPolyZipTypes<N, K, M, DEGREE>>,
+    ZipPlusParams<
+        TestPolyZipTypes<N, K, M, DEGREE>,
+        RaaCode<TestPolyZipTypes<N, K, M, DEGREE>, REPETITION_FACTOR>,
+    >,
     DenseMultilinearExtension<DensePolynomial<Int<N>, DEGREE>>,
 ) {
     setup_test_params_inner(num_vars, |poly_size| {
@@ -92,15 +87,15 @@ pub fn setup_poly_test_params<
     })
 }
 
-fn setup_test_params_inner<Zt: ZipTypes>(
+fn setup_test_params_inner<Zt: ZipTypes, Lc: LinearCode<Zt>>(
     num_vars: usize,
     prepare_evaluations: impl FnOnce(usize) -> Vec<Zt::Eval>,
-) -> (ZipPlusParams<Zt>, DenseMultilinearExtension<Zt::Eval>) {
+) -> (ZipPlusParams<Zt, Lc>, DenseMultilinearExtension<Zt::Eval>) {
     let poly_size = 1 << num_vars;
     let num_rows = 1 << num_vars.div_ceil(2);
 
     let mut transcript = MockTranscript::default();
-    let code = <Zt as ZipTypes>::Code::new(poly_size, true, &mut transcript);
+    let code = Lc::new(poly_size, true, &mut transcript);
     let pp = ZipPlusParams::new(num_vars, num_rows, code);
 
     let evaluations = prepare_evaluations(poly_size);
@@ -112,7 +107,7 @@ fn setup_test_params_inner<Zt: ZipTypes>(
 pub fn setup_full_protocol<F, const N: usize, const K: usize, const M: usize>(
     num_vars: usize,
 ) -> (
-    ZipPlusParams<TestZipTypes<N, K, M>>,
+    ZipPlusParams<TestZipTypes<N, K, M>, RaaCode<TestZipTypes<N, K, M>, REPETITION_FACTOR>>,
     ZipPlusCommitment,
     Vec<F>,
     F,
@@ -123,7 +118,7 @@ where
     F::Inner: Transcribable,
     Int<N>: ProjectableToField<F>,
 {
-    setup_full_protocol_inner::<_, _, _, _, _, _, N>(num_vars, setup_test_params, || {
+    setup_full_protocol_inner::<_, _, _, N>(num_vars, setup_test_params, || {
         (0..num_vars).map(|i| Int::from(i as i32 + 2)).collect()
     })
 }
@@ -137,7 +132,10 @@ pub fn setup_full_protocol_poly<
 >(
     num_vars: usize,
 ) -> (
-    ZipPlusParams<TestPolyZipTypes<N, K, M, DEGREE>>,
+    ZipPlusParams<
+        TestPolyZipTypes<N, K, M, DEGREE>,
+        RaaCode<TestPolyZipTypes<N, K, M, DEGREE>, REPETITION_FACTOR>,
+    >,
     ZipPlusCommitment,
     Vec<F>,
     F,
@@ -148,36 +146,29 @@ where
     F::Inner: Transcribable,
     DensePolynomial<Int<N>, DEGREE>: ProjectableToField<F>,
 {
-    setup_full_protocol_inner::<_, _, _, _, _, _, N>(num_vars, setup_poly_test_params, || {
+    setup_full_protocol_inner::<_, _, _, N>(num_vars, setup_poly_test_params, || {
         (0..num_vars).map(|i| Int::from(i as i32 + 2)).collect()
     })
 }
 
-fn setup_full_protocol_inner<Eval, Cw, Pt, CombR, Zt, F, const N: usize>(
+fn setup_full_protocol_inner<Zt, Lc, F, const N: usize>(
     num_vars: usize,
-    setup: impl FnOnce(usize) -> (ZipPlusParams<Zt>, DenseMultilinearExtension<Eval>),
-    prepare_evaluation_point: impl FnOnce() -> Vec<Pt>,
-) -> (ZipPlusParams<Zt>, ZipPlusCommitment, Vec<F>, F, Vec<u8>)
+    setup: impl FnOnce(usize) -> (ZipPlusParams<Zt, Lc>, DenseMultilinearExtension<Zt::Eval>),
+    prepare_evaluation_point: impl FnOnce() -> Vec<Zt::Pt>,
+) -> (ZipPlusParams<Zt, Lc>, ZipPlusCommitment, Vec<F>, F, Vec<u8>)
 where
-    Eval: Ring + for<'a> MulByScalar<&'a Pt>,
-    Cw: Ring + FromRef<Eval> + AsPackable + Transcribable,
-    CombR: Ring + FromRef<CombR> + Transcribable,
-    Zt: ZipTypes<
-            Eval = Eval,
-            Cw = Cw,
-            Pt = Pt,
-            CombR = CombR,
-            Code = RaaCode<Eval, Cw, CombR, REPETITION_FACTOR>,
-        >,
+    Zt: ZipTypes,
+    Zt::Eval: for<'a> MulByScalar<&'a Zt::Pt>,
+    Lc: LinearCode<Zt>,
     F: PrimeField + FromRef<Zt::Chal> + FromRef<Zt::Pt> + for<'a> MulByScalar<&'a F>,
     F::Inner: Transcribable,
-    Eval: ProjectableToField<F>,
+    Zt::Eval: ProjectableToField<F>,
 {
     let (pp, poly) = setup(num_vars);
 
     let (data, comm) = ZipPlus::commit(&pp, &poly).unwrap();
 
-    let point: Vec<Pt> = prepare_evaluation_point();
+    let point: Vec<Zt::Pt> = prepare_evaluation_point();
 
     let mut prover_transcript = PcsTranscript::new();
     let eval_f = ZipPlus::open(&pp, &poly, &data, &point, &mut prover_transcript).unwrap();
@@ -189,7 +180,7 @@ where
         let expected_eval = poly
             .evaluate(&point)
             .expect("failed to evaluate polynomial");
-        let project = Eval::prepare_projection(&read_field_projecting_element(&pp, &proof));
+        let project = Zt::Eval::prepare_projection(&read_field_projecting_element(&pp, &proof));
         assert_eq!(eval_f, project(&expected_eval));
     }
 
@@ -198,10 +189,11 @@ where
     (pp, comm, point_f, eval_f, proof)
 }
 
-pub fn read_field_projecting_element<Zt, F>(pp: &ZipPlusParams<Zt>, proof: &[u8]) -> F
+pub fn read_field_projecting_element<Zt, Lc, F>(pp: &ZipPlusParams<Zt, Lc>, proof: &[u8]) -> F
 where
     Zt: ZipTypes,
     Zt::Eval: ProjectableToField<F>,
+    Lc: LinearCode<Zt>,
     F: PrimeField + FromRef<Zt::Chal>,
 {
     let mut transcript = PcsTranscript::from_proof(proof);

--- a/zip-plus/src/pcs/test_utils.rs
+++ b/zip-plus/src/pcs/test_utils.rs
@@ -195,17 +195,15 @@ where
     // TODO: This shouldn't be necessary after we split testing and evaluation
     // phases
     if pp.num_rows > 1 {
-        for _ in 0..pp.linear_code.num_proximity_testing() {
-            let _ = transcript
-                .read_many::<Zt::CombR>(pp.linear_code.row_len())
-                .unwrap();
-            let _ = transcript
-                .fs_transcript
-                .get_challenges::<Zt::Chal>(Zt::Comb::DEGREE_BOUND);
-            let _ = transcript
-                .fs_transcript
-                .get_challenges::<Zt::Chal>(pp.num_rows);
-        }
+        let _ = transcript
+            .read_many::<Zt::CombR>(pp.linear_code.row_len())
+            .unwrap();
+        let _ = transcript
+            .fs_transcript
+            .get_challenges::<Zt::Chal>(Zt::Comb::DEGREE_BOUND);
+        let _ = transcript
+            .fs_transcript
+            .get_challenges::<Zt::Chal>(pp.num_rows);
     }
     for _ in 0..pp.linear_code.num_column_opening() {
         let _ = transcript.squeeze_challenge_idx(pp.linear_code.codeword_len());

--- a/zip-plus/src/pcs/utils.rs
+++ b/zip-plus/src/pcs/utils.rs
@@ -23,7 +23,7 @@ fn err_too_many_variates(function: &str, upto: usize, got: usize) -> ZipError {
 }
 
 // Ensures that polynomials and evaluation points are of appropriate size
-pub(super) fn validate_input<'a, Zt: ZipTypes + 'a, Pt: 'a>(
+pub(super) fn validate_input<'a, Zt: ZipTypes + 'a, Lc: LinearCode<Zt>, Pt: 'a>(
     function: &str,
     param_num_vars: usize,
     polys: impl Iterable<Item = &'a DenseMultilinearExtension<Zt::Eval>>,
@@ -35,7 +35,7 @@ pub(super) fn validate_input<'a, Zt: ZipTypes + 'a, Pt: 'a>(
         // challenge_bits + eval_elem_bits - 1, where d is the size of the messages
         // being encoded - so num_vars / 2
         let d = div!(param_num_vars, 2);
-        let codeword_bits = ilog_round_up!(mul!(Zt::Code::REPETITION_FACTOR, d), usize);
+        let codeword_bits = ilog_round_up!(mul!(Lc::REPETITION_FACTOR, d), usize);
         let mut challenge_bits = mul!(Zt::Chal::NUM_BYTES, 8);
         if Zt::Comb::DEGREE_BOUND > 0 {
             // This means we also draft alphas (multiplied with coeffs), which

--- a/zip-plus/src/pcs/utils.rs
+++ b/zip-plus/src/pcs/utils.rs
@@ -3,12 +3,14 @@ use crypto_primitives::PrimeField;
 use num_traits::Zero;
 use thiserror::Error;
 
-use crate::{ZipError, poly::mle::DenseMultilinearExtension, sub};
+use crate::{ZipError, add, div, ilog_round_up, mul, poly::mle::DenseMultilinearExtension, sub};
 
 use crate::{
+    code::LinearCode,
     merkle::{MerkleError, MerkleProof, MtHash},
-    pcs::structs::{AsPackable, ZipPlusHint},
+    pcs::structs::{AsPackable, ZipPlusHint, ZipTypes},
     pcs_transcript::PcsTranscript,
+    traits::Transcribable,
 };
 #[cfg(feature = "parallel")]
 use rayon::prelude::*;
@@ -20,11 +22,11 @@ fn err_too_many_variates(function: &str, upto: usize, got: usize) -> ZipError {
 }
 
 // Ensures that polynomials and evaluation points are of appropriate size
-pub(super) fn validate_input<'a, T: 'a, F: 'a>(
+pub(super) fn validate_input<'a, Zt: ZipTypes + 'a, Pt: 'a>(
     function: &str,
     param_num_vars: usize,
-    polys: impl Iterable<Item = &'a DenseMultilinearExtension<T>>,
-    points: impl Iterable<Item = &'a [F]>,
+    polys: impl Iterable<Item = &'a DenseMultilinearExtension<Zt::Eval>>,
+    points: impl Iterable<Item = &'a [Pt]>,
 ) -> Result<(), ZipError> {
     // Ensure all the number of variables in the polynomials don't exceed the limit
     for poly in polys.iter() {

--- a/zip-plus/src/pcs/utils.rs
+++ b/zip-plus/src/pcs/utils.rs
@@ -10,6 +10,7 @@ use crate::{
     merkle::{MerkleError, MerkleProof, MtHash},
     pcs::structs::{AsPackable, ZipPlusHint, ZipTypes},
     pcs_transcript::PcsTranscript,
+    poly::Polynomial,
     traits::Transcribable,
 };
 #[cfg(feature = "parallel")]
@@ -28,6 +29,33 @@ pub(super) fn validate_input<'a, Zt: ZipTypes + 'a, Pt: 'a>(
     polys: impl Iterable<Item = &'a DenseMultilinearExtension<Zt::Eval>>,
     points: impl Iterable<Item = &'a [Pt]>,
 ) -> Result<(), ZipError> {
+    // Check bit-width of the linear combinations
+    {
+        // Inner ring should be at most+ 2*log_2(\rho^{-1}*d) + \log_2(d) +
+        // challenge_bits + eval_elem_bits - 1, where d is the size of the messages
+        // being encoded - so num_vars / 2
+        let d = div!(param_num_vars, 2);
+        let codeword_bits = ilog_round_up!(mul!(Zt::Code::REPETITION_FACTOR, d), usize);
+        let mut challenge_bits = mul!(Zt::Chal::NUM_BYTES, 8);
+        if Zt::Comb::DEGREE_BOUND > 0 {
+            // This means we also draft alphas (multiplied with coeffs), which
+            // doubles the number of challenge bits
+            challenge_bits = mul!(challenge_bits, 2);
+        }
+        let max_lc_bits = mul!(Zt::CombR::NUM_BYTES, 8);
+        let actual_lc_bits: usize = add!(
+            add!(
+                add!(mul!(codeword_bits, 2), ilog_round_up!(d, usize)),
+                challenge_bits
+            ),
+            sub!(mul!(Zt::EvalR::NUM_BYTES, 8), 1)
+        );
+        assert!(
+            actual_lc_bits <= max_lc_bits,
+            "The number of bits used for linear combinations is too large: {actual_lc_bits} bits, max allowed is {max_lc_bits} bits"
+        );
+    }
+
     // Ensure all the number of variables in the polynomials don't exceed the limit
     for poly in polys.iter() {
         if param_num_vars < poly.num_vars {

--- a/zip-plus/src/pcs/verify_z.rs
+++ b/zip-plus/src/pcs/verify_z.rs
@@ -17,9 +17,9 @@ use ark_std::iterable::Iterable;
 use crypto_primitives::PrimeField;
 use itertools::Itertools;
 
-impl<Zt: ZipTypes> ZipPlus<Zt> {
+impl<Zt: ZipTypes, Lc: LinearCode<Zt>> ZipPlus<Zt, Lc> {
     pub fn verify<F>(
-        vp: &ZipPlusParams<Zt>,
+        vp: &ZipPlusParams<Zt, Lc>,
         comm: &ZipPlusCommitment,
         point_f: &[F],
         eval_f: &F,
@@ -29,12 +29,12 @@ impl<Zt: ZipTypes> ZipPlus<Zt> {
         F: PrimeField
             + FromRef<F>
             + FromRef<Zt::Chal>
-            + FromRef<<Zt::Code as LinearCode<Zt::Eval, Zt::Cw, Zt::CombR>>::Inner>
+            + FromRef<Lc::Inner>
             + for<'a> MulByScalar<&'a F>,
         F::Inner: Transcribable,
         Zt::Cw: ProjectableToField<F>,
     {
-        validate_input::<Zt, _>("verify", vp.num_vars, &[], [point_f])?;
+        validate_input::<Zt, Lc, _>("verify", vp.num_vars, &[], [point_f])?;
 
         let columns_opened = Self::verify_testing(vp, &comm.root, transcript)?;
 
@@ -54,7 +54,7 @@ impl<Zt: ZipTypes> ZipPlus<Zt> {
     }
 
     pub fn batch_verify<'a, F>(
-        vp: &ZipPlusParams<Zt>,
+        vp: &ZipPlusParams<Zt, Lc>,
         comms: impl Iterable<Item = &'a ZipPlusCommitment>,
         points: &[Vec<F>],
         evals: &[F],
@@ -64,7 +64,7 @@ impl<Zt: ZipTypes> ZipPlus<Zt> {
         F: PrimeField
             + FromRef<F>
             + FromRef<Zt::Chal>
-            + FromRef<<Zt::Code as LinearCode<Zt::Eval, Zt::Cw, Zt::CombR>>::Inner>
+            + FromRef<Lc::Inner>
             + for<'b> MulByScalar<&'b F>,
         F::Inner: Transcribable,
         Zt::Cw: ProjectableToField<F>,
@@ -77,7 +77,7 @@ impl<Zt: ZipTypes> ZipPlus<Zt> {
 
     #[allow(clippy::type_complexity)]
     pub(super) fn verify_testing(
-        vp: &ZipPlusParams<Zt>,
+        vp: &ZipPlusParams<Zt, Lc>,
         root: &MtHash,
         transcript: &mut PcsTranscript,
     ) -> Result<Vec<(usize, Vec<Zt::Cw>)>, ZipError> {
@@ -158,7 +158,7 @@ impl<Zt: ZipTypes> ZipPlus<Zt> {
     }
 
     fn verify_evaluation<F>(
-        vp: &ZipPlusParams<Zt>,
+        vp: &ZipPlusParams<Zt, Lc>,
         point_f: &[F],
         eval_f: &F,
         columns_opened: &[(usize, Vec<Zt::Cw>)],
@@ -166,10 +166,7 @@ impl<Zt: ZipTypes> ZipPlus<Zt> {
         projecting_element: F,
     ) -> Result<(), ZipError>
     where
-        F: PrimeField
-            + FromRef<F>
-            + FromRef<<Zt::Code as LinearCode<Zt::Eval, Zt::Cw, Zt::CombR>>::Inner>
-            + for<'a> MulByScalar<&'a F>,
+        F: PrimeField + FromRef<F> + FromRef<Lc::Inner> + for<'a> MulByScalar<&'a F>,
         F::Inner: Transcribable,
         Zt::Cw: ProjectableToField<F>,
     {
@@ -234,7 +231,7 @@ impl<Zt: ZipTypes> ZipPlus<Zt> {
 mod tests {
     use crate::{
         ZipError,
-        code::LinearCode,
+        code::{LinearCode, raa::RaaCode},
         field::F256,
         pcs::{
             structs::{ZipPlus, ZipTypes},
@@ -272,12 +269,13 @@ mod tests {
     type F = F256<ModP>;
 
     type Zt = TestZipTypes<N, K, M>;
-    type C = <Zt as ZipTypes>::Code;
+    type C = RaaCode<Zt, 4>;
 
     type PolyZt = TestPolyZipTypes<N, K, M, DEGREE>;
+    type PolyC = RaaCode<PolyZt, 4>;
 
-    type TestZip = ZipPlus<Zt>;
-    type TestPolyZip = ZipPlus<PolyZt>;
+    type TestZip = ZipPlus<Zt, C>;
+    type TestPolyZip = ZipPlus<PolyZt, PolyC>;
 
     #[test]
     fn successful_verification_of_valid_proof() {
@@ -715,6 +713,44 @@ mod tests {
             // Verifier replays verification from the same proof (also like the bench)
             let mut verifier_tx = PcsTranscript::from_proof(&proof);
             TestZip::verify(
+                &params,
+                &commitment,
+                &point.iter().map(F::from).collect::<Vec<_>>(),
+                &eval_f,
+                &mut verifier_tx,
+            )
+            .expect("verify");
+        }
+
+        inner::<12>();
+    }
+
+    /// Mirrors: `Zip+/Verify` for `poly_size=2^12`
+    #[test]
+    fn bench_p12_verify_poly() {
+        fn inner<const P: usize>() {
+            let mut rng = ThreadRng::default();
+            // Match the benchmark’s transcript usage for linear code construction
+            let mut keccak_transcript = KeccakTranscript::new();
+            let poly_size = 1 << P;
+            let linear_code = PolyC::new(poly_size, true, &mut keccak_transcript);
+            let params = TestPolyZip::setup(poly_size, linear_code);
+
+            let poly = DenseMultilinearExtension::rand(P, &mut rng);
+            let (data, commitment) = TestPolyZip::commit(&params, &poly).expect("commit");
+
+            // Same point choice as the bench
+            let point = vec![1i64; P].iter().map(|v| v.into()).collect_vec();
+
+            // Prover produces a proof once (exactly as in the bench)
+            let mut prover_tx = PcsTranscript::new();
+            let eval_f: F =
+                TestPolyZip::open(&params, &poly, &data, &point, &mut prover_tx).expect("open");
+            let proof = prover_tx.into_proof();
+
+            // Verifier replays verification from the same proof (also like the bench)
+            let mut verifier_tx = PcsTranscript::from_proof(&proof);
+            TestPolyZip::verify(
                 &params,
                 &commitment,
                 &point.iter().map(F::from).collect::<Vec<_>>(),

--- a/zip-plus/src/pcs/verify_z.rs
+++ b/zip-plus/src/pcs/verify_z.rs
@@ -34,8 +34,7 @@ impl<Zt: ZipTypes> ZipPlus<Zt> {
         F::Inner: Transcribable,
         Zt::Cw: ProjectableToField<F>,
     {
-        let no_polys = Vec::<DenseMultilinearExtension<bool>>::new();
-        validate_input("verify", vp.num_vars, &no_polys, [point_f])?;
+        validate_input::<Zt, _>("verify", vp.num_vars, &[], [point_f])?;
 
         let columns_opened = Self::verify_testing(vp, &comm.root, transcript)?;
 
@@ -83,28 +82,26 @@ impl<Zt: ZipTypes> ZipPlus<Zt> {
         transcript: &mut PcsTranscript,
     ) -> Result<Vec<(usize, Vec<Zt::Cw>)>, ZipError> {
         // Gather the coeffs and encoded combined rows per proximity test
-        let mut encoded_combined_rows: Vec<(Vec<Zt::Chal>, Vec<Zt::Chal>, Vec<Zt::CombR>)> =
-            Vec::with_capacity(vp.linear_code.num_proximity_testing());
+        let encoded_combined_rows: Option<(Vec<Zt::Chal>, Vec<Zt::Chal>, Vec<Zt::CombR>)> = if vp
+            .num_rows
+            > 1
+        {
+            // Values to evaluate the coefficients at
+            let alphas = transcript
+                .fs_transcript
+                .get_challenges(Zt::Comb::DEGREE_BOUND);
 
-        if vp.num_rows > 1 {
-            for _ in 0..vp.linear_code.num_proximity_testing() {
-                // Values to evaluate the coefficients at
-                let alphas = transcript
-                    .fs_transcript
-                    .get_challenges(Zt::Comb::DEGREE_BOUND);
+            // Coefficients for the linear combination of polynomial with evaluated
+            // coefficients
+            let coeffs = transcript.fs_transcript.get_challenges(vp.num_rows);
 
-                // Coefficients for the linear combination of polynomial with evaluated
-                // coefficients
-                let coeffs = transcript.fs_transcript.get_challenges(vp.num_rows);
+            let combined_row: Vec<Zt::CombR> = transcript.read_many(vp.linear_code.row_len())?;
 
-                let combined_row: Vec<Zt::CombR> =
-                    transcript.read_many(vp.linear_code.row_len())?;
-
-                let encoded_combined_row: Vec<Zt::CombR> =
-                    vp.linear_code.encode_wide(&combined_row);
-                encoded_combined_rows.push((alphas, coeffs, encoded_combined_row));
-            }
-        }
+            let encoded_combined_row: Vec<Zt::CombR> = vp.linear_code.encode_wide(&combined_row);
+            Some((alphas, coeffs, encoded_combined_row))
+        } else {
+            None
+        };
 
         let mut columns_opened: Vec<(usize, Vec<Zt::Cw>)> =
             Vec::with_capacity(vp.linear_code.num_column_opening());
@@ -113,7 +110,8 @@ impl<Zt: ZipTypes> ZipPlus<Zt> {
             let column_idx = transcript.squeeze_challenge_idx(vp.linear_code.codeword_len());
             let column_values = transcript.read_many(vp.num_rows)?;
 
-            for (alphas, coeffs, encoded_combined_row) in encoded_combined_rows.iter() {
+            if let Some((ref alphas, ref coeffs, ref encoded_combined_row)) = encoded_combined_rows
+            {
                 Self::verify_column_testing(
                     alphas,
                     coeffs,

--- a/zip-plus/src/pcs/verify_z.rs
+++ b/zip-plus/src/pcs/verify_z.rs
@@ -9,7 +9,7 @@ use crate::{
         utils::{ColumnOpening, point_to_tensor, validate_input},
     },
     pcs_transcript::PcsTranscript,
-    poly::{Polynomial, mle::DenseMultilinearExtension},
+    poly::Polynomial,
     traits::{FromRef, Transcribable, Transcript},
     utils::inner_product,
 };
@@ -104,9 +104,9 @@ impl<Zt: ZipTypes> ZipPlus<Zt> {
         };
 
         let mut columns_opened: Vec<(usize, Vec<Zt::Cw>)> =
-            Vec::with_capacity(vp.linear_code.num_column_opening());
+            Vec::with_capacity(Zt::NUM_COLUMN_OPENINGS);
 
-        for _ in 0..vp.linear_code.num_column_opening() {
+        for _ in 0..Zt::NUM_COLUMN_OPENINGS {
             let column_idx = transcript.squeeze_challenge_idx(vp.linear_code.codeword_len());
             let column_values = transcript.read_many(vp.num_rows)?;
 
@@ -234,7 +234,7 @@ impl<Zt: ZipTypes> ZipPlus<Zt> {
 mod tests {
     use crate::{
         ZipError,
-        code::{DefaultLinearCodeSpec, LinearCode},
+        code::LinearCode,
         field::F256,
         pcs::{
             structs::{ZipPlus, ZipTypes},
@@ -440,7 +440,7 @@ mod tests {
         let poly_size = 8; // row_len=4, num_rows=2 -> proximity checks are active
         let n = 3;
 
-        let linear_code = C::new(&DefaultLinearCodeSpec, poly_size, true, &mut keccak);
+        let linear_code = C::new(poly_size, true, &mut keccak);
         let pp = TestZip::setup(poly_size, linear_code);
 
         let evaluations: Vec<_> = (0..poly_size as i32)
@@ -517,12 +517,7 @@ mod tests {
         let n = 3;
         let poly_size = 1 << n;
         let mut keccak_transcript = KeccakTranscript::new();
-        let linear_code: C = C::new(
-            &DefaultLinearCodeSpec,
-            poly_size,
-            true,
-            &mut keccak_transcript,
-        );
+        let linear_code: C = C::new(poly_size, true, &mut keccak_transcript);
         let param = TestZip::setup(poly_size, linear_code);
         let evaluations: Vec<_> = (0..poly_size)
             .map(|_| <Zt as ZipTypes>::Eval::from(rng.random::<i8>()))
@@ -554,7 +549,7 @@ mod tests {
     fn verification_fails_if_evaluation_consistency_check_is_invalid() {
         let mut keccak = MockTranscript::default();
         let poly_size = 8;
-        let linear_code = C::new(&DefaultLinearCodeSpec, poly_size, true, &mut keccak);
+        let linear_code = C::new(poly_size, true, &mut keccak);
         let pp = TestZip::setup(poly_size, linear_code);
 
         let evaluations: Vec<_> = (0..poly_size as i32).map(Int::<INT_LIMBS>::from).collect();
@@ -601,7 +596,7 @@ mod tests {
     fn verification_succeeds_for_zero_polynomial() {
         let mut keccak = MockTranscript::default();
         let poly_size = 8;
-        let linear_code = C::new(&DefaultLinearCodeSpec, poly_size, true, &mut keccak);
+        let linear_code = C::new(poly_size, true, &mut keccak);
         let pp = TestZip::setup(poly_size, linear_code);
 
         let evaluations: Vec<_> = vec![Int::<INT_LIMBS>::from(0); poly_size];
@@ -628,7 +623,7 @@ mod tests {
     fn verification_succeeds_at_zero_point() {
         let mut keccak = MockTranscript::default();
         let poly_size = 8;
-        let linear_code = C::new(&DefaultLinearCodeSpec, poly_size, true, &mut keccak);
+        let linear_code = C::new(poly_size, true, &mut keccak);
         let pp = TestZip::setup(poly_size, linear_code);
 
         let evaluations: Vec<_> = (1..=poly_size as i32).map(Int::<INT_LIMBS>::from).collect();
@@ -656,7 +651,7 @@ mod tests {
     fn verification_fails_if_proximity_values_are_too_large() {
         let mut keccak = MockTranscript::default();
         let poly_size = 8;
-        let linear_code = C::new(&DefaultLinearCodeSpec, poly_size, true, &mut keccak);
+        let linear_code = C::new(poly_size, true, &mut keccak);
         let pp = TestZip::setup(poly_size, linear_code);
 
         let evaluations: Vec<_> = (1..=poly_size as i32).map(Int::<INT_LIMBS>::from).collect();
@@ -700,12 +695,7 @@ mod tests {
             // Match the benchmark’s transcript usage for linear code construction
             let mut keccak_transcript = KeccakTranscript::new();
             let poly_size = 1 << P;
-            let linear_code = C::new(
-                &DefaultLinearCodeSpec,
-                poly_size,
-                true,
-                &mut keccak_transcript,
-            );
+            let linear_code = C::new(poly_size, true, &mut keccak_transcript);
             let params = TestZip::setup(poly_size, linear_code);
 
             let poly = DenseMultilinearExtension::rand(P, &mut rng);

--- a/zip-plus/src/pcs/verify_z.rs
+++ b/zip-plus/src/pcs/verify_z.rs
@@ -26,11 +26,7 @@ impl<Zt: ZipTypes, Lc: LinearCode<Zt>> ZipPlus<Zt, Lc> {
         transcript: &mut PcsTranscript,
     ) -> Result<(), ZipError>
     where
-        F: PrimeField
-            + FromRef<F>
-            + FromRef<Zt::Chal>
-            + FromRef<Lc::Inner>
-            + for<'a> MulByScalar<&'a F>,
+        F: PrimeField + FromRef<F> + FromRef<Zt::Chal> + for<'a> MulByScalar<&'a F>,
         F::Inner: Transcribable,
         Zt::Cw: ProjectableToField<F>,
     {
@@ -61,11 +57,7 @@ impl<Zt: ZipTypes, Lc: LinearCode<Zt>> ZipPlus<Zt, Lc> {
         transcript: &mut PcsTranscript,
     ) -> Result<(), ZipError>
     where
-        F: PrimeField
-            + FromRef<F>
-            + FromRef<Zt::Chal>
-            + FromRef<Lc::Inner>
-            + for<'b> MulByScalar<&'b F>,
+        F: PrimeField + FromRef<F> + FromRef<Zt::Chal> + for<'b> MulByScalar<&'b F>,
         F::Inner: Transcribable,
         Zt::Cw: ProjectableToField<F>,
     {
@@ -166,7 +158,7 @@ impl<Zt: ZipTypes, Lc: LinearCode<Zt>> ZipPlus<Zt, Lc> {
         projecting_element: F,
     ) -> Result<(), ZipError>
     where
-        F: PrimeField + FromRef<F> + FromRef<Lc::Inner> + for<'a> MulByScalar<&'a F>,
+        F: PrimeField + FromRef<F> + for<'a> MulByScalar<&'a F>,
         F::Inner: Transcribable,
         Zt::Cw: ProjectableToField<F>,
     {

--- a/zip-plus/src/pcs/verify_z.rs
+++ b/zip-plus/src/pcs/verify_z.rs
@@ -74,25 +74,26 @@ impl<Zt: ZipTypes, Lc: LinearCode<Zt>> ZipPlus<Zt, Lc> {
         transcript: &mut PcsTranscript,
     ) -> Result<Vec<(usize, Vec<Zt::Cw>)>, ZipError> {
         // Gather the coeffs and encoded combined rows per proximity test
-        let encoded_combined_rows: Option<(Vec<Zt::Chal>, Vec<Zt::Chal>, Vec<Zt::CombR>)> = if vp
-            .num_rows
-            > 1
-        {
-            // Values to evaluate the coefficients at
-            let alphas = transcript
-                .fs_transcript
-                .get_challenges(Zt::Comb::DEGREE_BOUND);
+        let encoded_combined_rows: Option<(Vec<Zt::Chal>, Vec<Zt::Chal>, Vec<Zt::CombR>)> = {
+            if vp.num_rows > 1 {
+                // Values to evaluate the coefficients at
+                let alphas = transcript
+                    .fs_transcript
+                    .get_challenges(Zt::Comb::DEGREE_BOUND);
 
-            // Coefficients for the linear combination of polynomial with evaluated
-            // coefficients
-            let coeffs = transcript.fs_transcript.get_challenges(vp.num_rows);
+                // Coefficients for the linear combination of polynomial with evaluated
+                // coefficients
+                let coeffs = transcript.fs_transcript.get_challenges(vp.num_rows);
 
-            let combined_row: Vec<Zt::CombR> = transcript.read_many(vp.linear_code.row_len())?;
+                let combined_row: Vec<Zt::CombR> =
+                    transcript.read_many(vp.linear_code.row_len())?;
 
-            let encoded_combined_row: Vec<Zt::CombR> = vp.linear_code.encode_wide(&combined_row);
-            Some((alphas, coeffs, encoded_combined_row))
-        } else {
-            None
+                let encoded_combined_row: Vec<Zt::CombR> =
+                    vp.linear_code.encode_wide(&combined_row);
+                Some((alphas, coeffs, encoded_combined_row))
+            } else {
+                None
+            }
         };
 
         let mut columns_opened: Vec<(usize, Vec<Zt::Cw>)> =

--- a/zip-plus/src/poly/dense.rs
+++ b/zip-plus/src/poly/dense.rs
@@ -352,7 +352,7 @@ where
 
 impl<R: Ring + Named, const DEGREE: usize> Named for DensePolynomial<R, DEGREE> {
     fn type_name() -> String {
-        format!("DensePolynomial<{}, {DEGREE}>", R::type_name())
+        format!("Poly<{}, {DEGREE}>", R::type_name())
     }
 }
 

--- a/zip-plus/src/traits.rs
+++ b/zip-plus/src/traits.rs
@@ -91,6 +91,7 @@ impl<const LIMBS: usize> Named for Int<LIMBS> {
 pub trait Transcribable {
     /// Number of bytes required to represent this type.
     const NUM_BYTES: usize;
+    const NUM_BITS: usize = Self::NUM_BYTES * 8;
 
     /// Creates a new instance from a byte buffer.
     /// The buffer must be exactly `NUM_BYTES` long.

--- a/zip-plus/src/traits.rs
+++ b/zip-plus/src/traits.rs
@@ -23,10 +23,11 @@ macro_rules! impl_from_ref_for_primitive {
     };
 }
 
-impl_from_ref_for_primitive!(i128, [i64, i32, i16, i8]);
-impl_from_ref_for_primitive!(i64, [i32, i16, i8]);
-impl_from_ref_for_primitive!(i32, [i16, i8]);
-impl_from_ref_for_primitive!(i16, [i8]);
+impl_from_ref_for_primitive!(i128, [i128, i64, i32, i16, i8]);
+impl_from_ref_for_primitive!(i64, [i64, i32, i16, i8]);
+impl_from_ref_for_primitive!(i32, [i32, i16, i8]);
+impl_from_ref_for_primitive!(i16, [i16, i8]);
+impl_from_ref_for_primitive!(i8, [i8]);
 
 macro_rules! impl_int_from_primitive_ref {
     ($($t:ty),+) => {

--- a/zip-plus/src/utils.rs
+++ b/zip-plus/src/utils.rs
@@ -61,6 +61,18 @@ macro_rules! rem {
     };
 }
 
+#[macro_export]
+macro_rules! ilog_round_up {
+    ($a:expr, $tp: ty) => {{
+        let res = if $a.is_power_of_two() {
+            $a.ilog2()
+        } else {
+            add!($a.ilog2(), 1)
+        };
+        <$tp>::try_from(res).expect(concat!("ilog doesn't fit ", stringify!($tp)))
+    }};
+}
+
 pub(crate) fn inner_product<'a, 'b, Coeff, El, L, R>(lhs: L, rhs: R) -> El
 where
     Coeff: Clone + Default + 'a + 'b,


### PR DESCRIPTION
* Separated `LinearCode` from `ZipTypes` to make it dependent on `ZipTypes`. This simplifies linear code typing.
* Fixed an issue with `RaaCode` incorrectly calculating codeword bit-width upper bound for polynomials (it used polynomial size rather than the size of its coefficients)
* Adjusted benchmarks parameters as per discussion with @albert-garreta. Used primitive types instead of `Int<_>` where it was applicable.
* Removed `LinearCodeSpec`, replaced it with constants `ZipTypes::NUM_COLUMN_OPENINGS` and `LinearCode::REPETITION_FACTOR`
* Added new bounds check that ensures that bit-width of the linear combinations ring is enough to fit linear combinations