### PR TITLE
Improved RAA code

### DIFF
--- a/crypto-primitives/src/ring/crypto_bigint_int.rs
+++ b/crypto-primitives/src/ring/crypto_bigint_int.rs
@@ -4,7 +4,7 @@ use core::{
     fmt::{Debug, Display, Formatter, LowerHex, Result as FmtResult, UpperHex},
     hash::Hasher,
     iter::{Product, Sum},
-    ops::{Add, AddAssign, Mul, MulAssign, Rem, RemAssign, Shl, Shr, Sub, SubAssign},
+    ops::{Add, AddAssign, Mul, MulAssign, Neg, Rem, RemAssign, Shl, Shr, Sub, SubAssign},
 };
 use crypto_bigint::{
     CheckedMul as CryptoCheckedMul, CheckedSub as CryptoCheckedSub, Integer, Word,
@@ -205,6 +205,15 @@ impl<const LIMBS: usize> ConstOne for Int<LIMBS> {
 //
 // Basic arithmetic operations
 //
+
+impl<const LIMBS: usize> Neg for Int<LIMBS> {
+    type Output = Self;
+
+    fn neg(mut self) -> Self {
+        self.0 = self.0.wrapping_neg();
+        self
+    }
+}
 
 macro_rules! impl_basic_op {
     ($trait_name:tt, $trait_op:tt) => {

--- a/zip-plus/benches/zip_benches.rs
+++ b/zip-plus/benches/zip_benches.rs
@@ -36,6 +36,7 @@ type Code = RaaCode<BenchZipTypes, 4>;
 const RAA_CONFIG: RaaConfig = RaaConfig {
     check_for_overflows: false,
     permute_in_place: false,
+    flip_signs: true,
 };
 
 fn zip_benchmarks(c: &mut Criterion) {

--- a/zip-plus/benches/zip_benches.rs
+++ b/zip-plus/benches/zip_benches.rs
@@ -9,7 +9,11 @@ use criterion::{Criterion, criterion_group, criterion_main};
 use crypto_bigint::{U64, Uint};
 use crypto_primes::hazmat::MillerRabin;
 use crypto_primitives::crypto_bigint_int::Int;
-use zip_plus::{code::raa::RaaCode, pcs::structs::ZipTypes, utils::UintSemiring};
+use zip_plus::{
+    code::raa::{RaaCode, RaaConfig},
+    pcs::structs::ZipTypes,
+    utils::UintSemiring,
+};
 
 const INT_LIMBS: usize = U64::LIMBS;
 
@@ -29,9 +33,14 @@ impl ZipTypes for BenchZipTypes {
 }
 type Code = RaaCode<BenchZipTypes, 4>;
 
+const RAA_CONFIG: RaaConfig = RaaConfig {
+    check_for_overflows: false,
+    permute_in_place: false,
+};
+
 fn zip_benchmarks(c: &mut Criterion) {
     let mut group = c.benchmark_group("Zip+");
-    do_bench::<BenchZipTypes, Code>(&mut group);
+    do_bench::<BenchZipTypes, Code>(&mut group, RAA_CONFIG);
     group.finish();
 }
 

--- a/zip-plus/benches/zip_common.rs
+++ b/zip-plus/benches/zip_common.rs
@@ -25,24 +25,26 @@ use zip_plus::{
 
 type F = BoxedMontyField;
 
-pub fn do_bench<Zt: ZipTypes, Lc: LinearCode<Zt>>(group: &mut BenchmarkGroup<WallTime>)
-where
+pub fn do_bench<Zt: ZipTypes, Lc: LinearCode<Zt>>(
+    group: &mut BenchmarkGroup<WallTime>,
+    code_config: Lc::Config,
+) where
     StandardUniform: Distribution<Zt::Eval> + Distribution<Zt::Cw>,
     F: for<'a> FromWithConfig<&'a Zt::Chal> + for<'a> FromWithConfig<&'a Zt::Pt>,
     <F as Field>::Inner: FromRef<Zt::Fmod>,
     Zt::Eval: ProjectableToField<F>,
     Zt::Cw: ProjectableToField<F>,
 {
-    encode_rows::<Zt, Lc, 12>(group);
-    encode_rows::<Zt, Lc, 13>(group);
-    encode_rows::<Zt, Lc, 14>(group);
-    encode_rows::<Zt, Lc, 15>(group);
-    encode_rows::<Zt, Lc, 16>(group);
+    encode_rows::<Zt, Lc, 12>(group, code_config);
+    encode_rows::<Zt, Lc, 13>(group, code_config);
+    encode_rows::<Zt, Lc, 14>(group, code_config);
+    encode_rows::<Zt, Lc, 15>(group, code_config);
+    encode_rows::<Zt, Lc, 16>(group, code_config);
 
-    encode_single_row::<Zt, Lc, 128>(group);
-    encode_single_row::<Zt, Lc, 256>(group);
-    encode_single_row::<Zt, Lc, 512>(group);
-    encode_single_row::<Zt, Lc, 1024>(group);
+    encode_single_row::<Zt, Lc, 128>(group, code_config);
+    encode_single_row::<Zt, Lc, 256>(group, code_config);
+    encode_single_row::<Zt, Lc, 512>(group, code_config);
+    encode_single_row::<Zt, Lc, 1024>(group, code_config);
 
     merkle_root::<Zt, 12>(group);
     merkle_root::<Zt, 13>(group);
@@ -50,33 +52,34 @@ where
     merkle_root::<Zt, 15>(group);
     merkle_root::<Zt, 16>(group);
 
-    commit::<Zt, Lc, 12>(group);
-    commit::<Zt, Lc, 13>(group);
-    commit::<Zt, Lc, 14>(group);
-    commit::<Zt, Lc, 15>(group);
-    commit::<Zt, Lc, 16>(group);
+    commit::<Zt, Lc, 12>(group, code_config);
+    commit::<Zt, Lc, 13>(group, code_config);
+    commit::<Zt, Lc, 14>(group, code_config);
+    commit::<Zt, Lc, 15>(group, code_config);
+    commit::<Zt, Lc, 16>(group, code_config);
 
-    test::<Zt, Lc, 12>(group);
-    test::<Zt, Lc, 13>(group);
-    test::<Zt, Lc, 14>(group);
-    test::<Zt, Lc, 15>(group);
-    test::<Zt, Lc, 16>(group);
+    test::<Zt, Lc, 12>(group, code_config);
+    test::<Zt, Lc, 13>(group, code_config);
+    test::<Zt, Lc, 14>(group, code_config);
+    test::<Zt, Lc, 15>(group, code_config);
+    test::<Zt, Lc, 16>(group, code_config);
 
-    evaluate::<Zt, Lc, 12>(group);
-    evaluate::<Zt, Lc, 13>(group);
-    evaluate::<Zt, Lc, 14>(group);
-    evaluate::<Zt, Lc, 15>(group);
-    evaluate::<Zt, Lc, 16>(group);
+    evaluate::<Zt, Lc, 12>(group, code_config);
+    evaluate::<Zt, Lc, 13>(group, code_config);
+    evaluate::<Zt, Lc, 14>(group, code_config);
+    evaluate::<Zt, Lc, 15>(group, code_config);
+    evaluate::<Zt, Lc, 16>(group, code_config);
 
-    verify::<Zt, Lc, 12>(group);
-    verify::<Zt, Lc, 13>(group);
-    verify::<Zt, Lc, 14>(group);
-    verify::<Zt, Lc, 15>(group);
-    verify::<Zt, Lc, 16>(group);
+    verify::<Zt, Lc, 12>(group, code_config);
+    verify::<Zt, Lc, 13>(group, code_config);
+    verify::<Zt, Lc, 14>(group, code_config);
+    verify::<Zt, Lc, 15>(group, code_config);
+    verify::<Zt, Lc, 16>(group, code_config);
 }
 
 pub fn encode_rows<Zt: ZipTypes, Lc: LinearCode<Zt>, const P: usize>(
     group: &mut BenchmarkGroup<WallTime>,
+    code_config: Lc::Config,
 ) where
     StandardUniform: Distribution<Zt::Eval>,
 {
@@ -89,7 +92,7 @@ pub fn encode_rows<Zt: ZipTypes, Lc: LinearCode<Zt>, const P: usize>(
         |b| {
             let mut rng = ThreadRng::default();
             let poly_size = 1 << P;
-            let linear_code = Lc::new(poly_size, false);
+            let linear_code = Lc::new(poly_size, code_config);
             let params = ZipPlus::setup(poly_size, linear_code);
             let row_len = params.linear_code.row_len();
             let codeword_len = params.linear_code.codeword_len();
@@ -108,6 +111,7 @@ pub fn encode_rows<Zt: ZipTypes, Lc: LinearCode<Zt>, const P: usize>(
 
 pub fn encode_single_row<Zt: ZipTypes, Lc: LinearCode<Zt>, const ROW_LEN: usize>(
     group: &mut BenchmarkGroup<WallTime>,
+    code_config: Lc::Config,
 ) where
     StandardUniform: Distribution<Zt::Eval>,
 {
@@ -120,7 +124,7 @@ pub fn encode_single_row<Zt: ZipTypes, Lc: LinearCode<Zt>, const ROW_LEN: usize>
         |b| {
             let mut rng = ThreadRng::default();
             let poly_size = ROW_LEN * ROW_LEN;
-            let linear_code = Lc::new(poly_size, false);
+            let linear_code = Lc::new(poly_size, code_config);
             assert_eq!(linear_code.row_len(), ROW_LEN, "Unexpected row_len");
             let message: Vec<<Zt as ZipTypes>::Eval> =
                 (0..ROW_LEN).map(|_i| rng.random()).collect();
@@ -156,12 +160,13 @@ where
 
 pub fn commit<Zt: ZipTypes, Lc: LinearCode<Zt>, const P: usize>(
     group: &mut BenchmarkGroup<WallTime>,
+    code_config: Lc::Config,
 ) where
     StandardUniform: Distribution<Zt::Eval>,
 {
     let mut rng = ThreadRng::default();
     let poly_size = 1 << P;
-    let linear_code = Lc::new(poly_size, false);
+    let linear_code = Lc::new(poly_size, code_config);
     let params = ZipPlus::setup(poly_size, linear_code);
 
     group.bench_function(
@@ -188,14 +193,16 @@ pub fn commit<Zt: ZipTypes, Lc: LinearCode<Zt>, const P: usize>(
     );
 }
 
-pub fn test<Zt: ZipTypes, Lc: LinearCode<Zt>, const P: usize>(group: &mut BenchmarkGroup<WallTime>)
-where
+pub fn test<Zt: ZipTypes, Lc: LinearCode<Zt>, const P: usize>(
+    group: &mut BenchmarkGroup<WallTime>,
+    code_config: Lc::Config,
+) where
     StandardUniform: Distribution<Zt::Eval>,
 {
     let mut rng = ThreadRng::default();
 
     let poly_size = 1 << P;
-    let linear_code = Lc::new(poly_size, false);
+    let linear_code = Lc::new(poly_size, code_config);
     let params = ZipPlus::setup(poly_size, linear_code);
 
     let poly = DenseMultilinearExtension::rand(P, &mut rng, Zero::zero());
@@ -220,6 +227,7 @@ where
 
 pub fn evaluate<Zt: ZipTypes, Lc: LinearCode<Zt>, const P: usize>(
     group: &mut BenchmarkGroup<WallTime>,
+    code_config: Lc::Config,
 ) where
     StandardUniform: Distribution<Zt::Eval>,
     F: for<'a> FromWithConfig<&'a Zt::Chal> + for<'a> FromWithConfig<&'a Zt::Pt>,
@@ -229,7 +237,7 @@ pub fn evaluate<Zt: ZipTypes, Lc: LinearCode<Zt>, const P: usize>(
     let mut rng = ThreadRng::default();
 
     let poly_size = 1 << P;
-    let linear_code = Lc::new(poly_size, false);
+    let linear_code = Lc::new(poly_size, code_config);
     let params = ZipPlus::setup(poly_size, linear_code);
 
     let poly = DenseMultilinearExtension::rand(P, &mut rng, Zero::zero());
@@ -265,6 +273,7 @@ pub fn evaluate<Zt: ZipTypes, Lc: LinearCode<Zt>, const P: usize>(
 
 pub fn verify<Zt: ZipTypes, Lc: LinearCode<Zt>, const P: usize>(
     group: &mut BenchmarkGroup<WallTime>,
+    code_config: Lc::Config,
 ) where
     StandardUniform: Distribution<Zt::Eval>,
     F: for<'a> FromWithConfig<&'a Zt::Chal> + for<'a> FromWithConfig<&'a Zt::Pt>,
@@ -274,7 +283,7 @@ pub fn verify<Zt: ZipTypes, Lc: LinearCode<Zt>, const P: usize>(
 {
     let mut rng = ThreadRng::default();
     let poly_size = 1 << P;
-    let linear_code = Lc::new(poly_size, false);
+    let linear_code = Lc::new(poly_size, code_config);
     let params = ZipPlus::setup(poly_size, linear_code);
 
     let poly = DenseMultilinearExtension::rand(P, &mut rng, Zero::zero());

--- a/zip-plus/benches/zip_plus_benches.rs
+++ b/zip-plus/benches/zip_plus_benches.rs
@@ -37,7 +37,7 @@ type Code<const D: usize> = RaaCode<BenchZipPlusTypes<D>, 4>;
 const RAA_CONFIG: RaaConfig = RaaConfig {
     check_for_overflows: false,
     permute_in_place: true,
-    flip_signs: true,
+    flip_signs: false,
 };
 
 fn zip_plus_benchmarks(c: &mut Criterion) {

--- a/zip-plus/benches/zip_plus_benches.rs
+++ b/zip-plus/benches/zip_plus_benches.rs
@@ -36,7 +36,8 @@ type Code<const D: usize> = RaaCode<BenchZipPlusTypes<D>, 4>;
 
 const RAA_CONFIG: RaaConfig = RaaConfig {
     check_for_overflows: false,
-    permute_in_place: false,
+    permute_in_place: true,
+    flip_signs: true,
 };
 
 fn zip_plus_benchmarks(c: &mut Criterion) {

--- a/zip-plus/benches/zip_plus_benches.rs
+++ b/zip-plus/benches/zip_plus_benches.rs
@@ -10,7 +10,10 @@ use crypto_bigint::{U64, Uint};
 use crypto_primes::hazmat::MillerRabin;
 use crypto_primitives::crypto_bigint_int::Int;
 use zip_plus::{
-    code::raa::RaaCode, pcs::structs::ZipTypes, poly::dense::DensePolynomial, utils::UintSemiring,
+    code::raa::{RaaCode, RaaConfig},
+    pcs::structs::ZipTypes,
+    poly::dense::DensePolynomial,
+    utils::UintSemiring,
 };
 
 const INT_LIMBS: usize = U64::LIMBS;
@@ -31,11 +34,16 @@ impl<const D: usize> ZipTypes for BenchZipPlusTypes<D> {
 }
 type Code<const D: usize> = RaaCode<BenchZipPlusTypes<D>, 4>;
 
+const RAA_CONFIG: RaaConfig = RaaConfig {
+    check_for_overflows: false,
+    permute_in_place: false,
+};
+
 fn zip_plus_benchmarks(c: &mut Criterion) {
     let mut group = c.benchmark_group("Zip+");
 
-    do_bench::<BenchZipPlusTypes<31>, Code<31>>(&mut group);
-    do_bench::<BenchZipPlusTypes<63>, Code<63>>(&mut group);
+    do_bench::<BenchZipPlusTypes<31>, Code<31>>(&mut group, RAA_CONFIG);
+    do_bench::<BenchZipPlusTypes<63>, Code<63>>(&mut group, RAA_CONFIG);
 
     group.finish();
 }

--- a/zip-plus/src/code.rs
+++ b/zip-plus/src/code.rs
@@ -4,6 +4,8 @@ use crate::{pcs::structs::ZipTypes, traits::FromRef};
 use crypto_primitives::PrimeField;
 
 pub trait LinearCode<Zt: ZipTypes>: Sync + Send {
+    type Config: Copy;
+
     /// Repetition factor, a.k.a. inverse rate, the ratio of codeword length to
     /// input row length. Has to be at a power of 2.
     ///
@@ -12,7 +14,7 @@ pub trait LinearCode<Zt: ZipTypes>: Sync + Send {
     /// makes using it too much of a hassle.
     const REPETITION_FACTOR: usize;
 
-    fn new(poly_size: usize, check_for_overflows: bool) -> Self;
+    fn new(poly_size: usize, cfg: Self::Config) -> Self;
 
     /// Length of each input row before encoding
     fn row_len(&self) -> usize;

--- a/zip-plus/src/code/raa.rs
+++ b/zip-plus/src/code/raa.rs
@@ -1,14 +1,16 @@
-use crypto_primitives::PrimeField;
-use num_traits::CheckedAdd;
-use std::{marker::PhantomData, ops::AddAssign};
-
 use crate::{
     add,
     code::LinearCode,
-    mul,
+    mul, neg,
     pcs::structs::ZipTypes,
     traits::{ConstTranscribable, FromRef},
     utils::shuffle_seeded,
+};
+use crypto_primitives::PrimeField;
+use num_traits::{CheckedAdd, CheckedNeg};
+use std::{
+    marker::PhantomData,
+    ops::{AddAssign, Neg},
 };
 
 /// Implementation of a repeat-accumulate-accumulate (RAA) codes over the binary
@@ -42,13 +44,22 @@ pub struct RaaConfig {
     /// Whether to permute the codeword in place, instead of copying it using a
     /// precomputed permutation.
     pub permute_in_place: bool,
+
+    /// Whether to flip the signs of every other codeword entry, leading to
+    /// smaller codewords.
+    pub flip_signs: bool,
 }
 
 impl<Zt: ZipTypes, const REP: usize> RaaCode<Zt, REP> {
     /// Do the actual encoding, as per RAA spec
     fn encode_inner<In, Out>(&self, row: &[In]) -> Vec<Out>
     where
-        Out: CheckedAdd + for<'a> AddAssign<&'a Out> + FromRef<In> + Clone,
+        Out: Neg<Output = Out>
+            + CheckedNeg
+            + CheckedAdd
+            + for<'a> AddAssign<&'a Out>
+            + FromRef<In>
+            + Clone,
     {
         debug_assert_eq!(
             row.len(),
@@ -57,6 +68,9 @@ impl<Zt: ZipTypes, const REP: usize> RaaCode<Zt, REP> {
         );
 
         let mut result: Vec<Out> = repeat(row, REP);
+        if self.cfg.flip_signs {
+            flip_even_signs(&mut result, self.cfg.check_for_overflows);
+        }
         if self.cfg.permute_in_place {
             shuffle_seeded(&mut result, self.perm_1_seed);
         } else {
@@ -66,6 +80,9 @@ impl<Zt: ZipTypes, const REP: usize> RaaCode<Zt, REP> {
             accumulate(&mut result);
         } else {
             accumulate_unchecked(&mut result);
+        }
+        if self.cfg.flip_signs {
+            flip_even_signs(&mut result, self.cfg.check_for_overflows);
         }
         if self.cfg.permute_in_place {
             shuffle_seeded(&mut result, self.perm_2_seed);
@@ -230,6 +247,39 @@ where
     perm.iter().map(|&i| data[i].clone()).collect()
 }
 
+/// Flip every other entry in the codeword, starting from the second one.
+fn flip_even_signs<Out>(result: &mut [Out], check_for_overflows: bool)
+where
+    Out: Neg<Output = Out> + CheckedNeg + Clone,
+{
+    if check_for_overflows {
+        flip_even_signs_checked(result);
+    } else {
+        flip_even_signs_unchecked(result);
+    }
+}
+
+fn flip_even_signs_checked<Out>(result: &mut [Out])
+where
+    Out: CheckedNeg + Clone,
+{
+    // Flip every other entry in the codeword
+    for i in (1..result.len()).step_by(2) {
+        result[i] = neg!(result[i]);
+    }
+}
+
+/// Flip every other entry in the codeword, starting from the second one.
+fn flip_even_signs_unchecked<Out>(result: &mut [Out])
+where
+    Out: Neg<Output = Out> + Clone,
+{
+    // Flip every other entry in the codeword
+    for i in (1..result.len()).step_by(2) {
+        result[i] = result[i].clone().neg();
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use crypto_bigint::U64;
@@ -255,14 +305,17 @@ mod tests {
     {
         for check_for_overflows in [true, false] {
             for permute_in_place in [true, false] {
-                let code = RaaCode::<Zt, REPETITION_FACTOR>::new(
-                    poly_size,
-                    RaaConfig {
-                        check_for_overflows,
-                        permute_in_place,
-                    },
-                );
-                f(&code)
+                for flip_signs in [true, false] {
+                    let code = RaaCode::<Zt, REPETITION_FACTOR>::new(
+                        poly_size,
+                        RaaConfig {
+                            check_for_overflows,
+                            permute_in_place,
+                            flip_signs,
+                        },
+                    );
+                    f(&code)
+                }
             }
         }
     }
@@ -376,19 +429,30 @@ mod tests {
     /// against a known output.
     #[test]
     fn encoding_produces_predictable_results() {
-        test_raa::<TestZipTypes<N, K, M>, _>(16, |code| {
-            let a: Vec<Int<N>> = (1..=4).map(Int::<N>::from).collect();
+        let a: Vec<Int<N>> = (1..=4).map(Int::<N>::from).collect();
 
-            let encode_a: Vec<Int<K>> = code.encode(&a);
-            assert_eq!(
-                encode_a,
-                [
-                    0x1E, 0x36, 0x39, 0x5A, 0x70, 0x7E, 0xA5, 0xC1, 0xCB, 0xDC, 0xF9, 0x11E, 0x124,
-                    0x14C, 0x14D, 0x160
-                ]
-                .map(Int::<K>::from)
-            );
-        })
+        for check_for_overflows in [true, false] {
+            for permute_in_place in [true, false] {
+                let code = RaaCode::<TestZipTypes<N, K, M>, REPETITION_FACTOR>::new(
+                    16,
+                    RaaConfig {
+                        check_for_overflows,
+                        permute_in_place,
+                        flip_signs: false,
+                    },
+                );
+
+                let encode_a: Vec<Int<K>> = code.encode(&a);
+                assert_eq!(
+                    encode_a,
+                    [
+                        0x1E, 0x36, 0x39, 0x5A, 0x70, 0x7E, 0xA5, 0xC1, 0xCB, 0xDC, 0xF9, 0x11E,
+                        0x124, 0x14C, 0x14D, 0x160
+                    ]
+                    .map(Int::<K>::from)
+                );
+            }
+        }
     }
 
     #[test]
@@ -416,6 +480,7 @@ mod tests {
                 RaaConfig {
                     check_for_overflows: true,
                     permute_in_place: true,
+                    flip_signs: false,
                 },
             );
             code_in_place.encode(&data)
@@ -427,6 +492,7 @@ mod tests {
                 RaaConfig {
                     check_for_overflows: true,
                     permute_in_place: false,
+                    flip_signs: false,
                 },
             );
             code_cloning.encode(&data)
@@ -448,6 +514,7 @@ mod tests {
             RaaConfig {
                 check_for_overflows: true,
                 permute_in_place: false,
+                flip_signs: false,
             },
         );
     }

--- a/zip-plus/src/code/raa.rs
+++ b/zip-plus/src/code/raa.rs
@@ -215,8 +215,12 @@ fn accumulate<I>(input: &mut [I])
 where
     I: CheckedAdd + Clone,
 {
-    for i in 1..input.len() {
-        input[i] = add!(input[i], &input[i - 1], "Accumulation overflow");
+    if let Some(first) = input.first().cloned() {
+        let mut acc = first;
+        for curr in input.iter_mut().skip(1) {
+            acc = add!(curr, &acc, "Accumulation overflow");
+            *curr = acc.clone();
+        }
     }
 }
 
@@ -225,17 +229,15 @@ fn accumulate_unchecked<I>(input: &mut [I])
 where
     I: for<'a> AddAssign<&'a I> + Clone,
 {
-    for i in 1..input.len() {
-        // This allows us to circumvent Rust bounds checking
-        unsafe {
-            let input_i: *mut I = input.get_unchecked_mut(i);
-            let input_i: &mut I = &mut *input_i;
-            // Note:
-            // For Int ring, AddAssign here still results in a panic, but that's more
-            // efficient than doing a checked_add and converting ConstCtOption
-            // into Option and panicking later.
-            *input_i += input.get_unchecked(i - 1);
-        };
+    if let Some(first) = input.first().cloned() {
+        let mut acc = first;
+        for i in 1..input.len() {
+            // Avoid bound checking
+            unsafe {
+                acc += input.get_unchecked(i);
+                *input.get_unchecked_mut(i) = acc.clone();
+            };
+        }
     }
 }
 

--- a/zip-plus/src/code/raa.rs
+++ b/zip-plus/src/code/raa.rs
@@ -15,12 +15,33 @@ use crate::{
 /// field, as defined by the Blaze paper (https://eprint.iacr.org/2024/1609)
 #[derive(Debug, Clone)]
 pub struct RaaCode<Zt: ZipTypes, const REP: usize> {
-    /// Whether to check for overflows during encoding
-    check_for_overflows: bool,
+    cfg: RaaConfig,
 
     row_len: usize,
 
     phantom: PhantomData<Zt>,
+
+    /// Randomness seed for the first permutation
+    perm_1_seed: u64,
+
+    /// Randomness seed for the second permutation
+    perm_2_seed: u64,
+
+    /// First permutation
+    perm_1: Vec<usize>,
+
+    /// Second permutation
+    perm_2: Vec<usize>,
+}
+
+#[derive(Debug, Clone, Copy)]
+pub struct RaaConfig {
+    /// Whether to check for overflows during encoding
+    pub check_for_overflows: bool,
+
+    /// Whether to permute the codeword in place, instead of copying it using a
+    /// precomputed permutation.
+    pub permute_in_place: bool,
 }
 
 impl<Zt: ZipTypes, const REP: usize> RaaCode<Zt, REP> {
@@ -35,19 +56,23 @@ impl<Zt: ZipTypes, const REP: usize> RaaCode<Zt, REP> {
             "Row length must match the code's row length"
         );
 
-        // We don't need a secure/unpredictable randomness here, so use fixed seeds
-        const PERM_1_SEED: u64 = 1;
-        const PERM_2_SEED: u64 = 2;
-
         let mut result: Vec<Out> = repeat(row, REP);
-        shuffle_seeded(&mut result, PERM_1_SEED);
-        if self.check_for_overflows {
+        if self.cfg.permute_in_place {
+            shuffle_seeded(&mut result, self.perm_1_seed);
+        } else {
+            result = clone_shuffled(&result, &self.perm_1);
+        }
+        if self.cfg.check_for_overflows {
             accumulate(&mut result);
         } else {
             accumulate_unchecked(&mut result);
         }
-        shuffle_seeded(&mut result, PERM_2_SEED);
-        if self.check_for_overflows {
+        if self.cfg.permute_in_place {
+            shuffle_seeded(&mut result, self.perm_2_seed);
+        } else {
+            result = clone_shuffled(&result, &self.perm_2);
+        }
+        if self.cfg.check_for_overflows {
             accumulate(&mut result);
         } else {
             accumulate_unchecked(&mut result);
@@ -58,9 +83,11 @@ impl<Zt: ZipTypes, const REP: usize> RaaCode<Zt, REP> {
 }
 
 impl<Zt: ZipTypes, const REP: usize> LinearCode<Zt> for RaaCode<Zt, REP> {
+    type Config = RaaConfig;
+
     const REPETITION_FACTOR: usize = REP;
 
-    fn new(poly_size: usize, check_for_overflows: bool) -> Self {
+    fn new(poly_size: usize, cfg: RaaConfig) -> Self {
         assert!(
             REP.is_power_of_two(),
             "Repetition factor must be a power of two"
@@ -98,9 +125,24 @@ impl<Zt: ZipTypes, const REP: usize> LinearCode<Zt> for RaaCode<Zt, REP> {
             codeword_type_bits
         );
 
+        // We don't need a secure/unpredictable randomness here, so use fixed seeds
+        const PERM_1_SEED: u64 = 1;
+        const PERM_2_SEED: u64 = 2;
+
+        let codeword_len = mul!(row_len, REP);
+
+        let mut perm_1: Vec<usize> = (0..codeword_len).collect();
+        shuffle_seeded(&mut perm_1, PERM_1_SEED);
+        let mut perm_2: Vec<usize> = (0..codeword_len).collect();
+        shuffle_seeded(&mut perm_2, PERM_2_SEED);
+
         Self {
-            check_for_overflows,
+            cfg,
             row_len,
+            perm_1_seed: PERM_1_SEED,
+            perm_2_seed: PERM_2_SEED,
+            perm_1,
+            perm_2,
             phantom: PhantomData,
         }
     }
@@ -180,6 +222,14 @@ where
     }
 }
 
+/// Clone the data using a precomputed permutation.
+fn clone_shuffled<T>(data: &[T], perm: &[usize]) -> Vec<T>
+where
+    T: Clone,
+{
+    perm.iter().map(|&i| data[i].clone()).collect()
+}
+
 #[cfg(test)]
 mod tests {
     use crypto_bigint::U64;
@@ -204,8 +254,16 @@ mod tests {
         F: Fn(&RaaCode<Zt, REPETITION_FACTOR>),
     {
         for check_for_overflows in [true, false] {
-            let code = RaaCode::<Zt, REPETITION_FACTOR>::new(poly_size, check_for_overflows);
-            f(&code)
+            for permute_in_place in [true, false] {
+                let code = RaaCode::<Zt, REPETITION_FACTOR>::new(
+                    poly_size,
+                    RaaConfig {
+                        check_for_overflows,
+                        permute_in_place,
+                    },
+                );
+                f(&code)
+            }
         }
     }
 
@@ -349,12 +407,49 @@ mod tests {
     }
 
     #[test]
+    fn in_place_permutation_should_not_affect_order() {
+        let data: Vec<Int<N>> = (1..=1024).map(Int::<N>::from).collect();
+        let poly_size = data.len() * data.len();
+        let codeword_1: Vec<Int<K>> = {
+            let code_in_place = RaaCode::<TestZipTypes<N, K, M>, REPETITION_FACTOR>::new(
+                poly_size,
+                RaaConfig {
+                    check_for_overflows: true,
+                    permute_in_place: true,
+                },
+            );
+            code_in_place.encode(&data)
+        };
+
+        let codeword_2: Vec<Int<K>> = {
+            let code_cloning = RaaCode::<TestZipTypes<N, K, M>, REPETITION_FACTOR>::new(
+                poly_size,
+                RaaConfig {
+                    check_for_overflows: true,
+                    permute_in_place: false,
+                },
+            );
+            code_cloning.encode(&data)
+        };
+        assert_eq!(
+            codeword_1, codeword_2,
+            "In-place permutation should not affect the final codeword"
+        );
+    }
+
+    #[test]
     #[should_panic]
     fn constructor_panics_on_insufficient_codeword_width() {
         const N: usize = 1;
         const K: usize = 1;
 
-        let _code = RaaCode::<TestZipTypes<N, K, N>, REPETITION_FACTOR>::new(1 << 30, true);
+        let _code = RaaCode::<TestZipTypes<N, K, N>, REPETITION_FACTOR>::new(
+            1 << 30,
+            RaaConfig {
+                check_for_overflows: true,
+                permute_in_place: false,
+            },
+        );
     }
 
     #[test]

--- a/zip-plus/src/pcs/phase_commit.rs
+++ b/zip-plus/src/pcs/phase_commit.rs
@@ -270,7 +270,7 @@ mod tests {
 
     #[test]
     fn commit_succeeds_for_small_polynomial() {
-        let code = C::new(16, true);
+        let code = C::new(16, RAA_CFG);
         let pp = ZipPlusParams::new(4, 4, code);
 
         let evaluations = vec![Int::from(42); 16];
@@ -282,7 +282,7 @@ mod tests {
 
     #[test]
     fn commit_succeeds_for_two_variables() {
-        let code = C::new(4, true);
+        let code = C::new(4, RAA_CFG);
         let pp = ZipPlusParams::new(2, 2, code);
 
         let evaluations = vec![Int::from(1), Int::from(2), Int::from(3), Int::from(4)];
@@ -430,7 +430,7 @@ mod tests {
         let results: Vec<Vec<Int<4>>> = (0..10)
             .into_par_iter()
             .map(|_| {
-                let code = C::new(poly_size, true);
+                let code = C::new(poly_size, RAA_CFG);
                 let pp = ZipPlusParams::new(num_vars, 8, code);
 
                 TestZip::encode_rows(
@@ -479,7 +479,7 @@ mod tests {
 
     #[test]
     fn encode_rows_succeeds_for_single_row() {
-        let code = C::new(4, true);
+        let code = C::new(4, RAA_CFG);
         let pp = ZipPlusParams::new(2, 1, code);
 
         // Create a polynomial with 2 variables and 4 evaluations
@@ -496,7 +496,7 @@ mod tests {
 
     #[test]
     fn encode_rows_succeeds_for_single_poly_row() {
-        let code = PolyC::new(4, true);
+        let code = PolyC::new(4, RAA_CFG);
         let pp = ZipPlusParams::new(2, 1, code);
 
         // Create a polynomial with 2 variables and 4 evaluations
@@ -654,7 +654,7 @@ mod tests {
         let mut rng = rng();
         let num_vars = 4;
         let poly_size = 1 << num_vars;
-        let linear_code = C::new(poly_size, true);
+        let linear_code = C::new(poly_size, RAA_CFG);
         let param = TestZip::setup(poly_size, linear_code);
         let evaluations: Vec<_> = (0..poly_size)
             .map(|_| <Zt as ZipTypes>::Eval::from(rng.random::<i8>()))

--- a/zip-plus/src/pcs/phase_verify.rs
+++ b/zip-plus/src/pcs/phase_verify.rs
@@ -532,7 +532,7 @@ mod tests {
         let poly_size = 8; // row_len=4, num_rows=2 -> proximity checks are active
         let n = 3;
 
-        let linear_code = C::new(poly_size, true);
+        let linear_code = C::new(poly_size, RAA_CFG);
         let pp = TestZip::setup(poly_size, linear_code);
 
         let evaluations: Vec<_> = (0..poly_size as i32)
@@ -615,7 +615,7 @@ mod tests {
 
         let n = 3;
         let poly_size = 1 << n;
-        let linear_code: C = C::new(poly_size, true);
+        let linear_code: C = C::new(poly_size, RAA_CFG);
         let pp = TestZip::setup(poly_size, linear_code);
         let evaluations: Vec<_> = (0..poly_size)
             .map(|_| <Zt as ZipTypes>::Eval::from(rng.random::<i8>()))
@@ -647,7 +647,7 @@ mod tests {
     #[test]
     fn verification_fails_if_evaluation_consistency_check_is_invalid() {
         let poly_size = 8;
-        let linear_code = C::new(poly_size, true);
+        let linear_code = C::new(poly_size, RAA_CFG);
         let pp = TestZip::setup(poly_size, linear_code);
 
         let evaluations: Vec<_> = (0..poly_size as i32).map(Int::<INT_LIMBS>::from).collect();
@@ -693,7 +693,7 @@ mod tests {
     #[test]
     fn verification_succeeds_for_zero_polynomial() {
         let poly_size = 8;
-        let linear_code = C::new(poly_size, true);
+        let linear_code = C::new(poly_size, RAA_CFG);
         let pp = TestZip::setup(poly_size, linear_code);
 
         let evaluations: Vec<_> = vec![Int::<INT_LIMBS>::from(0); poly_size];
@@ -724,7 +724,7 @@ mod tests {
     fn verification_succeeds_at_zero_point() {
         let num_vars = 3;
         let poly_size = 1 << num_vars;
-        let linear_code = C::new(poly_size, true);
+        let linear_code = C::new(poly_size, RAA_CFG);
         let pp = TestZip::setup(poly_size, linear_code);
 
         let evaluations: Vec<_> = (1..=poly_size as i32).map(Int::<INT_LIMBS>::from).collect();
@@ -813,7 +813,7 @@ mod tests {
     #[test]
     fn verification_fails_if_proximity_values_are_too_large() {
         let poly_size = 8;
-        let linear_code = C::new(poly_size, true);
+        let linear_code = C::new(poly_size, RAA_CFG);
         let pp = TestZip::setup(poly_size, linear_code);
 
         let evaluations: Vec<_> = (1..=poly_size as i32).map(Int::<INT_LIMBS>::from).collect();
@@ -859,7 +859,7 @@ mod tests {
             let mut rng = ThreadRng::default();
             // Match the benchmark’s transcript usage for linear code construction
             let poly_size = 1 << P;
-            let linear_code = C::new(poly_size, true);
+            let linear_code = C::new(poly_size, RAA_CFG);
             let pp = TestZip::setup(poly_size, linear_code);
 
             let mle = DenseMultilinearExtension::rand(P, &mut rng, Zero::zero());
@@ -897,7 +897,7 @@ mod tests {
             let mut rng = ThreadRng::default();
             // Match the benchmark’s transcript usage for linear code construction
             let poly_size = 1 << P;
-            let linear_code = PolyC::new(poly_size, true);
+            let linear_code = PolyC::new(poly_size, RAA_CFG);
             let pp = TestPolyZip::setup(poly_size, linear_code);
 
             let mle = DenseMultilinearExtension::rand(P, &mut rng, Zero::zero());

--- a/zip-plus/src/pcs/structs.rs
+++ b/zip-plus/src/pcs/structs.rs
@@ -11,7 +11,7 @@ use crypto_primitives::{
 };
 use num_traits::CheckedMul;
 use p3_field::Packable;
-use std::marker::PhantomData;
+use std::{marker::PhantomData, ops::Neg};
 
 pub trait ZipTypes: Send + Sync {
     const NUM_COLUMN_OPENINGS: usize;
@@ -26,6 +26,7 @@ pub trait ZipTypes: Send + Sync {
     /// Ring of codeword elements, at least as wide as the evaluation ring
     type Cw: FixedRing
         + Polynomial<Self::CwR>
+        + Neg<Output = Self::Cw>
         + ConstTranscribable
         + AsPackable
         + FromRef<Self::Eval>
@@ -45,6 +46,7 @@ pub trait ZipTypes: Send + Sync {
 
     /// Coefficient ring of linear combination polynomial [Self::Comb]
     type CombR: ConstIntRing
+        + Neg<Output = Self::CombR>
         + ConstTranscribable
         + FromRef<Self::CombR>
         + for<'a> MulByScalar<&'a Self::Chal>;

--- a/zip-plus/src/pcs/test_utils.rs
+++ b/zip-plus/src/pcs/test_utils.rs
@@ -36,6 +36,7 @@ pub const REPETITION_FACTOR: usize = 4;
 pub const RAA_CFG: RaaConfig = RaaConfig {
     check_for_overflows: true,
     permute_in_place: false,
+    flip_signs: true,
 };
 
 pub struct TestZipTypes<const N: usize, const K: usize, const M: usize> {}

--- a/zip-plus/src/pcs/test_utils.rs
+++ b/zip-plus/src/pcs/test_utils.rs
@@ -7,7 +7,10 @@
 )]
 
 use crate::{
-    code::{LinearCode, raa::RaaCode},
+    code::{
+        LinearCode,
+        raa::{RaaCode, RaaConfig},
+    },
     pcs::{
         ZipPlusProof,
         structs::{
@@ -28,7 +31,12 @@ use crypto_primitives::{
 use itertools::Itertools;
 use num_traits::Zero;
 
-const REPETITION_FACTOR: usize = 4;
+pub const REPETITION_FACTOR: usize = 4;
+
+pub const RAA_CFG: RaaConfig = RaaConfig {
+    check_for_overflows: true,
+    permute_in_place: false,
+};
 
 pub struct TestZipTypes<const N: usize, const K: usize, const M: usize> {}
 impl<const N: usize, const K: usize, const M: usize> ZipTypes for TestZipTypes<N, K, M> {
@@ -101,14 +109,14 @@ pub fn setup_poly_test_params<
     })
 }
 
-fn setup_test_params_inner<Zt: ZipTypes, Lc: LinearCode<Zt>>(
+fn setup_test_params_inner<Zt: ZipTypes, Lc: LinearCode<Zt, Config = RaaConfig>>(
     num_vars: usize,
     prepare_evaluations: impl FnOnce(usize) -> Vec<Zt::Eval>,
 ) -> (ZipPlusParams<Zt, Lc>, DenseMultilinearExtension<Zt::Eval>) {
     let poly_size = 1 << num_vars;
     let num_rows = 1 << num_vars.div_ceil(2);
 
-    let code = Lc::new(poly_size, true);
+    let code = Lc::new(poly_size, RAA_CFG);
     let pp = ZipPlusParams::new(num_vars, num_rows, code);
 
     let evaluations = prepare_evaluations(poly_size);

--- a/zip-plus/src/poly/dense.rs
+++ b/zip-plus/src/poly/dense.rs
@@ -14,7 +14,7 @@ use std::{
     hash::Hash,
     iter,
     iter::{Product, Sum},
-    ops::{Add, AddAssign, Mul, MulAssign, Sub, SubAssign},
+    ops::{Add, AddAssign, Mul, MulAssign, Neg, Sub, SubAssign},
 };
 // TODO: rename rename to univariate
 
@@ -148,6 +148,17 @@ impl<R: Ring + Zero + One, const DEGREE: usize> One for DensePolynomial<R, DEGRE
             coeff_0: R::one(),
             coeffs: array::from_fn::<_, DEGREE, _>(|_| R::zero()),
         }
+    }
+}
+
+impl<R: Ring + Neg<Output = R>, const DEGREE: usize> Neg for DensePolynomial<R, DEGREE> {
+    type Output = Self;
+
+    #[allow(clippy::arithmetic_side_effects)] // By design
+    fn neg(mut self) -> Self::Output {
+        self.coeff_0 = -self.coeff_0;
+        self.coeffs.iter_mut().for_each(|c| *c = -c.clone());
+        self
     }
 }
 

--- a/zip-plus/src/utils.rs
+++ b/zip-plus/src/utils.rs
@@ -16,6 +16,16 @@ const WORD_FACTOR: usize = 1;
 const WORD_FACTOR: usize = 2;
 
 #[macro_export]
+macro_rules! neg {
+    ($a:expr) => {
+        neg!($a, "Negation overflow")
+    };
+    ($a:expr, $msg:expr) => {
+        $a.checked_neg().expect($msg)
+    };
+}
+
+#[macro_export]
 macro_rules! add {
     ($a:expr, $b:expr) => {
         add!($a, $b, "Addition overflow")


### PR DESCRIPTION
Added two new configuration options to RAA code:
* `flip_signs` - if set, signs of code entries on even position would be flipped twice (after repetition, and after first permutation) - as requested by @albert-garreta to make codeword entries smaller on average
* `permute_in_place` - if unset, permutation order would be precomputed and used to copy data in the permuted order. This is faster than permuting in-place using RNG when entries are sufficiently small
* For integers, setting `permute_in_place = false` leads to ~2-2.5x speed boost
* For polynomials, performance gets worse, so `permute_in_place` is still enabled for them