### PR TITLE
Improved Merkle tree

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,3 +30,7 @@ cast_sign_loss = "deny"
 needless_return = "deny"
 panicking_overflow_checks = "deny"
 unwrap_used = "deny"
+
+[profile.release]
+lto = true # Enable Link Time Optimization
+codegen-units = 1 # Slower compilation but potentially better optimization

--- a/crypto-primitives/src/matrix.rs
+++ b/crypto-primitives/src/matrix.rs
@@ -1,4 +1,5 @@
 use alloc::vec::Vec;
+use core::mem::{ManuallyDrop, MaybeUninit};
 
 /// A matrix, rectangular table of values
 pub trait Matrix<T> {
@@ -8,13 +9,17 @@ pub trait Matrix<T> {
     /// Number of columns in this matrix
     fn num_cols(&self) -> usize;
 
-    fn rows<'a>(&'a self) -> impl Iterator<Item = impl Iterator<Item = (usize, &'a T)>>
+    fn cells<'a>(&'a self) -> impl Iterator<Item = impl Iterator<Item = (usize, &'a T)>>
     where
         T: 'a;
+
+    fn is_empty(&self) -> bool {
+        self.num_rows() == 0 || self.num_cols() == 0
+    }
 }
 
 /// Sparse matrix is a matrix with a fixed number non-zero of elements per row
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Default, Eq, PartialEq)]
 pub struct SparseMatrix<T> {
     /// Number of rows
     pub num_rows: usize,
@@ -43,7 +48,7 @@ impl<T> Matrix<T> for SparseMatrix<T> {
         self.num_cols
     }
 
-    fn rows<'a>(&'a self) -> impl Iterator<Item = impl Iterator<Item = (usize, &'a T)>>
+    fn cells<'a>(&'a self) -> impl Iterator<Item = impl Iterator<Item = (usize, &'a T)>>
     where
         T: 'a,
     {
@@ -71,19 +76,82 @@ where
     }
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Default, Eq, PartialEq)]
 pub struct DenseRowMatrix<T> {
+    /// Number of rows
+    pub num_rows: usize,
+
     /// Number of columns
     pub num_cols: usize,
 
-    /// Rows of dense matrix
-    pub rows: Vec<Vec<T>>,
+    /// Linearized rows of dense matrix
+    pub data: Vec<T>,
+}
+
+impl<T: Clone> DenseRowMatrix<T> {
+    pub fn uninit(num_rows: usize, num_cols: usize) -> DenseRowMatrix<MaybeUninit<T>> {
+        let full_capacity = num_rows
+            .checked_mul(num_cols)
+            .expect("Overflow in matrix size calculation");
+        let mut data = Vec::with_capacity(full_capacity);
+        // Safety: It's safe to create an uninitialized vector of `MaybeUninit<T>`
+        unsafe { data.set_len(full_capacity) };
+        DenseRowMatrix {
+            num_rows,
+            num_cols,
+            data,
+        }
+    }
+
+    pub fn as_rows(&self) -> impl Iterator<Item = &[T]> {
+        self.data.chunks_exact(self.num_cols)
+    }
+
+    pub fn as_rows_mut(&mut self) -> impl Iterator<Item = &mut [T]> {
+        self.data.chunks_exact_mut(self.num_cols)
+    }
+
+    pub fn to_rows_slices(&self) -> Vec<&[T]> {
+        self.as_rows().collect()
+    }
+
+    pub fn to_rows_slices_mut(&mut self) -> Vec<&mut [T]> {
+        self.as_rows_mut().collect()
+    }
+
+    pub fn to_rows(&self) -> Vec<Vec<T>> {
+        self.data
+            .chunks_exact(self.num_cols)
+            .map(|row| row.to_vec())
+            .collect()
+    }
+}
+
+impl<T> DenseRowMatrix<MaybeUninit<T>> {
+    /// Mark the matrix as initialized, converting it to a `DenseRowMatrix<T>`.
+    /// Attempts to do so in place without copying the data.
+    ///
+    /// # Safety
+    /// The caller must ensure that all elements in `self.data` are initialized.
+    pub unsafe fn init(self) -> DenseRowMatrix<T> {
+        // Prevent `source` from being dropped while we steal its parts.
+        let mut v = ManuallyDrop::new(self.data);
+        let (ptr, len, cap) = (v.as_mut_ptr(), v.len(), v.capacity());
+        // Safety: MaybeUninit<T> can be safely converted to T if all elements are
+        // initialized.
+        let data = unsafe { Vec::from_raw_parts(ptr.cast::<T>(), len, cap) };
+        DenseRowMatrix {
+            num_rows: self.num_rows,
+            num_cols: self.num_cols,
+            data,
+        }
+    }
 }
 
 impl<T> Matrix<T> for DenseRowMatrix<T> {
     #[inline]
     fn num_rows(&self) -> usize {
-        self.rows.len()
+        self.num_rows
     }
 
     #[inline]
@@ -91,11 +159,13 @@ impl<T> Matrix<T> for DenseRowMatrix<T> {
         self.num_cols
     }
 
-    fn rows<'a>(&'a self) -> impl Iterator<Item = impl Iterator<Item = (usize, &'a T)>>
+    fn cells<'a>(&'a self) -> impl Iterator<Item = impl Iterator<Item = (usize, &'a T)>>
     where
         T: 'a,
     {
-        self.rows.iter().map(|row| row.iter().enumerate())
+        self.data
+            .chunks_exact(self.num_cols)
+            .map(|row| row.iter().enumerate())
     }
 }
 
@@ -103,8 +173,9 @@ impl<T> From<Vec<Vec<T>>> for DenseRowMatrix<T> {
     fn from(value: Vec<Vec<T>>) -> Self {
         let num_cols = value.iter().map(|row| row.len()).max().unwrap_or(0);
         DenseRowMatrix {
+            num_rows: value.len(),
             num_cols,
-            rows: value,
+            data: value.into_iter().flatten().collect(),
         }
     }
 }

--- a/crypto-primitives/src/ring/crypto_bigint_int.rs
+++ b/crypto-primitives/src/ring/crypto_bigint_int.rs
@@ -210,6 +210,9 @@ impl<const LIMBS: usize> Neg for Int<LIMBS> {
     type Output = Self;
 
     fn neg(mut self) -> Self {
+        // Mimic rust's default behavior for numbers - panic in debug mode if negating
+        // MIN
+        debug_assert_ne!(self, Self::MIN, "negation of MIN would overflow");
         self.0 = self.0.wrapping_neg();
         self
     }

--- a/zip-plus/Cargo.toml
+++ b/zip-plus/Cargo.toml
@@ -26,18 +26,8 @@ rand = "0.9"
 rand_core = "0.9"
 rayon = { version = "1.10", optional = true }
 blake3 = "1.8.2"
-transpose = "0.2.3"
 uninit = "0.6.2"
 crypto-primes = "0.7.0-pre.3"
-
-# P3
-p3-merkle-tree = { git = "https://github.com/Plonky3/Plonky3.git", rev = "5ebf8e4" }
-p3-symmetric = { git = "https://github.com/Plonky3/Plonky3.git", rev = "5ebf8e4" }
-p3-field = { git = "https://github.com/Plonky3/Plonky3.git", rev = "5ebf8e4" }
-p3-commit = { git = "https://github.com/Plonky3/Plonky3.git", rev = "5ebf8e4" }
-p3-matrix = { git = "https://github.com/Plonky3/Plonky3.git", rev = "5ebf8e4" }
-p3-util = { git = "https://github.com/Plonky3/Plonky3.git", rev = "5ebf8e4" }
-p3-maybe-rayon = { git = "https://github.com/Plonky3/Plonky3.git", rev = "5ebf8e4", features = [] }
 
 [dev-dependencies]
 criterion = { workspace = true }

--- a/zip-plus/benches/zip_common.rs
+++ b/zip-plus/benches/zip_common.rs
@@ -10,7 +10,8 @@ use ark_std::{
 };
 use criterion::{BenchmarkGroup, measurement::WallTime};
 use crypto_primitives::{
-    Field, FromWithConfig, IntoWithConfig, PrimeField, crypto_bigint_boxed_monty::BoxedMontyField,
+    DenseRowMatrix, Field, FromWithConfig, IntoWithConfig, PrimeField,
+    crypto_bigint_boxed_monty::BoxedMontyField,
 };
 use itertools::Itertools;
 use num_traits::{One, Zero};
@@ -145,20 +146,15 @@ where
     let leaves = (0..num_leaves)
         .map(|_| rng.random::<<Zt as ZipTypes>::Cw>())
         .collect_vec();
+    let matrix: DenseRowMatrix<_> = vec![leaves.clone()].into();
+    let rows = matrix.to_rows_slices();
 
     group.bench_function(
         format!("MerkleRoot: {}, leaves=2^{P}", Zt::Cw::type_name()),
         |b| {
-            b.iter_custom(|iters| {
-                let mut total_duration = Duration::ZERO;
-                for _ in 0..iters {
-                    let rows = vec![leaves.clone()];
-                    let timer = Instant::now();
-                    let tree = MerkleTree::new(rows);
-                    black_box(tree.root());
-                    total_duration += timer.elapsed();
-                }
-                total_duration
+            b.iter(|| {
+                let tree = MerkleTree::new(&rows);
+                black_box(tree.root());
             })
         },
     );

--- a/zip-plus/benches/zip_common.rs
+++ b/zip-plus/benches/zip_common.rs
@@ -95,14 +95,13 @@ pub fn encode_rows<Zt: ZipTypes, Lc: LinearCode<Zt>, const P: usize>(
             let linear_code = Lc::new(poly_size, code_config);
             let params = ZipPlus::setup(poly_size, linear_code);
             let row_len = params.linear_code.row_len();
-            let codeword_len = params.linear_code.codeword_len();
             let poly = DenseMultilinearExtension::<<Zt as ZipTypes>::Eval>::rand(
                 P,
                 &mut rng,
                 Zero::zero(),
             );
             b.iter(|| {
-                let cw = ZipPlus::encode_rows(&params, codeword_len, row_len, &poly.evaluations);
+                let cw = ZipPlus::encode_rows(&params, row_len, &poly.evaluations);
                 black_box(cw)
             })
         },
@@ -150,9 +149,16 @@ where
     group.bench_function(
         format!("MerkleRoot: {}, leaves=2^{P}", Zt::Cw::type_name()),
         |b| {
-            b.iter(|| {
-                let tree = MerkleTree::new(&leaves, num_leaves);
-                black_box(tree.root());
+            b.iter_custom(|iters| {
+                let mut total_duration = Duration::ZERO;
+                for _ in 0..iters {
+                    let rows = vec![leaves.clone()];
+                    let timer = Instant::now();
+                    let tree = MerkleTree::new(rows);
+                    black_box(tree.root());
+                    total_duration += timer.elapsed();
+                }
+                total_duration
             })
         },
     );

--- a/zip-plus/src/merkle.rs
+++ b/zip-plus/src/merkle.rs
@@ -1,14 +1,5 @@
-use crate::{
-    pcs::structs::AsPackable,
-    traits::{ConstTranscribable, Transcribable},
-    utils::ReinterpretVector,
-};
+use crate::{add, traits::ConstTranscribable, utils::parallelize_into_iter_map_collect};
 use itertools::Itertools;
-use p3_commit::{BatchOpeningRef, Mmcs};
-use p3_field::Packable;
-use p3_matrix::{Dimensions, Matrix as P3Matrix};
-use p3_merkle_tree::MerkleTreeMmcs;
-use p3_symmetric::{CryptographicHasher, PseudoCompressionFunction};
 use std::{
     fmt,
     fmt::{Display, Formatter},
@@ -57,62 +48,21 @@ where
     }
 }
 
-#[derive(Debug, Default, Clone)]
-struct MtHasher;
-
-impl<T: ConstTranscribable + Clone> CryptographicHasher<T, [u8; HASH_OUT_LEN]> for MtHasher {
-    fn hash_iter<I>(&self, input: I) -> [u8; HASH_OUT_LEN]
-    where
-        I: IntoIterator<Item = T>,
-    {
-        let mut hasher = blake3::Hasher::new();
-        let mut buf = vec![0_u8; T::NUM_BYTES];
-        for item in input {
-            item.write_transcription_bytes(&mut buf);
-            hasher.update(&buf);
-        }
-        hasher.finalize().into()
-    }
-}
-
-#[derive(Debug, Default, Clone)]
-struct MtPerm;
-
-impl PseudoCompressionFunction<[u8; HASH_OUT_LEN], 2> for MtPerm {
-    fn compress(&self, input: [[u8; HASH_OUT_LEN]; 2]) -> [u8; HASH_OUT_LEN] {
-        let mut hasher = blake3::Hasher::new();
-        for ref item in input {
-            hasher.update(item);
-        }
-        hasher.finalize().into()
-    }
-}
-
-type Matrix<T> = TransposedMatrix<T>;
-type MtMmcs<T> = MerkleTreeMmcs<T, u8, MtHasher, MtPerm, HASH_OUT_LEN>;
-type P3MerkleTree<T> = p3_merkle_tree::MerkleTree<T, u8, Matrix<T>, HASH_OUT_LEN>;
-
 #[derive(Debug, Default)]
-pub struct MerkleTree<T>
-where
-    T: Packable + Transcribable + Clone + Send + Sync,
-{
-    inner: Option<MerkleTreeInner<T>>,
+pub struct MerkleTree {
+    inner: Option<MerkleTreeInner>,
 }
 
 #[derive(Debug)]
-struct MerkleTreeInner<T> {
-    prover_data: P3MerkleTree<T>,
-    matrix_dims: Dimensions,
+struct MerkleTreeInner {
+    /// First vector is leaves, last vector is root
+    layers: Vec<Vec<MtHash>>,
 }
 
-impl<T> MerkleTree<T>
-where
-    T: Packable + ConstTranscribable + Clone + Send + Sync,
-{
-    pub fn new<S>(rows: Vec<Vec<S>>) -> Self
+impl MerkleTree {
+    pub fn new<S>(rows: &[&[S]]) -> Self
     where
-        S: AsPackable<Packable = T>,
+        S: ConstTranscribable + Clone + Send + Sync,
     {
         assert!(!rows.is_empty());
         let row_width = rows[0].len();
@@ -123,93 +73,216 @@ where
         );
         assert!(row_width.is_power_of_two());
 
-        // Each matrix row is hashed together to form a leaf in the Merkle tree.
-        // Thus, we need to use a transposed matrix to have original columns as leaves.
-        let matrix = {
-            let rows = unsafe { ReinterpretVector::reinterpret_vector(rows) };
-            // Safe because we just initialized all elements of `columns`, and
-            // MaybeUninit<T> is #[repr(transparent)].
-            Matrix::new(rows)
-        };
+        let leaves = hash_leaves(rows, row_width);
+        let inner = build_merkle_tree_from_leaves(leaves);
 
-        let matrix_dims = matrix.dimensions();
-        let prover_data = P3MerkleTree::new::<T, _, _, _>(&MtHasher, &MtPerm, vec![matrix]);
-
-        Self {
-            inner: Some(MerkleTreeInner {
-                prover_data,
-                matrix_dims,
-            }),
-        }
+        Self { inner: Some(inner) }
     }
 
     pub fn root(&self) -> MtHash {
-        MtHash(
-            *self
-                .inner
-                .as_ref()
-                .expect("Merkle tree not initialized")
-                .prover_data
-                .root()
-                .as_ref(),
-        )
+        self.inner
+            .as_ref()
+            .expect("Merkle tree not initialized")
+            .layers
+            .last()
+            .and_then(|v| v.first())
+            .cloned()
+            .expect("Merkle tree has no root node")
     }
+}
+
+fn hash_leaves<S>(rows: &[&[S]], m_cols: usize) -> Vec<MtHash>
+where
+    S: ConstTranscribable + Send + Sync,
+{
+    parallelize_into_iter_map_collect(0..m_cols, |i| {
+        let mut hasher = blake3::Hasher::new();
+        let mut buf = vec![0_u8; S::NUM_BYTES];
+        for row in rows.iter() {
+            let v = &row[i];
+            v.write_transcription_bytes(&mut buf);
+            hasher.update(&buf);
+        }
+        hasher.finalize().into()
+    })
+}
+
+#[allow(clippy::unwrap_used)] // Using unwrap here never panics
+fn build_merkle_tree_from_leaves(nodes: Vec<MtHash>) -> MerkleTreeInner {
+    if nodes.is_empty() {
+        return MerkleTreeInner {
+            layers: vec![vec![blake3::Hasher::new().finalize().into()]],
+        };
+    }
+    assert!(
+        nodes.len().is_power_of_two(),
+        "Number of leaves must be a power of two"
+    );
+    let tree_height = nodes.len().trailing_zeros() as usize;
+    let mut layers = Vec::with_capacity(tree_height);
+    layers.push(nodes);
+
+    loop {
+        let (chunked_prev_layer, []) = layers.last().unwrap().as_chunks::<2>() else {
+            unreachable!(
+                "Leaves length must be a power of two, so we should always have an even number of nodes"
+            )
+        };
+        let layer: Vec<MtHash> = chunked_prev_layer
+            .iter()
+            .map(|hash_pair: &[MtHash; 2]| {
+                let mut hasher = blake3::Hasher::new();
+                hasher.update(&hash_pair[0].0);
+                hasher.update(&hash_pair[1].0);
+                hasher.finalize().into()
+            })
+            .collect();
+        let level_size = layer.len();
+        layers.push(layer);
+        if level_size == 1 {
+            break; // We reached the root
+        }
+    }
+    MerkleTreeInner { layers }
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct MerkleProof {
-    pub path: Vec<MtHash>,
-    pub matrix_dims: Dimensions,
+    /// Siblings along the path from leaf to root. Does not include the leaf and
+    /// root hashes.
+    pub siblings: Vec<MtHash>,
+    /// Index of the leaf being proven
+    pub leaf_index: usize,
+    /// Total number of leaves in the tree
+    pub tree_size: usize,
 }
 
 impl MerkleProof {
-    pub fn new(path: Vec<MtHash>, matrix_dims: Dimensions) -> Self {
-        MerkleProof { path, matrix_dims }
+    pub fn new(path: Vec<MtHash>, leaf_index: usize, tree_size: usize) -> Self {
+        assert!(!path.is_empty(), "Merkle proof path cannot be empty");
+        assert!(leaf_index < tree_size, "Leaf index out of bounds");
+        Self {
+            siblings: path,
+            leaf_index,
+            tree_size,
+        }
     }
 
-    pub fn create_proof<T>(merkle_tree: &MerkleTree<T>, leaf: usize) -> Result<Self, MerkleError>
-    where
-        T: Packable + ConstTranscribable + Clone,
-    {
+    #[allow(clippy::arithmetic_side_effects)] // Using intentionally, overflow isn't possible
+    pub fn create_proof(merkle_tree: &MerkleTree, leaf_index: usize) -> Result<Self, MerkleError> {
         let mt = merkle_tree
             .inner
             .as_ref()
             .ok_or(MerkleError::InvalidRootHash)?;
-        let prover = MtMmcs::<T>::new(MtHasher, MtPerm);
-        let opening = prover.open_batch(leaf, &mt.prover_data);
-        let path = opening.opening_proof.into_iter().map(MtHash).collect();
-        Ok(Self::new(path, mt.matrix_dims))
+
+        let mut siblings = Vec::new();
+        let mut layer_idx = 0;
+        let mut current_layer = &mt.layers[layer_idx];
+        let mut current_index = leaf_index;
+
+        loop {
+            // Determine if current node is left (even) or right (odd) child
+            let is_left_child = current_index.is_multiple_of(2);
+
+            if is_left_child {
+                // Left child, sibling is on the right
+                let sibling_index = current_index + 1;
+                if sibling_index < current_layer.len() {
+                    siblings.push(current_layer[sibling_index].clone());
+                } else {
+                    // We've reached the root
+                    debug_assert_eq!(layer_idx, mt.layers.len() - 1);
+                    break;
+                }
+            } else {
+                // Right child, sibling is on the left
+                let sibling_index = current_index - 1;
+                siblings.push(current_layer[sibling_index].clone());
+            }
+
+            current_index /= 2;
+            layer_idx += 1;
+            current_layer = &mt.layers[layer_idx];
+        }
+
+        Ok(MerkleProof {
+            siblings,
+            leaf_index,
+            tree_size: mt.layers[0].len(),
+        })
     }
 
-    pub fn verify<S, T>(
+    pub fn verify<S>(
         &self,
         root: &MtHash,
-        leaf_values: Vec<S>,
+        leaf_values: &[S],
         leaf_index: usize,
     ) -> Result<(), MerkleError>
     where
-        S: AsPackable<Packable = T>,
-        T: Packable + ConstTranscribable + Clone,
+        S: ConstTranscribable,
     {
-        let prover = MtMmcs::<T>::new(MtHasher, MtPerm);
+        if self.siblings.is_empty() {
+            return Err(MerkleError::InvalidMerkleProof(
+                "Merkle proof siblings was empty".to_owned(),
+            ));
+        }
+        if leaf_index != self.leaf_index {
+            return Err(MerkleError::InvalidLeafIndex(leaf_index));
+        }
 
-        let leaf_values = unsafe { ReinterpretVector::reinterpret_vector(leaf_values) };
+        let mut buf = vec![0_u8; S::NUM_BYTES];
+        let mut current_hash: MtHash = {
+            let mut hasher = blake3::Hasher::new();
+            for v in leaf_values.iter() {
+                v.write_transcription_bytes(&mut buf);
+                hasher.update(&buf);
+            }
+            hasher.finalize().into()
+        };
+        let mut current_index = self.leaf_index;
+        let mut level_size = self.tree_size;
+        let mut siblings_iter = self.siblings.iter();
 
-        let values = vec![leaf_values];
-        let proof = self.path.iter().map(|h| h.0).collect_vec();
-        let proof = BatchOpeningRef::new(&values, &proof);
-        prover
-            .verify_batch(&root.0.into(), &[self.matrix_dims], leaf_index, proof)
-            .map_err(|e| {
-                MerkleError::InvalidMerkleProof(format!("Failed to validate Merkle proof: {:?}", e))
-            })
+        while level_size > 1 {
+            // Determine if current node is left (even) or right (odd) child
+            let is_left_child = current_index.is_multiple_of(2);
+
+            let sibling_hash = siblings_iter.next().ok_or(MerkleError::InvalidMerkleProof(
+                "Not enough siblings in proof".to_owned(),
+            ))?;
+
+            let mut hasher = blake3::Hasher::new();
+            if is_left_child {
+                hasher.update(&current_hash.0);
+                hasher.update(&sibling_hash.0);
+            } else {
+                hasher.update(&sibling_hash.0);
+                hasher.update(&current_hash.0);
+            }
+
+            current_hash = hasher.finalize().into();
+
+            current_index /= 2;
+            level_size = level_size.div_ceil(2);
+        }
+
+        if siblings_iter.next().is_some() {
+            return Err(MerkleError::InvalidMerklePathLength {
+                expected: self.siblings.len(),
+                actual: add!(self.siblings.len(), 1),
+            });
+        }
+
+        if &current_hash != root {
+            return Err(MerkleError::InvalidRootHash);
+        }
+        Ok(())
     }
 }
 
 impl Display for MerkleProof {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
-        writeln!(f, "Merkle Path: {}", self.path.iter().join(", "))?;
-        writeln!(f, "Matrix Dimensions: {}", self.matrix_dims)?;
+        writeln!(f, "Merkle Path: {}", self.siblings.iter().join(", "))?;
         Ok(())
     }
 }
@@ -225,7 +298,7 @@ pub enum MerkleError {
     #[error("Invalid Merkle path length: expected {expected}, got {actual}")]
     InvalidMerklePathLength { expected: usize, actual: usize },
 
-    #[error("Invalid leaf index: {0} is out of bounds")]
+    #[error("Invalid leaf index: {0}")]
     InvalidLeafIndex(usize),
 
     #[error("Invalid root hash")]
@@ -236,46 +309,6 @@ pub enum MerkleError {
 
     #[error("Failed to write merkle proof")]
     FailedMerkleProofWriting,
-}
-
-#[derive(Clone, Debug, PartialEq, Eq)]
-pub struct TransposedMatrix<T> {
-    columns: Vec<Vec<T>>,
-    column_len: usize,
-}
-
-impl<T> TransposedMatrix<T> {
-    pub fn new(columns: Vec<Vec<T>>) -> Self {
-        let column_len = columns.first().map_or(0, Vec::len);
-        Self {
-            columns,
-            column_len,
-        }
-    }
-}
-
-impl<T> p3_matrix::Matrix<T> for TransposedMatrix<T>
-where
-    T: Packable + ConstTranscribable + Clone + Send + Sync,
-{
-    fn width(&self) -> usize {
-        self.columns.len()
-    }
-
-    fn height(&self) -> usize {
-        self.column_len
-    }
-
-    unsafe fn get_unchecked(&self, r: usize, c: usize) -> T {
-        unsafe { *self.columns.get_unchecked(c).get_unchecked(r) }
-    }
-
-    unsafe fn row_unchecked(
-        &self,
-        r: usize,
-    ) -> impl IntoIterator<Item = T, IntoIter = impl Iterator<Item = T> + Send + Sync> {
-        unsafe { self.columns.iter().map(move |col| *col.get_unchecked(r)) }
-    }
 }
 
 #[cfg(test)]
@@ -294,7 +327,7 @@ mod tests {
             .map(|_| Int::random(&mut rng))
             .collect::<Vec<Int<N>>>();
 
-        let merkle_tree = MerkleTree::new(vec![leaves_data.clone()]);
+        let merkle_tree = MerkleTree::new(&[leaves_data.as_slice()]);
 
         // Print tree structure after merklizing
         let root = merkle_tree.root();
@@ -304,9 +337,12 @@ mod tests {
                 MerkleProof::create_proof(&merkle_tree, i).expect("Merkle proof creation failed");
 
             // Verify the proof
-            proof
-                .verify(&root, vec![*leaf], i)
-                .expect("Merkle proof verification failed");
+            let result = proof.verify(&root, &[*leaf], i);
+            assert!(
+                result.is_ok(),
+                "Merkle proof verification failed for leaf index {i}: {}",
+                result.err().unwrap()
+            );
         }
     }
 }

--- a/zip-plus/src/merkle.rs
+++ b/zip-plus/src/merkle.rs
@@ -1,5 +1,4 @@
 use crate::{
-    div,
     pcs::structs::AsPackable,
     traits::{ConstTranscribable, Transcribable},
     utils::ReinterpretVector,
@@ -7,16 +6,14 @@ use crate::{
 use itertools::Itertools;
 use p3_commit::{BatchOpeningRef, Mmcs};
 use p3_field::Packable;
-use p3_matrix::{Dimensions, Matrix as P3Matrix, dense::RowMajorMatrix};
+use p3_matrix::{Dimensions, Matrix as P3Matrix};
 use p3_merkle_tree::MerkleTreeMmcs;
 use p3_symmetric::{CryptographicHasher, PseudoCompressionFunction};
 use std::{
     fmt,
     fmt::{Display, Formatter},
-    io::Write,
 };
 use thiserror::Error;
-use uninit::AsMaybeUninit;
 
 pub const HASH_OUT_LEN: usize = blake3::OUT_LEN;
 
@@ -51,6 +48,15 @@ impl ConstTranscribable for MtHash {
     }
 }
 
+impl<B> From<B> for MtHash
+where
+    B: Into<[u8; HASH_OUT_LEN]>,
+{
+    fn from(b: B) -> Self {
+        MtHash(b.into())
+    }
+}
+
 #[derive(Debug, Default, Clone)]
 struct MtHasher;
 
@@ -63,7 +69,7 @@ impl<T: ConstTranscribable + Clone> CryptographicHasher<T, [u8; HASH_OUT_LEN]> f
         let mut buf = vec![0_u8; T::NUM_BYTES];
         for item in input {
             item.write_transcription_bytes(&mut buf);
-            hasher.write_all(&buf).expect("Failed to write to hasher");
+            hasher.update(&buf);
         }
         hasher.finalize().into()
     }
@@ -76,13 +82,13 @@ impl PseudoCompressionFunction<[u8; HASH_OUT_LEN], 2> for MtPerm {
     fn compress(&self, input: [[u8; HASH_OUT_LEN]; 2]) -> [u8; HASH_OUT_LEN] {
         let mut hasher = blake3::Hasher::new();
         for ref item in input {
-            hasher.write_all(item).expect("Failed to write to hasher");
+            hasher.update(item);
         }
         hasher.finalize().into()
     }
 }
 
-type Matrix<T> = RowMajorMatrix<T>;
+type Matrix<T> = TransposedMatrix<T>;
 type MtMmcs<T> = MerkleTreeMmcs<T, u8, MtHasher, MtPerm, HASH_OUT_LEN>;
 type P3MerkleTree<T> = p3_merkle_tree::MerkleTree<T, u8, Matrix<T>, HASH_OUT_LEN>;
 
@@ -104,32 +110,26 @@ impl<T> MerkleTree<T>
 where
     T: Packable + ConstTranscribable + Clone + Send + Sync,
 {
-    pub fn new<S>(rows: &[S], row_width: usize) -> Self
+    pub fn new<S>(rows: Vec<Vec<S>>) -> Self
     where
         S: AsPackable<Packable = T>,
     {
-        assert!(rows.len().is_power_of_two());
-        assert!(rows.len().is_multiple_of(row_width));
+        assert!(!rows.is_empty());
+        let row_width = rows[0].len();
         assert!(row_width > 0);
+        assert!(
+            rows.iter().all(|row| row.len() == row_width),
+            "All rows must have the same width"
+        );
+        assert!(row_width.is_power_of_two());
 
         // Each matrix row is hashed together to form a leaf in the Merkle tree.
-        // Thus, we need to transpose a matrix to have original columns as leaves.
+        // Thus, we need to use a transposed matrix to have original columns as leaves.
         let matrix = {
-            let mut columns: Vec<T> = Vec::with_capacity(rows.len());
-            let column_height = div!(rows.len(), row_width);
-            let rows = unsafe { ReinterpretVector::reinterpret_slice(rows) };
-            transpose::transpose(
-                rows.as_ref_uninit(),
-                columns.spare_capacity_mut(),
-                row_width,
-                column_height,
-            );
+            let rows = unsafe { ReinterpretVector::reinterpret_vector(rows) };
             // Safe because we just initialized all elements of `columns`, and
             // MaybeUninit<T> is #[repr(transparent)].
-            unsafe {
-                columns.set_len(rows.len());
-            }
-            Matrix::new(columns, column_height)
+            Matrix::new(rows)
         };
 
         let matrix_dims = matrix.dimensions();
@@ -238,6 +238,46 @@ pub enum MerkleError {
     FailedMerkleProofWriting,
 }
 
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct TransposedMatrix<T> {
+    columns: Vec<Vec<T>>,
+    column_len: usize,
+}
+
+impl<T> TransposedMatrix<T> {
+    pub fn new(columns: Vec<Vec<T>>) -> Self {
+        let column_len = columns.first().map_or(0, Vec::len);
+        Self {
+            columns,
+            column_len,
+        }
+    }
+}
+
+impl<T> p3_matrix::Matrix<T> for TransposedMatrix<T>
+where
+    T: Packable + ConstTranscribable + Clone + Send + Sync,
+{
+    fn width(&self) -> usize {
+        self.columns.len()
+    }
+
+    fn height(&self) -> usize {
+        self.column_len
+    }
+
+    unsafe fn get_unchecked(&self, r: usize, c: usize) -> T {
+        unsafe { *self.columns.get_unchecked(c).get_unchecked(r) }
+    }
+
+    unsafe fn row_unchecked(
+        &self,
+        r: usize,
+    ) -> impl IntoIterator<Item = T, IntoIter = impl Iterator<Item = T> + Send + Sync> {
+        unsafe { self.columns.iter().map(move |col| *col.get_unchecked(r)) }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -254,7 +294,7 @@ mod tests {
             .map(|_| Int::random(&mut rng))
             .collect::<Vec<Int<N>>>();
 
-        let merkle_tree = MerkleTree::new(&leaves_data, leaves_data.len());
+        let merkle_tree = MerkleTree::new(vec![leaves_data.clone()]);
 
         // Print tree structure after merklizing
         let root = merkle_tree.root();

--- a/zip-plus/src/pcs/phase_commit.rs
+++ b/zip-plus/src/pcs/phase_commit.rs
@@ -7,9 +7,8 @@ use crate::{
         utils::validate_input,
     },
     poly::mle::DenseMultilinearExtension,
-    utils::{num_threads, parallelize_iter},
+    utils::{num_threads, parallelize_for_each},
 };
-use uninit::out_ref::Out;
 
 impl<Zt: ZipTypes, Lc: LinearCode<Zt>> ZipPlus<Zt, Lc> {
     /// Creates a commitment to a multilinear polynomial using the ZIP PCS
@@ -75,11 +74,10 @@ impl<Zt: ZipTypes, Lc: LinearCode<Zt>> ZipPlus<Zt, Lc> {
         );
 
         let row_len = pp.linear_code.row_len();
-        let codeword_len = pp.linear_code.codeword_len();
 
-        let rows = Self::encode_rows(pp, codeword_len, row_len, &poly.evaluations);
+        let rows = Self::encode_rows(pp, row_len, &poly.evaluations);
 
-        let merkle_tree = MerkleTree::new(&rows, codeword_len);
+        let merkle_tree = MerkleTree::new(rows.clone());
         let root = merkle_tree.root();
 
         Ok((
@@ -107,13 +105,12 @@ impl<Zt: ZipTypes, Lc: LinearCode<Zt>> ZipPlus<Zt, Lc> {
     pub fn commit_no_merkle(
         pp: &ZipPlusParams<Zt, Lc>,
         poly: &DenseMultilinearExtension<Zt::Eval>,
-    ) -> Result<Vec<Zt::Cw>, ZipError> {
+    ) -> Result<Vec<Vec<Zt::Cw>>, ZipError> {
         validate_input::<Zt, Lc, bool>("commit", pp.num_vars, [poly], None)?;
 
         let row_len = pp.linear_code.row_len();
-        let codeword_len = pp.linear_code.codeword_len();
 
-        let rows = Self::encode_rows(pp, codeword_len, row_len, &poly.evaluations);
+        let rows = Self::encode_rows(pp, row_len, &poly.evaluations);
 
         Ok(rows)
     }
@@ -160,33 +157,25 @@ impl<Zt: ZipTypes, Lc: LinearCode<Zt>> ZipPlus<Zt, Lc> {
     #[allow(clippy::arithmetic_side_effects)]
     pub fn encode_rows(
         pp: &ZipPlusParams<Zt, Lc>,
-        codeword_len: usize,
         row_len: usize,
         evals: &[Zt::Eval],
-    ) -> Vec<Zt::Cw> {
+    ) -> Vec<Vec<Zt::Cw>> {
         let rows_per_thread = pp.num_rows.div_ceil(num_threads());
-        let mut encoded_rows: Vec<Zt::Cw> = Vec::with_capacity(pp.num_rows * codeword_len);
+        let mut encoded_rows: Vec<Vec<Zt::Cw>> = vec![vec![]; pp.num_rows];
 
-        parallelize_iter(
+        parallelize_for_each(
             encoded_rows
-                .spare_capacity_mut()
-                .chunks_mut(rows_per_thread * codeword_len)
+                .chunks_mut(rows_per_thread)
                 .zip(evals.chunks(rows_per_thread * row_len)),
-            |(encoded_chunk, evals)| {
-                for (row, evals) in encoded_chunk
-                    .chunks_exact_mut(codeword_len)
+            |(encoded_rows_chunk, evals)| {
+                for (row, evals) in encoded_rows_chunk
+                    .iter_mut()
                     .zip(evals.chunks_exact(row_len))
                 {
-                    let encoded: Vec<Zt::Cw> = pp.linear_code.encode(evals);
-                    Out::from(row).copy_from_slice(encoded.as_slice());
+                    *row = pp.linear_code.encode(evals);
                 }
             },
         );
-
-        // Safe because we have just initialized all elements.
-        unsafe {
-            encoded_rows.set_len(pp.num_rows * codeword_len);
-        }
 
         encoded_rows
     }
@@ -320,14 +309,12 @@ mod tests {
     #[test]
     fn encode_rows_produces_correct_size() {
         let (pp, poly) = setup_test_params(3);
-        let encoded = TestZip::encode_rows(
-            &pp,
-            pp.linear_code.codeword_len(),
-            pp.linear_code.row_len(),
-            &poly.evaluations,
-        );
+        let encoded = TestZip::encode_rows(&pp, pp.linear_code.row_len(), &poly.evaluations);
 
-        assert_eq!(encoded.len(), pp.num_rows * pp.linear_code.codeword_len());
+        assert_eq!(encoded.len(), pp.num_rows);
+        for row in &encoded {
+            assert_eq!(row.len(), pp.linear_code.codeword_len());
+        }
     }
 
     /// Verifies that the output of `encode_rows` is semantically correct by
@@ -335,17 +322,9 @@ mod tests {
     #[test]
     fn encoded_rows_match_linear_code_definition() {
         let (pp, poly) = setup_test_params(3);
-        let encoded = TestZip::encode_rows(
-            &pp,
-            pp.linear_code.codeword_len(),
-            pp.linear_code.row_len(),
-            &poly.evaluations,
-        );
+        let encoded = TestZip::encode_rows(&pp, pp.linear_code.row_len(), &poly.evaluations);
 
-        for (i, row_chunk) in encoded
-            .chunks_exact(pp.linear_code.codeword_len())
-            .enumerate()
-        {
+        for (i, row_chunk) in encoded.iter().enumerate() {
             let start = i * pp.linear_code.row_len();
             let end = start + pp.linear_code.row_len();
             let row_evals = &poly.evaluations[start..end];
@@ -366,10 +345,10 @@ mod tests {
         let (mut data, commitment) = TestZip::commit(&pp, &poly).unwrap();
 
         if !data.rows.is_empty() {
-            data.rows[0] = Int::from(999999);
+            data.rows[0][0] = Int::from(999999);
             let codeword_len = pp.linear_code.codeword_len();
-            let corrupted_row = &data.rows[0..codeword_len];
-            let new_tree = MerkleTree::new(corrupted_row, corrupted_row.len());
+            let corrupted_row = &data.rows[0][0..codeword_len];
+            let new_tree = MerkleTree::new(vec![corrupted_row.to_vec()]);
             assert_ne!(
                 new_tree.root(),
                 commitment.root,
@@ -396,15 +375,18 @@ mod tests {
     #[test]
     fn encoded_rows_are_nonzero_for_nonzero_input() {
         let (pp, poly) = setup_test_params(3);
-        let encoded = TestZip::encode_rows(
-            &pp,
-            pp.linear_code.codeword_len(),
-            pp.linear_code.row_len(),
-            &poly.evaluations,
-        );
+        let encoded = TestZip::encode_rows(&pp, pp.linear_code.row_len(), &poly.evaluations);
 
-        assert_eq!(encoded.len(), pp.num_rows * pp.linear_code.codeword_len());
-        let non_zero_count = encoded.iter().filter(|&&x| x != Int::from(0)).count();
+        assert_eq!(encoded.len(), pp.num_rows);
+        for row in &encoded {
+            assert_eq!(row.len(), pp.linear_code.codeword_len());
+        }
+
+        let non_zero_count = encoded
+            .iter()
+            .flatten()
+            .filter(|&&x| x != Int::from(0))
+            .count();
         assert!(non_zero_count > 0);
     }
 
@@ -413,7 +395,10 @@ mod tests {
         let (pp, poly) = setup_test_params(3);
         let (hint, _) = TestZip::commit(&pp, &poly).unwrap();
 
-        assert_eq!(hint.rows.len(), pp.num_rows * pp.linear_code.codeword_len());
+        assert_eq!(hint.rows.len(), pp.num_rows);
+        for row in &hint.rows {
+            assert_eq!(row.len(), pp.linear_code.codeword_len());
+        }
     }
 
     #[test]
@@ -427,18 +412,13 @@ mod tests {
         let poly =
             DenseMultilinearExtension::from_evaluations_vec(num_vars, evaluations, Zero::zero());
 
-        let results: Vec<Vec<Int<4>>> = (0..10)
+        let results: Vec<Vec<Vec<Int<4>>>> = (0..10)
             .into_par_iter()
             .map(|_| {
                 let code = C::new(poly_size, RAA_CFG);
                 let pp = ZipPlusParams::new(num_vars, 8, code);
 
-                TestZip::encode_rows(
-                    &pp,
-                    pp.linear_code.codeword_len(),
-                    pp.linear_code.row_len(),
-                    &poly.evaluations,
-                )
+                TestZip::encode_rows(&pp, pp.linear_code.row_len(), &poly.evaluations)
             })
             .collect();
 
@@ -485,13 +465,9 @@ mod tests {
         // Create a polynomial with 2 variables and 4 evaluations
         let evaluations = vec![Int::from(5); 4];
         let poly = DenseMultilinearExtension::from_evaluations_vec(2, evaluations, Zero::zero());
-        let encoded = TestZip::encode_rows(
-            &pp,
-            pp.linear_code.codeword_len(),
-            pp.linear_code.row_len(),
-            &poly.evaluations,
-        );
-        assert_eq!(encoded.len(), pp.linear_code.codeword_len());
+        let encoded = TestZip::encode_rows(&pp, pp.linear_code.row_len(), &poly.evaluations);
+        assert_eq!(encoded.len(), 1);
+        assert_eq!(encoded[0].len(), pp.linear_code.codeword_len());
     }
 
     #[test]
@@ -506,13 +482,9 @@ mod tests {
             DensePolynomial::new(vec![Int::from(5), Int::from(6)]),
         ];
         let poly = DenseMultilinearExtension::from_evaluations_vec(2, evaluations, Zero::zero());
-        let encoded = TestPolyZip::encode_rows(
-            &pp,
-            pp.linear_code.codeword_len(),
-            pp.linear_code.row_len(),
-            &poly.evaluations,
-        );
-        assert_eq!(encoded.len(), pp.linear_code.codeword_len());
+        let encoded = TestPolyZip::encode_rows(&pp, pp.linear_code.row_len(), &poly.evaluations);
+        assert_eq!(encoded.len(), 1);
+        assert_eq!(encoded[0].len(), pp.linear_code.codeword_len());
     }
 
     #[test]
@@ -539,12 +511,7 @@ mod tests {
     #[test]
     fn linear_code_preserves_linearity() {
         let (pp, poly) = setup_test_params(4);
-        let encoded = TestZip::encode_rows(
-            &pp,
-            pp.linear_code.codeword_len(),
-            pp.linear_code.row_len(),
-            &poly.evaluations,
-        );
+        let encoded = TestZip::encode_rows(&pp, pp.linear_code.row_len(), &poly.evaluations);
         let row_len = pp.linear_code.row_len();
         let codeword_len = pp.linear_code.codeword_len();
         let row1_evals = &poly.evaluations[0..row_len];
@@ -555,8 +522,8 @@ mod tests {
             .map(|i| a * row1_evals[i] + b.resize() * row2_evals[i])
             .collect();
         let combined_encoded = pp.linear_code.encode(&combined_evals);
-        let row1_encoded = &encoded[0..codeword_len];
-        let row2_encoded = &encoded[codeword_len..2 * codeword_len];
+        let row1_encoded = &encoded[0];
+        let row2_encoded = &encoded[1];
         let expected_combined: Vec<_> = (0..codeword_len)
             .map(|i| a.resize() * row1_encoded[i] + b.resize() * row2_encoded[i])
             .collect();
@@ -596,23 +563,18 @@ mod tests {
         let max_val = Int::<INT_LIMBS>::from(i64::MAX);
         let poly =
             DenseMultilinearExtension::from_evaluations_vec(3, vec![max_val; 8], Zero::zero());
-        let encoded_rows = TestZip::encode_rows(
-            &pp,
-            pp.linear_code.codeword_len(),
-            pp.linear_code.row_len(),
-            &poly.evaluations,
-        );
-        assert_eq!(
-            encoded_rows.len(),
-            pp.num_rows * pp.linear_code.codeword_len()
-        );
+        let encoded_rows = TestZip::encode_rows(&pp, pp.linear_code.row_len(), &poly.evaluations);
+        assert_eq!(encoded_rows.len(), pp.num_rows);
+        for row in &encoded_rows {
+            assert_eq!(row.len(), pp.linear_code.codeword_len());
+        }
     }
 
     #[test]
-    #[should_panic(expected = "rows.len().is_power_of_two()")]
+    #[should_panic(expected = "row_width.is_power_of_two()")]
     fn merkle_tree_new_panics_on_non_power_of_two_leaves() {
         let leaves_data: Vec<Int<INT_LIMBS>> = (0..7).map(Int::from).collect();
-        let _ = MerkleTree::new(&leaves_data, leaves_data.len());
+        let _ = MerkleTree::new(vec![leaves_data]);
     }
 
     #[test]

--- a/zip-plus/src/pcs/phase_commit.rs
+++ b/zip-plus/src/pcs/phase_commit.rs
@@ -1,4 +1,3 @@
-use itertools::Itertools;
 use crate::{
     ZipError,
     code::LinearCode,
@@ -10,8 +9,8 @@ use crate::{
     poly::mle::DenseMultilinearExtension,
     utils::{num_threads, parallelize_for_each},
 };
-use uninit::out_ref::Out;
 use crypto_primitives::DenseRowMatrix;
+use uninit::out_ref::Out;
 
 impl<Zt: ZipTypes, Lc: LinearCode<Zt>> ZipPlus<Zt, Lc> {
     /// Creates a commitment to a multilinear polynomial using the ZIP PCS
@@ -80,8 +79,7 @@ impl<Zt: ZipTypes, Lc: LinearCode<Zt>> ZipPlus<Zt, Lc> {
 
         let cw_matrix = Self::encode_rows(pp, row_len, &poly.evaluations);
 
-        let rows = cw_matrix.as_rows().map(|v| v.to_vec()).collect_vec();
-        let merkle_tree = MerkleTree::new(rows);
+        let merkle_tree = MerkleTree::new(&cw_matrix.to_rows_slices());
         let root = merkle_tree.root();
 
         Ok((
@@ -186,9 +184,7 @@ impl<Zt: ZipTypes, Lc: LinearCode<Zt>> ZipPlus<Zt, Lc> {
         );
 
         // Safe because we have just initialized all elements.
-        unsafe {
-            encoded_matrix.init()
-        }
+        unsafe { encoded_matrix.init() }
     }
 }
 
@@ -211,8 +207,10 @@ mod tests {
         poly::{dense::DensePolynomial, mle::DenseMultilinearExtension},
     };
     use crypto_bigint::{Random, U64, U256, Word};
+    use crypto_primitives::{
+        Matrix, crypto_bigint_boxed_monty::BoxedMontyField, crypto_bigint_int::Int,
+    };
     use itertools::Itertools;
-    use crypto_primitives::{crypto_bigint_boxed_monty::BoxedMontyField, crypto_bigint_int::Int, Matrix};
     use num_traits::Zero;
     use rand::{Rng, rng};
 
@@ -358,7 +356,7 @@ mod tests {
         let mut cw_matrix = data.cw_matrix.to_rows();
         cw_matrix[0][0] = Int::from(999999);
         let corrupted_row = cw_matrix[0].clone();
-        let new_tree = MerkleTree::new(vec![corrupted_row.to_vec()]);
+        let new_tree = MerkleTree::new(&[corrupted_row.as_slice()]);
         assert_ne!(
             new_tree.root(),
             commitment.root,
@@ -584,7 +582,7 @@ mod tests {
     #[should_panic(expected = "row_width.is_power_of_two()")]
     fn merkle_tree_new_panics_on_non_power_of_two_leaves() {
         let leaves_data: Vec<Int<INT_LIMBS>> = (0..7).map(Int::from).collect();
-        let _ = MerkleTree::new(vec![leaves_data]);
+        let _ = MerkleTree::new(&[leaves_data.as_slice()]);
     }
 
     #[test]

--- a/zip-plus/src/pcs/phase_commit.rs
+++ b/zip-plus/src/pcs/phase_commit.rs
@@ -1,3 +1,4 @@
+use itertools::Itertools;
 use crate::{
     ZipError,
     code::LinearCode,
@@ -9,6 +10,8 @@ use crate::{
     poly::mle::DenseMultilinearExtension,
     utils::{num_threads, parallelize_for_each},
 };
+use uninit::out_ref::Out;
+use crypto_primitives::DenseRowMatrix;
 
 impl<Zt: ZipTypes, Lc: LinearCode<Zt>> ZipPlus<Zt, Lc> {
     /// Creates a commitment to a multilinear polynomial using the ZIP PCS
@@ -75,13 +78,14 @@ impl<Zt: ZipTypes, Lc: LinearCode<Zt>> ZipPlus<Zt, Lc> {
 
         let row_len = pp.linear_code.row_len();
 
-        let rows = Self::encode_rows(pp, row_len, &poly.evaluations);
+        let cw_matrix = Self::encode_rows(pp, row_len, &poly.evaluations);
 
-        let merkle_tree = MerkleTree::new(rows.clone());
+        let rows = cw_matrix.as_rows().map(|v| v.to_vec()).collect_vec();
+        let merkle_tree = MerkleTree::new(rows);
         let root = merkle_tree.root();
 
         Ok((
-            ZipPlusHint::new(rows, merkle_tree),
+            ZipPlusHint::new(cw_matrix, merkle_tree),
             ZipPlusCommitment { root },
         ))
     }
@@ -105,13 +109,12 @@ impl<Zt: ZipTypes, Lc: LinearCode<Zt>> ZipPlus<Zt, Lc> {
     pub fn commit_no_merkle(
         pp: &ZipPlusParams<Zt, Lc>,
         poly: &DenseMultilinearExtension<Zt::Eval>,
-    ) -> Result<Vec<Vec<Zt::Cw>>, ZipError> {
+    ) -> Result<DenseRowMatrix<Zt::Cw>, ZipError> {
         validate_input::<Zt, Lc, bool>("commit", pp.num_vars, [poly], None)?;
 
         let row_len = pp.linear_code.row_len();
 
         let rows = Self::encode_rows(pp, row_len, &poly.evaluations);
-
         Ok(rows)
     }
 
@@ -159,25 +162,33 @@ impl<Zt: ZipTypes, Lc: LinearCode<Zt>> ZipPlus<Zt, Lc> {
         pp: &ZipPlusParams<Zt, Lc>,
         row_len: usize,
         evals: &[Zt::Eval],
-    ) -> Vec<Vec<Zt::Cw>> {
+    ) -> DenseRowMatrix<Zt::Cw> {
+        let codeword_len = pp.linear_code.codeword_len();
         let rows_per_thread = pp.num_rows.div_ceil(num_threads());
-        let mut encoded_rows: Vec<Vec<Zt::Cw>> = vec![vec![]; pp.num_rows];
+        // Performance: Using DenseRowMatrix's linearized row in an uninit form
+        // is much more performant that using Vec<Vec<_>>.
+        let mut encoded_matrix = DenseRowMatrix::<Zt::Cw>::uninit(pp.num_rows, codeword_len);
 
         parallelize_for_each(
-            encoded_rows
-                .chunks_mut(rows_per_thread)
+            encoded_matrix
+                .data
+                .chunks_mut(rows_per_thread * codeword_len)
                 .zip(evals.chunks(rows_per_thread * row_len)),
-            |(encoded_rows_chunk, evals)| {
-                for (row, evals) in encoded_rows_chunk
-                    .iter_mut()
+            |(encoded_chunk, evals)| {
+                for (row, evals) in encoded_chunk
+                    .chunks_exact_mut(codeword_len)
                     .zip(evals.chunks_exact(row_len))
                 {
-                    *row = pp.linear_code.encode(evals);
+                    let encoded: Vec<Zt::Cw> = pp.linear_code.encode(evals);
+                    Out::from(row).copy_from_slice(encoded.as_slice());
                 }
             },
         );
 
-        encoded_rows
+        // Safe because we have just initialized all elements.
+        unsafe {
+            encoded_matrix.init()
+        }
     }
 }
 
@@ -200,7 +211,8 @@ mod tests {
         poly::{dense::DensePolynomial, mle::DenseMultilinearExtension},
     };
     use crypto_bigint::{Random, U64, U256, Word};
-    use crypto_primitives::{crypto_bigint_boxed_monty::BoxedMontyField, crypto_bigint_int::Int};
+    use itertools::Itertools;
+    use crypto_primitives::{crypto_bigint_boxed_monty::BoxedMontyField, crypto_bigint_int::Int, Matrix};
     use num_traits::Zero;
     use rand::{Rng, rng};
 
@@ -311,10 +323,8 @@ mod tests {
         let (pp, poly) = setup_test_params(3);
         let encoded = TestZip::encode_rows(&pp, pp.linear_code.row_len(), &poly.evaluations);
 
-        assert_eq!(encoded.len(), pp.num_rows);
-        for row in &encoded {
-            assert_eq!(row.len(), pp.linear_code.codeword_len());
-        }
+        assert_eq!(encoded.num_rows, pp.num_rows);
+        assert_eq!(encoded.num_cols, pp.linear_code.codeword_len());
     }
 
     /// Verifies that the output of `encode_rows` is semantically correct by
@@ -324,7 +334,7 @@ mod tests {
         let (pp, poly) = setup_test_params(3);
         let encoded = TestZip::encode_rows(&pp, pp.linear_code.row_len(), &poly.evaluations);
 
-        for (i, row_chunk) in encoded.iter().enumerate() {
+        for (i, row_chunk) in encoded.as_rows().enumerate() {
             let start = i * pp.linear_code.row_len();
             let end = start + pp.linear_code.row_len();
             let row_evals = &poly.evaluations[start..end];
@@ -342,19 +352,18 @@ mod tests {
     #[test]
     fn corrupted_encoding_changes_merkle_root() {
         let (pp, poly) = setup_test_params(3);
-        let (mut data, commitment) = TestZip::commit(&pp, &poly).unwrap();
+        let (data, commitment) = TestZip::commit(&pp, &poly).unwrap();
 
-        if !data.rows.is_empty() {
-            data.rows[0][0] = Int::from(999999);
-            let codeword_len = pp.linear_code.codeword_len();
-            let corrupted_row = &data.rows[0][0..codeword_len];
-            let new_tree = MerkleTree::new(vec![corrupted_row.to_vec()]);
-            assert_ne!(
-                new_tree.root(),
-                commitment.root,
-                "Corruption should change Merkle root"
-            );
-        }
+        assert!(!data.cw_matrix.is_empty());
+        let mut cw_matrix = data.cw_matrix.to_rows();
+        cw_matrix[0][0] = Int::from(999999);
+        let corrupted_row = cw_matrix[0].clone();
+        let new_tree = MerkleTree::new(vec![corrupted_row.to_vec()]);
+        assert_ne!(
+            new_tree.root(),
+            commitment.root,
+            "Corruption should change Merkle root"
+        );
     }
 
     #[test]
@@ -369,7 +378,7 @@ mod tests {
         let (single_data, single_commitment) = single_result.unwrap();
 
         assert_eq!(batch_commitment.root, single_commitment.root);
-        assert_eq!(batch_data.rows, single_data.rows);
+        assert_eq!(batch_data.cw_matrix, single_data.cw_matrix);
     }
 
     #[test]
@@ -377,13 +386,11 @@ mod tests {
         let (pp, poly) = setup_test_params(3);
         let encoded = TestZip::encode_rows(&pp, pp.linear_code.row_len(), &poly.evaluations);
 
-        assert_eq!(encoded.len(), pp.num_rows);
-        for row in &encoded {
-            assert_eq!(row.len(), pp.linear_code.codeword_len());
-        }
+        assert_eq!(encoded.num_rows, pp.num_rows);
+        assert_eq!(encoded.num_cols, pp.linear_code.codeword_len());
 
         let non_zero_count = encoded
-            .iter()
+            .as_rows()
             .flatten()
             .filter(|&&x| x != Int::from(0))
             .count();
@@ -395,10 +402,8 @@ mod tests {
         let (pp, poly) = setup_test_params(3);
         let (hint, _) = TestZip::commit(&pp, &poly).unwrap();
 
-        assert_eq!(hint.rows.len(), pp.num_rows);
-        for row in &hint.rows {
-            assert_eq!(row.len(), pp.linear_code.codeword_len());
-        }
+        assert_eq!(hint.cw_matrix.num_rows, pp.num_rows);
+        assert_eq!(hint.cw_matrix.num_cols, pp.linear_code.codeword_len());
     }
 
     #[test]
@@ -418,7 +423,13 @@ mod tests {
                 let code = C::new(poly_size, RAA_CFG);
                 let pp = ZipPlusParams::new(num_vars, 8, code);
 
-                TestZip::encode_rows(&pp, pp.linear_code.row_len(), &poly.evaluations)
+                let rows = TestZip::encode_rows(&pp, pp.linear_code.row_len(), &poly.evaluations);
+                let rows: Vec<Vec<_>> = rows
+                    .data
+                    .chunks_exact(pp.linear_code.codeword_len())
+                    .map(|chunk| chunk.to_vec())
+                    .collect();
+                rows
             })
             .collect();
 
@@ -466,8 +477,8 @@ mod tests {
         let evaluations = vec![Int::from(5); 4];
         let poly = DenseMultilinearExtension::from_evaluations_vec(2, evaluations, Zero::zero());
         let encoded = TestZip::encode_rows(&pp, pp.linear_code.row_len(), &poly.evaluations);
-        assert_eq!(encoded.len(), 1);
-        assert_eq!(encoded[0].len(), pp.linear_code.codeword_len());
+        assert_eq!(encoded.num_rows, 1);
+        assert_eq!(encoded.num_cols, pp.linear_code.codeword_len());
     }
 
     #[test]
@@ -483,8 +494,8 @@ mod tests {
         ];
         let poly = DenseMultilinearExtension::from_evaluations_vec(2, evaluations, Zero::zero());
         let encoded = TestPolyZip::encode_rows(&pp, pp.linear_code.row_len(), &poly.evaluations);
-        assert_eq!(encoded.len(), 1);
-        assert_eq!(encoded[0].len(), pp.linear_code.codeword_len());
+        assert_eq!(encoded.num_rows, 1);
+        assert_eq!(encoded.num_cols, pp.linear_code.codeword_len());
     }
 
     #[test]
@@ -522,8 +533,9 @@ mod tests {
             .map(|i| a * row1_evals[i] + b.resize() * row2_evals[i])
             .collect();
         let combined_encoded = pp.linear_code.encode(&combined_evals);
-        let row1_encoded = &encoded[0];
-        let row2_encoded = &encoded[1];
+        let rows = encoded.as_rows().collect_vec();
+        let row1_encoded = rows[0];
+        let row2_encoded = rows[1];
         let expected_combined: Vec<_> = (0..codeword_len)
             .map(|i| a.resize() * row1_encoded[i] + b.resize() * row2_encoded[i])
             .collect();
@@ -564,10 +576,8 @@ mod tests {
         let poly =
             DenseMultilinearExtension::from_evaluations_vec(3, vec![max_val; 8], Zero::zero());
         let encoded_rows = TestZip::encode_rows(&pp, pp.linear_code.row_len(), &poly.evaluations);
-        assert_eq!(encoded_rows.len(), pp.num_rows);
-        for row in &encoded_rows {
-            assert_eq!(row.len(), pp.linear_code.codeword_len());
-        }
+        assert_eq!(encoded_rows.num_rows, pp.num_rows);
+        assert_eq!(encoded_rows.num_cols, pp.linear_code.codeword_len());
     }
 
     #[test]

--- a/zip-plus/src/pcs/phase_test.rs
+++ b/zip-plus/src/pcs/phase_test.rs
@@ -57,23 +57,18 @@ impl<Zt: ZipTypes, Lc: LinearCode<Zt>> ZipPlus<Zt, Lc> {
         // Open merkle tree for each column drawn
         for _ in 0..Zt::NUM_COLUMN_OPENINGS {
             let column = transcript.squeeze_challenge_idx(pp.linear_code.codeword_len());
-            Self::open_merkle_trees_for_column(pp, commit_hint, column, &mut transcript)?;
+            Self::open_merkle_trees_for_column(commit_hint, column, &mut transcript)?;
         }
 
         Ok(transcript.into())
     }
 
     pub(super) fn open_merkle_trees_for_column(
-        pp: &ZipPlusParams<Zt, Lc>,
         commit_hint: &ZipPlusHint<Zt::Cw>,
         column: usize,
         transcript: &mut PcsTranscript,
     ) -> Result<(), ZipError> {
-        let column_values = commit_hint
-            .rows
-            .iter()
-            .skip(column)
-            .step_by(pp.linear_code.codeword_len());
+        let column_values = commit_hint.rows.iter().map(|row| &row[column]);
 
         // Write the elements in the squeezed column to the shared transcript
         transcript.write_const_many(column_values)?;
@@ -93,7 +88,7 @@ impl<Zt: ZipTypes, Lc: LinearCode<Zt>> ZipPlus<Zt, Lc> {
 )]
 mod tests {
     use crate::{
-        code::{LinearCode, raa::RaaCode},
+        code::raa::RaaCode,
         merkle::MerkleTree,
         pcs::{
             structs::{ZipPlus, ZipPlusHint},
@@ -148,11 +143,10 @@ mod tests {
 
         let mut corrupted_rows = original_hint.rows.clone();
         if !corrupted_rows.is_empty() {
-            corrupted_rows[0] += Int::ONE;
+            corrupted_rows[0][0] += Int::ONE;
         }
 
-        let codeword_len = pp.linear_code.codeword_len();
-        let corrupted_merkle_tree = MerkleTree::new(&corrupted_rows, codeword_len);
+        let corrupted_merkle_tree = MerkleTree::new(corrupted_rows.clone());
         let corrupted_rows_hint = ZipPlusHint::new(corrupted_rows, corrupted_merkle_tree);
 
         let result = TestZip::test(&pp, &poly, &corrupted_rows_hint);

--- a/zip-plus/src/pcs/phase_test.rs
+++ b/zip-plus/src/pcs/phase_test.rs
@@ -68,7 +68,7 @@ impl<Zt: ZipTypes, Lc: LinearCode<Zt>> ZipPlus<Zt, Lc> {
         column: usize,
         transcript: &mut PcsTranscript,
     ) -> Result<(), ZipError> {
-        let column_values = commit_hint.rows.iter().map(|row| &row[column]);
+        let column_values = commit_hint.cw_matrix.as_rows().map(|row| &row[column]);
 
         // Write the elements in the squeezed column to the shared transcript
         transcript.write_const_many(column_values)?;
@@ -141,13 +141,13 @@ mod tests {
 
         let (original_hint, _) = TestZip::commit(&pp, &poly).unwrap();
 
-        let mut corrupted_rows = original_hint.rows.clone();
+        let mut corrupted_rows = original_hint.cw_matrix.to_rows();
         if !corrupted_rows.is_empty() {
             corrupted_rows[0][0] += Int::ONE;
         }
 
         let corrupted_merkle_tree = MerkleTree::new(corrupted_rows.clone());
-        let corrupted_rows_hint = ZipPlusHint::new(corrupted_rows, corrupted_merkle_tree);
+        let corrupted_rows_hint = ZipPlusHint::new(corrupted_rows.into(), corrupted_merkle_tree);
 
         let result = TestZip::test(&pp, &poly, &corrupted_rows_hint);
 

--- a/zip-plus/src/pcs/phase_test.rs
+++ b/zip-plus/src/pcs/phase_test.rs
@@ -139,15 +139,14 @@ mod tests {
         let num_vars = 4;
         let (pp, poly) = setup_test_params(num_vars);
 
-        let (original_hint, _) = TestZip::commit(&pp, &poly).unwrap();
+        let (mut original_hint, _) = TestZip::commit(&pp, &poly).unwrap();
 
-        let mut corrupted_rows = original_hint.cw_matrix.to_rows();
-        if !corrupted_rows.is_empty() {
-            corrupted_rows[0][0] += Int::ONE;
-        }
+        let mut corrupted_rows = original_hint.cw_matrix.to_rows_slices_mut();
+        assert!(!corrupted_rows.is_empty());
+        corrupted_rows[0][0] += Int::ONE;
 
-        let corrupted_merkle_tree = MerkleTree::new(corrupted_rows.clone());
-        let corrupted_rows_hint = ZipPlusHint::new(corrupted_rows.into(), corrupted_merkle_tree);
+        let corrupted_merkle_tree = MerkleTree::new(&original_hint.cw_matrix.to_rows_slices());
+        let corrupted_rows_hint = ZipPlusHint::new(original_hint.cw_matrix, corrupted_merkle_tree);
 
         let result = TestZip::test(&pp, &poly, &corrupted_rows_hint);
 

--- a/zip-plus/src/pcs/phase_verify.rs
+++ b/zip-plus/src/pcs/phase_verify.rs
@@ -463,17 +463,20 @@ mod tests {
 
         let (original_data, comm) = TestZip::commit(&pp, &mle).unwrap();
 
-        let mut corrupted_rows = original_data.cw_matrix.to_rows();
-        let codeword_len = pp.linear_code.codeword_len();
-        // Proximity distance is half the codeword length for the default spec.
-        // We corrupt more than half of the first row to ensure it's not close.
-        let corruption_count = codeword_len / 2 + 1;
-        for i in 0..corruption_count {
-            corrupted_rows[0][i] += Int::ONE;
+        let mut corrupted_data = original_data.cw_matrix.clone();
+        {
+            let mut corrupted_rows = corrupted_data.to_rows_slices_mut();
+            let codeword_len = pp.linear_code.codeword_len();
+            // Proximity distance is half the codeword length for the default spec.
+            // We corrupt more than half of the first row to ensure it's not close.
+            let corruption_count = codeword_len / 2 + 1;
+            for i in 0..corruption_count {
+                corrupted_rows[0][i] += Int::ONE;
+            }
         }
 
-        let corrupted_merkle_tree = MerkleTree::new(corrupted_rows.clone());
-        let corrupted_data = ZipPlusHint::new(corrupted_rows.into(), corrupted_merkle_tree);
+        let corrupted_merkle_tree = MerkleTree::new(&corrupted_data.to_rows_slices());
+        let corrupted_data = ZipPlusHint::new(corrupted_data, corrupted_merkle_tree);
 
         let point: Vec<<Zt as ZipTypes>::Pt> =
             (0..num_vars).map(|i| Int::from(i as i32 + 2)).collect();

--- a/zip-plus/src/pcs/phase_verify.rs
+++ b/zip-plus/src/pcs/phase_verify.rs
@@ -463,7 +463,7 @@ mod tests {
 
         let (original_data, comm) = TestZip::commit(&pp, &mle).unwrap();
 
-        let mut corrupted_rows = original_data.rows.clone();
+        let mut corrupted_rows = original_data.cw_matrix.to_rows();
         let codeword_len = pp.linear_code.codeword_len();
         // Proximity distance is half the codeword length for the default spec.
         // We corrupt more than half of the first row to ensure it's not close.
@@ -473,7 +473,7 @@ mod tests {
         }
 
         let corrupted_merkle_tree = MerkleTree::new(corrupted_rows.clone());
-        let corrupted_data = ZipPlusHint::new(corrupted_rows, corrupted_merkle_tree);
+        let corrupted_data = ZipPlusHint::new(corrupted_rows.into(), corrupted_merkle_tree);
 
         let point: Vec<<Zt as ZipTypes>::Pt> =
             (0..num_vars).map(|i| Int::from(i as i32 + 2)).collect();
@@ -624,7 +624,7 @@ mod tests {
             .collect();
 
         let (mut data, comm) = TestZip::commit(&pp, &mle).unwrap();
-        data.rows[0][0] += Int::ONE;
+        data.cw_matrix.to_rows_slices_mut()[0][0] += Int::ONE;
 
         let test_transcript = TestZip::test(&pp, &mle, &data).unwrap();
         let (eval_f, proof) = TestZip::evaluate::<F>(&pp, &mle, &point, test_transcript).unwrap();

--- a/zip-plus/src/pcs/phase_verify.rs
+++ b/zip-plus/src/pcs/phase_verify.rs
@@ -469,12 +469,10 @@ mod tests {
         // We corrupt more than half of the first row to ensure it's not close.
         let corruption_count = codeword_len / 2 + 1;
         for i in 0..corruption_count {
-            if i < corrupted_rows.len() {
-                corrupted_rows[i] += Int::ONE;
-            }
+            corrupted_rows[0][i] += Int::ONE;
         }
 
-        let corrupted_merkle_tree = MerkleTree::new(&corrupted_rows, codeword_len);
+        let corrupted_merkle_tree = MerkleTree::new(corrupted_rows.clone());
         let corrupted_data = ZipPlusHint::new(corrupted_rows, corrupted_merkle_tree);
 
         let point: Vec<<Zt as ZipTypes>::Pt> =
@@ -626,9 +624,7 @@ mod tests {
             .collect();
 
         let (mut data, comm) = TestZip::commit(&pp, &mle).unwrap();
-        if !data.rows.is_empty() {
-            data.rows[0] += Int::ONE;
-        }
+        data.rows[0][0] += Int::ONE;
 
         let test_transcript = TestZip::test(&pp, &mle, &data).unwrap();
         let (eval_f, proof) = TestZip::evaluate::<F>(&pp, &mle, &point, test_transcript).unwrap();

--- a/zip-plus/src/pcs/structs.rs
+++ b/zip-plus/src/pcs/structs.rs
@@ -6,9 +6,7 @@ use crate::{
     traits::{ConstTranscribable, FromRef, Named, SimpleSemiring},
     utils::ReinterpretVector,
 };
-use crypto_primitives::{
-    ConstIntRing, FixedRing, FromWithConfig, PrimeField, crypto_bigint_int::Int,
-};
+use crypto_primitives::{ConstIntRing, FixedRing, FromWithConfig, PrimeField, crypto_bigint_int::Int, DenseRowMatrix};
 use num_traits::CheckedMul;
 use p3_field::Packable;
 use std::{marker::PhantomData, ops::Neg};
@@ -99,14 +97,14 @@ impl<Zt: ZipTypes, Lc: LinearCode<Zt>> ZipPlusParams<Zt, Lc> {
 pub struct ZipPlusHint<R: AsPackable> {
     /// The encoded rows of the polynomial matrix representation, referred to as
     /// "u-hat" in the Zinc paper
-    pub rows: Vec<Vec<R>>,
+    pub cw_matrix: DenseRowMatrix<R>,
     /// Merkle trees of entire matrix
     pub merkle_tree: MerkleTree<R::Packable>,
 }
 
 impl<R: AsPackable> ZipPlusHint<R> {
-    pub fn new(rows: Vec<Vec<R>>, merkle_tree: MerkleTree<R::Packable>) -> ZipPlusHint<R> {
-        ZipPlusHint { rows, merkle_tree }
+    pub fn new(cw_matrix: DenseRowMatrix<R>, merkle_tree: MerkleTree<R::Packable>) -> ZipPlusHint<R> {
+        ZipPlusHint { cw_matrix, merkle_tree }
     }
 
     pub fn root(&self) -> MtHash {

--- a/zip-plus/src/pcs/structs.rs
+++ b/zip-plus/src/pcs/structs.rs
@@ -99,13 +99,13 @@ impl<Zt: ZipTypes, Lc: LinearCode<Zt>> ZipPlusParams<Zt, Lc> {
 pub struct ZipPlusHint<R: AsPackable> {
     /// The encoded rows of the polynomial matrix representation, referred to as
     /// "u-hat" in the Zinc paper
-    pub rows: Vec<R>,
+    pub rows: Vec<Vec<R>>,
     /// Merkle trees of entire matrix
     pub merkle_tree: MerkleTree<R::Packable>,
 }
 
 impl<R: AsPackable> ZipPlusHint<R> {
-    pub fn new(rows: Vec<R>, merkle_tree: MerkleTree<R::Packable>) -> ZipPlusHint<R> {
+    pub fn new(rows: Vec<Vec<R>>, merkle_tree: MerkleTree<R::Packable>) -> ZipPlusHint<R> {
         ZipPlusHint { rows, merkle_tree }
     }
 

--- a/zip-plus/src/pcs/structs.rs
+++ b/zip-plus/src/pcs/structs.rs
@@ -4,11 +4,11 @@ use crate::{
     poly::Polynomial,
     primality::PrimalityTest,
     traits::{ConstTranscribable, FromRef, Named, SimpleSemiring},
-    utils::ReinterpretVector,
 };
-use crypto_primitives::{ConstIntRing, FixedRing, FromWithConfig, PrimeField, crypto_bigint_int::Int, DenseRowMatrix};
+use crypto_primitives::{
+    ConstIntRing, DenseRowMatrix, FixedRing, FromWithConfig, PrimeField, crypto_bigint_int::Int,
+};
 use num_traits::CheckedMul;
-use p3_field::Packable;
 use std::{marker::PhantomData, ops::Neg};
 
 pub trait ZipTypes: Send + Sync {
@@ -26,7 +26,6 @@ pub trait ZipTypes: Send + Sync {
         + Polynomial<Self::CwR>
         + Neg<Output = Self::Cw>
         + ConstTranscribable
-        + AsPackable
         + FromRef<Self::Eval>
         + Named
         + Copy;
@@ -94,17 +93,20 @@ impl<Zt: ZipTypes, Lc: LinearCode<Zt>> ZipPlusParams<Zt, Lc> {
 /// Full data of zip commitment to a multilinear polynomial, including encoded
 /// rows and Merkle tree, kept by the prover for the testing phase.
 #[derive(Debug, Default)]
-pub struct ZipPlusHint<R: AsPackable> {
+pub struct ZipPlusHint<R> {
     /// The encoded rows of the polynomial matrix representation, referred to as
     /// "u-hat" in the Zinc paper
     pub cw_matrix: DenseRowMatrix<R>,
     /// Merkle trees of entire matrix
-    pub merkle_tree: MerkleTree<R::Packable>,
+    pub merkle_tree: MerkleTree,
 }
 
-impl<R: AsPackable> ZipPlusHint<R> {
-    pub fn new(cw_matrix: DenseRowMatrix<R>, merkle_tree: MerkleTree<R::Packable>) -> ZipPlusHint<R> {
-        ZipPlusHint { cw_matrix, merkle_tree }
+impl<R> ZipPlusHint<R> {
+    pub fn new(cw_matrix: DenseRowMatrix<R>, merkle_tree: MerkleTree) -> ZipPlusHint<R> {
+        ZipPlusHint {
+            cw_matrix,
+            merkle_tree,
+        }
     }
 
     pub fn root(&self) -> MtHash {
@@ -118,48 +120,6 @@ impl<R: AsPackable> ZipPlusHint<R> {
 pub struct ZipPlusCommitment {
     /// Roots of the merkle tree of entire matrix
     pub root: MtHash,
-}
-
-pub trait AsPackable: Clone + ReinterpretVector<Self::Packable> {
-    type Packable: Packable + ConstTranscribable + Clone + Send + Sync;
-}
-
-macro_rules! impl_as_packable_for_primitives {
-    ($($source:ty as $packable:ty),+) => {
-        $(
-            unsafe impl ReinterpretVector<$packable> for $source {}
-
-            impl AsPackable for $source {
-                type Packable = $packable;
-            }
-        )+
-    };
-}
-
-impl_as_packable_for_primitives!(i8 as u8, i16 as u16, i32 as u32, i64 as u64, i128 as u128);
-
-impl<const LIMBS: usize> AsPackable for Int<LIMBS> {
-    type Packable = PackedInt<LIMBS>;
-}
-
-#[derive(Copy, Clone, Default, PartialEq, Eq, Debug)]
-#[repr(transparent)]
-pub struct PackedInt<const LIMBS: usize>(pub(crate) Int<LIMBS>);
-
-unsafe impl<const N: usize> ReinterpretVector<PackedInt<N>> for Int<N> {}
-
-impl<const LIMBS: usize> Packable for PackedInt<LIMBS> {}
-
-impl<const LIMBS: usize> ConstTranscribable for PackedInt<LIMBS> {
-    const NUM_BYTES: usize = Int::<LIMBS>::NUM_BYTES;
-
-    fn read_transcription_bytes(bytes: &[u8]) -> Self {
-        Self(<Int<LIMBS> as ConstTranscribable>::read_transcription_bytes(bytes))
-    }
-
-    fn write_transcription_bytes(&self, buf: &mut [u8]) {
-        ConstTranscribable::write_transcription_bytes(&self.0, buf)
-    }
 }
 
 pub trait MulByScalar<Rhs>: Sized {

--- a/zip-plus/src/pcs/test_utils.rs
+++ b/zip-plus/src/pcs/test_utils.rs
@@ -31,7 +31,7 @@ use crypto_primitives::{
 use itertools::Itertools;
 use num_traits::Zero;
 
-pub const REPETITION_FACTOR: usize = 4;
+const REPETITION_FACTOR: usize = 4;
 
 pub const RAA_CFG: RaaConfig = RaaConfig {
     check_for_overflows: true,

--- a/zip-plus/src/pcs/utils.rs
+++ b/zip-plus/src/pcs/utils.rs
@@ -7,7 +7,7 @@ use crate::{ZipError, add, div, ilog_round_up, mul, poly::mle::DenseMultilinearE
 use crate::{
     code::LinearCode,
     merkle::{MerkleError, MerkleProof, MtHash},
-    pcs::structs::{AsPackable, ZipPlusHint, ZipTypes},
+    pcs::structs::{ZipPlusHint, ZipTypes},
     pcs_transcript::PcsTranscript,
     poly::Polynomial,
     traits::ConstTranscribable,
@@ -216,7 +216,7 @@ where
 pub struct ColumnOpening {}
 
 impl ColumnOpening {
-    pub fn open_at_column<T: AsPackable>(
+    pub fn open_at_column<T: ConstTranscribable>(
         column: usize,
         commit_hint: &ZipPlusHint<T>,
         transcript: &mut PcsTranscript,
@@ -228,7 +228,7 @@ impl ColumnOpening {
         Ok(())
     }
 
-    pub fn verify_column<T: AsPackable>(
+    pub fn verify_column<T: ConstTranscribable>(
         root: &MtHash,
         column: &[T],
         column_index: usize,
@@ -237,7 +237,7 @@ impl ColumnOpening {
         let proof = transcript
             .read_merkle_proof()
             .map_err(|_| MerkleError::FailedMerkleProofReading)?;
-        proof.verify(root, column.to_vec(), column_index)?;
+        proof.verify(root, column, column_index)?;
         Ok(())
     }
 }

--- a/zip-plus/src/pcs_transcript.rs
+++ b/zip-plus/src/pcs_transcript.rs
@@ -1,6 +1,5 @@
 use crypto_primitives::PrimeField;
 use itertools::Itertools;
-use p3_matrix::Dimensions;
 use std::io::{Cursor, ErrorKind, Read, Write};
 
 use crate::{
@@ -183,9 +182,8 @@ impl PcsTranscript {
 
     pub fn read_merkle_proof(&mut self) -> Result<MerkleProof, ZipError> {
         // Read the dimensions of matrix used to construct the Merkle tree
-        let width = self.read_usize()?;
-        let height = self.read_usize()?;
-        let dimensions = Dimensions { width, height };
+        let leaf_index = self.read_usize()?;
+        let tree_size = self.read_usize()?;
 
         // Read the length of the merkle path first
         let path_length = self.read_usize()?;
@@ -193,21 +191,21 @@ impl PcsTranscript {
         // Read each element of the merkle path
         let merkle_path = self.read_const_many(path_length)?;
 
-        Ok(MerkleProof::new(merkle_path, dimensions))
+        Ok(MerkleProof::new(merkle_path, leaf_index, tree_size))
     }
 
     pub fn write_merkle_proof(&mut self, proof: &MerkleProof) -> Result<(), ZipError> {
         let mut buf = [0u8; size_of::<u64>()];
 
         // Write the dimensions of matrix used to construct the Merkle tree
-        self.write_usize(proof.matrix_dims.width, &mut buf)?;
-        self.write_usize(proof.matrix_dims.height, &mut buf)?;
+        self.write_usize(proof.leaf_index, &mut buf)?;
+        self.write_usize(proof.tree_size, &mut buf)?;
 
         // Write the length of the merkle path first
-        self.write_usize(proof.path.len(), &mut buf)?;
+        self.write_usize(proof.siblings.len(), &mut buf)?;
 
         // Write each element of the merkle path
-        self.write_const_many(&proof.path)?;
+        self.write_const_many(&proof.siblings)?;
         Ok(())
     }
 }

--- a/zip-plus/src/poly/dense.rs
+++ b/zip-plus/src/poly/dense.rs
@@ -1,12 +1,10 @@
 use super::{EvaluationError, Polynomial};
 use crate::{
-    pcs::structs::{AsPackable, MulByScalar, ProjectableToField},
+    pcs::structs::{MulByScalar, ProjectableToField},
     traits::{ConstTranscribable, FromRef, Named},
-    utils::ReinterpretVector,
 };
 use crypto_primitives::{FromWithConfig, IntoWithConfig, PrimeField, Ring};
 use num_traits::{CheckedAdd, CheckedMul, CheckedNeg, CheckedSub, One, Zero};
-use p3_field::Packable;
 use rand::{distr::StandardUniform, prelude::*};
 use std::{
     array,
@@ -484,40 +482,5 @@ where
                 .evaluate_at_point(&r_powers)
                 .expect("Failed to evaluate polynomial at point")
         }
-    }
-}
-
-//
-// PackableDensePolynomial
-//
-
-impl<R: AsPackable, const DEGREE: usize> AsPackable for DensePolynomial<R, DEGREE> {
-    type Packable = PackableDensePolynomial<R::Packable, DEGREE>;
-}
-
-#[derive(Debug, Clone, Default, PartialEq, Eq)]
-#[repr(transparent)]
-pub struct PackableDensePolynomial<R, const DEGREE: usize>(DensePolynomial<R, DEGREE>);
-
-impl<R: Copy, const DEGREE: usize> Copy for PackableDensePolynomial<R, DEGREE> {}
-
-impl<R: Packable, const DEGREE: usize> Packable for PackableDensePolynomial<R, DEGREE> {}
-
-unsafe impl<R: AsPackable, const DEGREE: usize>
-    ReinterpretVector<PackableDensePolynomial<R::Packable, DEGREE>> for DensePolynomial<R, DEGREE>
-{
-}
-
-impl<R: ConstTranscribable + Default, const DEGREE: usize> ConstTranscribable
-    for PackableDensePolynomial<R, DEGREE>
-{
-    const NUM_BYTES: usize = DensePolynomial::<R, DEGREE>::NUM_BYTES;
-
-    fn read_transcription_bytes(bytes: &[u8]) -> Self {
-        Self(DensePolynomial::read_transcription_bytes(bytes))
-    }
-
-    fn write_transcription_bytes(&self, buf: &mut [u8]) {
-        self.0.write_transcription_bytes(buf)
     }
 }

--- a/zip-plus/src/poly/mle/dense.rs
+++ b/zip-plus/src/poly/mle/dense.rs
@@ -89,7 +89,7 @@ impl<R: Ring> DenseMultilinearExtension<R> {
         // build dense vector representing the sparse padded matrix
         let mut v = vec![zero.clone(); padded_rows * padded_cols];
 
-        for (row_i, row) in matrix.rows().enumerate() {
+        for (row_i, row) in matrix.cells().enumerate() {
             for (col_i, val) in row {
                 v[(padded_cols * row_i) + col_i] = val.clone();
             }

--- a/zip-plus/src/utils.rs
+++ b/zip-plus/src/utils.rs
@@ -8,7 +8,13 @@ use itertools::Itertools;
 use num_traits::{CheckedAdd, ConstOne, One, Zero};
 use rand::{rngs::StdRng, seq::SliceRandom};
 use rand_core::SeedableRng;
-use std::ops::{Mul, SubAssign};
+use std::{
+    iter::Iterator,
+    ops::{Mul, SubAssign},
+};
+
+#[cfg(feature = "parallel")]
+use rayon::prelude::*;
 
 #[cfg(target_pointer_width = "64")]
 const WORD_FACTOR: usize = 1;
@@ -112,6 +118,30 @@ pub(crate) fn num_threads() -> usize {
     return 1;
 }
 
+#[cfg(not(feature = "parallel"))]
+pub(crate) fn parallelize_into_iter_map_collect<I, T, F, R, C>(iterable: I, f: F) -> C
+where
+    I: Send + IntoIterator<Item = T>,
+    T: Send,
+    R: Send,
+    F: Fn(T) -> R + Send + Sync + Clone,
+    C: FromIterator<R>,
+{
+    iterable.into_iter().map(f).collect()
+}
+
+#[cfg(feature = "parallel")]
+pub(crate) fn parallelize_into_iter_map_collect<I, T, F, R, C>(iterable: I, f: F) -> C
+where
+    I: Send + IntoParallelIterator<Item = T>,
+    T: Send,
+    R: Send,
+    F: Fn(T) -> R + Send + Sync + Clone,
+    C: FromParallelIterator<R>,
+{
+    iterable.into_par_iter().map(f).collect()
+}
+
 pub(crate) fn parallelize_for_each<I, T, F>(iter: I, f: F)
 where
     I: Send + Iterator<Item = T>,
@@ -210,205 +240,6 @@ pub(super) fn shuffle_seeded<T>(slice: &mut [T], seed: u64) {
     let mut rng = StdRng::seed_from_u64(seed);
     slice.shuffle(&mut rng);
 }
-
-/// Reinterpret a `Vec<Self>` as a `Vec<Target>` **without copying**.
-///
-/// This trait provides a zero-copy conversion between vectors whose element
-/// types are *layout-compatible*. It is meant for cases like transparent
-/// newtypes (`#[repr(transparent)] struct Newtype(Inner);`) where the two
-/// types have identical ABI (size and alignment) and the *value validity*
-/// requirements of `Target` are **no stricter** than those of `Self`.
-///
-/// # What this does
-///
-/// Given ownership of a `Vec<Self>`, the implementation:
-/// - Prevents the original vector from being dropped (`ManuallyDrop`),
-/// - Reuses its allocation, pointer, length, and capacity unchanged,
-/// - Reinterprets the element pointer as `*mut Target`,
-/// - Constructs a new `Vec<Target>` with the same buffer.
-///
-/// No bytes are moved or rewritten. This is O(1).
-///
-/// # Why this trait is `unsafe`
-///
-/// This is an **`unsafe trait`** because **implementing** it asserts a
-/// *per-type* contract that the compiler cannot verify. A bad impl can cause
-/// undefined behavior in safe code that *uses* the impl. See
-/// the *Implementor requirements* section below.
-///
-/// Additionally, the **method** is `unsafe` because each **call site** must
-/// ensure the conversion is valid for the particular `Vec<Self>` value being
-/// reinterpreted. (You may choose to make the method safe and keep only the
-/// trait unsafe; keeping both is conservative but redundant.)
-///
-/// # Safety
-///
-/// ## Caller requirements (for each call to [`reinterpret_vector`])
-///
-/// You must uphold all of the following at the call site:
-///
-/// 1. **Layout equivalence** `size_of::<Self>() == size_of::<Target>()` and
-///    `align_of::<Self>() == align_of::<Target>()`. This implementation
-///    *asserts* these at compile time, failing the build if they do not hold.
-///    (Do not remove those checks.)
-///
-/// 2. **Validity subset** Every bit-pattern that is a valid `Self` value must
-///    also be a valid `Target` value. In other words, `Target` must **not**
-///    impose stricter validity or niche invariants than `Self`.
-///
-///    **Counterexamples (do NOT reinterpret into these):**
-///    - `*mut T` → `NonNull<T>` (null is valid for `*mut T` but **invalid** for
-///      `NonNull<T>`).
-///    - `u64` → `core::num::NonZeroU64`.
-///    - `Option<NonNull<T>>` has niche optimization differences compared to raw
-///      pointers.
-///
-/// 3. **Drop semantics remain sound** Dropping `Vec<Target>` must be sound for
-///    all elements coming from `Vec<Self>`. If `Target` has a custom `Drop`
-///    impl that relies on invariants not guaranteed by `Self`, the conversion
-///    is unsound.
-///
-/// 4. **Ownership/uniqueness is preserved** After calling this function, the
-///    original `Vec<Self>` **must not** be used again. (The function takes it
-///    by value and places it in `ManuallyDrop` to prevent double-free.)
-///
-/// ## Implementor requirements (for each `unsafe impl`)
-///
-/// When you write `unsafe impl ReinterpretVector<Target> for Self`, you are
-/// promising that for **any** `Vec<Self>`:
-///
-/// - `Self` and `Target` are layout-identical (same size and alignment) — e.g.
-///   `Target` is `#[repr(transparent)]` over `Self`, or is otherwise guaranteed
-///   to share ABI with `Self`.
-/// - The set of valid `Self` values is a subset of the valid `Target` values.
-///   No stricter validity or niche invariants are introduced by `Target`.
-/// - Dropping a `Target` produced from arbitrary valid `Self` bytes is sound
-///   (no additional assumptions in `Drop`).
-///
-/// If you cannot *globally* guarantee these at the type level, do **not**
-/// implement this trait. Prefer a dedicated constructor that validates data or
-/// a fallible conversion (`TryFrom<Vec<Self>> for Vec<Target>` that maps
-/// elements).
-///
-/// ### Recommended: seal the trait
-///
-/// To prevent downstream crates from writing unsound impls, consider “sealing”
-/// the trait (making it unimplementable outside your crate) and providing only
-/// vetted `unsafe impl`s for your own types.
-///
-/// # Edge cases and notes
-///
-/// - **Zero-Sized Types (ZSTs):** Reinterpreting between ZSTs is fine if
-///   alignment matches. `Vec<T>` for ZST `T` uses a dangling non-null pointer;
-///   `Vec::from_raw_parts` supports this. The compile-time size/alignment
-///   asserts still gate the conversion.
-/// - **Uninhabited types (`!`):** `Vec<!>` cannot exist; do not attempt.
-/// - **Provenance / aliasing:** We preserve the original allocation, pointer,
-///   length, and capacity. Only the *type* of the element pointer changes (with
-///   equal alignment), which is allowed under Rust’s aliasing rules for
-///   layout-identical types when validity is preserved.
-/// - **Send/Sync auto-traits:** `Vec<Target>` may have different `Send`/`Sync`
-///   auto-trait behavior than `Vec<Self>`. That is a *type-system* effect at
-///   compile time; the runtime conversion does not change the buffer contents.
-/// - **Alternative (borrowed view):** If you only need a temporary view, prefer
-///   reinterpreting slices to avoid ownership transfer: ```ignore // SAFETY:
-///   same layout + lifetime/aliasing upheld let view: &[Target] = unsafe {
-///   core::slice::from_raw_parts(vec_self.as_ptr().cast::<Target>(),
-///   vec_self.len()) }; ```
-///
-/// # Examples
-///
-/// Transparent newtype over a primitive:
-///
-/// # Implementation notes
-///
-/// - The internal `const` block uses compile-time `assert!`s to fail builds
-///   when layout differs. Keep these assertions to defend against accidental
-///   misuse.
-/// - The method uses `ManuallyDrop` to avoid dropping `source` before we
-///   reconstruct a `Vec<Target>` from its raw parts. This prevents double-free.
-/// - `Vec::from_raw_parts` is used in an `unsafe` block because we must
-///   guarantee that `(ptr, len, cap)` originated from a
-///   `Vec<Target>`-compatible allocation. The trait’s contract + layout asserts
-///   provide that guarantee.
-/// - Consider enabling `#![deny(unsafe_op_in_unsafe_fn)]` at the crate root so
-///   that all unsafe operations within this `unsafe fn` remain explicitly
-///   marked and audited.
-///
-/// # When to prefer a safe, copying conversion
-///
-/// If `Target` applies *any* additional invariants (non-zero, non-null, range
-/// restrictions, encoding constraints, etc.), use a per-element conversion
-/// (`map(Into::into)` or `try_map`) that can validate or fail gracefully.
-/// Zero-copy reinterprets are only appropriate when the types are truly the
-/// same at the byte level.
-///
-/// ---
-pub unsafe trait ReinterpretVector<Target: Sized>: Sized {
-    /// Reinterpret a `Vec<Self>` as a `Vec<Target>` **without copying**.
-    ///
-    /// See the trait-level documentation for full safety requirements and
-    /// examples.
-    ///
-    /// # Safety
-    ///
-    /// Caller must ensure layout equivalence, validity preservation, and sound
-    /// drop semantics for `Target` given elements produced from `Self`. After
-    /// calling, the `source` vector must not be used again.
-    unsafe fn reinterpret_vector(source: Vec<Self>) -> Vec<Target> {
-        use std::mem::ManuallyDrop;
-        const {
-            // Keep these to enforce layout at compile time.
-            assert!(std::mem::size_of::<Self>() == std::mem::size_of::<Target>());
-            assert!(std::mem::align_of::<Self>() == std::mem::align_of::<Target>());
-        }
-        // Prevent `source` from being dropped while we steal its parts.
-        let mut v = ManuallyDrop::new(source);
-        let (ptr, len, cap) = (v.as_mut_ptr(), v.len(), v.capacity());
-        // SAFETY:
-        // - ptr/len/cap come from a `Vec<Self>` allocation of `cap` elements,
-        // - size/align equality ensures `Vec<Target>` layout compatibility,
-        // - ownership of the buffer is transferred, `source` will not be used again.
-        unsafe { Vec::from_raw_parts(ptr.cast::<Target>(), len, cap) }
-    }
-
-    /// Reinterpret a borrowed slice `&[Self]` as `&[Target]` **without
-    /// copying**.
-    ///
-    /// This is an O(1) borrowed view that preserves the original lifetime and
-    /// does not take ownership of the buffer.
-    ///
-    /// # Safety
-    ///
-    /// The caller must ensure:
-    /// 1. **Layout equivalence**: `size_of::<Self>() == size_of::<Target>()`
-    ///    and `align_of::<Self>() == align_of::<Target>()`. (Enforced via
-    ///    compile-time asserts.)
-    /// 2. **Validity subset**: Every valid `Self` bit-pattern is also a valid
-    ///    `Target`. (No stricter validity or niche invariants are introduced by
-    ///    `Target`.)
-    /// 3. **Aliasing rules**: The returned `&[Target]` must not be used to
-    ///    violate Rust’s aliasing model (e.g., you must not concurrently mutate
-    ///    the same memory via `Self` references while holding this
-    ///    `&[Target]`).
-    ///
-    /// Unlike the vector method, there are no drop-semantics concerns here
-    /// because no ownership is transferred; this is a view only.
-    unsafe fn reinterpret_slice(source: &[Self]) -> &[Target] {
-        const {
-            assert!(std::mem::size_of::<Self>() == std::mem::size_of::<Target>());
-            assert!(std::mem::align_of::<Self>() == std::mem::align_of::<Target>());
-        }
-        // SAFETY:
-        // - `source.as_ptr()` points to `len` contiguous `Self` elements.
-        // - Equal size/align means it is valid to view the same bytes as `Target`.
-        // - Lifetime `'a` is preserved; no ownership is taken.
-        unsafe { core::slice::from_raw_parts(source.as_ptr().cast::<Target>(), source.len()) }
-    }
-}
-
-// unsafe impl<T> ReinterpretVector<T> for T {}
-unsafe impl<S, T> ReinterpretVector<Vec<T>> for Vec<S> where S: ReinterpretVector<T> {}
 
 //
 // Semiring wrapper for Uint

--- a/zip-plus/src/utils.rs
+++ b/zip-plus/src/utils.rs
@@ -112,7 +112,7 @@ pub(crate) fn num_threads() -> usize {
     return 1;
 }
 
-pub(crate) fn parallelize_iter<I, T, F>(iter: I, f: F)
+pub(crate) fn parallelize_for_each<I, T, F>(iter: I, f: F)
 where
     I: Send + Iterator<Item = T>,
     T: Send,
@@ -142,7 +142,7 @@ where
         if chunk_size < num_threads {
             f((v, 0));
         } else {
-            parallelize_iter(v.chunks_mut(chunk_size).zip((0..).step_by(chunk_size)), f);
+            parallelize_for_each(v.chunks_mut(chunk_size).zip((0..).step_by(chunk_size)), f);
         }
     }
 
@@ -407,7 +407,8 @@ pub unsafe trait ReinterpretVector<Target: Sized>: Sized {
     }
 }
 
-unsafe impl<T> ReinterpretVector<T> for T {}
+// unsafe impl<T> ReinterpretVector<T> for T {}
+unsafe impl<S, T> ReinterpretVector<Vec<T>> for Vec<S> where S: ReinterpretVector<T> {}
 
 //
 // Semiring wrapper for Uint


### PR DESCRIPTION
* Evaluations are now encoded as a table, not as a single vector - this makes working with codewords more natural.
* Removed codewords transposition by using rows representation and getting columns via index.
* Replaced P3's MT implementation with a naive one - turns out it's ~20% faster, especially when using column-first representation
* Removed all P3 supporting code.