### PR TITLE
Semiring primitive

### DIFF
--- a/crypto-primitives/src/field.rs
+++ b/crypto-primitives/src/field.rs
@@ -7,7 +7,7 @@ pub mod crypto_bigint_boxed_monty;
 #[cfg(feature = "crypto_bigint")]
 pub mod crypto_bigint_const_monty;
 
-use crate::{ConstIntRing, IntRing, ring::Ring};
+use crate::{ConstIntRing, ring::Ring};
 use core::{
     fmt::Debug,
     ops::{Div, DivAssign, Neg},

--- a/crypto-primitives/src/field/ark_ff_field.rs
+++ b/crypto-primitives/src/field/ark_ff_field.rs
@@ -1,5 +1,5 @@
 use super::*;
-use crate::Semiring;
+use crate::{Semiring, boolean::Boolean};
 use ark_ff::{
     AdditiveGroup, CubicExtConfig, CubicExtField, LegendreSymbol, QuadExtConfig, QuadExtField,
     SqrtPrecomputation, fields::Field as ArkWrappedField,
@@ -375,6 +375,18 @@ impl_from_delegate!(i8, i16, i32, i64, i128);
 impl<F: ArkWrappedField> From<bool> for ArkField<F> {
     fn from(value: bool) -> Self {
         if value { Self::one() } else { Self::zero() }
+    }
+}
+
+impl<F: ArkWrappedField> From<Boolean> for ArkField<F> {
+    fn from(value: Boolean) -> Self {
+        Self::from(*value)
+    }
+}
+
+impl<F: ArkWrappedField> From<&Boolean> for ArkField<F> {
+    fn from(value: &Boolean) -> Self {
+        Self::from(**value)
     }
 }
 

--- a/crypto-primitives/src/field/ark_ff_field.rs
+++ b/crypto-primitives/src/field/ark_ff_field.rs
@@ -1,4 +1,5 @@
 use super::*;
+use crate::Semiring;
 use ark_ff::{
     AdditiveGroup, CubicExtConfig, CubicExtField, LegendreSymbol, QuadExtConfig, QuadExtField,
     SqrtPrecomputation, fields::Field as ArkWrappedField,
@@ -380,6 +381,8 @@ impl<F: ArkWrappedField> From<bool> for ArkField<F> {
 //
 // Ring and Field
 //
+
+impl<F: ArkWrappedField> Semiring for ArkField<F> {}
 
 impl<F: ArkWrappedField> Ring for ArkField<F> {}
 

--- a/crypto-primitives/src/field/ark_ff_field.rs
+++ b/crypto-primitives/src/field/ark_ff_field.rs
@@ -379,7 +379,7 @@ impl<F: ArkWrappedField> From<bool> for ArkField<F> {
 }
 
 //
-// Ring and Field
+// Semiring, Ring and Field
 //
 
 impl<F: ArkWrappedField> Semiring for ArkField<F> {}

--- a/crypto-primitives/src/field/ark_ff_fp.rs
+++ b/crypto-primitives/src/field/ark_ff_fp.rs
@@ -1,5 +1,5 @@
 use super::*;
-use crate::{IntRing, IntSemiring, Semiring};
+use crate::{IntRing, IntSemiring, Semiring, boolean::Boolean};
 use ark_ff::{
     AdditiveGroup, BigInt, BigInteger, FftField, FpConfig, LegendreSymbol, MontBackend, MontConfig,
     SqrtPrecomputation,
@@ -398,6 +398,18 @@ impl<P: FpConfig<N>, const N: usize> From<bool> for Fp<P, N> {
         } else {
             <Self as ConstZero>::ZERO
         }
+    }
+}
+
+impl<P: FpConfig<N>, const N: usize> From<Boolean> for Fp<P, N> {
+    fn from(value: Boolean) -> Self {
+        Self::from(*value)
+    }
+}
+
+impl<P: FpConfig<N>, const N: usize> From<&Boolean> for Fp<P, N> {
+    fn from(value: &Boolean) -> Self {
+        Self::from(**value)
     }
 }
 

--- a/crypto-primitives/src/field/ark_ff_fp.rs
+++ b/crypto-primitives/src/field/ark_ff_fp.rs
@@ -426,7 +426,7 @@ impl<P: FpConfig<N>, const N: usize> From<Fp<P, N>> for BigUint {
 }
 
 //
-// Ring and Field
+// Semiring, Ring and Field
 //
 
 impl<P: FpConfig<N>, const N: usize> Semiring for Fp<P, N> {}

--- a/crypto-primitives/src/field/ark_ff_fp.rs
+++ b/crypto-primitives/src/field/ark_ff_fp.rs
@@ -1,4 +1,5 @@
 use super::*;
+use crate::{IntRing, IntSemiring, Semiring};
 use ark_ff::{
     AdditiveGroup, BigInt, BigInteger, FftField, FpConfig, LegendreSymbol, MontBackend, MontConfig,
     SqrtPrecomputation,
@@ -428,9 +429,11 @@ impl<P: FpConfig<N>, const N: usize> From<Fp<P, N>> for BigUint {
 // Ring and Field
 //
 
+impl<P: FpConfig<N>, const N: usize> Semiring for Fp<P, N> {}
+
 impl<P: FpConfig<N>, const N: usize> Ring for Fp<P, N> {}
 
-impl<P: FpConfig<N>, const N: usize> IntRing for Fp<P, N> {
+impl<P: FpConfig<N>, const N: usize> IntSemiring for Fp<P, N> {
     fn is_odd(&self) -> bool {
         self.0.into_bigint().is_odd()
     }
@@ -438,7 +441,9 @@ impl<P: FpConfig<N>, const N: usize> IntRing for Fp<P, N> {
     fn is_even(&self) -> bool {
         self.0.into_bigint().is_even()
     }
+}
 
+impl<P: FpConfig<N>, const N: usize> IntRing for Fp<P, N> {
     fn checked_abs(&self) -> Option<Self> {
         Some(*self)
     }

--- a/crypto-primitives/src/field/crypto_bigint_boxed_monty.rs
+++ b/crypto-primitives/src/field/crypto_bigint_boxed_monty.rs
@@ -1,5 +1,5 @@
 use super::*;
-use crate::crypto_bigint_int::Int;
+use crate::{IntRing, IntSemiring, Semiring, crypto_bigint_int::Int};
 use core::{
     cmp::Ordering,
     fmt::{Debug, Display, Formatter, Result as FmtResult},
@@ -462,9 +462,11 @@ impl<const LIMBS: usize> FromWithConfig<&crypto_bigint::Uint<LIMBS>> for BoxedMo
 // Ring and Field
 //
 
+impl Semiring for BoxedMontyField {}
+
 impl Ring for BoxedMontyField {}
 
-impl IntRing for BoxedMontyField {
+impl IntSemiring for BoxedMontyField {
     fn is_odd(&self) -> bool {
         // Sadly there's no efficient way to implement this for Montgomery form
         self.0.retrieve().is_odd().into()
@@ -474,7 +476,9 @@ impl IntRing for BoxedMontyField {
         // Sadly there's no efficient way to implement this for Montgomery form
         self.0.retrieve().is_even().into()
     }
+}
 
+impl IntRing for BoxedMontyField {
     fn checked_abs(&self) -> Option<Self> {
         Some(self.clone())
     }

--- a/crypto-primitives/src/field/crypto_bigint_boxed_monty.rs
+++ b/crypto-primitives/src/field/crypto_bigint_boxed_monty.rs
@@ -459,7 +459,7 @@ impl<const LIMBS: usize> FromWithConfig<&crypto_bigint::Uint<LIMBS>> for BoxedMo
 }
 
 //
-// Ring and Field
+// Semiring, Ring and Field
 //
 
 impl Semiring for BoxedMontyField {}

--- a/crypto-primitives/src/field/crypto_bigint_boxed_monty.rs
+++ b/crypto-primitives/src/field/crypto_bigint_boxed_monty.rs
@@ -1,5 +1,5 @@
 use super::*;
-use crate::{IntRing, IntSemiring, Semiring, crypto_bigint_int::Int};
+use crate::{IntRing, IntSemiring, Semiring, boolean::Boolean, crypto_bigint_int::Int};
 use core::{
     cmp::Ordering,
     fmt::{Debug, Display, Formatter, Result as FmtResult},
@@ -408,6 +408,18 @@ impl FromWithConfig<bool> for BoxedMontyField {
 
 impl FromWithConfig<&bool> for BoxedMontyField {
     fn from_with_cfg(value: &bool, cfg: &Self::Config) -> Self {
+        Self::from_with_cfg(*value, cfg)
+    }
+}
+
+impl FromWithConfig<Boolean> for BoxedMontyField {
+    fn from_with_cfg(value: Boolean, cfg: &Self::Config) -> Self {
+        Self::from_with_cfg(*value, cfg)
+    }
+}
+
+impl FromWithConfig<&Boolean> for BoxedMontyField {
+    fn from_with_cfg(value: &Boolean, cfg: &Self::Config) -> Self {
         Self::from_with_cfg(*value, cfg)
     }
 }

--- a/crypto-primitives/src/field/crypto_bigint_const_monty.rs
+++ b/crypto-primitives/src/field/crypto_bigint_const_monty.rs
@@ -1,5 +1,5 @@
 use super::*;
-use crate::{IntRing, IntSemiring, Semiring, crypto_bigint_int::Int};
+use crate::{IntRing, IntSemiring, Semiring, crypto_bigint_int::Int, crypto_bigint_uint::Uint};
 use core::{
     cmp::Ordering,
     fmt::{Debug, Display, Formatter, Result as FmtResult},
@@ -9,7 +9,7 @@ use core::{
     str::FromStr,
 };
 use crypto_bigint::{
-    Integer, Limb, Uint,
+    Integer, Limb,
     modular::{ConstMontyForm, ConstMontyParams as Params, Retrieve},
     subtle::{Choice, ConditionallySelectable, ConstantTimeEq},
 };
@@ -57,27 +57,27 @@ impl<Mod: Params<LIMBS>, const LIMBS: usize> ConstMontyField<Mod, LIMBS> {
     /// Retrieves the integer currently encoded in this [`ConstMontyForm`],
     /// guaranteed to be reduced.
     pub const fn retrieve(&self) -> Uint<LIMBS> {
-        self.0.retrieve()
+        Uint::new(self.0.retrieve())
     }
 
     /// Access the `ConstMontyForm` value in Montgomery form.
     pub const fn as_montgomery(&self) -> &Uint<LIMBS> {
-        self.0.as_montgomery()
+        Uint::new_ref(self.0.as_montgomery())
     }
 
     /// Mutably access the `ConstMontyForm` value in Montgomery form.
     pub fn as_montgomery_mut(&mut self) -> &mut Uint<LIMBS> {
-        self.0.as_montgomery_mut()
+        Uint::new_ref_mut(self.0.as_montgomery_mut())
     }
 
     /// Create a `ConstMontyForm` from a value in Montgomery form.
     pub const fn from_montgomery(integer: Uint<LIMBS>) -> Self {
-        Self(ConstMontyForm::from_montgomery(integer))
+        Self(ConstMontyForm::from_montgomery(integer.into_inner()))
     }
 
     /// Extract the value from the `ConstMontyForm` in Montgomery form.
     pub const fn to_montgomery(&self) -> Uint<LIMBS> {
-        self.0.to_montgomery()
+        Uint::new(self.0.to_montgomery())
     }
 
     /// Performs division by 2, that is returns `x` such that `x + x = self`.
@@ -96,7 +96,7 @@ impl<Mod: Params<LIMBS>, const LIMBS: usize> ConstMontyField<Mod, LIMBS> {
         exponent: &Uint<RHS_LIMBS>,
         exponent_bits: u32,
     ) -> Self {
-        Self(self.0.pow_bounded_exp(exponent, exponent_bits))
+        Self(self.0.pow_bounded_exp(exponent.inner(), exponent_bits))
     }
 }
 
@@ -145,8 +145,8 @@ impl<Mod: Params<LIMBS>, const LIMBS: usize> FromStr for ConstMontyField<Mod, LI
     type Err = ();
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        let uint = Uint::<LIMBS>::from_str_radix_vartime(s, 10).map_err(|_| ())?;
-        Ok(Self(ConstMontyForm::new(&uint)))
+        let uint = Uint::<LIMBS>::from_str(s)?;
+        Ok(Self(ConstMontyForm::new(uint.inner())))
     }
 }
 
@@ -421,7 +421,7 @@ macro_rules! impl_from_unsigned {
             impl<Mod: Params<LIMBS>, const LIMBS: usize> From<$t> for ConstMontyField<Mod, LIMBS> {
                 fn from(value: $t) -> Self {
                     let value = Uint::from(value);
-                    Self(ConstMontyForm::new(&value))
+                    Self(ConstMontyForm::new(value.inner()))
                 }
             }
 
@@ -442,7 +442,7 @@ macro_rules! impl_from_signed {
                 #![allow(clippy::arithmetic_side_effects)]
                 fn from(value: $t) -> Self {
                     let magnitude = Uint::from(value.abs_diff(0));
-                    let form = ConstMontyForm::new(&magnitude);
+                    let form = ConstMontyForm::new(magnitude.inner());
                     Self(if value.is_negative() { -form } else { form })
                 }
             }
@@ -473,7 +473,7 @@ impl<Mod: Params<LIMBS>, const LIMBS: usize> From<Uint<LIMBS>> for ConstMontyFie
 
 impl<Mod: Params<LIMBS>, const LIMBS: usize> From<&Uint<LIMBS>> for ConstMontyField<Mod, LIMBS> {
     fn from(value: &Uint<LIMBS>) -> Self {
-        Self(ConstMontyForm::new(value))
+        Self(ConstMontyForm::new(value.inner()))
     }
 }
 
@@ -522,7 +522,7 @@ impl<Mod: Params<LIMBS>, const LIMBS: usize, const LIMBS2: usize> From<&crypto_b
 }
 
 //
-// Ring and Field
+// Semiring, Ring and Field
 //
 
 impl<Mod: Params<LIMBS>, const LIMBS: usize> Semiring for ConstMontyField<Mod, LIMBS> {}
@@ -606,7 +606,7 @@ impl<Mod: Params<LIMBS>, const LIMBS: usize> crypto_bigint::Random for ConstMont
 impl<'de, Mod, const LIMBS: usize> serde::Deserialize<'de> for ConstMontyField<Mod, LIMBS>
 where
     Mod: Params<LIMBS>,
-    Uint<LIMBS>: crypto_bigint::Encoding,
+    crypto_bigint::Uint<LIMBS>: crypto_bigint::Encoding,
 {
     #[inline(always)]
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
@@ -621,7 +621,7 @@ where
 impl<Mod, const LIMBS: usize> serde::Serialize for ConstMontyField<Mod, LIMBS>
 where
     Mod: Params<LIMBS>,
-    Uint<LIMBS>: crypto_bigint::Encoding,
+    crypto_bigint::Uint<LIMBS>: crypto_bigint::Encoding,
 {
     #[inline(always)]
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
@@ -676,7 +676,7 @@ impl<Mod: Params<LIMBS>, const LIMBS: usize> crypto_bigint::Square for ConstMont
 }
 
 impl<Mod: Params<LIMBS>, const LIMBS: usize> Retrieve for ConstMontyField<Mod, LIMBS> {
-    type Output = <ConstMontyForm<Mod, LIMBS> as Retrieve>::Output;
+    type Output = Uint<LIMBS>;
     fn retrieve(&self) -> Self::Output {
         self.retrieve()
     }
@@ -1005,7 +1005,7 @@ mod tests {
 
     #[test]
     fn wrapper_methods() {
-        let value = ConstMontyForm::new(&Uint::from(42_u64));
+        let value = ConstMontyForm::new(Uint::from(42_u64).inner());
         let field = F::new(value);
 
         // Test inner and into_inner
@@ -1202,7 +1202,7 @@ mod tests {
         assert_eq!(d, F::from(-654_i64));
 
         // Conversions from and to ConstMontyForm
-        let mont_form = ConstMontyForm::new(&Uint::<{ U256::LIMBS }>::from(999_u64));
+        let mont_form = ConstMontyForm::new(Uint::<{ U256::LIMBS }>::from(999_u64).inner());
         let f: F = mont_form.into();
         let f2 = F::new(mont_form);
         assert_eq!(f, f2);

--- a/crypto-primitives/src/field/crypto_bigint_const_monty.rs
+++ b/crypto-primitives/src/field/crypto_bigint_const_monty.rs
@@ -1,5 +1,8 @@
 use super::*;
-use crate::{IntRing, IntSemiring, Semiring, crypto_bigint_int::Int, crypto_bigint_uint::Uint};
+use crate::{
+    IntRing, IntSemiring, Semiring, boolean::Boolean, crypto_bigint_int::Int,
+    crypto_bigint_uint::Uint,
+};
 use core::{
     cmp::Ordering,
     fmt::{Debug, Display, Formatter, Result as FmtResult},
@@ -462,6 +465,18 @@ impl_from_signed!(i8, i16, i32, i64, i128);
 impl<Mod: Params<LIMBS>, const LIMBS: usize> From<bool> for ConstMontyField<Mod, LIMBS> {
     fn from(value: bool) -> Self {
         if value { Self::ONE } else { Self::ZERO }
+    }
+}
+
+impl<Mod: Params<LIMBS>, const LIMBS: usize> From<Boolean> for ConstMontyField<Mod, LIMBS> {
+    fn from(value: Boolean) -> Self {
+        Self::from(*value)
+    }
+}
+
+impl<Mod: Params<LIMBS>, const LIMBS: usize> From<&Boolean> for ConstMontyField<Mod, LIMBS> {
+    fn from(value: &Boolean) -> Self {
+        Self::from(**value)
     }
 }
 

--- a/crypto-primitives/src/field/crypto_bigint_const_monty.rs
+++ b/crypto-primitives/src/field/crypto_bigint_const_monty.rs
@@ -1,5 +1,5 @@
 use super::*;
-use crate::crypto_bigint_int::Int;
+use crate::{IntRing, IntSemiring, Semiring, crypto_bigint_int::Int};
 use core::{
     cmp::Ordering,
     fmt::{Debug, Display, Formatter, Result as FmtResult},
@@ -525,9 +525,11 @@ impl<Mod: Params<LIMBS>, const LIMBS: usize, const LIMBS2: usize> From<&crypto_b
 // Ring and Field
 //
 
+impl<Mod: Params<LIMBS>, const LIMBS: usize> Semiring for ConstMontyField<Mod, LIMBS> {}
+
 impl<Mod: Params<LIMBS>, const LIMBS: usize> Ring for ConstMontyField<Mod, LIMBS> {}
 
-impl<Mod: Params<LIMBS>, const LIMBS: usize> IntRing for ConstMontyField<Mod, LIMBS> {
+impl<Mod: Params<LIMBS>, const LIMBS: usize> IntSemiring for ConstMontyField<Mod, LIMBS> {
     fn is_odd(&self) -> bool {
         // Sadly there's no efficient way to implement this for Montgomery form
         self.0.retrieve().is_odd().into()
@@ -537,7 +539,9 @@ impl<Mod: Params<LIMBS>, const LIMBS: usize> IntRing for ConstMontyField<Mod, LI
         // Sadly there's no efficient way to implement this for Montgomery form
         self.0.retrieve().is_even().into()
     }
+}
 
+impl<Mod: Params<LIMBS>, const LIMBS: usize> IntRing for ConstMontyField<Mod, LIMBS> {
     fn checked_abs(&self) -> Option<Self> {
         Some(*self)
     }

--- a/crypto-primitives/src/lib.rs
+++ b/crypto-primitives/src/lib.rs
@@ -5,61 +5,9 @@ pub mod field;
 pub(crate) mod helpers;
 pub mod matrix;
 pub mod ring;
+pub mod semiring;
 
 pub use field::*;
 pub use matrix::*;
 pub use ring::*;
-
-// FIXME
-/// Implements CheckedNeg, CheckedAdd, CheckedSub, CheckedMul, CheckedShl, and
-/// CheckedShr traits for the given type under the assumption that the type
-/// implements the corresponding operations without overflow.
-#[macro_export]
-macro_rules! trivial_checked_ops {
-    (
-        $(<
-            $(
-                $(const )?$lt:tt $( : $clt:tt $(+ $dlt:tt )* )?
-            ),+
-        >)?
-    ) => {
-        impl$(< $( $lt $( : $clt $(+ $dlt )* )? ),+ >)? num_traits::CheckedNeg for Qqwe { //$t {
-            fn checked_neg(self) -> Option<Self> {
-                Some(-self)
-            }
-        }
-
-        /*impl num_traits::CheckedAdd for $t {
-            fn checked_add(self, other: Self) -> Option<Self> {
-                Some(self + other)
-            }
-        }
-
-        impl num_traits::CheckedSub for $t {
-            fn checked_sub(self, other: Self) -> Option<Self> {
-                Some(self - other)
-            }
-        }
-
-        impl num_traits::CheckedMul for $t {
-            fn checked_mul(self, other: Self) -> Option<Self> {
-                Some(self * other)
-            }
-        }
-
-        impl num_traits::CheckedShl for $t {
-            fn checked_shl(self, shift: u32) -> Option<Self> {
-                Some(self << shift)
-            }
-        }
-
-        impl num_traits::CheckedShr for $t {
-            fn checked_shr(self, shift: u32) -> Option<Self> {
-                Some(self >> shift)
-            }
-        }*/
-    };
-}
-
-// trivial_checked_ops!(<A, B, C>);
-// trivial_checked_ops!(<Mod: ConstMontyParams, const LIMBS: usize>);
+pub use semiring::*;

--- a/crypto-primitives/src/ring.rs
+++ b/crypto-primitives/src/ring.rs
@@ -39,8 +39,8 @@ impl<T> IntRingWithRem for T where
 pub trait IntRingWithShifts: IntRing + IntSemiringWithShifts {}
 impl<T> IntRingWithShifts for T where T: IntRing + IntSemiringWithShifts {}
 
-pub trait ConstIntRing: IntRing + ConstIntSemiring {}
-impl<T> ConstIntRing for T where T: IntRing + ConstIntSemiring {}
+pub trait ConstIntRing: IntRing + ConstIntSemiring + From<i8> {}
+impl<T> ConstIntRing for T where T: IntRing + ConstIntSemiring + From<i8> {}
 
 macro_rules! primitive_int_ring {
     ($t:ident) => {

--- a/crypto-primitives/src/ring.rs
+++ b/crypto-primitives/src/ring.rs
@@ -1,66 +1,23 @@
 #[cfg(feature = "crypto_bigint")]
 pub mod crypto_bigint_int;
 
-use core::{
-    fmt::{Debug, Display},
-    hash::Hash,
-    iter::{Product, Sum},
-    ops::{
-        Add, AddAssign, Mul, MulAssign, Rem, RemAssign, Shl, ShlAssign, Shr, ShrAssign, Sub,
-        SubAssign,
-    },
-    str::FromStr,
-};
-use num_traits::{
-    CheckedAdd, CheckedMul, CheckedNeg, CheckedRem, CheckedSub, ConstOne, ConstZero, One, Pow, Zero,
-};
+use crate::{ConstIntSemiring, FixedSemiring, IntSemiring, IntSemiringWithShifts, Semiring};
+use core::ops::{Neg, Rem, RemAssign};
+use num_traits::{CheckedNeg, CheckedRem};
 
-/// A ring is like a field without a multiplicative inverse or division.
-pub trait Ring:
-    // Core traits
-    Sized
-    + Debug
-    + Display
-    + Clone
-    + PartialEq
-    + Eq
-    + Sync
-    + Send
-    + Hash
-    // Arithmetic operations consuming rhs
-    + CheckedNeg
-    + CheckedAdd
-    + CheckedSub
-    + CheckedMul
-    + AddAssign
-    + SubAssign
-    + MulAssign
-    + Sum
-    + Product
-    // Arithmetic operations with rhs reference
-    + for<'a> Add<&'a Self, Output=Self>
-    + for<'a> Sub<&'a Self, Output=Self>
-    + for<'a> Mul<&'a Self, Output=Self>
-    + for<'a> AddAssign<&'a Self>
-    + for<'a> SubAssign<&'a Self>
-    + for<'a> MulAssign<&'a Self>
-    + for<'a> Sum<&'a Self>
-    + for<'a> Product<&'a Self>
-    {}
+/// A ring is a semiring with subtraction, meaning it has an additive inverse
+/// for every element.
+pub trait Ring: Semiring + Neg<Output = Self> + CheckedNeg {}
 
 /// Ring whose zero and one elements can be constructed from the type alone.
-pub trait FixedRing: Ring + Default + Zero + One {}
-impl<T> FixedRing for T where T: Ring + Default + Zero + One {}
+pub trait FixedRing: Ring + FixedSemiring {}
+impl<T> FixedRing for T where T: Ring + FixedSemiring {}
 
-pub trait ConstRing: FixedRing + ConstZero + ConstOne + From<bool> + From<i8> {}
-impl<T> ConstRing for T where T: FixedRing + ConstZero + ConstOne + From<bool> + From<i8> {}
+pub trait ConstRing: FixedRing + FixedSemiring {}
+impl<T> ConstRing for T where T: FixedRing + FixedSemiring {}
 
 /// Ring of integers, usually denoted as `Z`.
-pub trait IntRing: Ring + PartialOrd + Pow<u32> {
-    fn is_odd(&self) -> bool;
-
-    fn is_even(&self) -> bool;
-
+pub trait IntRing: Ring + IntSemiring {
     /// Checked absolute value. Computes `self.abs()`, returning `None` if `self
     /// == MIN`.
     fn checked_abs(&self) -> Option<Self>;
@@ -79,30 +36,16 @@ impl<T> IntRingWithRem for T where
 {
 }
 
-pub trait IntRingWithShifts:
-    IntRing + Shl<u32> + Shr<u32> + ShlAssign<u32> + ShrAssign<u32>
-{
-}
-impl<T> IntRingWithShifts for T where
-    T: IntRing + Shl<u32> + Shr<u32> + ShlAssign<u32> + ShrAssign<u32>
-{
-}
+pub trait IntRingWithShifts: IntRing + IntSemiringWithShifts {}
+impl<T> IntRingWithShifts for T where T: IntRing + IntSemiringWithShifts {}
 
-pub trait ConstIntRing: IntRing + ConstRing + FromStr {}
-impl<T> ConstIntRing for T where T: IntRing + ConstRing + FromStr {}
+pub trait ConstIntRing: IntRing + ConstIntSemiring {}
+impl<T> ConstIntRing for T where T: IntRing + ConstIntSemiring {}
 
 macro_rules! primitive_int_ring {
     ($t:ident) => {
         impl Ring for $t {}
         impl IntRing for $t {
-            fn is_odd(&self) -> bool {
-                *self & 1 == 1
-            }
-
-            fn is_even(&self) -> bool {
-                *self & 1 == 0
-            }
-
             fn checked_abs(&self) -> Option<Self> {
                 $t::checked_abs(*self)
             }

--- a/crypto-primitives/src/ring/crypto_bigint_int.rs
+++ b/crypto-primitives/src/ring/crypto_bigint_int.rs
@@ -2,9 +2,13 @@ use super::*;
 use core::{
     cmp::Ordering,
     fmt::{Debug, Display, Formatter, LowerHex, Result as FmtResult, UpperHex},
-    hash::Hasher,
+    hash::{Hash, Hasher},
     iter::{Product, Sum},
-    ops::{Add, AddAssign, Mul, MulAssign, Neg, Rem, RemAssign, Shl, Shr, Sub, SubAssign},
+    ops::{
+        Add, AddAssign, Mul, MulAssign, Neg, Rem, RemAssign, Shl, ShlAssign, Shr, ShrAssign, Sub,
+        SubAssign,
+    },
+    str::FromStr,
 };
 use crypto_bigint::{
     CheckedMul as CryptoCheckedMul, CheckedSub as CryptoCheckedSub, Integer, Word,
@@ -511,9 +515,11 @@ impl<const LIMBS: usize, const LIMBS2: usize> TryFrom<&crypto_bigint::Uint<LIMBS
 // Ring and IntRing
 //
 
+impl<const LIMBS: usize> Semiring for Int<LIMBS> {}
+
 impl<const LIMBS: usize> Ring for Int<LIMBS> {}
 
-impl<const LIMBS: usize> IntRing for Int<LIMBS> {
+impl<const LIMBS: usize> IntSemiring for Int<LIMBS> {
     fn is_odd(&self) -> bool {
         self.0.is_odd().into()
     }
@@ -521,7 +527,9 @@ impl<const LIMBS: usize> IntRing for Int<LIMBS> {
     fn is_even(&self) -> bool {
         self.0.is_even().into()
     }
+}
 
+impl<const LIMBS: usize> IntRing for Int<LIMBS> {
     fn is_positive(&self) -> bool {
         self.0.is_positive().into()
     }

--- a/crypto-primitives/src/ring/crypto_bigint_int.rs
+++ b/crypto-primitives/src/ring/crypto_bigint_int.rs
@@ -1,4 +1,5 @@
 use super::*;
+use crate::{crypto_bigint_uint::Uint, impl_pow_via_repeated_squaring};
 use core::{
     cmp::Ordering,
     fmt::{Debug, Display, Formatter, LowerHex, Result as FmtResult, UpperHex},
@@ -12,16 +13,12 @@ use core::{
 };
 use crypto_bigint::{
     CheckedMul as CryptoCheckedMul, CheckedSub as CryptoCheckedSub, Integer, Word,
-    subtle::{
-        Choice, ConditionallySelectable, ConstantTimeEq, ConstantTimeGreater, ConstantTimeLess,
-    },
 };
 use num_traits::{
     CheckedAdd, CheckedMul, CheckedNeg, CheckedRem, CheckedSub, ConstOne, ConstZero, One, Pow, Zero,
 };
 use pastey::paste;
 
-use crate::impl_pow_via_repeated_squaring;
 #[cfg(feature = "rand")]
 use rand::{distr::StandardUniform, prelude::*, rand_core::TryRngCore};
 
@@ -34,6 +31,20 @@ impl<const LIMBS: usize> Int<LIMBS> {
     #[inline(always)]
     pub const fn new(value: crypto_bigint::Int<LIMBS>) -> Self {
         Self(value)
+    }
+
+    #[inline(always)]
+    pub const fn new_ref(value: &crypto_bigint::Int<LIMBS>) -> &Self {
+        // Safety: Int<LIMBS> is #[repr(transparent)] and is guaranteed to have the
+        // same memory layout as crypto_bigint::Int
+        unsafe { &*(value as *const crypto_bigint::Int<LIMBS> as *const Self) }
+    }
+
+    #[inline(always)]
+    pub const fn new_ref_mut(value: &mut crypto_bigint::Int<LIMBS>) -> &mut Self {
+        // Safety: Int<LIMBS> is #[repr(transparent)] and is guaranteed to have the
+        // same memory layout as crypto_bigint::Int
+        unsafe { &mut *(value as *mut crypto_bigint::Int<LIMBS> as *mut Self) }
     }
 
     /// Get the reference to the wrapped value
@@ -70,6 +81,10 @@ impl<const LIMBS: usize> Int<LIMBS> {
     /// See [crypto_bigint::Int::cmp_vartime]
     pub const fn cmp_vartime(&self, rhs: &Self) -> Ordering {
         self.0.cmp_vartime(&rhs.0)
+    }
+
+    pub const fn as_uint(&self) -> &Uint<LIMBS> {
+        Uint::new_ref(self.0.as_uint())
     }
 }
 
@@ -512,7 +527,7 @@ impl<const LIMBS: usize, const LIMBS2: usize> TryFrom<&crypto_bigint::Uint<LIMBS
     }
 }
 //
-// Ring and IntRing
+// Semiring and Ring
 //
 
 impl<const LIMBS: usize> Semiring for Int<LIMBS> {}
@@ -596,30 +611,31 @@ where
 // Traits from crypto_bigint
 //
 
-impl<const LIMBS: usize> ConstantTimeEq for Int<LIMBS> {
+impl<const LIMBS: usize> crypto_bigint::subtle::ConstantTimeEq for Int<LIMBS> {
     #[inline]
-    fn ct_eq(&self, other: &Self) -> Choice {
-        ConstantTimeEq::ct_eq(&self.0, &other.0)
+    fn ct_eq(&self, other: &Self) -> crypto_bigint::subtle::Choice {
+        crypto_bigint::subtle::ConstantTimeEq::ct_eq(&self.0, &other.0)
     }
 }
 
-impl<const LIMBS: usize> ConstantTimeGreater for Int<LIMBS> {
+impl<const LIMBS: usize> crypto_bigint::subtle::ConstantTimeGreater for Int<LIMBS> {
     #[inline]
-    fn ct_gt(&self, other: &Self) -> Choice {
-        ConstantTimeGreater::ct_gt(&self.0, &other.0)
+    fn ct_gt(&self, other: &Self) -> crypto_bigint::subtle::Choice {
+        crypto_bigint::subtle::ConstantTimeGreater::ct_gt(&self.0, &other.0)
     }
 }
 
-impl<const LIMBS: usize> ConstantTimeLess for Int<LIMBS> {
+impl<const LIMBS: usize> crypto_bigint::subtle::ConstantTimeLess for Int<LIMBS> {
     #[inline]
-    fn ct_lt(&self, other: &Self) -> Choice {
-        ConstantTimeLess::ct_lt(&self.0, &other.0)
+    fn ct_lt(&self, other: &Self) -> crypto_bigint::subtle::Choice {
+        crypto_bigint::subtle::ConstantTimeLess::ct_lt(&self.0, &other.0)
     }
 }
 
-impl<const LIMBS: usize> ConditionallySelectable for Int<LIMBS> {
-    fn conditional_select(a: &Self, b: &Self, choice: Choice) -> Self {
-        ConditionallySelectable::conditional_select(&a.0, &b.0, choice).into()
+impl<const LIMBS: usize> crypto_bigint::subtle::ConditionallySelectable for Int<LIMBS> {
+    fn conditional_select(a: &Self, b: &Self, choice: crypto_bigint::subtle::Choice) -> Self {
+        crypto_bigint::subtle::ConditionallySelectable::conditional_select(&a.0, &b.0, choice)
+            .into()
     }
 }
 
@@ -706,26 +722,11 @@ mod tests {
     fn checked_operations() {
         let a = Int4::from(10_i64);
         let b = Int4::from(5_i64);
-        let zero = Int4::ZERO;
 
-        // Test checked_add
-        let c = a.checked_add(&b).unwrap();
-        assert_eq!(c, Int4::from(15_i64));
-
-        // Test checked_sub
-        let d = a.checked_sub(&b).unwrap();
-        assert_eq!(d, Int4::from(5_i64));
-
-        // Test checked_mul
-        let e = a.checked_mul(&b).unwrap();
-        assert_eq!(e, Int4::from(50_i64));
-
-        // Test checked_rem
-        let f = a.checked_rem(&b).unwrap();
-        assert_eq!(f, Int4::ZERO);
-
-        // Test checked_rem with zero divisor
-        assert!(a.checked_rem(&zero).is_none());
+        assert_eq!(a.checked_add(&b), Some(Int4::from(15_i64)));
+        assert_eq!(a.checked_sub(&b), Some(Int4::from(5_i64)));
+        assert_eq!(a.checked_mul(&b), Some(Int4::from(50_i64)));
+        assert_eq!(a.checked_rem(&b), Some(Int4::ZERO));
     }
 
     #[allow(clippy::op_ref)]
@@ -911,7 +912,6 @@ mod tests {
 
     #[test]
     fn aggregate_operations() {
-        // Test Sum trait
         let values: Vec<Int4> = [1_i64, 2_i64, 3_i64].into_iter().map(Int::from).collect();
         let sum: Int4 = values.iter().sum();
         assert_eq!(sum, Int4::from(6_i64));
@@ -1020,6 +1020,9 @@ mod tests {
 
         // MIN - 1 should overflow in checked_sub
         assert!(min.checked_sub(&one).is_none());
+
+        // checked_rem with zero divisor
+        assert!(max.checked_rem(&Int4::ZERO).is_none());
 
         // Test operations with large shifts
         let x = Int4::from(1_i64);
@@ -1175,7 +1178,9 @@ mod tests {
 
     #[test]
     fn constant_time_traits() {
-        use crypto_bigint::subtle::Choice;
+        use crypto_bigint::subtle::{
+            Choice, ConditionallySelectable, ConstantTimeEq, ConstantTimeGreater, ConstantTimeLess,
+        };
 
         let a = Int4::from(10_i64);
         let b = Int4::from(20_i64);

--- a/crypto-primitives/src/semiring.rs
+++ b/crypto-primitives/src/semiring.rs
@@ -1,4 +1,6 @@
 pub mod boolean;
+#[cfg(feature = "crypto_bigint")]
+pub mod crypto_bigint_uint;
 
 use core::{
     fmt::{Debug, Display},
@@ -52,8 +54,8 @@ pub trait Semiring:
 pub trait FixedSemiring: Semiring + Default + Zero + One {}
 impl<T> FixedSemiring for T where T: Semiring + Default + Zero + One {}
 
-pub trait ConstSemiring: FixedSemiring + ConstZero + ConstOne + From<bool> + From<i8> {}
-impl<T> ConstSemiring for T where T: FixedSemiring + ConstZero + ConstOne + From<bool> + From<i8> {}
+pub trait ConstSemiring: FixedSemiring + ConstZero + ConstOne + From<bool> {}
+impl<T> ConstSemiring for T where T: FixedSemiring + ConstZero + ConstOne + From<bool> {}
 
 /// Semiring of integers
 pub trait IntSemiring: Semiring + PartialOrd + Pow<u32> {

--- a/crypto-primitives/src/semiring.rs
+++ b/crypto-primitives/src/semiring.rs
@@ -1,3 +1,5 @@
+pub mod boolean;
+
 use core::{
     fmt::{Debug, Display},
     hash::Hash,

--- a/crypto-primitives/src/semiring.rs
+++ b/crypto-primitives/src/semiring.rs
@@ -1,0 +1,99 @@
+use core::{
+    fmt::{Debug, Display},
+    hash::Hash,
+    iter::{Product, Sum},
+    ops::{Add, AddAssign, Mul, MulAssign, Shl, ShlAssign, Shr, ShrAssign, Sub, SubAssign},
+    str::FromStr,
+};
+use num_traits::{CheckedAdd, CheckedMul, CheckedSub, ConstOne, ConstZero, One, Pow, Zero};
+
+/// A semiring is a mathematical structure that consists of a set equipped with
+/// two binary operations: addition and multiplication. The addition operation
+/// is commutative and associative, has an identity element (zero), and every
+/// element has an additive inverse. The multiplication operation is
+/// associative, has an identity element (one), and distributes over addition.
+/// However, unlike a ring, a semiring does not require the existence of
+/// additive inverses for all elements.
+/// Even though subtraction is not required, we include it here for convenience.
+pub trait Semiring:
+    // Core traits
+    Sized
+    + Debug
+    + Display
+    + Clone
+    + PartialEq
+    + Eq
+    + Sync
+    + Send
+    + Hash
+    // Arithmetic operations consuming rhs
+    + CheckedAdd
+    + CheckedSub
+    + CheckedMul
+    + AddAssign
+    + SubAssign
+    + MulAssign
+    + Sum
+    + Product
+    // Arithmetic operations with rhs reference
+    + for<'a> Add<&'a Self, Output=Self>
+    + for<'a> Sub<&'a Self, Output=Self>
+    + for<'a> Mul<&'a Self, Output=Self>
+    + for<'a> AddAssign<&'a Self>
+    + for<'a> SubAssign<&'a Self>
+    + for<'a> MulAssign<&'a Self>
+    + for<'a> Sum<&'a Self>
+    + for<'a> Product<&'a Self>
+    {}
+
+/// Ring whose zero and one elements can be constructed from the type alone.
+pub trait FixedSemiring: Semiring + Default + Zero + One {}
+impl<T> FixedSemiring for T where T: Semiring + Default + Zero + One {}
+
+pub trait ConstSemiring: FixedSemiring + ConstZero + ConstOne + From<bool> + From<i8> {}
+impl<T> ConstSemiring for T where T: FixedSemiring + ConstZero + ConstOne + From<bool> + From<i8> {}
+
+/// Semiring of integers
+pub trait IntSemiring: Semiring + PartialOrd + Pow<u32> {
+    fn is_odd(&self) -> bool;
+
+    fn is_even(&self) -> bool;
+}
+
+pub trait IntSemiringWithShifts:
+    IntSemiring + Shl<u32> + Shr<u32> + ShlAssign<u32> + ShrAssign<u32>
+{
+}
+impl<T> IntSemiringWithShifts for T where
+    T: IntSemiring + Shl<u32> + Shr<u32> + ShlAssign<u32> + ShrAssign<u32>
+{
+}
+
+pub trait ConstIntSemiring: IntSemiring + ConstSemiring + FromStr {}
+impl<T> ConstIntSemiring for T where T: IntSemiring + ConstSemiring + FromStr {}
+
+macro_rules! primitive_int_semiring {
+    ($t:ident) => {
+        impl Semiring for $t {}
+        impl IntSemiring for $t {
+            fn is_odd(&self) -> bool {
+                *self & 1 == 1
+            }
+
+            fn is_even(&self) -> bool {
+                *self & 1 == 0
+            }
+        }
+    };
+}
+
+primitive_int_semiring!(i8);
+primitive_int_semiring!(i16);
+primitive_int_semiring!(i32);
+primitive_int_semiring!(i64);
+primitive_int_semiring!(i128);
+primitive_int_semiring!(u8);
+primitive_int_semiring!(u16);
+primitive_int_semiring!(u32);
+primitive_int_semiring!(u64);
+primitive_int_semiring!(u128);

--- a/crypto-primitives/src/semiring/boolean.rs
+++ b/crypto-primitives/src/semiring/boolean.rs
@@ -3,10 +3,13 @@ use core::{
     fmt::{Debug, Display, Formatter, Result as FmtResult},
     hash::{Hash, Hasher},
     iter::{Product, Sum},
-    ops::{Add, AddAssign, Mul, MulAssign, Sub, SubAssign},
+    ops::{Add, AddAssign, Deref, Mul, MulAssign, Sub, SubAssign},
     str::{FromStr, ParseBoolError},
 };
 use num_traits::{CheckedAdd, CheckedMul, CheckedSub, ConstOne, ConstZero, One, Pow, Zero};
+
+#[cfg(feature = "rand")]
+use rand::{distr::StandardUniform, prelude::*};
 
 /// A boolean semiring where true represents 1 and false represents 0.
 /// Arithmetic operations behave like modulo-2 arithmetic:
@@ -71,6 +74,15 @@ impl Default for Boolean {
     #[inline(always)]
     fn default() -> Self {
         Self::FALSE
+    }
+}
+
+impl Deref for Boolean {
+    type Target = bool;
+
+    #[inline(always)]
+    fn deref(&self) -> &Self::Target {
+        &self.0
     }
 }
 
@@ -333,6 +345,17 @@ impl IntSemiring for Boolean {
 
     fn is_even(&self) -> bool {
         !self.0
+    }
+}
+
+//
+// RNG
+//
+
+#[cfg(feature = "rand")]
+impl Distribution<Boolean> for StandardUniform {
+    fn sample<R: Rng + ?Sized>(&self, rng: &mut R) -> Boolean {
+        Boolean::new(rng.random())
     }
 }
 

--- a/crypto-primitives/src/semiring/boolean.rs
+++ b/crypto-primitives/src/semiring/boolean.rs
@@ -1,0 +1,664 @@
+use crate::{IntSemiring, Semiring};
+use core::{
+    fmt::{Debug, Display, Formatter, Result as FmtResult},
+    hash::{Hash, Hasher},
+    iter::{Product, Sum},
+    ops::{Add, AddAssign, Mul, MulAssign, Sub, SubAssign},
+    str::{FromStr, ParseBoolError},
+};
+use num_traits::{CheckedAdd, CheckedMul, CheckedSub, ConstOne, ConstZero, One, Pow, Zero};
+
+/// A boolean semiring where true represents 1 and false represents 0.
+/// Arithmetic operations behave like modulo-2 arithmetic:
+/// - In debug mode: overflow panics (e.g., true + true panics)
+/// - In release mode: overflow wraps (e.g., true + true = false)
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+#[repr(transparent)]
+pub struct Boolean(bool);
+
+impl Boolean {
+    pub const FALSE: Self = Self(false);
+    pub const TRUE: Self = Self(true);
+
+    /// Creates a new Boolean from a bool value
+    #[inline(always)]
+    pub const fn new(value: bool) -> Self {
+        Self(value)
+    }
+
+    /// Get the inner bool value
+    #[inline(always)]
+    pub const fn inner(&self) -> bool {
+        self.0
+    }
+
+    /// Convert to the inner bool value
+    #[inline(always)]
+    pub const fn into_inner(self) -> bool {
+        self.0
+    }
+
+    /// Convert to u8 (0 or 1)
+    #[inline(always)]
+    pub const fn to_u8(&self) -> u8 {
+        self.0 as u8
+    }
+
+    /// Create from u8 (0 is false, non-zero is true)
+    #[inline(always)]
+    pub const fn from_u8(value: u8) -> Self {
+        Self(value != 0)
+    }
+}
+
+//
+// Core traits
+//
+
+impl Debug for Boolean {
+    fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
+        Debug::fmt(&self.0, f)
+    }
+}
+
+impl Display for Boolean {
+    fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
+        Display::fmt(&self.0, f)
+    }
+}
+
+impl Default for Boolean {
+    #[inline(always)]
+    fn default() -> Self {
+        Self::FALSE
+    }
+}
+
+impl Hash for Boolean {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        self.0.hash(state)
+    }
+}
+
+impl FromStr for Boolean {
+    type Err = ParseBoolError;
+
+    /// In addition to "true" and "false", also supports "1" and "0".
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "1" => Ok(Self::TRUE),
+            "0" => Ok(Self::FALSE),
+            _ => bool::from_str(s).map(Self),
+        }
+    }
+}
+
+//
+// Zero and One traits
+//
+
+impl Zero for Boolean {
+    #[inline(always)]
+    fn zero() -> Self {
+        Self::FALSE
+    }
+
+    #[inline(always)]
+    fn is_zero(&self) -> bool {
+        !self.0
+    }
+}
+
+impl One for Boolean {
+    #[inline(always)]
+    fn one() -> Self {
+        Self::TRUE
+    }
+}
+
+impl ConstZero for Boolean {
+    const ZERO: Self = Self::FALSE;
+}
+
+impl ConstOne for Boolean {
+    const ONE: Self = Self::TRUE;
+}
+
+//
+// From implementations
+//
+
+impl From<bool> for Boolean {
+    #[inline(always)]
+    fn from(value: bool) -> Self {
+        Self(value)
+    }
+}
+
+impl From<Boolean> for bool {
+    #[inline(always)]
+    fn from(value: Boolean) -> Self {
+        value.0
+    }
+}
+
+//
+// Basic arithmetic operations
+//
+
+impl Add for Boolean {
+    type Output = Self;
+
+    #[inline(always)]
+    fn add(self, rhs: Self) -> Self::Output {
+        self.add(&rhs)
+    }
+}
+
+impl<'a> Add<&'a Boolean> for Boolean {
+    type Output = Self;
+
+    fn add(self, rhs: &'a Self) -> Self::Output {
+        // In debug mode, panic on overflow (when both are true)
+        debug_assert!(!(self.0 && rhs.0), "attempt to add with overflow");
+
+        // Addition is XOR in modulo 2
+        Self(self.0 ^ rhs.0)
+    }
+}
+
+impl Sub for Boolean {
+    type Output = Self;
+
+    #[inline(always)]
+    fn sub(self, rhs: Self) -> Self::Output {
+        self.sub(&rhs)
+    }
+}
+
+impl<'a> Sub<&'a Boolean> for Boolean {
+    type Output = Self;
+
+    fn sub(self, rhs: &'a Self) -> Self::Output {
+        // In debug mode, panic on underflow
+        debug_assert!(self.0 || !rhs.0, "attempt to subtract with overflow");
+
+        // Otherwise, subtraction is exactly like addition, XOR in modulo 2
+        Self(self.0 ^ rhs.0)
+    }
+}
+
+impl Mul for Boolean {
+    type Output = Self;
+
+    #[inline(always)]
+    fn mul(self, rhs: Self) -> Self::Output {
+        self.mul(&rhs)
+    }
+}
+
+impl<'a> Mul<&'a Boolean> for Boolean {
+    type Output = Self;
+
+    #[inline(always)]
+    fn mul(self, rhs: &'a Self) -> Self::Output {
+        // Boolean multiplication is AND
+        Self(self.0 && rhs.0)
+    }
+}
+
+//
+// Arithmetic assign operations
+//
+
+macro_rules! impl_assign_op {
+    ($trait_name:tt, $trait_op:tt, $op_method:ident) => {
+        #[allow(clippy::arithmetic_side_effects)]
+        impl $trait_name for Boolean {
+            #[inline(always)]
+            fn $trait_op(&mut self, rhs: Self) {
+                self.$trait_op(&rhs);
+            }
+        }
+
+        #[allow(clippy::arithmetic_side_effects)]
+        impl $trait_name<&Boolean> for Boolean {
+            #[inline(always)]
+            fn $trait_op(&mut self, rhs: &Self) {
+                *self = self.$op_method(rhs);
+            }
+        }
+    };
+}
+
+impl_assign_op!(AddAssign, add_assign, add);
+impl_assign_op!(SubAssign, sub_assign, sub);
+impl_assign_op!(MulAssign, mul_assign, mul);
+
+//
+// Checked arithmetic operations
+//
+
+impl CheckedAdd for Boolean {
+    fn checked_add(&self, rhs: &Self) -> Option<Self> {
+        // Overflow when both are true
+        if self.0 && rhs.0 {
+            None
+        } else {
+            Some(Self(self.0 ^ rhs.0))
+        }
+    }
+}
+
+impl CheckedSub for Boolean {
+    fn checked_sub(&self, rhs: &Self) -> Option<Self> {
+        // Underflow when false - true
+        if !self.0 && rhs.0 {
+            None
+        } else {
+            Some(Self(self.0 ^ rhs.0))
+        }
+    }
+}
+
+impl CheckedMul for Boolean {
+    #[inline(always)]
+    fn checked_mul(&self, rhs: &Self) -> Option<Self> {
+        // Multiplication never overflows
+        Some(Self(self.0 && rhs.0))
+    }
+}
+
+//
+// Aggregate operations
+//
+
+#[allow(clippy::arithmetic_side_effects)]
+impl Sum for Boolean {
+    fn sum<I: Iterator<Item = Self>>(iter: I) -> Self {
+        iter.fold(Self::FALSE, |acc, x| acc + x)
+    }
+}
+
+#[allow(clippy::arithmetic_side_effects)]
+impl<'a> Sum<&'a Boolean> for Boolean {
+    fn sum<I: Iterator<Item = &'a Self>>(iter: I) -> Self {
+        iter.fold(Self::FALSE, |acc, x| acc + x)
+    }
+}
+
+#[allow(clippy::arithmetic_side_effects)]
+impl Product for Boolean {
+    fn product<I: Iterator<Item = Self>>(iter: I) -> Self {
+        iter.fold(Self::TRUE, |acc, x| acc * x)
+    }
+}
+
+#[allow(clippy::arithmetic_side_effects)]
+impl<'a> Product<&'a Boolean> for Boolean {
+    fn product<I: Iterator<Item = &'a Self>>(iter: I) -> Self {
+        iter.fold(Self::TRUE, |acc, x| acc * x)
+    }
+}
+
+//
+// Power operation
+//
+
+impl Pow<u32> for Boolean {
+    type Output = Self;
+
+    fn pow(self, rhs: u32) -> Self::Output {
+        // 0^0 = 1 (by convention)
+        // 0^n = 0 for n > 0
+        // 1^n = 1 for all n
+        if rhs == 0 || self.0 {
+            Self::TRUE
+        } else {
+            Self::FALSE
+        }
+    }
+}
+
+//
+// Trait implementations for Semiring hierarchy
+//
+
+impl Semiring for Boolean {}
+
+impl IntSemiring for Boolean {
+    fn is_odd(&self) -> bool {
+        self.0
+    }
+
+    fn is_even(&self) -> bool {
+        !self.0
+    }
+}
+
+//
+// Tests
+//
+
+#[allow(
+    clippy::arithmetic_side_effects,
+    clippy::cast_lossless,
+    clippy::op_ref,
+    clippy::bool_assert_comparison
+)]
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::ensure_type_implements_trait;
+    use alloc::{vec, vec::Vec};
+
+    #[test]
+    fn ensure_blanket_traits() {
+        ensure_type_implements_trait!(Boolean, Semiring);
+        ensure_type_implements_trait!(Boolean, IntSemiring);
+    }
+
+    #[test]
+    fn constants() {
+        assert_eq!(Boolean::FALSE, Boolean(false));
+        assert_eq!(Boolean::TRUE, Boolean(true));
+        assert_eq!(Boolean::ZERO, Boolean(false));
+        assert_eq!(Boolean::ONE, Boolean(true));
+    }
+
+    #[test]
+    fn basic_operations_no_overflow() {
+        let f = Boolean::FALSE;
+        let t = Boolean::TRUE;
+
+        // Addition without overflow
+        assert_eq!(f + f, f);
+        assert_eq!(f + t, t);
+        assert_eq!(t + f, t);
+
+        // Subtraction without underflow
+        assert_eq!(f - f, f);
+        assert_eq!(t - f, t);
+        assert_eq!(t - t, f);
+
+        // Multiplication (never overflows)
+        assert_eq!(f * f, f);
+        assert_eq!(f * t, f);
+        assert_eq!(t * f, f);
+        assert_eq!(t * t, t);
+    }
+
+    #[test]
+    #[cfg_attr(
+        debug_assertions,
+        should_panic(expected = "attempt to add with overflow")
+    )]
+    fn add_overflow_behavior() {
+        let t = Boolean::TRUE;
+        let _result = t + t;
+
+        // In release mode, this wraps to false
+        #[cfg(not(debug_assertions))]
+        assert_eq!(_result, Boolean::FALSE);
+    }
+
+    #[test]
+    #[cfg_attr(
+        debug_assertions,
+        should_panic(expected = "attempt to subtract with overflow")
+    )]
+    fn sub_underflow_behavior() {
+        let f = Boolean::FALSE;
+        let t = Boolean::TRUE;
+        let _result = f - t;
+
+        // In release mode, this wraps to true (255 & 1 = 1)
+        #[cfg(not(debug_assertions))]
+        assert_eq!(_result, Boolean::TRUE);
+    }
+
+    #[test]
+    fn checked_operations() {
+        let f = Boolean::FALSE;
+        let t = Boolean::TRUE;
+
+        // Checked add
+        assert_eq!(f.checked_add(&f), Some(f));
+        assert_eq!(f.checked_add(&t), Some(t));
+        assert_eq!(t.checked_add(&f), Some(t));
+        assert_eq!(t.checked_add(&t), None); // Overflow
+
+        // Checked sub
+        assert_eq!(f.checked_sub(&f), Some(f));
+        assert_eq!(t.checked_sub(&f), Some(t));
+        assert_eq!(t.checked_sub(&t), Some(f));
+        assert_eq!(f.checked_sub(&t), None); // Underflow
+
+        // Checked mul (never fails)
+        assert_eq!(f.checked_mul(&f), Some(f));
+        assert_eq!(f.checked_mul(&t), Some(f));
+        assert_eq!(t.checked_mul(&f), Some(f));
+        assert_eq!(t.checked_mul(&t), Some(t));
+    }
+
+    #[test]
+    fn reference_operations() {
+        let f = Boolean::FALSE;
+        let t = Boolean::TRUE;
+
+        // Test reference-based addition
+        assert_eq!(f + &f, f);
+        assert_eq!(f + &t, t);
+
+        // Test reference-based subtraction
+        assert_eq!(t - &f, t);
+        assert_eq!(t - &t, f);
+
+        // Test reference-based multiplication
+        assert_eq!(f * &t, f);
+        assert_eq!(t * &t, t);
+    }
+
+    #[test]
+    fn assign_operations() {
+        let f = Boolean::FALSE;
+        let t = Boolean::TRUE;
+
+        // AddAssign
+        let mut a = f;
+        a += t;
+        assert_eq!(a, t);
+
+        // SubAssign
+        let mut b = t;
+        b -= t;
+        assert_eq!(b, f);
+
+        // MulAssign
+        let mut c = t;
+        c *= t;
+        assert_eq!(c, t);
+
+        // Reference assign operations
+        let mut d = f;
+        d += &t;
+        assert_eq!(d, t);
+
+        let mut e = t;
+        e -= &f;
+        assert_eq!(e, t);
+
+        let mut g = t;
+        g *= &t;
+        assert_eq!(g, t);
+    }
+
+    #[test]
+    fn conversions() {
+        // From bool
+        assert_eq!(Boolean::from(true), Boolean::TRUE);
+        assert_eq!(Boolean::from(false), Boolean::FALSE);
+
+        // To bool
+        assert_eq!(bool::from(Boolean::TRUE), true);
+        assert_eq!(bool::from(Boolean::FALSE), false);
+
+        // Methods
+        assert_eq!(Boolean::new(true).inner(), true);
+        assert_eq!(Boolean::new(false).into_inner(), false);
+        assert_eq!(Boolean::TRUE.to_u8(), 1);
+        assert_eq!(Boolean::FALSE.to_u8(), 0);
+        assert_eq!(Boolean::from_u8(0), Boolean::FALSE);
+        assert_eq!(Boolean::from_u8(1), Boolean::TRUE);
+        assert_eq!(Boolean::from_u8(2), Boolean::TRUE);
+    }
+
+    #[test]
+    fn from_str() {
+        assert_eq!("true".parse::<Boolean>(), Ok(Boolean::TRUE));
+        assert_eq!("false".parse::<Boolean>(), Ok(Boolean::FALSE));
+        assert_eq!("1".parse::<Boolean>(), Ok(Boolean::TRUE));
+        assert_eq!("0".parse::<Boolean>(), Ok(Boolean::FALSE));
+        assert!("invalid".parse::<Boolean>().is_err());
+        assert!("2".parse::<Boolean>().is_err());
+    }
+
+    #[test]
+    fn pow_operation() {
+        let f = Boolean::FALSE;
+        let t = Boolean::TRUE;
+
+        // 0^0 = 1 by convention
+        assert_eq!(f.pow(0), t);
+
+        // 0^n = 0 for n > 0
+        assert_eq!(f.pow(1), f);
+        assert_eq!(f.pow(2), f);
+        assert_eq!(f.pow(100), f);
+
+        // 1^n = 1 for all n
+        assert_eq!(t.pow(0), t);
+        assert_eq!(t.pow(1), t);
+        assert_eq!(t.pow(2), t);
+        assert_eq!(t.pow(100), t);
+    }
+
+    #[test]
+    fn int_semiring_traits() {
+        let f = Boolean::FALSE;
+        let t = Boolean::TRUE;
+
+        // is_odd
+        assert!(!f.is_odd());
+        assert!(t.is_odd());
+
+        // is_even
+        assert!(f.is_even());
+        assert!(!t.is_even());
+    }
+
+    #[test]
+    fn zero_and_one_traits() {
+        assert_eq!(Boolean::zero(), Boolean::FALSE);
+        assert_eq!(Boolean::one(), Boolean::ONE);
+
+        assert!(Boolean::FALSE.is_zero());
+        assert!(!Boolean::TRUE.is_zero());
+    }
+
+    #[test]
+    fn aggregate_operations() {
+        // Sum
+        let values: Vec<Boolean> = vec![Boolean::FALSE, Boolean::TRUE, Boolean::FALSE];
+        let sum: Boolean = values.iter().sum();
+        assert_eq!(sum, Boolean::TRUE);
+
+        let sum2: Boolean = values.into_iter().sum();
+        assert_eq!(sum2, Boolean::TRUE);
+
+        // Product
+        let values: Vec<Boolean> = vec![Boolean::TRUE, Boolean::TRUE, Boolean::TRUE];
+        let product: Boolean = values.iter().product();
+        assert_eq!(product, Boolean::TRUE);
+
+        let values_with_false: Vec<Boolean> = vec![Boolean::TRUE, Boolean::FALSE, Boolean::TRUE];
+        let product2: Boolean = values_with_false.into_iter().product();
+        assert_eq!(product2, Boolean::FALSE);
+
+        // Empty collections
+        let empty: Vec<Boolean> = vec![];
+        let empty_sum: Boolean = empty.iter().sum();
+        assert_eq!(empty_sum, Boolean::ZERO);
+
+        let empty: Vec<Boolean> = vec![];
+        let empty_product: Boolean = empty.into_iter().product();
+        assert_eq!(empty_product, Boolean::ONE);
+    }
+
+    #[test]
+    fn ordering() {
+        let f = Boolean::FALSE;
+        let t = Boolean::TRUE;
+
+        assert!(f < t);
+        assert!(f <= t);
+        assert!(f <= f);
+        assert!(t > f);
+        assert!(t >= f);
+        assert!(t >= t);
+        assert_eq!(f, f);
+        assert_eq!(t, t);
+        assert_ne!(f, t);
+    }
+
+    #[test]
+    fn debug_and_display() {
+        use alloc::format;
+
+        assert_eq!(format!("{:?}", Boolean::TRUE), "true");
+        assert_eq!(format!("{:?}", Boolean::FALSE), "false");
+        assert_eq!(format!("{}", Boolean::TRUE), "true");
+        assert_eq!(format!("{}", Boolean::FALSE), "false");
+    }
+
+    #[test]
+    fn hash() {
+        use core::hash::{Hash, Hasher};
+
+        // Simple hash implementation for testing
+        struct SimpleHasher(u64);
+
+        impl Hasher for SimpleHasher {
+            fn finish(&self) -> u64 {
+                self.0
+            }
+
+            fn write(&mut self, bytes: &[u8]) {
+                for &byte in bytes {
+                    self.0 = self.0.wrapping_mul(31).wrapping_add(byte as u64);
+                }
+            }
+        }
+
+        let mut hasher1 = SimpleHasher(0);
+        Boolean::TRUE.hash(&mut hasher1);
+        let hash1 = hasher1.finish();
+
+        let mut hasher2 = SimpleHasher(0);
+        Boolean::TRUE.hash(&mut hasher2);
+        let hash2 = hasher2.finish();
+
+        assert_eq!(hash1, hash2);
+
+        let mut hasher3 = SimpleHasher(0);
+        Boolean::FALSE.hash(&mut hasher3);
+        let hash3 = hasher3.finish();
+
+        assert_ne!(hash1, hash3);
+    }
+
+    #[test]
+    fn default() {
+        assert_eq!(Boolean::default(), Boolean::FALSE);
+    }
+}

--- a/crypto-primitives/src/semiring/boolean.rs
+++ b/crypto-primitives/src/semiring/boolean.rs
@@ -321,7 +321,7 @@ impl Pow<u32> for Boolean {
 }
 
 //
-// Trait implementations for Semiring hierarchy
+// Semiring
 //
 
 impl Semiring for Boolean {}
@@ -349,13 +349,12 @@ impl IntSemiring for Boolean {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::ensure_type_implements_trait;
+    use crate::{ConstIntSemiring, ensure_type_implements_trait};
     use alloc::{vec, vec::Vec};
 
     #[test]
     fn ensure_blanket_traits() {
-        ensure_type_implements_trait!(Boolean, Semiring);
-        ensure_type_implements_trait!(Boolean, IntSemiring);
+        ensure_type_implements_trait!(Boolean, ConstIntSemiring);
     }
 
     #[test]

--- a/crypto-primitives/src/semiring/crypto_bigint_uint.rs
+++ b/crypto-primitives/src/semiring/crypto_bigint_uint.rs
@@ -1,0 +1,1158 @@
+use super::*;
+use crate::{crypto_bigint_int::Int, impl_pow_via_repeated_squaring};
+use core::{
+    cmp::Ordering,
+    fmt::{Debug, Display, Formatter, LowerHex, Result as FmtResult, UpperHex},
+    hash::{Hash, Hasher},
+    iter::{Product, Sum},
+    ops::{
+        Add, AddAssign, Mul, MulAssign, Rem, RemAssign, Shl, ShlAssign, Shr, ShrAssign, Sub,
+        SubAssign,
+    },
+    str::FromStr,
+};
+use crypto_bigint::{Integer, Limb, Word};
+use num_traits::{
+    CheckedAdd, CheckedMul, CheckedRem, CheckedSub, ConstOne, ConstZero, One, Pow, Zero,
+};
+use pastey::paste;
+
+#[cfg(feature = "rand")]
+use rand::{distr::StandardUniform, prelude::*, rand_core::TryRngCore};
+
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+#[repr(transparent)]
+pub struct Uint<const LIMBS: usize>(crypto_bigint::Uint<LIMBS>);
+
+impl<const LIMBS: usize> Uint<LIMBS> {
+    /// Wraps a given value into this wrapper type
+    #[inline(always)]
+    pub const fn new(value: crypto_bigint::Uint<LIMBS>) -> Self {
+        Self(value)
+    }
+
+    #[inline(always)]
+    pub const fn new_ref(value: &crypto_bigint::Uint<LIMBS>) -> &Self {
+        // Safety: Uint<LIMBS> is #[repr(transparent)] and is guaranteed to have the
+        // same memory layout as crypto_bigint::Uint
+        unsafe { &*(value as *const crypto_bigint::Uint<LIMBS> as *const Self) }
+    }
+
+    #[inline(always)]
+    pub const fn new_ref_mut(value: &mut crypto_bigint::Uint<LIMBS>) -> &mut Self {
+        // Safety: Uint<LIMBS> is #[repr(transparent)] and is guaranteed to have the
+        // same memory layout as crypto_bigint::Uint
+        unsafe { &mut *(value as *mut crypto_bigint::Uint<LIMBS> as *mut Self) }
+    }
+
+    /// Get the reference to the wrapped value
+    #[inline(always)]
+    pub const fn inner(&self) -> &crypto_bigint::Uint<LIMBS> {
+        &self.0
+    }
+
+    /// Get the wrapped value, consuming self
+    #[inline(always)]
+    pub const fn into_inner(self) -> crypto_bigint::Uint<LIMBS> {
+        self.0
+    }
+
+    /// See [crypto_bigint::Uint::from_words]
+    #[inline(always)]
+    pub const fn from_words(arr: [Word; LIMBS]) -> Self {
+        Self(crypto_bigint::Uint::from_words(arr))
+    }
+
+    /// See [crypto_bigint::Uint::to_words]
+    #[inline]
+    pub const fn to_words(self) -> [Word; LIMBS] {
+        self.0.to_words()
+    }
+
+    /// See [crypto_bigint::Uint::as_words]
+    pub const fn as_words(&self) -> &[Word; LIMBS] {
+        self.0.as_words()
+    }
+
+    /// See [crypto_bigint::Uint::as_mut_words]
+    pub const fn as_mut_words(&mut self) -> &mut [Word; LIMBS] {
+        self.0.as_mut_words()
+    }
+
+    /// See [crypto_bigint::Uint::as_limbs]
+    pub const fn as_limbs(&self) -> &[Limb; LIMBS] {
+        self.0.as_limbs()
+    }
+
+    /// See [crypto_bigint::Uint::as_mut_limbs]
+    pub const fn as_mut_limbs(&mut self) -> &mut [Limb; LIMBS] {
+        self.0.as_mut_limbs()
+    }
+
+    /// See [crypto_bigint::Uint::to_limbs]
+    pub const fn to_limbs(self) -> [Limb; LIMBS] {
+        self.0.to_limbs()
+    }
+
+    /// See [crypto_bigint::Uint::resize]
+    #[inline(always)]
+    pub const fn resize<const T: usize>(&self) -> Uint<T> {
+        Uint::<T>(self.0.resize())
+    }
+
+    pub const fn checked_resize<const T: usize>(&self) -> Option<Uint<T>> {
+        match checked_resize::<LIMBS, T>(&self.0) {
+            None => None,
+            Some(inner) => Some(Uint(inner)),
+        }
+    }
+
+    /// See [crypto_bigint::Uint::cmp_vartime]
+    pub const fn cmp_vartime(&self, rhs: &Self) -> Ordering {
+        self.0.cmp_vartime(&rhs.0)
+    }
+
+    /// See [crypto_bigint::Uint::as_int]
+    pub const fn as_int(&self) -> &Int<LIMBS> {
+        Int::new_ref(self.0.as_int())
+    }
+}
+
+const fn checked_resize<const SRC: usize, const DST: usize>(
+    num: &crypto_bigint::Uint<SRC>,
+) -> Option<crypto_bigint::Uint<DST>> {
+    if SRC > DST {
+        let max = Uint::<DST>::MAX.0.resize();
+        let cmp = num.cmp_vartime(&max);
+        if cmp.is_gt() {
+            return None;
+        }
+    }
+    Some(num.resize())
+}
+
+macro_rules! define_consts {
+    ($($name:ident),+) => {
+        $(pub const $name: Self = Self(crypto_bigint::Uint::<LIMBS>::$name);)+
+    };
+}
+
+impl<const LIMBS: usize> Uint<LIMBS> {
+    define_consts!(MAX);
+
+    /// Total size of the represented integer in bits.
+    pub const BITS: u32 = crypto_bigint::Uint::<LIMBS>::BITS;
+
+    /// Total size of the represented integer in bytes.
+    pub const BYTES: usize = crypto_bigint::Uint::<LIMBS>::BYTES;
+
+    /// The number of limbs used on this platform.
+    pub const LIMBS: usize = LIMBS;
+}
+
+//
+// Core traits
+//
+
+impl<const LIMBS: usize> Debug for Uint<LIMBS> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
+        Debug::fmt(&self.0, f)
+    }
+}
+
+impl<const LIMBS: usize> Display for Uint<LIMBS> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
+        Display::fmt(&self.0, f)
+    }
+}
+
+impl<const LIMBS: usize> Default for Uint<LIMBS> {
+    #[inline(always)]
+    fn default() -> Self {
+        Self::ZERO
+    }
+}
+
+impl<const LIMBS: usize> LowerHex for Uint<LIMBS> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
+        LowerHex::fmt(&self.0, f)
+    }
+}
+
+impl<const LIMBS: usize> UpperHex for Uint<LIMBS> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
+        UpperHex::fmt(&self.0, f)
+    }
+}
+
+impl<const LIMBS: usize> Hash for Uint<LIMBS> {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        self.0.hash(state)
+    }
+}
+
+impl<const LIMBS: usize> FromStr for Uint<LIMBS> {
+    type Err = ();
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let uint = crypto_bigint::Uint::<LIMBS>::from_str_radix_vartime(s, 10).map_err(|_| ())?;
+        Ok(Self(uint))
+    }
+}
+
+//
+// Zero and One traits
+//
+
+impl<const LIMBS: usize> Zero for Uint<LIMBS> {
+    #[inline(always)]
+    fn zero() -> Self {
+        Self::ZERO
+    }
+
+    #[inline(always)]
+    fn is_zero(&self) -> bool {
+        self.0.is_zero()
+    }
+}
+
+impl<const LIMBS: usize> One for Uint<LIMBS> {
+    #[inline(always)]
+    fn one() -> Self {
+        Self::ONE
+    }
+}
+
+impl<const LIMBS: usize> ConstZero for Uint<LIMBS> {
+    const ZERO: Self = Self(crypto_bigint::Uint::ZERO);
+}
+
+impl<const LIMBS: usize> ConstOne for Uint<LIMBS> {
+    const ONE: Self = Self(crypto_bigint::Uint::ONE);
+}
+
+//
+// Basic arithmetic operations
+//
+
+macro_rules! impl_basic_op {
+    ($trait_name:tt, $trait_op:tt) => {
+        impl<const LIMBS: usize> $trait_name for Uint<LIMBS> {
+            type Output = Self;
+
+            #[inline(always)]
+            fn $trait_op(self, rhs: Self) -> Self::Output {
+                self.$trait_op(&rhs)
+            }
+        }
+
+        impl<'a, const LIMBS: usize> $trait_name<&'a Self> for Uint<LIMBS> {
+            type Output = Self;
+
+            #[inline(always)]
+            fn $trait_op(self, rhs: &'a Self) -> Self::Output {
+                Self(self.0.$trait_op(&rhs.0))
+            }
+        }
+    };
+}
+
+impl_basic_op!(Add, add);
+impl_basic_op!(Sub, sub);
+impl_basic_op!(Mul, mul);
+
+impl<const LIMBS: usize> Rem for Uint<LIMBS> {
+    type Output = Self;
+
+    #[inline(always)]
+    fn rem(self, rhs: Self) -> Self::Output {
+        self.rem(&rhs)
+    }
+}
+
+impl<'a, const LIMBS: usize> Rem<&'a Self> for Uint<LIMBS> {
+    type Output = Self;
+
+    fn rem(self, rhs: &'a Self) -> Self::Output {
+        let non_zero = crypto_bigint::NonZero::new(rhs.0).expect("division by zero");
+        Self(self.0.rem(&non_zero))
+    }
+}
+
+impl<const LIMBS: usize> Shl<u32> for Uint<LIMBS> {
+    type Output = Self;
+
+    #[inline(always)]
+    fn shl(self, rhs: u32) -> Self::Output {
+        Self(self.0.shl(rhs))
+    }
+}
+
+impl<const LIMBS: usize> Shr<u32> for Uint<LIMBS> {
+    type Output = Self;
+
+    #[inline(always)]
+    fn shr(self, rhs: u32) -> Self::Output {
+        Self(self.0.shr(rhs))
+    }
+}
+
+impl<const LIMBS: usize> Pow<u32> for Uint<LIMBS> {
+    type Output = Self;
+
+    impl_pow_via_repeated_squaring!();
+}
+
+//
+// Checked arithmetic operations
+//
+
+impl<const LIMBS: usize> CheckedAdd for Uint<LIMBS> {
+    fn checked_add(&self, other: &Self) -> Option<Self> {
+        let (result, overflow) = self.0.carrying_add(&other.0, crypto_bigint::Limb::ZERO);
+        if overflow.0 != 0 {
+            None
+        } else {
+            Some(Self(result))
+        }
+    }
+}
+
+impl<const LIMBS: usize> CheckedSub for Uint<LIMBS> {
+    fn checked_sub(&self, other: &Self) -> Option<Self> {
+        let (result, borrow) = self.0.borrowing_sub(&other.0, crypto_bigint::Limb::ZERO);
+        if borrow.0 != 0 {
+            None
+        } else {
+            Some(Self(result))
+        }
+    }
+}
+
+impl<const LIMBS: usize> CheckedMul for Uint<LIMBS> {
+    fn checked_mul(&self, other: &Self) -> Option<Self> {
+        // Use widening_mul which returns (lo, hi)
+        let (lo, hi) = self.0.widening_mul(&other.0);
+        if hi.is_zero() { Some(Self(lo)) } else { None }
+    }
+}
+
+impl<const LIMBS: usize> CheckedRem for Uint<LIMBS> {
+    fn checked_rem(&self, other: &Self) -> Option<Self> {
+        let non_zero = crypto_bigint::NonZero::new(other.0).into_option()?;
+        Some(Self(self.0.rem(&non_zero)))
+    }
+}
+
+//
+// Arithmetic assign operations
+//
+
+macro_rules! impl_assign_op {
+    ($trait_name:tt, $trait_op:tt) => {
+        impl<const LIMBS: usize> $trait_name<Self> for Uint<LIMBS> {
+            #[inline(always)]
+            fn $trait_op(&mut self, rhs: Self) {
+                self.$trait_op(&rhs);
+            }
+        }
+
+        impl<'a, const LIMBS: usize> $trait_name<&'a Self> for Uint<LIMBS> {
+            #[inline(always)]
+            fn $trait_op(&mut self, rhs: &'a Self) {
+                self.0.$trait_op(&rhs.0);
+            }
+        }
+    };
+}
+
+impl_assign_op!(AddAssign, add_assign);
+impl_assign_op!(SubAssign, sub_assign);
+impl_assign_op!(MulAssign, mul_assign);
+
+impl<const LIMBS: usize> RemAssign for Uint<LIMBS> {
+    #[inline(always)]
+    fn rem_assign(&mut self, rhs: Self) {
+        self.rem_assign(&rhs);
+    }
+}
+
+impl<'a, const LIMBS: usize> RemAssign<&'a Self> for Uint<LIMBS> {
+    #![allow(clippy::arithmetic_side_effects)]
+    fn rem_assign(&mut self, rhs: &'a Self) {
+        let non_zero = crypto_bigint::NonZero::new(rhs.0).expect("division by zero");
+        self.0 %= non_zero;
+    }
+}
+
+impl<const LIMBS: usize> ShlAssign<u32> for Uint<LIMBS> {
+    #[inline(always)]
+    fn shl_assign(&mut self, rhs: u32) {
+        self.0.shl_assign(rhs);
+    }
+}
+
+impl<const LIMBS: usize> ShrAssign<u32> for Uint<LIMBS> {
+    #[inline(always)]
+    fn shr_assign(&mut self, rhs: u32) {
+        self.0.shr_assign(rhs);
+    }
+}
+
+//
+// Aggregate operations
+//
+
+impl<const LIMBS: usize> Sum for Uint<LIMBS> {
+    fn sum<I: Iterator<Item = Self>>(iter: I) -> Self {
+        iter.fold(Self::zero(), |acc, x| {
+            acc.checked_add(&x).expect("overflow in sum")
+        })
+    }
+}
+
+impl<'a, const LIMBS: usize> Sum<&'a Self> for Uint<LIMBS> {
+    fn sum<I: Iterator<Item = &'a Self>>(iter: I) -> Self {
+        iter.fold(Self::zero(), |acc, x| {
+            acc.checked_add(x).expect("overflow in sum")
+        })
+    }
+}
+
+impl<const LIMBS: usize> Product for Uint<LIMBS> {
+    fn product<I: Iterator<Item = Self>>(iter: I) -> Self {
+        iter.fold(Self::one(), |acc, x| {
+            acc.checked_mul(&x).expect("overflow in product")
+        })
+    }
+}
+
+impl<'a, const LIMBS: usize> Product<&'a Self> for Uint<LIMBS> {
+    fn product<I: Iterator<Item = &'a Self>>(iter: I) -> Self {
+        iter.fold(Self::one(), |acc, x| {
+            acc.checked_mul(x).expect("overflow in product")
+        })
+    }
+}
+
+//
+// Conversions
+//
+
+impl<const LIMBS: usize> From<crypto_bigint::Uint<LIMBS>> for Uint<LIMBS> {
+    #[inline(always)]
+    fn from(value: crypto_bigint::Uint<LIMBS>) -> Self {
+        Self(value)
+    }
+}
+
+impl<const LIMBS: usize> From<Uint<LIMBS>> for crypto_bigint::Uint<LIMBS> {
+    #[inline(always)]
+    fn from(value: Uint<LIMBS>) -> Self {
+        value.0
+    }
+}
+
+impl<const LIMBS: usize> From<bool> for Uint<LIMBS> {
+    #[inline(always)]
+    fn from(value: bool) -> Self {
+        Self(crypto_bigint::Uint::<LIMBS>::from(u8::from(value)))
+    }
+}
+
+macro_rules! impl_from_primitive {
+    ($($t:ty),+) => {
+        $(
+            impl<const LIMBS: usize> From<$t> for Uint<LIMBS> {
+                fn from(value: $t) -> Self {
+                    assert!(core::mem::size_of::<$t>() <= crypto_bigint::Uint::<LIMBS>::BYTES,
+                            "`{}` is too large to fit into `Uint<{LIMBS}>`", stringify!($t));
+                    Self(crypto_bigint::Uint::<LIMBS>::from(value))
+                }
+            }
+
+            impl<'a, const LIMBS: usize> From<&'a $t> for Uint<LIMBS> {
+                #[inline(always)]
+                fn from(value: &$t) -> Self {
+                    Self::from(*value)
+                }
+            }
+
+            impl<const LIMBS: usize> Uint<LIMBS> {
+            paste! {
+                /// Create a Uint from a primitive type.
+                pub const fn [<from_ $t>](n: $t) -> Self {
+                    Self(crypto_bigint::Uint::<LIMBS>::[<from_ $t>](n))
+                }
+            }
+            }
+        )+
+    };
+}
+
+impl_from_primitive!(u8, u16, u32, u64, u128);
+
+impl<const LIMBS: usize, const LIMBS2: usize> TryFrom<&crypto_bigint::Uint<LIMBS2>>
+    for Uint<LIMBS>
+{
+    type Error = ();
+
+    fn try_from(num: &crypto_bigint::Uint<LIMBS2>) -> Result<Self, Self::Error> {
+        checked_resize(num).map(Self).ok_or(())
+    }
+}
+
+//
+// Semiring
+//
+
+impl<const LIMBS: usize> Semiring for Uint<LIMBS> {}
+
+impl<const LIMBS: usize> IntSemiring for Uint<LIMBS> {
+    fn is_odd(&self) -> bool {
+        self.0.is_odd().into()
+    }
+
+    fn is_even(&self) -> bool {
+        self.0.is_even().into()
+    }
+}
+
+//
+// RNG
+//
+
+#[cfg(feature = "rand")]
+impl<const LIMBS: usize> Distribution<Uint<LIMBS>> for StandardUniform {
+    fn sample<R: Rng + ?Sized>(&self, rng: &mut R) -> Uint<LIMBS> {
+        crypto_bigint::Random::random(rng)
+    }
+}
+
+#[cfg(feature = "rand")]
+impl<const LIMBS: usize> crypto_bigint::Random for Uint<LIMBS> {
+    fn try_random<R: TryRngCore + ?Sized>(rng: &mut R) -> Result<Self, R::Error> {
+        crypto_bigint::Uint::try_random(rng).map(Self)
+    }
+}
+
+//
+// Serialization and Deserialization
+//
+
+#[cfg(feature = "serde")]
+impl<'de, const LIMBS: usize> serde::Deserialize<'de> for Uint<LIMBS>
+where
+    crypto_bigint::Uint<LIMBS>: crypto_bigint::Encoding,
+{
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        crypto_bigint::Uint::<LIMBS>::deserialize(deserializer).map(Self)
+    }
+}
+
+#[cfg(feature = "serde")]
+impl<const LIMBS: usize> serde::Serialize for Uint<LIMBS>
+where
+    crypto_bigint::Uint<LIMBS>: crypto_bigint::Encoding,
+{
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        self.0.serialize(serializer)
+    }
+}
+
+//
+// Traits from crypto_bigint
+//
+
+impl<const LIMBS: usize> crypto_bigint::subtle::ConstantTimeEq for Uint<LIMBS> {
+    #[inline]
+    fn ct_eq(&self, other: &Self) -> crypto_bigint::subtle::Choice {
+        crypto_bigint::subtle::ConstantTimeEq::ct_eq(&self.0, &other.0)
+    }
+}
+
+impl<const LIMBS: usize> crypto_bigint::subtle::ConstantTimeGreater for Uint<LIMBS> {
+    #[inline]
+    fn ct_gt(&self, other: &Self) -> crypto_bigint::subtle::Choice {
+        crypto_bigint::subtle::ConstantTimeGreater::ct_gt(&self.0, &other.0)
+    }
+}
+
+impl<const LIMBS: usize> crypto_bigint::subtle::ConstantTimeLess for Uint<LIMBS> {
+    #[inline]
+    fn ct_lt(&self, other: &Self) -> crypto_bigint::subtle::Choice {
+        crypto_bigint::subtle::ConstantTimeLess::ct_lt(&self.0, &other.0)
+    }
+}
+
+impl<const LIMBS: usize> crypto_bigint::subtle::ConditionallySelectable for Uint<LIMBS> {
+    fn conditional_select(a: &Self, b: &Self, choice: crypto_bigint::subtle::Choice) -> Self {
+        crypto_bigint::subtle::ConditionallySelectable::conditional_select(&a.0, &b.0, choice)
+            .into()
+    }
+}
+
+impl<const LIMBS: usize> crypto_bigint::Bounded for Uint<LIMBS> {
+    const BITS: u32 = Self::BITS;
+    const BYTES: usize = Self::BYTES;
+}
+
+impl<const LIMBS: usize> crypto_bigint::Constants for Uint<LIMBS> {
+    const MAX: Self = Self::MAX;
+}
+
+#[allow(clippy::arithmetic_side_effects, clippy::cast_lossless)]
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::ensure_type_implements_trait;
+    use alloc::{format, string::ToString, vec::Vec};
+
+    #[cfg(target_pointer_width = "64")]
+    const WORD_FACTOR: usize = 1;
+    #[cfg(target_pointer_width = "32")]
+    const WORD_FACTOR: usize = 2;
+
+    type Uint1 = Uint<WORD_FACTOR>;
+    type Uint2 = Uint<{ WORD_FACTOR * 2 }>;
+    type Uint4 = Uint<{ WORD_FACTOR * 4 }>;
+
+    #[test]
+    fn ensure_blanket_traits() {
+        ensure_type_implements_trait!(Uint4, ConstIntSemiring);
+        ensure_type_implements_trait!(Uint4, IntSemiringWithShifts);
+    }
+
+    #[test]
+    fn basic_operations() {
+        let a = Uint4::from(10_u64);
+        let b = Uint4::from(5_u64);
+
+        // Test addition
+        assert_eq!(a + b, Uint4::from(15_u64));
+
+        // Test subtraction
+        assert_eq!(a - b, Uint4::from(5_u64));
+
+        // Test multiplication
+        assert_eq!(a * b, Uint4::from(50_u64));
+
+        // Test remainder
+        assert_eq!(a % b, Uint4::ZERO);
+
+        // Test shl
+        let x = Uint1::from(0x0001_u64);
+        assert_eq!(x << 0, x);
+        assert_eq!(x << 1, 0x0002_u64.into());
+        assert_eq!(x << 15, 0x8000_u64.into());
+
+        // Test shr
+        let x = Uint4::from(0x8000_u32);
+        assert_eq!(x >> 0, x);
+        assert_eq!(x >> 1, 0x4000_u64.into());
+        assert_eq!(x >> 15, 0x0001_u64.into());
+    }
+
+    #[test]
+    #[should_panic(expected = "`shift` within the bit size of the integer")]
+    fn shl_panics_on_overflow() {
+        let x = Uint1::from(0x0001_u64);
+        let _ = x << 64;
+    }
+
+    #[test]
+    fn checked_operations() {
+        let a = Uint4::from(10_u64);
+        let b = Uint4::from(5_u64);
+
+        assert_eq!(a.checked_add(&b), Some(Uint4::from(15_u64)));
+        assert_eq!(a.checked_sub(&b), Some(Uint4::from(5_u64)));
+        assert_eq!(a.checked_mul(&b), Some(Uint4::from(50_u64)));
+        assert_eq!(a.checked_rem(&b), Some(Uint4::ZERO));
+
+        // Test underflow
+        assert!(b.checked_sub(&a).is_none());
+    }
+
+    #[allow(clippy::op_ref)]
+    #[test]
+    fn reference_operations() {
+        let a = Uint4::from(10_u64);
+        let b = Uint4::from(5_u64);
+
+        // Test reference-based addition
+        let c = a + &b;
+        assert_eq!(c, Uint4::from(15_u64));
+
+        // Test reference-based subtraction
+        let d = a - &b;
+        assert_eq!(d, Uint4::from(5_u64));
+
+        // Test reference-based multiplication
+        let e = a * &b;
+        assert_eq!(e, Uint4::from(50_u64));
+
+        // Test reference-based remainder
+        let f = a % &b;
+        assert_eq!(f, Uint4::ZERO);
+    }
+
+    #[test]
+    fn conversions() {
+        // Test From<crypto_bigint::Uint> for Uint
+        let original = crypto_bigint::Uint::from(123_u64);
+        let wrapped: Uint4 = original.into();
+        assert_eq!(wrapped.0, original);
+
+        // Test From<Uint> for crypto_bigint::Uint
+        let wrapped = Uint4::from(456_u64);
+        let unwrapped: crypto_bigint::Uint<{ 4 * WORD_FACTOR }> = wrapped.into();
+        assert_eq!(unwrapped, crypto_bigint::Uint::from(456_u64));
+
+        // Test conversion methods
+        let value = crypto_bigint::Uint::from(789_u64);
+        let wrapped = Uint4::new(value);
+        assert_eq!(wrapped.inner(), &value);
+        assert_eq!(wrapped.into_inner(), value);
+    }
+
+    #[test]
+    fn pow_operation() {
+        // Test basic exponentiation
+        let base = Uint4::from(2_u64);
+
+        // 2^0 = 1
+        assert_eq!(base.pow(0), Uint4::one());
+
+        // 2^1 = 2
+        assert_eq!(base.pow(1), base);
+
+        // 2^3 = 8
+        assert_eq!(base.pow(3), Uint4::from(8_u64));
+
+        // 2^10 = 1024
+        assert_eq!(base.pow(10), Uint4::from(1024_u64));
+
+        // Test with different base
+        let base = Uint4::from(3_u64);
+
+        // 3^4 = 81
+        assert_eq!(base.pow(4), Uint4::from(81_u64));
+
+        // Test with base 1
+        let base = Uint4::from(1_u64);
+        assert_eq!(base.pow(1000), Uint4::from(1_u64));
+
+        // Test with base 0
+        let base = Uint4::from(0_u64);
+        assert_eq!(base.pow(0), Uint4::one()); // 0^0 = 1 by convention
+        assert_eq!(base.pow(10), Uint4::zero()); // 0^n = 0 for n > 0
+    }
+
+    #[test]
+    fn rem_assign_operations() {
+        // Test RemAssign with owned value
+        let mut a = Uint4::from(17_u64);
+        let b = Uint4::from(5_u64);
+        a %= b;
+        assert_eq!(a, Uint4::from(2_u64));
+
+        // Test RemAssign with reference
+        let mut c = Uint4::from(19_u64);
+        let d = Uint4::from(6_u64);
+        c %= &d;
+        assert_eq!(c, Uint4::from(1_u64));
+
+        // Test with divisor 1
+        let mut e = Uint4::from(42_u64);
+        let one = Uint4::one();
+        e %= &one;
+        assert_eq!(e, Uint4::zero());
+    }
+
+    #[test]
+    #[should_panic(expected = "division by zero")]
+    fn rem_assign_panics_on_zero_divisor() {
+        let mut a = Uint4::from(10_u64);
+        let zero = Uint4::zero();
+        a %= zero;
+    }
+
+    #[test]
+    fn resize_method() {
+        // Test resizing to same size
+        let a = Uint4::from(0x12345678_u64);
+        let resized_same = a.resize::<4>();
+        assert_eq!(resized_same, a);
+
+        // Test resizing to larger size
+        let b = Uint2::from(0x9ABCDEF0_u64);
+        let resized_larger = b.resize::<4>();
+        assert_eq!(
+            resized_larger.into_inner().to_words()[0],
+            b.into_inner().to_words()[0]
+        );
+        assert_eq!(
+            resized_larger.into_inner().to_words()[1],
+            b.into_inner().to_words()[1]
+        );
+        assert_eq!(resized_larger.into_inner().to_words()[2], 0);
+        assert_eq!(resized_larger.into_inner().to_words()[3], 0);
+
+        // Test resizing to smaller size (truncation)
+        let c = Uint4::from(0x1234567890ABCDEF_u64);
+        let resized_smaller = c.resize::<2>();
+        assert_eq!(
+            resized_smaller.into_inner().to_words()[0],
+            c.into_inner().to_words()[0]
+        );
+        assert_eq!(
+            resized_smaller.into_inner().to_words()[1],
+            c.into_inner().to_words()[1]
+        );
+    }
+
+    #[test]
+    fn from_words() {
+        // Test with single limb
+        let words = [0x1234567890ABCDEF];
+        let a = Uint1::from_words(words);
+        assert_eq!(a.into_inner().to_words()[0], words[0]);
+
+        // Test with multiple limbs
+        let words = [
+            0x1234567890ABCDEF,
+            0xFEDCBA9876543210,
+            0x0F0F0F0F0F0F0F0F,
+            0xF0F0F0F0F0F0F0F0,
+        ];
+        let b = Uint4::from_words(words);
+        let b_words = b.into_inner().to_words();
+        for i in 0..4 {
+            assert_eq!(b_words[i], words[i]);
+        }
+    }
+
+    #[test]
+    fn aggregate_operations() {
+        let values: Vec<Uint4> = [1_u64, 2_u64, 3_u64].into_iter().map(Uint::from).collect();
+        assert_eq!(values.iter().sum::<Uint4>(), Uint4::from(6_u64));
+        assert_eq!(values.into_iter().sum::<Uint4>(), Uint4::from(6_u64));
+
+        let values: Vec<Uint4> = [2_u64, 3_u64, 4_u64].into_iter().map(Uint::from).collect();
+        assert_eq!(values.iter().product::<Uint4>(), Uint4::from(24_u64));
+    }
+
+    #[test]
+    fn from_primitive() {
+        // Test from_u8
+        let a = Uint4::from_u8(42);
+        assert_eq!(a, Uint4::from(42_u64));
+
+        // Test from_u16
+        let c = Uint4::from_u16(12345);
+        assert_eq!(c, Uint4::from(12345_u64));
+
+        // Test from_u32
+        let e = Uint4::from_u32(1234567890);
+        assert_eq!(e, Uint4::from(1234567890_u64));
+
+        // Test from_u64
+        let g = Uint4::from_u64(1234567890123456789);
+        assert_eq!(g, Uint4::from(1234567890123456789_u64));
+
+        // Test from_u128
+        let i = Uint4::from_u128(1234567890123456789012345678901234567);
+        assert_eq!(
+            i.into_inner(),
+            crypto_bigint::Uint::from(1234567890123456789012345678901234567_u128)
+        );
+    }
+
+    #[test]
+    fn from_primitive_edge_cases() {
+        for value in [u32::MIN, u32::MAX] {
+            let i = Uint1::from(value);
+            let j = Uint2::from(value);
+            assert_eq!(i.resize(), j);
+        }
+
+        for value in [u64::MIN, u64::MAX] {
+            let i = Uint1::from(value);
+            let j = Uint2::from(value);
+            assert_eq!(i.resize(), j);
+        }
+
+        for value in [u128::MIN, u128::MAX] {
+            let i = Uint2::from(value);
+            let j = Uint::<3>::from(value);
+            assert_eq!(i.resize(), j);
+        }
+    }
+
+    #[should_panic]
+    #[test]
+    fn from_too_large_primitive() {
+        // Test from_u128
+        let _ = Uint1::from(u128::MAX);
+    }
+
+    #[test]
+    fn edge_cases() {
+        // Test operations with MAX values
+        let max = Uint4::MAX;
+        let one = Uint4::one();
+
+        // MAX + 1 should overflow in checked_add
+        assert!(max.checked_add(&one).is_none());
+
+        // MAX - MAX = 0
+        assert_eq!(max.checked_sub(&max).unwrap(), Uint4::zero());
+
+        // Test operations with MIN values (0 for unsigned)
+        let min = Uint4::ZERO;
+
+        // MIN - 1 should overflow in checked_sub
+        assert!(min.checked_sub(&one).is_none());
+
+        // Test operations with large shifts
+        let x = Uint4::from(1_u64);
+
+        // Shift left by almost the bit limit
+        let shifted = x << (Uint4::BITS - 1);
+        assert_eq!(shifted, Uint4::from_words([0, 0, 0, 0x8000000000000000]));
+
+        // Test with large powers that don't overflow
+        let two = Uint4::from(2_u64);
+        let large_power = two.pow(100); // 2^100 is large but fits in 256 bits
+
+        // 2^100 should be divisible by 2^10 = 1024 with no remainder
+        assert_eq!(large_power % Uint4::from(1024_u64), Uint4::zero());
+
+        // 2^100 / 2 = 2^99
+        let half_power = large_power >> 1;
+        assert_eq!(half_power << 1, large_power);
+    }
+
+    #[test]
+    fn assign_operations() {
+        // Test AddAssign
+        let mut a = Uint4::from(10_u64);
+        a += Uint4::from(5_u64);
+        assert_eq!(a, Uint4::from(15_u64));
+
+        let mut b = Uint4::from(20_u64);
+        b += &Uint4::from(3_u64);
+        assert_eq!(b, Uint4::from(23_u64));
+
+        // Test SubAssign
+        let mut c = Uint4::from(10_u64);
+        c -= Uint4::from(3_u64);
+        assert_eq!(c, Uint4::from(7_u64));
+
+        let mut d = Uint4::from(50_u64);
+        d -= &Uint4::from(25_u64);
+        assert_eq!(d, Uint4::from(25_u64));
+
+        // Test MulAssign
+        let mut e = Uint4::from(7_u64);
+        e *= Uint4::from(6_u64);
+        assert_eq!(e, Uint4::from(42_u64));
+
+        let mut f = Uint4::from(3_u64);
+        f *= &Uint4::from(4_u64);
+        assert_eq!(f, Uint4::from(12_u64));
+
+        let mut f = Uint1::from(2_u64);
+        f <<= 2;
+        assert_eq!(f, Uint1::from(8_u64)); // 2 << 2 = 8
+        f <<= 61;
+        assert_eq!(f, Uint1::ZERO);
+
+        let mut f = Uint1::from(3_u64);
+        f >>= 1;
+        assert_eq!(f, Uint1::from(1_u64)); // 3 >> 1 = 1
+        f >>= 1;
+        assert_eq!(f, Uint1::ZERO);
+    }
+
+    #[test]
+    fn formatting() {
+        let a = Uint1::from(255_u64);
+        let b = Uint1::MAX;
+
+        // Test Debug
+        assert_eq!(format!("{:?}", a), "Uint(0x00000000000000FF)");
+        assert_eq!(format!("{:?}", b), "Uint(0xFFFFFFFFFFFFFFFF)");
+
+        // Test Display
+        assert_eq!(format!("{}", a), "00000000000000FF");
+        assert_eq!(format!("{}", b), "FFFFFFFFFFFFFFFF");
+
+        // Test LowerHex
+        assert_eq!(format!("{:x}", a), "00000000000000ff");
+        assert_eq!(format!("{:x}", b), "ffffffffffffffff");
+
+        // Test UpperHex
+        assert_eq!(format!("{:X}", a), "00000000000000FF");
+        assert_eq!(format!("{:X}", b), "FFFFFFFFFFFFFFFF");
+    }
+
+    #[test]
+    fn default_trait() {
+        let default_val: Uint4 = Default::default();
+        assert_eq!(default_val, Uint4::ZERO);
+        assert!(default_val.is_zero());
+    }
+
+    #[test]
+    fn constants() {
+        // Test MAX
+        assert!(Uint4::MAX > Uint4::ZERO);
+
+        // Test BITS, BYTES, LIMBS
+        assert_eq!(Uint4::BITS, 256);
+        assert_eq!(Uint4::BYTES, 32);
+        assert_eq!(Uint4::LIMBS, 4);
+
+        assert_eq!(Uint2::BITS, 128);
+        assert_eq!(Uint2::BYTES, 16);
+        assert_eq!(Uint2::LIMBS, 2);
+    }
+
+    #[test]
+    fn cmp_vartime() {
+        let a = Uint4::from(10_u64);
+        let b = Uint4::from(20_u64);
+        let c = Uint4::from(10_u64);
+
+        assert_eq!(a.cmp_vartime(&b), Ordering::Less);
+        assert_eq!(b.cmp_vartime(&a), Ordering::Greater);
+        assert_eq!(a.cmp_vartime(&c), Ordering::Equal);
+    }
+
+    #[test]
+    fn cross_size_conversions() {
+        // Test resize methods
+        let a = Uint2::from(12345_u64);
+        let b: Option<Uint4> = a.checked_resize();
+        assert_eq!(b, Some(Uint::from(12345_u64)));
+        let b: Uint4 = a.resize();
+        assert_eq!(b, Uint::from(12345_u64));
+
+        let a = Uint2::from_u128(u128::MAX);
+        let b: Option<Uint1> = a.checked_resize();
+        assert_eq!(b, None);
+        let b: Uint1 = a.resize();
+        assert_eq!(b, Uint::MAX);
+
+        // Test From<&crypto_bigint::Uint<LIMBS>> for Uint<LIMBS2>
+        let c = crypto_bigint::Uint::<{ 2 * WORD_FACTOR }>::from(67890_u64);
+        let d: Uint4 = (&c).try_into().unwrap();
+        assert_eq!(d, Uint4::from(67890_u64));
+
+        // Test reference conversions from primitives
+        let val = 42_u32;
+        let e = Uint4::from(&val);
+        assert_eq!(e, Uint4::from(42_u64));
+    }
+
+    #[test]
+    fn constant_time_traits() {
+        use crypto_bigint::subtle::{
+            Choice, ConditionallySelectable, ConstantTimeEq, ConstantTimeGreater, ConstantTimeLess,
+        };
+
+        let a = Uint4::from(10_u64);
+        let b = Uint4::from(20_u64);
+        let c = Uint4::from(10_u64);
+
+        // Test ConstantTimeEq
+        assert_eq!(a.ct_eq(&c).unwrap_u8(), 1);
+        assert_eq!(a.ct_eq(&b).unwrap_u8(), 0);
+
+        // Test ConstantTimeGreater
+        assert_eq!(b.ct_gt(&a).unwrap_u8(), 1);
+        assert_eq!(a.ct_gt(&b).unwrap_u8(), 0);
+
+        // Test ConstantTimeLess
+        assert_eq!(a.ct_lt(&b).unwrap_u8(), 1);
+        assert_eq!(b.ct_lt(&a).unwrap_u8(), 0);
+
+        // Test ConditionallySelectable
+        let selected_true = Uint4::conditional_select(&a, &b, Choice::from(0));
+        assert_eq!(selected_true, a);
+
+        let selected_false = Uint4::conditional_select(&a, &b, Choice::from(1));
+        assert_eq!(selected_false, b);
+    }
+
+    #[test]
+    fn crypto_bigint_traits() {
+        use crypto_bigint::{Bounded, Constants};
+
+        // Test Bounded trait
+        assert_eq!(<Uint4 as Bounded>::BITS, 256);
+        assert_eq!(<Uint4 as Bounded>::BYTES, 32);
+
+        // Test Constants trait
+        assert_eq!(<Uint4 as Constants>::MAX, Uint4::MAX);
+    }
+
+    #[test]
+    fn from_str() {
+        // Test parsing from string
+        let a: Uint4 = "123".parse().unwrap();
+        assert_eq!(a, Uint4::from(123_u64));
+
+        let c: Uint4 = "0".parse().unwrap();
+        assert_eq!(c, Uint4::zero());
+
+        let d: Uint4 = "1".parse().unwrap();
+        assert_eq!(d, Uint4::one());
+        assert_eq!(u64::MAX.to_string().parse::<Uint1>().unwrap(), Uint1::MAX);
+
+        // Test invalid cases
+        assert!("0x123".parse::<Uint4>().is_err());
+        assert!("abc".parse::<Uint4>().is_err());
+        assert!("12.34".parse::<Uint4>().is_err());
+        assert!("".parse::<Uint4>().is_err());
+        assert!("-456".parse::<Uint4>().is_err()); // Negative not allowed for unsigned
+
+        // Number doesn't fit Uint1
+        assert!(
+            ((u64::MAX as u128) + 1)
+                .to_string()
+                .parse::<Uint1>()
+                .is_err()
+        );
+    }
+
+    #[cfg(feature = "rand")]
+    #[test]
+    fn random_generation() {
+        use rand::prelude::*;
+
+        // Use a seeded RNG for reproducibility
+        let mut rng = StdRng::seed_from_u64(1);
+
+        // Test crypto_bigint::Random trait
+        let random1: Uint4 = crypto_bigint::Random::random(&mut rng);
+        let random2: Uint4 = crypto_bigint::Random::random(&mut rng);
+
+        // Random values should be different
+        assert_ne!(random1, random2);
+
+        // Test Distribution trait
+        let random3: Uint4 = rng.random();
+        let random4: Uint4 = rng.random();
+
+        assert_ne!(random3, random4);
+    }
+}

--- a/zip-plus/benches/zip_benches.rs
+++ b/zip-plus/benches/zip_benches.rs
@@ -6,13 +6,12 @@ mod zip_common;
 use zip_common::*;
 
 use criterion::{Criterion, criterion_group, criterion_main};
-use crypto_bigint::{U64, Uint};
-use crypto_primes::hazmat::MillerRabin;
-use crypto_primitives::crypto_bigint_int::Int;
+use crypto_bigint::U64;
+use crypto_primitives::{crypto_bigint_int::Int, crypto_bigint_uint::Uint};
 use zip_plus::{
     code::raa::{RaaCode, RaaConfig},
     pcs::structs::ZipTypes,
-    utils::UintSemiring,
+    primality::MillerRabin,
 };
 
 const INT_LIMBS: usize = U64::LIMBS;
@@ -24,8 +23,8 @@ impl ZipTypes for BenchZipTypes {
     type Eval = Self::EvalR;
     type CwR = i64;
     type Cw = Self::CwR;
-    type Fmod = UintSemiring<{ INT_LIMBS * 4 }>;
-    type PrimeTest = MillerRabin<Uint<{ INT_LIMBS * 4 }>>;
+    type Fmod = Uint<{ INT_LIMBS * 4 }>;
+    type PrimeTest = MillerRabin;
     type Chal = i128;
     type Pt = i128;
     type CombR = Int<{ INT_LIMBS * 3 }>;

--- a/zip-plus/benches/zip_plus_benches.rs
+++ b/zip-plus/benches/zip_plus_benches.rs
@@ -6,14 +6,13 @@ mod zip_common;
 use zip_common::*;
 
 use criterion::{Criterion, criterion_group, criterion_main};
-use crypto_bigint::{U64, Uint};
-use crypto_primes::hazmat::MillerRabin;
-use crypto_primitives::crypto_bigint_int::Int;
+use crypto_bigint::U64;
+use crypto_primitives::{crypto_bigint_int::Int, crypto_bigint_uint::Uint};
 use zip_plus::{
     code::raa::{RaaCode, RaaConfig},
     pcs::structs::ZipTypes,
     poly::dense::DensePolynomial,
-    utils::UintSemiring,
+    primality::MillerRabin,
 };
 
 const INT_LIMBS: usize = U64::LIMBS;
@@ -25,8 +24,8 @@ impl<const D: usize> ZipTypes for BenchZipPlusTypes<D> {
     type Eval = DensePolynomial<Self::EvalR, D>;
     type CwR = i32;
     type Cw = DensePolynomial<Self::CwR, D>;
-    type Fmod = UintSemiring<{ INT_LIMBS * 4 }>;
-    type PrimeTest = MillerRabin<Uint<{ INT_LIMBS * 4 }>>;
+    type Fmod = Uint<{ INT_LIMBS * 4 }>;
+    type PrimeTest = MillerRabin;
     type Chal = i128;
     type Pt = i128;
     type CombR = Int<{ INT_LIMBS * 5 }>;

--- a/zip-plus/src/field/boxed_monty.rs
+++ b/zip-plus/src/field/boxed_monty.rs
@@ -1,11 +1,11 @@
 use crate::{
     pcs::structs::{MulByScalar, ProjectableToField},
     traits::FromRef,
-    utils::UintSemiring,
 };
 use crypto_bigint::BoxedUint;
 use crypto_primitives::{
     IntoWithConfig, PrimeField, crypto_bigint_boxed_monty::BoxedMontyField, crypto_bigint_int::Int,
+    crypto_bigint_uint::Uint,
 };
 use num_traits::CheckedMul;
 
@@ -21,10 +21,10 @@ impl FromRef<Self> for BoxedMontyField {
     }
 }
 
-impl<const LIMBS: usize> FromRef<UintSemiring<LIMBS>> for BoxedUint {
+impl<const LIMBS: usize> FromRef<Uint<LIMBS>> for BoxedUint {
     #[inline]
-    fn from_ref(value: &UintSemiring<LIMBS>) -> Self {
-        value.0.into()
+    fn from_ref(value: &Uint<LIMBS>) -> Self {
+        value.inner().into()
     }
 }
 

--- a/zip-plus/src/field/const_monty.rs
+++ b/zip-plus/src/field/const_monty.rs
@@ -1,13 +1,11 @@
 use crate::{
     pcs::structs::{MulByScalar, ProjectableToField},
     traits::{ConstTranscribable, FromRef},
-    utils::UintSemiring,
 };
-use crypto_bigint::{
-    Uint,
-    modular::{ConstMontyForm, ConstMontyParams},
+use crypto_bigint::modular::{ConstMontyForm, ConstMontyParams};
+use crypto_primitives::{
+    crypto_bigint_const_monty::ConstMontyField, crypto_bigint_int::Int, crypto_bigint_uint::Uint,
 };
-use crypto_primitives::{crypto_bigint_const_monty::ConstMontyField, crypto_bigint_int::Int};
 use num_traits::CheckedMul;
 
 impl<Mod: ConstMontyParams<LIMBS>, const LIMBS: usize> MulByScalar<&Self>
@@ -32,11 +30,11 @@ macro_rules! impl_from_primitive_ref {
 }
 impl_from_primitive_ref!(u8, u16, u32, u64, u128);
 
-impl<Mod: ConstMontyParams<LIMBS>, const LIMBS: usize> FromRef<UintSemiring<LIMBS>>
+impl<Mod: ConstMontyParams<LIMBS>, const LIMBS: usize> FromRef<Uint<LIMBS>>
     for ConstMontyForm<Mod, LIMBS>
 {
-    fn from_ref(value: &UintSemiring<LIMBS>) -> Self {
-        ConstMontyForm::new(&value.0)
+    fn from_ref(value: &Uint<LIMBS>) -> Self {
+        ConstMontyForm::new(value.inner())
     }
 }
 
@@ -65,11 +63,11 @@ impl<Mod: ConstMontyParams<LIMBS>, const LIMBS: usize> ConstTranscribable
     const NUM_BYTES: usize = Uint::<LIMBS>::NUM_BYTES;
 
     fn read_transcription_bytes(bytes: &[u8]) -> Self {
-        ConstMontyForm::from_montgomery(Uint::read_transcription_bytes(bytes))
+        ConstMontyForm::from_montgomery(Uint::read_transcription_bytes(bytes).into_inner())
     }
 
     fn write_transcription_bytes(&self, buf: &mut [u8]) {
-        self.as_montgomery().write_transcription_bytes(buf)
+        Uint::new_ref(self.as_montgomery()).write_transcription_bytes(buf)
     }
 }
 
@@ -151,7 +149,7 @@ mod tests {
             for i in 0..128 {
                 if (x >> i) & 1 == 1 { acc += F::from(1u64) * F::from(1u64 << i.min(63)); }
             }
-            let u = crypto_bigint::Uint::<{ U256::LIMBS }>::from(x);
+            let u = Uint::<{ U256::LIMBS }>::from(x);
             let g2: F = F::from(u);
             prop_assert_eq!(f, g2);
         }
@@ -176,7 +174,7 @@ mod tests {
 
         #[test]
         fn prop_from_uint_roundtrip_through_uint(x in any_u128()) {
-            let u: crypto_bigint::Uint<{ U256::LIMBS }> = crypto_bigint::Uint::from(x);
+            let u: Uint<{ U256::LIMBS }> = Uint::from(x);
             let g_from_uint: F = u.into();
             let g_direct: F = F::from(x);
             prop_assert_eq!(g_from_uint, g_direct);

--- a/zip-plus/src/pcs/structs.rs
+++ b/zip-plus/src/pcs/structs.rs
@@ -3,10 +3,11 @@ use crate::{
     merkle::{MerkleTree, MtHash},
     poly::Polynomial,
     primality::PrimalityTest,
-    traits::{ConstTranscribable, FromRef, Named, SimpleSemiring},
+    traits::{ConstTranscribable, FromRef, Named},
 };
 use crypto_primitives::{
-    ConstIntRing, DenseRowMatrix, FixedRing, FromWithConfig, PrimeField, crypto_bigint_int::Int,
+    ConstIntRing, ConstIntSemiring, DenseRowMatrix, FixedRing, FromWithConfig, PrimeField,
+    crypto_bigint_int::Int,
 };
 use num_traits::CheckedMul;
 use std::{marker::PhantomData, ops::Neg};
@@ -31,7 +32,7 @@ pub trait ZipTypes: Send + Sync {
         + Copy;
 
     /// Semiring type used to draft field modulus elements, natural numbers
-    type Fmod: SimpleSemiring + ConstTranscribable + Named;
+    type Fmod: ConstIntSemiring + ConstTranscribable + Named;
     type PrimeTest: PrimalityTest<Self::Fmod>;
 
     /// Ring of challenge elements (coefficients) to perform a random linear

--- a/zip-plus/src/pcs/test_utils.rs
+++ b/zip-plus/src/pcs/test_utils.rs
@@ -19,14 +19,13 @@ use crate::{
     },
     pcs_transcript::PcsTranscript,
     poly::{dense::DensePolynomial, mle::DenseMultilinearExtension},
+    primality::MillerRabin,
     traits::{FromRef, Transcribable, Transcript},
-    utils::UintSemiring,
 };
-use crypto_bigint::{BoxedUint, Uint};
-use crypto_primes::hazmat::MillerRabin;
+use crypto_bigint::BoxedUint;
 use crypto_primitives::{
     FromWithConfig, IntoWithConfig, PrimeField, crypto_bigint_boxed_monty::BoxedMontyField,
-    crypto_bigint_int::Int,
+    crypto_bigint_int::Int, crypto_bigint_uint::Uint,
 };
 use itertools::Itertools;
 use num_traits::Zero;
@@ -46,8 +45,8 @@ impl<const N: usize, const K: usize, const M: usize> ZipTypes for TestZipTypes<N
     type Eval = Int<N>;
     type CwR = Int<K>;
     type Cw = Int<K>;
-    type Fmod = UintSemiring<K>;
-    type PrimeTest = MillerRabin<Uint<K>>;
+    type Fmod = Uint<K>;
+    type PrimeTest = MillerRabin;
     type Chal = Int<N>;
     type Pt = Int<N>;
     type CombR = Int<M>;
@@ -64,8 +63,8 @@ impl<const N: usize, const K: usize, const M: usize, const DEGREE: usize> ZipTyp
     type Eval = DensePolynomial<Int<N>, DEGREE>;
     type CwR = Int<K>;
     type Cw = DensePolynomial<Int<K>, DEGREE>;
-    type Fmod = UintSemiring<K>;
-    type PrimeTest = MillerRabin<Uint<K>>;
+    type Fmod = Uint<K>;
+    type PrimeTest = MillerRabin;
     type Chal = Int<N>;
     type Pt = Int<N>;
     type CombR = Int<M>;
@@ -137,7 +136,7 @@ pub fn setup_full_protocol<F, const N: usize, const K: usize, const M: usize>(
 )
 where
     F: PrimeField + for<'a> FromWithConfig<&'a Int<N>> + for<'a> MulByScalar<&'a F>,
-    F::Inner: FromRef<UintSemiring<K>> + Transcribable,
+    F::Inner: FromRef<Uint<K>> + Transcribable,
     Int<N>: ProjectableToField<F>,
 {
     setup_full_protocol_inner::<_, _, _, N>(num_vars, setup_test_params, || {
@@ -165,7 +164,7 @@ pub fn setup_full_protocol_poly<
 )
 where
     F: PrimeField + for<'a> FromWithConfig<&'a Int<N>> + for<'a> MulByScalar<&'a F>,
-    F::Inner: FromRef<UintSemiring<K>> + Transcribable,
+    F::Inner: FromRef<Uint<K>> + Transcribable,
     DensePolynomial<Int<N>, DEGREE>: ProjectableToField<F>,
 {
     setup_full_protocol_inner::<_, _, _, N>(num_vars, setup_poly_test_params, || {

--- a/zip-plus/src/poly/dense.rs
+++ b/zip-plus/src/poly/dense.rs
@@ -3,7 +3,7 @@ use crate::{
     pcs::structs::{MulByScalar, ProjectableToField},
     traits::{ConstTranscribable, FromRef, Named},
 };
-use crypto_primitives::{FromWithConfig, IntoWithConfig, PrimeField, Ring};
+use crypto_primitives::{FromWithConfig, IntoWithConfig, PrimeField, Ring, Semiring};
 use num_traits::{CheckedAdd, CheckedMul, CheckedNeg, CheckedSub, One, Zero};
 use rand::{distr::StandardUniform, prelude::*};
 use std::{
@@ -361,6 +361,8 @@ impl<'a, R: Ring, const DEGREE: usize> Product<&'a Self> for DensePolynomial<R, 
         })
     }
 }
+
+impl<R: Ring, const DEGREE: usize> Semiring for DensePolynomial<R, DEGREE> {}
 
 impl<R: Ring, const DEGREE: usize> Ring for DensePolynomial<R, DEGREE> {}
 

--- a/zip-plus/src/primality.rs
+++ b/zip-plus/src/primality.rs
@@ -1,17 +1,19 @@
-use crate::utils::UintSemiring;
-use crypto_bigint::{Odd, Uint};
-use crypto_primes::hazmat::MillerRabin;
+use crypto_bigint::Odd;
+use crypto_primitives::crypto_bigint_uint::Uint;
 
 pub trait PrimalityTest<R> {
     fn is_probably_prime(candidate: &R) -> bool;
 }
 
-impl<const LIMBS: usize> PrimalityTest<UintSemiring<LIMBS>> for MillerRabin<Uint<LIMBS>> {
-    fn is_probably_prime(candidate: &UintSemiring<LIMBS>) -> bool {
-        let Some(odd) = Odd::new(candidate.0).into_option() else {
+#[derive(Debug, Clone, Copy)]
+pub struct MillerRabin {}
+
+impl<const LIMBS: usize> PrimalityTest<Uint<LIMBS>> for MillerRabin {
+    fn is_probably_prime(candidate: &Uint<LIMBS>) -> bool {
+        let Some(odd) = Odd::new(*candidate.inner()).into_option() else {
             return false;
         };
-        let test = Self::new(odd);
+        let test = crypto_primes::hazmat::MillerRabin::new(odd);
         test.test_base_two().is_probably_prime()
     }
 }

--- a/zip-plus/src/traits.rs
+++ b/zip-plus/src/traits.rs
@@ -1,8 +1,5 @@
 use crate::primality::PrimalityTest;
-use crypto_primitives::crypto_bigint_int::Int;
-use num_traits::ConstOne;
-use std::ops::SubAssign;
-
+use crypto_primitives::{ConstIntSemiring, crypto_bigint_int::Int};
 //
 // FromRef
 //
@@ -52,20 +49,6 @@ impl<const LIMBS: usize, const LIMBS2: usize> FromRef<Int<LIMBS2>> for Int<LIMBS
     fn from_ref(value: &Int<LIMBS2>) -> Self {
         Self::try_from(value.inner()).expect("Destination Int type is too small")
     }
-}
-
-//
-// Simple semiring
-//
-
-/// A simple semiring, used only to generate random field modulus.
-// TODO(alex): Convert to a proper crypto primitive?
-pub trait SimpleSemiring: ConstOne + SubAssign {
-    const BYTES: usize;
-
-    fn is_zero(&self) -> bool;
-
-    fn is_even(&self) -> bool;
 }
 
 //
@@ -153,5 +136,5 @@ pub trait Transcript {
         (0..n).map(|_| self.get_challenge()).collect()
     }
 
-    fn get_prime<R: SimpleSemiring + ConstTranscribable, T: PrimalityTest<R>>(&mut self) -> R;
+    fn get_prime<R: ConstIntSemiring + ConstTranscribable, T: PrimalityTest<R>>(&mut self) -> R;
 }

--- a/zip-plus/src/transcript.rs
+++ b/zip-plus/src/transcript.rs
@@ -1,8 +1,8 @@
 use crate::{
     primality::PrimalityTest,
-    traits::{ConstTranscribable, SimpleSemiring, Transcribable, Transcript},
+    traits::{ConstTranscribable, Transcribable, Transcript},
 };
-use crypto_primitives::PrimeField;
+use crypto_primitives::{ConstIntSemiring, PrimeField};
 use sha3::{Digest, Keccak256};
 
 /// A cryptographic transcript implementation using the Keccak-256 hash
@@ -92,7 +92,7 @@ impl Transcript for KeccakTranscript {
     }
 
     #[allow(clippy::arithmetic_side_effects)]
-    fn get_prime<R: SimpleSemiring + ConstTranscribable, T: PrimalityTest<R>>(&mut self) -> R {
+    fn get_prime<R: ConstIntSemiring + ConstTranscribable, T: PrimalityTest<R>>(&mut self) -> R {
         let buf = &mut vec![0u8; R::NUM_BYTES];
         loop {
             let mut prime_candidate: R = self.gen_random(buf);

--- a/zip-plus/src/utils.rs
+++ b/zip-plus/src/utils.rs
@@ -1,17 +1,14 @@
 use crate::{
     pcs::structs::MulByScalar,
-    traits::{ConstTranscribable, Named, SimpleSemiring, Transcribable},
+    traits::{ConstTranscribable, Named, Transcribable},
 };
-use crypto_bigint::{BitOps, BoxedUint, Integer, Uint, Word};
-use crypto_primitives::crypto_bigint_int::Int;
+use crypto_bigint::{BitOps, BoxedUint, Word};
+use crypto_primitives::{crypto_bigint_int::Int, crypto_bigint_uint::Uint};
 use itertools::Itertools;
-use num_traits::{CheckedAdd, ConstOne, One, Zero};
+use num_traits::CheckedAdd;
 use rand::{rngs::StdRng, seq::SliceRandom};
 use rand_core::SeedableRng;
-use std::{
-    iter::Iterator,
-    ops::{Mul, SubAssign},
-};
+use std::iter::Iterator;
 
 #[cfg(feature = "parallel")]
 use rayon::prelude::*;
@@ -242,49 +239,6 @@ pub(super) fn shuffle_seeded<T>(slice: &mut [T], seed: u64) {
 }
 
 //
-// Semiring wrapper for Uint
-//
-
-pub struct UintSemiring<const LIMBS: usize>(pub Uint<LIMBS>);
-
-impl<const LIMBS: usize> ConstOne for UintSemiring<LIMBS> {
-    const ONE: Self = Self(Uint::<LIMBS>::ONE);
-}
-
-impl<const LIMBS: usize> One for UintSemiring<LIMBS> {
-    fn one() -> Self {
-        Self::ONE
-    }
-}
-
-impl<const LIMBS: usize> SubAssign for UintSemiring<LIMBS> {
-    #[allow(clippy::arithmetic_side_effects)]
-    fn sub_assign(&mut self, rhs: Self) {
-        self.0 -= rhs.0;
-    }
-}
-
-impl<const LIMBS: usize> Mul for UintSemiring<LIMBS> {
-    type Output = Self;
-
-    fn mul(self, rhs: Self) -> Self::Output {
-        Self(self.0.mul(rhs.0))
-    }
-}
-
-impl<const LIMBS: usize> SimpleSemiring for UintSemiring<LIMBS> {
-    const BYTES: usize = Uint::<LIMBS>::NUM_BYTES;
-
-    fn is_zero(&self) -> bool {
-        self.0.is_zero()
-    }
-
-    fn is_even(&self) -> bool {
-        self.0.is_even().into()
-    }
-}
-
-//
 // Named implementations
 //
 
@@ -309,7 +263,7 @@ impl<const LIMBS: usize> Named for Int<LIMBS> {
     }
 }
 
-impl<const LIMBS: usize> Named for UintSemiring<LIMBS> {
+impl<const LIMBS: usize> Named for Uint<LIMBS> {
     fn type_name() -> String {
         format!("Uint<{}>", LIMBS)
     }
@@ -377,11 +331,11 @@ impl<const LIMBS: usize> ConstTranscribable for Int<LIMBS> {
     const NUM_BYTES: usize = Uint::<LIMBS>::NUM_BYTES;
 
     fn read_transcription_bytes(bytes: &[u8]) -> Self {
-        (*<Uint<LIMBS> as ConstTranscribable>::read_transcription_bytes(bytes).as_int()).into()
+        *<Uint<LIMBS> as ConstTranscribable>::read_transcription_bytes(bytes).as_int()
     }
 
     fn write_transcription_bytes(&self, buf: &mut [u8]) {
-        ConstTranscribable::write_transcription_bytes(self.inner().as_uint(), buf)
+        ConstTranscribable::write_transcription_bytes(self.as_uint(), buf)
     }
 }
 
@@ -427,18 +381,6 @@ impl Transcribable for BoxedUint {
             // vector
             buf[(i * W_SIZE)..(i * W_SIZE + W_SIZE)].copy_from_slice(w.to_le_bytes().as_ref());
         }
-    }
-}
-
-impl<const LIMBS: usize> ConstTranscribable for UintSemiring<LIMBS> {
-    const NUM_BYTES: usize = Uint::<LIMBS>::NUM_BYTES;
-
-    fn read_transcription_bytes(bytes: &[u8]) -> Self {
-        Self(<Uint<LIMBS> as ConstTranscribable>::read_transcription_bytes(bytes))
-    }
-
-    fn write_transcription_bytes(&self, buf: &mut [u8]) {
-        ConstTranscribable::write_transcription_bytes(&self.0, buf)
     }
 }
 


### PR DESCRIPTION
* Added a `Semiring` primitive, essentially a ring with no additive inverse. It fits unsigned integers.
* Added trivial implementations for all unsigned int types.
* Added semiring wrappers `crypto_bigint::Uint` and `bool` types.
* Changed `Int` wrapper to work with `Uint` wrapper instead of with `crypto_bigint::Uint` directly
* Removed `SimpleSemiring` as it's now replaced by full-fledged `Semiring`.
* Added indirection to Miller-Rabin to allow us to implement it for arbitrary semirings.

Zip+ logic itself remains unchanged.