### PR TITLE
Boolean evalutaions

### DIFF
--- a/zip-plus/benches/zip_benches.rs
+++ b/zip-plus/benches/zip_benches.rs
@@ -35,7 +35,6 @@ type Code = RaaCode<BenchZipTypes, 4>;
 const RAA_CONFIG: RaaConfig = RaaConfig {
     check_for_overflows: false,
     permute_in_place: false,
-    flip_signs: true,
 };
 
 fn zip_benchmarks(c: &mut Criterion) {

--- a/zip-plus/benches/zip_plus_benches.rs
+++ b/zip-plus/benches/zip_plus_benches.rs
@@ -7,7 +7,7 @@ use zip_common::*;
 
 use criterion::{Criterion, criterion_group, criterion_main};
 use crypto_bigint::U64;
-use crypto_primitives::{crypto_bigint_int::Int, crypto_bigint_uint::Uint};
+use crypto_primitives::{boolean::Boolean, crypto_bigint_int::Int, crypto_bigint_uint::Uint};
 use zip_plus::{
     code::raa::{RaaCode, RaaConfig},
     pcs::structs::ZipTypes,
@@ -20,7 +20,7 @@ const INT_LIMBS: usize = U64::LIMBS;
 struct BenchZipPlusTypes<const D: usize> {}
 impl<const D: usize> ZipTypes for BenchZipPlusTypes<D> {
     const NUM_COLUMN_OPENINGS: usize = 650;
-    type EvalR = i8; // TODO: Use binary polynomials for evaluations
+    type EvalR = Boolean;
     type Eval = DensePolynomial<Self::EvalR, D>;
     type CwR = i32;
     type Cw = DensePolynomial<Self::CwR, D>;

--- a/zip-plus/benches/zip_plus_benches.rs
+++ b/zip-plus/benches/zip_plus_benches.rs
@@ -36,7 +36,6 @@ type Code<const D: usize> = RaaCode<BenchZipPlusTypes<D>, 4>;
 const RAA_CONFIG: RaaConfig = RaaConfig {
     check_for_overflows: false,
     permute_in_place: true,
-    flip_signs: false,
 };
 
 fn zip_plus_benchmarks(c: &mut Criterion) {

--- a/zip-plus/src/code.rs
+++ b/zip-plus/src/code.rs
@@ -1,4 +1,5 @@
 pub mod raa;
+pub mod raa_sign_flip;
 
 use crate::{pcs::structs::ZipTypes, traits::FromRef};
 use crypto_primitives::PrimeField;

--- a/zip-plus/src/code/raa.rs
+++ b/zip-plus/src/code/raa.rs
@@ -1,39 +1,35 @@
 use crate::{
     add,
     code::LinearCode,
-    mul, neg,
+    mul,
     pcs::structs::ZipTypes,
     traits::{ConstTranscribable, FromRef},
     utils::shuffle_seeded,
 };
 use crypto_primitives::PrimeField;
-use num_traits::{CheckedAdd, CheckedNeg};
-use std::{
-    marker::PhantomData,
-    ops::{AddAssign, Neg},
-};
+use num_traits::CheckedAdd;
+use std::{marker::PhantomData, ops::AddAssign};
 
 /// Implementation of a repeat-accumulate-accumulate (RAA) codes over the binary
 /// field, as defined by the Blaze paper (https://eprint.iacr.org/2024/1609)
 #[derive(Debug, Clone)]
 pub struct RaaCode<Zt: ZipTypes, const REP: usize> {
-    cfg: RaaConfig,
+    pub(crate) cfg: RaaConfig,
 
-    row_len: usize,
-
-    phantom: PhantomData<Zt>,
-
+    pub(crate) row_len: usize,
     /// Randomness seed for the first permutation
-    perm_1_seed: u64,
+    pub(crate) perm_1_seed: u64,
 
     /// Randomness seed for the second permutation
-    perm_2_seed: u64,
+    pub(crate) perm_2_seed: u64,
 
     /// First permutation
-    perm_1: Vec<usize>,
+    pub(crate) perm_1: Vec<usize>,
 
     /// Second permutation
-    perm_2: Vec<usize>,
+    pub(crate) perm_2: Vec<usize>,
+
+    phantom: PhantomData<Zt>,
 }
 
 #[derive(Debug, Clone, Copy)]
@@ -44,22 +40,13 @@ pub struct RaaConfig {
     /// Whether to permute the codeword in place, instead of copying it using a
     /// precomputed permutation.
     pub permute_in_place: bool,
-
-    /// Whether to flip the signs of every other codeword entry, leading to
-    /// smaller codewords.
-    pub flip_signs: bool,
 }
 
 impl<Zt: ZipTypes, const REP: usize> RaaCode<Zt, REP> {
     /// Do the actual encoding, as per RAA spec
     fn encode_inner<In, Out>(&self, row: &[In]) -> Vec<Out>
     where
-        Out: Neg<Output = Out>
-            + CheckedNeg
-            + CheckedAdd
-            + for<'a> AddAssign<&'a Out>
-            + FromRef<In>
-            + Clone,
+        Out: CheckedAdd + for<'a> AddAssign<&'a Out> + FromRef<In> + Clone,
     {
         debug_assert_eq!(
             row.len(),
@@ -68,9 +55,6 @@ impl<Zt: ZipTypes, const REP: usize> RaaCode<Zt, REP> {
         );
 
         let mut result: Vec<Out> = repeat(row, REP);
-        if self.cfg.flip_signs {
-            flip_even_signs(&mut result, self.cfg.check_for_overflows);
-        }
         if self.cfg.permute_in_place {
             shuffle_seeded(&mut result, self.perm_1_seed);
         } else {
@@ -80,9 +64,6 @@ impl<Zt: ZipTypes, const REP: usize> RaaCode<Zt, REP> {
             accumulate(&mut result);
         } else {
             accumulate_unchecked(&mut result);
-        }
-        if self.cfg.flip_signs {
-            flip_even_signs(&mut result, self.cfg.check_for_overflows);
         }
         if self.cfg.permute_in_place {
             shuffle_seeded(&mut result, self.perm_2_seed);
@@ -191,7 +172,10 @@ impl<Zt: ZipTypes, const REP: usize> LinearCode<Zt> for RaaCode<Zt, REP> {
 
 /// Repeat the given slice N times, e.g `[1,2,3] => [1,2,3,1,2,3]`
 #[allow(clippy::arithmetic_side_effects)]
-fn repeat<In, Out: FromRef<In> + Clone>(input: &[In], repetition_factor: usize) -> Vec<Out> {
+pub(crate) fn repeat<In, Out: FromRef<In> + Clone>(
+    input: &[In],
+    repetition_factor: usize,
+) -> Vec<Out> {
     input
         .iter()
         .map(Out::from_ref)
@@ -211,7 +195,7 @@ fn repeat<In, Out: FromRef<In> + Clone>(input: &[In], repetition_factor: usize) 
 /// 1 1 1 1
 /// ```
 #[allow(clippy::arithmetic_side_effects)] // Clippy is too dumb to realize `i - 1` is safe here
-fn accumulate<I>(input: &mut [I])
+pub(crate) fn accumulate<I>(input: &mut [I])
 where
     I: CheckedAdd + Clone,
 {
@@ -225,7 +209,7 @@ where
 }
 
 #[allow(clippy::arithmetic_side_effects)]
-fn accumulate_unchecked<I>(input: &mut [I])
+pub(crate) fn accumulate_unchecked<I>(input: &mut [I])
 where
     I: for<'a> AddAssign<&'a I> + Clone,
 {
@@ -242,44 +226,11 @@ where
 }
 
 /// Clone the data using a precomputed permutation.
-fn clone_shuffled<T>(data: &[T], perm: &[usize]) -> Vec<T>
+pub(crate) fn clone_shuffled<T>(data: &[T], perm: &[usize]) -> Vec<T>
 where
     T: Clone,
 {
     perm.iter().map(|&i| data[i].clone()).collect()
-}
-
-/// Flip every other entry in the codeword, starting from the second one.
-fn flip_even_signs<Out>(result: &mut [Out], check_for_overflows: bool)
-where
-    Out: Neg<Output = Out> + CheckedNeg + Clone,
-{
-    if check_for_overflows {
-        flip_even_signs_checked(result);
-    } else {
-        flip_even_signs_unchecked(result);
-    }
-}
-
-fn flip_even_signs_checked<Out>(result: &mut [Out])
-where
-    Out: CheckedNeg + Clone,
-{
-    // Flip every other entry in the codeword
-    for i in (1..result.len()).step_by(2) {
-        result[i] = neg!(result[i]);
-    }
-}
-
-/// Flip every other entry in the codeword, starting from the second one.
-fn flip_even_signs_unchecked<Out>(result: &mut [Out])
-where
-    Out: Neg<Output = Out> + Clone,
-{
-    // Flip every other entry in the codeword
-    for i in (1..result.len()).step_by(2) {
-        result[i] = result[i].clone().neg();
-    }
 }
 
 #[cfg(test)]
@@ -307,17 +258,14 @@ mod tests {
     {
         for check_for_overflows in [true, false] {
             for permute_in_place in [true, false] {
-                for flip_signs in [true, false] {
-                    let code = RaaCode::<Zt, REPETITION_FACTOR>::new(
-                        poly_size,
-                        RaaConfig {
-                            check_for_overflows,
-                            permute_in_place,
-                            flip_signs,
-                        },
-                    );
-                    f(&code)
-                }
+                let code = RaaCode::<Zt, REPETITION_FACTOR>::new(
+                    poly_size,
+                    RaaConfig {
+                        check_for_overflows,
+                        permute_in_place,
+                    },
+                );
+                f(&code)
             }
         }
     }
@@ -440,7 +388,6 @@ mod tests {
                     RaaConfig {
                         check_for_overflows,
                         permute_in_place,
-                        flip_signs: false,
                     },
                 );
 
@@ -482,7 +429,6 @@ mod tests {
                 RaaConfig {
                     check_for_overflows: true,
                     permute_in_place: true,
-                    flip_signs: false,
                 },
             );
             code_in_place.encode(&data)
@@ -494,7 +440,6 @@ mod tests {
                 RaaConfig {
                     check_for_overflows: true,
                     permute_in_place: false,
-                    flip_signs: false,
                 },
             );
             code_cloning.encode(&data)
@@ -516,7 +461,6 @@ mod tests {
             RaaConfig {
                 check_for_overflows: true,
                 permute_in_place: false,
-                flip_signs: false,
             },
         );
     }

--- a/zip-plus/src/code/raa_sign_flip.rs
+++ b/zip-plus/src/code/raa_sign_flip.rs
@@ -1,0 +1,138 @@
+use super::raa::*;
+use crate::{
+    code::LinearCode, neg, pcs::structs::ZipTypes, traits::FromRef, utils::shuffle_seeded,
+};
+use crypto_primitives::{PrimeField, Ring};
+use num_traits::{CheckedAdd, CheckedNeg};
+use std::ops::{AddAssign, Neg};
+
+/// Implementation of a repeat-accumulate-accumulate (RAA) codes.
+/// Flips signs of every second entry in the codeword, starting from the second
+/// one.
+#[derive(Debug, Clone)]
+pub struct RaaSignFlippingCode<Zt: ZipTypes, const REP: usize>
+where
+    Zt::Cw: Ring,
+{
+    raa: RaaCode<Zt, REP>,
+}
+
+impl<Zt: ZipTypes, const REP: usize> RaaSignFlippingCode<Zt, REP>
+where
+    Zt::Cw: Ring,
+{
+    /// Do the actual encoding, as per RAA spec
+    fn encode_inner<In, Out>(&self, row: &[In]) -> Vec<Out>
+    where
+        Out: Neg<Output = Out>
+            + CheckedNeg
+            + CheckedAdd
+            + for<'a> AddAssign<&'a Out>
+            + FromRef<In>
+            + Clone,
+    {
+        debug_assert_eq!(
+            row.len(),
+            self.raa.row_len,
+            "Row length must match the code's row length"
+        );
+
+        let mut result: Vec<Out> = repeat(row, REP);
+        flip_even_signs(&mut result, self.raa.cfg.check_for_overflows);
+        if self.raa.cfg.permute_in_place {
+            shuffle_seeded(&mut result, self.raa.perm_1_seed);
+        } else {
+            result = clone_shuffled(&result, &self.raa.perm_1);
+        }
+        if self.raa.cfg.check_for_overflows {
+            accumulate(&mut result);
+        } else {
+            accumulate_unchecked(&mut result);
+        }
+        flip_even_signs(&mut result, self.raa.cfg.check_for_overflows);
+        if self.raa.cfg.permute_in_place {
+            shuffle_seeded(&mut result, self.raa.perm_2_seed);
+        } else {
+            result = clone_shuffled(&result, &self.raa.perm_2);
+        }
+        if self.raa.cfg.check_for_overflows {
+            accumulate(&mut result);
+        } else {
+            accumulate_unchecked(&mut result);
+        }
+        debug_assert_eq!(result.len(), self.codeword_len());
+        result
+    }
+}
+
+impl<Zt: ZipTypes, const REP: usize> LinearCode<Zt> for RaaSignFlippingCode<Zt, REP>
+where
+    Zt::Cw: Ring,
+{
+    type Config = <RaaCode<Zt, REP> as LinearCode<Zt>>::Config;
+
+    const REPETITION_FACTOR: usize = REP;
+
+    fn new(poly_size: usize, cfg: Self::Config) -> Self {
+        Self {
+            raa: RaaCode::new(poly_size, cfg),
+        }
+    }
+
+    fn row_len(&self) -> usize {
+        self.raa.row_len()
+    }
+
+    #[allow(clippy::arithmetic_side_effects)]
+    fn codeword_len(&self) -> usize {
+        self.raa.codeword_len()
+    }
+
+    fn encode(&self, row: &[Zt::Eval]) -> Vec<Zt::Cw> {
+        self.encode_inner(row)
+    }
+
+    fn encode_wide(&self, row: &[Zt::CombR]) -> Vec<Zt::CombR> {
+        self.encode_inner(row)
+    }
+
+    fn encode_f<F>(&self, row: &[F]) -> Vec<F>
+    where
+        F: PrimeField + FromRef<F>,
+    {
+        self.encode_inner(row)
+    }
+}
+
+/// Flip every other entry in the codeword, starting from the second one.
+fn flip_even_signs<Out>(result: &mut [Out], check_for_overflows: bool)
+where
+    Out: Neg<Output = Out> + CheckedNeg + Clone,
+{
+    if check_for_overflows {
+        flip_even_signs_checked(result);
+    } else {
+        flip_even_signs_unchecked(result);
+    }
+}
+
+fn flip_even_signs_checked<Out>(result: &mut [Out])
+where
+    Out: CheckedNeg + Clone,
+{
+    // Flip every other entry in the codeword
+    for i in (1..result.len()).step_by(2) {
+        result[i] = neg!(result[i]);
+    }
+}
+
+/// Flip every other entry in the codeword, starting from the second one.
+fn flip_even_signs_unchecked<Out>(result: &mut [Out])
+where
+    Out: Neg<Output = Out> + Clone,
+{
+    // Flip every other entry in the codeword
+    for i in (1..result.len()).step_by(2) {
+        result[i] = result[i].clone().neg();
+    }
+}

--- a/zip-plus/src/field/boxed_monty.rs
+++ b/zip-plus/src/field/boxed_monty.rs
@@ -4,7 +4,7 @@ use crate::{
 };
 use crypto_bigint::BoxedUint;
 use crypto_primitives::{
-    IntoWithConfig, PrimeField, crypto_bigint_boxed_monty::BoxedMontyField, crypto_bigint_int::Int,
+    FromWithConfig, IntoWithConfig, PrimeField, crypto_bigint_boxed_monty::BoxedMontyField,
     crypto_bigint_uint::Uint,
 };
 use num_traits::CheckedMul;
@@ -28,12 +28,15 @@ impl<const LIMBS: usize> FromRef<Uint<LIMBS>> for BoxedUint {
     }
 }
 
-impl<const LIMBS: usize> ProjectableToField<BoxedMontyField> for Int<LIMBS> {
+impl<T> ProjectableToField<BoxedMontyField> for T
+where
+    BoxedMontyField: for<'a> FromWithConfig<&'a T>,
+{
     fn prepare_projection(
         sampled_value: &BoxedMontyField,
     ) -> impl Fn(&Self) -> BoxedMontyField + 'static {
         let config = sampled_value.cfg().clone();
-        move |value: &Int<LIMBS>| value.into_with_cfg(&config)
+        move |value: &T| value.into_with_cfg(&config)
     }
 }
 

--- a/zip-plus/src/pcs/phase_commit.rs
+++ b/zip-plus/src/pcs/phase_commit.rs
@@ -198,7 +198,7 @@ mod tests {
     use std::slice::from_ref;
 
     use crate::{
-        code::{LinearCode, raa::RaaCode},
+        code::{LinearCode, raa::RaaCode, raa_sign_flip::RaaSignFlippingCode},
         merkle::{MerkleTree, MtHash},
         pcs::{
             structs::{ZipPlus, ZipPlusParams, ZipTypes},
@@ -222,7 +222,7 @@ mod tests {
     const DEGREE: usize = 2;
 
     type Zt = TestZipTypes<N, K, M>;
-    type C = RaaCode<Zt, 4>;
+    type C = RaaSignFlippingCode<Zt, 4>;
 
     type PolyZt = TestPolyZipTypes<N, K, M, DEGREE>;
     type PolyC = RaaCode<PolyZt, 4>;

--- a/zip-plus/src/pcs/phase_commit.rs
+++ b/zip-plus/src/pcs/phase_commit.rs
@@ -208,7 +208,8 @@ mod tests {
     };
     use crypto_bigint::{Random, U64, U256, Word};
     use crypto_primitives::{
-        Matrix, crypto_bigint_boxed_monty::BoxedMontyField, crypto_bigint_int::Int,
+        Matrix, boolean::Boolean, crypto_bigint_boxed_monty::BoxedMontyField,
+        crypto_bigint_int::Int,
     };
     use itertools::Itertools;
     use num_traits::Zero;
@@ -486,9 +487,9 @@ mod tests {
 
         // Create a polynomial with 2 variables and 4 evaluations
         let evaluations = vec![
-            DensePolynomial::new(vec![1, 2]),
-            DensePolynomial::new(vec![3, 4]),
-            DensePolynomial::new(vec![5, 6]),
+            DensePolynomial::new(vec![Boolean::FALSE, Boolean::FALSE]),
+            DensePolynomial::new(vec![Boolean::FALSE, Boolean::TRUE]),
+            DensePolynomial::new(vec![Boolean::TRUE, Boolean::FALSE]),
         ];
         let poly = DenseMultilinearExtension::from_evaluations_vec(2, evaluations, Zero::zero());
         let encoded = TestPolyZip::encode_rows(&pp, pp.linear_code.row_len(), &poly.evaluations);

--- a/zip-plus/src/pcs/phase_commit.rs
+++ b/zip-plus/src/pcs/phase_commit.rs
@@ -224,7 +224,7 @@ mod tests {
     type Zt = TestZipTypes<N, K, M>;
     type C = RaaSignFlippingCode<Zt, 4>;
 
-    type PolyZt = TestPolyZipTypes<N, K, M, DEGREE>;
+    type PolyZt = TestPolyZipTypes<K, M, DEGREE>;
     type PolyC = RaaCode<PolyZt, 4>;
 
     type TestZip = ZipPlus<Zt, C>;
@@ -486,9 +486,9 @@ mod tests {
 
         // Create a polynomial with 2 variables and 4 evaluations
         let evaluations = vec![
-            DensePolynomial::new(vec![Int::from(1), Int::from(2)]),
-            DensePolynomial::new(vec![Int::from(3), Int::from(4)]),
-            DensePolynomial::new(vec![Int::from(5), Int::from(6)]),
+            DensePolynomial::new(vec![1, 2]),
+            DensePolynomial::new(vec![3, 4]),
+            DensePolynomial::new(vec![5, 6]),
         ];
         let poly = DenseMultilinearExtension::from_evaluations_vec(2, evaluations, Zero::zero());
         let encoded = TestPolyZip::encode_rows(&pp, pp.linear_code.row_len(), &poly.evaluations);

--- a/zip-plus/src/pcs/phase_test.rs
+++ b/zip-plus/src/pcs/phase_test.rs
@@ -110,7 +110,7 @@ mod tests {
     type Zt = TestZipTypes<N, K, M>;
     type C = RaaSignFlippingCode<Zt, 4>;
 
-    type PolyZt = TestPolyZipTypes<N, K, M, DEGREE>;
+    type PolyZt = TestPolyZipTypes<K, M, DEGREE>;
     type PolyC = RaaCode<PolyZt, 4>;
 
     type TestZip = ZipPlus<Zt, C>;

--- a/zip-plus/src/pcs/phase_test.rs
+++ b/zip-plus/src/pcs/phase_test.rs
@@ -88,7 +88,7 @@ impl<Zt: ZipTypes, Lc: LinearCode<Zt>> ZipPlus<Zt, Lc> {
 )]
 mod tests {
     use crate::{
-        code::raa::RaaCode,
+        code::{raa::RaaCode, raa_sign_flip::RaaSignFlippingCode},
         merkle::MerkleTree,
         pcs::{
             structs::{ZipPlus, ZipPlusHint},
@@ -108,7 +108,7 @@ mod tests {
     const DEGREE: usize = 2;
 
     type Zt = TestZipTypes<N, K, M>;
-    type C = RaaCode<Zt, 4>;
+    type C = RaaSignFlippingCode<Zt, 4>;
 
     type PolyZt = TestPolyZipTypes<N, K, M, DEGREE>;
     type PolyC = RaaCode<PolyZt, 4>;

--- a/zip-plus/src/pcs/phase_verify.rs
+++ b/zip-plus/src/pcs/phase_verify.rs
@@ -256,7 +256,7 @@ mod tests {
     type Zt = TestZipTypes<N, K, M>;
     type C = RaaSignFlippingCode<Zt, 4>;
 
-    type PolyZt = TestPolyZipTypes<N, K, M, DEGREE>;
+    type PolyZt = TestPolyZipTypes<K, M, DEGREE>;
     type PolyC = RaaCode<PolyZt, 4>;
 
     type TestZip = ZipPlus<Zt, C>;
@@ -367,8 +367,8 @@ mod tests {
                 setup_full_protocol_poly::<F, N, K, M, DEGREE>(num_vars);
 
             let different_evals = {
-                let different_eval_coeffs: Vec<_> = (1..=((1 << num_vars) * DEGREE as i32))
-                    .map(|x| Int::from_i32(x + 20))
+                let different_eval_coeffs: Vec<_> = (1..=((1 << num_vars) * DEGREE as i8))
+                    .map(|x| x + 20)
                     .collect_vec();
                 different_eval_coeffs
                     .chunks_exact(DEGREE)
@@ -903,7 +903,7 @@ mod tests {
             let (data, commitment) = TestPolyZip::commit(&pp, &mle).expect("commit");
 
             // Same point choice as the bench
-            let point = vec![1i64; P].iter().map(|v| v.into()).collect_vec();
+            let point = vec![1i64; P].iter().map(|v| (*v).into()).collect_vec();
 
             // Prover produces a proof once (exactly as in the bench)
             let test_proof = TestPolyZip::test(&pp, &mle, &data).unwrap();

--- a/zip-plus/src/pcs/phase_verify.rs
+++ b/zip-plus/src/pcs/phase_verify.rs
@@ -368,7 +368,7 @@ mod tests {
 
             let different_evals = {
                 let different_eval_coeffs: Vec<_> = (1..=((1 << num_vars) * DEGREE as i8))
-                    .map(|x| x + 20)
+                    .map(|x| (x % 3 == 0).into())
                     .collect_vec();
                 different_eval_coeffs
                     .chunks_exact(DEGREE)

--- a/zip-plus/src/pcs/phase_verify.rs
+++ b/zip-plus/src/pcs/phase_verify.rs
@@ -222,7 +222,7 @@ impl<Zt: ZipTypes, Lc: LinearCode<Zt>> ZipPlus<Zt, Lc> {
 mod tests {
     use crate::{
         ZipError,
-        code::{LinearCode, raa::RaaCode},
+        code::{LinearCode, raa::RaaCode, raa_sign_flip::RaaSignFlippingCode},
         merkle::MerkleTree,
         pcs::{
             ZipPlusProof,
@@ -254,7 +254,7 @@ mod tests {
     type F = BoxedMontyField;
 
     type Zt = TestZipTypes<N, K, M>;
-    type C = RaaCode<Zt, 4>;
+    type C = RaaSignFlippingCode<Zt, 4>;
 
     type PolyZt = TestPolyZipTypes<N, K, M, DEGREE>;
     type PolyC = RaaCode<PolyZt, 4>;

--- a/zip-plus/src/pcs/structs.rs
+++ b/zip-plus/src/pcs/structs.rs
@@ -6,8 +6,8 @@ use crate::{
     traits::{ConstTranscribable, FromRef, Named},
 };
 use crypto_primitives::{
-    ConstIntRing, ConstIntSemiring, DenseRowMatrix, FixedRing, FromWithConfig, PrimeField,
-    crypto_bigint_int::Int,
+    ConstIntRing, ConstIntSemiring, DenseRowMatrix, FixedRing, FixedSemiring, FromWithConfig,
+    PrimeField, crypto_bigint_int::Int,
 };
 use num_traits::CheckedMul;
 use std::{marker::PhantomData, ops::Neg};
@@ -16,13 +16,13 @@ pub trait ZipTypes: Send + Sync {
     const NUM_COLUMN_OPENINGS: usize;
 
     /// Coefficient ring of evaluation polynomial [Self::Eval]
-    type EvalR: ConstIntRing + ConstTranscribable + Named;
-    /// Ring of witness/polynomial evaluations on boolean hypercube
-    type Eval: FixedRing + Named + Polynomial<Self::EvalR>;
+    type EvalR: ConstIntSemiring + ConstTranscribable + Named;
+    /// Semiring of witness/polynomial evaluations on boolean hypercube
+    type Eval: FixedSemiring + Named + Polynomial<Self::EvalR>;
 
-    /// Coefficient ring of codeword polynomial [Self::Cw]
-    type CwR: ConstIntRing + ConstTranscribable + Named;
-    /// Ring of codeword elements, at least as wide as the evaluation ring
+    /// Coefficient semiring of codeword polynomial [Self::Cw]
+    type CwR: ConstIntSemiring + ConstTranscribable + Named;
+    /// Semiring of codeword elements, at least as wide as the evaluation ring
     type Cw: FixedRing
         + Polynomial<Self::CwR>
         + Neg<Output = Self::Cw>

--- a/zip-plus/src/pcs/structs.rs
+++ b/zip-plus/src/pcs/structs.rs
@@ -23,9 +23,8 @@ pub trait ZipTypes: Send + Sync {
     /// Coefficient semiring of codeword polynomial [Self::Cw]
     type CwR: ConstIntSemiring + ConstTranscribable + Named;
     /// Semiring of codeword elements, at least as wide as the evaluation ring
-    type Cw: FixedRing
+    type Cw: FixedSemiring
         + Polynomial<Self::CwR>
-        + Neg<Output = Self::Cw>
         + ConstTranscribable
         + FromRef<Self::Eval>
         + Named

--- a/zip-plus/src/pcs/structs.rs
+++ b/zip-plus/src/pcs/structs.rs
@@ -6,8 +6,8 @@ use crate::{
     traits::{ConstTranscribable, FromRef, Named},
 };
 use crypto_primitives::{
-    ConstIntRing, ConstIntSemiring, DenseRowMatrix, FixedRing, FixedSemiring, FromWithConfig,
-    PrimeField, crypto_bigint_int::Int,
+    ConstIntRing, ConstIntSemiring, DenseRowMatrix, FixedRing, FixedSemiring, PrimeField,
+    crypto_bigint_int::Int,
 };
 use num_traits::CheckedMul;
 use std::{marker::PhantomData, ops::Neg};
@@ -173,21 +173,3 @@ pub trait ProjectableToField<F: PrimeField> {
     /// to a prime field using the given sampled value.
     fn prepare_projection(sampled_value: &F) -> impl Fn(&Self) -> F + 'static;
 }
-
-macro_rules! impl_projectable_to_field_for_primitives {
-    ($($t:ty),*) => {
-        $(
-            impl<F> ProjectableToField<F> for $t
-            where
-                F: PrimeField + FromWithConfig<$t>,
-            {
-                fn prepare_projection(sampled_value: &F) -> impl Fn(&Self) -> F + 'static {
-                    let cfg = sampled_value.cfg().clone();
-                    move |x: &Self| F::from_with_cfg(*x, &cfg)
-                }
-            }
-        )*
-    };
-}
-
-impl_projectable_to_field_for_primitives!(i8, i16, i32, i64, i128);

--- a/zip-plus/src/pcs/test_utils.rs
+++ b/zip-plus/src/pcs/test_utils.rs
@@ -10,6 +10,7 @@ use crate::{
     code::{
         LinearCode,
         raa::{RaaCode, RaaConfig},
+        raa_sign_flip::RaaSignFlippingCode,
     },
     pcs::{
         ZipPlusProof,
@@ -35,7 +36,6 @@ const REPETITION_FACTOR: usize = 4;
 pub const RAA_CFG: RaaConfig = RaaConfig {
     check_for_overflows: true,
     permute_in_place: false,
-    flip_signs: true,
 };
 
 pub struct TestZipTypes<const N: usize, const K: usize, const M: usize> {}
@@ -75,7 +75,10 @@ impl<const N: usize, const K: usize, const M: usize, const DEGREE: usize> ZipTyp
 pub fn setup_test_params<const N: usize, const K: usize, const M: usize>(
     num_vars: usize,
 ) -> (
-    ZipPlusParams<TestZipTypes<N, K, M>, RaaCode<TestZipTypes<N, K, M>, REPETITION_FACTOR>>,
+    ZipPlusParams<
+        TestZipTypes<N, K, M>,
+        RaaSignFlippingCode<TestZipTypes<N, K, M>, REPETITION_FACTOR>,
+    >,
     DenseMultilinearExtension<Int<N>>,
 ) {
     setup_test_params_inner(num_vars, |poly_size| {
@@ -128,7 +131,10 @@ fn setup_test_params_inner<Zt: ZipTypes, Lc: LinearCode<Zt, Config = RaaConfig>>
 pub fn setup_full_protocol<F, const N: usize, const K: usize, const M: usize>(
     num_vars: usize,
 ) -> (
-    ZipPlusParams<TestZipTypes<N, K, M>, RaaCode<TestZipTypes<N, K, M>, REPETITION_FACTOR>>,
+    ZipPlusParams<
+        TestZipTypes<N, K, M>,
+        RaaSignFlippingCode<TestZipTypes<N, K, M>, REPETITION_FACTOR>,
+    >,
     ZipPlusCommitment,
     Vec<F>,
     F,

--- a/zip-plus/src/pcs/test_utils.rs
+++ b/zip-plus/src/pcs/test_utils.rs
@@ -25,8 +25,8 @@ use crate::{
 };
 use crypto_bigint::BoxedUint;
 use crypto_primitives::{
-    FromWithConfig, IntoWithConfig, PrimeField, crypto_bigint_boxed_monty::BoxedMontyField,
-    crypto_bigint_int::Int, crypto_bigint_uint::Uint,
+    FromWithConfig, IntSemiring, IntoWithConfig, PrimeField, boolean::Boolean,
+    crypto_bigint_boxed_monty::BoxedMontyField, crypto_bigint_int::Int, crypto_bigint_uint::Uint,
 };
 use itertools::Itertools;
 use num_traits::Zero;
@@ -53,13 +53,12 @@ impl<const N: usize, const K: usize, const M: usize> ZipTypes for TestZipTypes<N
     type Comb = Self::CombR;
 }
 
-pub struct TestPolyZipTypes<const K: usize, const M: usize, const DEGREE: usize> {
-}
+pub struct TestPolyZipTypes<const K: usize, const M: usize, const DEGREE: usize> {}
 impl<const K: usize, const M: usize, const DEGREE: usize> ZipTypes
     for TestPolyZipTypes<K, M, DEGREE>
 {
     const NUM_COLUMN_OPENINGS: usize = 650;
-    type EvalR = i8;
+    type EvalR = Boolean;
     type Eval = DensePolynomial<Self::EvalR, DEGREE>;
     type CwR = i32;
     type Cw = DensePolynomial<Self::CwR, DEGREE>;
@@ -87,11 +86,7 @@ pub fn setup_test_params<const N: usize, const K: usize, const M: usize>(
 }
 
 /// Helper function to set up common parameters for tests.
-pub fn setup_poly_test_params<
-    const K: usize,
-    const M: usize,
-    const DEGREE: usize,
->(
+pub fn setup_poly_test_params<const K: usize, const M: usize, const DEGREE: usize>(
     num_vars: usize,
 ) -> (
     ZipPlusParams<
@@ -101,7 +96,9 @@ pub fn setup_poly_test_params<
     DenseMultilinearExtension<<TestPolyZipTypes<K, M, DEGREE> as ZipTypes>::Eval>,
 ) {
     setup_test_params_inner(num_vars, |poly_size| {
-        let eval_coeffs: Vec<_> = (1..=(poly_size * DEGREE) as i8).collect_vec();
+        let eval_coeffs: Vec<_> = (1..=(poly_size * DEGREE) as i8)
+            .map(|v| v.is_odd().into())
+            .collect_vec();
         eval_coeffs
             .chunks_exact(DEGREE)
             .map(DensePolynomial::new)

--- a/zip-plus/src/pcs/test_utils.rs
+++ b/zip-plus/src/pcs/test_utils.rs
@@ -42,33 +42,33 @@ pub struct TestZipTypes<const N: usize, const K: usize, const M: usize> {}
 impl<const N: usize, const K: usize, const M: usize> ZipTypes for TestZipTypes<N, K, M> {
     const NUM_COLUMN_OPENINGS: usize = 650;
     type EvalR = Int<N>;
-    type Eval = Int<N>;
+    type Eval = Self::EvalR;
     type CwR = Int<K>;
-    type Cw = Int<K>;
+    type Cw = Self::CwR;
     type Fmod = Uint<K>;
     type PrimeTest = MillerRabin;
     type Chal = Int<N>;
     type Pt = Int<N>;
     type CombR = Int<M>;
-    type Comb = Int<M>;
+    type Comb = Self::CombR;
 }
 
-pub struct TestPolyZipTypes<const N: usize, const K: usize, const M: usize, const DEGREE: usize> {
+pub struct TestPolyZipTypes<const K: usize, const M: usize, const DEGREE: usize> {
 }
-impl<const N: usize, const K: usize, const M: usize, const DEGREE: usize> ZipTypes
-    for TestPolyZipTypes<N, K, M, DEGREE>
+impl<const K: usize, const M: usize, const DEGREE: usize> ZipTypes
+    for TestPolyZipTypes<K, M, DEGREE>
 {
     const NUM_COLUMN_OPENINGS: usize = 650;
-    type EvalR = Int<N>;
-    type Eval = DensePolynomial<Int<N>, DEGREE>;
-    type CwR = Int<K>;
-    type Cw = DensePolynomial<Int<K>, DEGREE>;
+    type EvalR = i8;
+    type Eval = DensePolynomial<Self::EvalR, DEGREE>;
+    type CwR = i32;
+    type Cw = DensePolynomial<Self::CwR, DEGREE>;
     type Fmod = Uint<K>;
     type PrimeTest = MillerRabin;
-    type Chal = Int<N>;
-    type Pt = Int<N>;
+    type Chal = i128;
+    type Pt = i128;
     type CombR = Int<M>;
-    type Comb = DensePolynomial<Int<M>, DEGREE>;
+    type Comb = DensePolynomial<Self::CombR, DEGREE>;
 }
 
 /// Helper function to set up common parameters for tests.
@@ -79,7 +79,7 @@ pub fn setup_test_params<const N: usize, const K: usize, const M: usize>(
         TestZipTypes<N, K, M>,
         RaaSignFlippingCode<TestZipTypes<N, K, M>, REPETITION_FACTOR>,
     >,
-    DenseMultilinearExtension<Int<N>>,
+    DenseMultilinearExtension<<TestZipTypes<N, K, M> as ZipTypes>::Eval>,
 ) {
     setup_test_params_inner(num_vars, |poly_size| {
         (1..=poly_size as i32).map(Int::from).collect()
@@ -88,7 +88,6 @@ pub fn setup_test_params<const N: usize, const K: usize, const M: usize>(
 
 /// Helper function to set up common parameters for tests.
 pub fn setup_poly_test_params<
-    const N: usize,
     const K: usize,
     const M: usize,
     const DEGREE: usize,
@@ -96,15 +95,13 @@ pub fn setup_poly_test_params<
     num_vars: usize,
 ) -> (
     ZipPlusParams<
-        TestPolyZipTypes<N, K, M, DEGREE>,
-        RaaCode<TestPolyZipTypes<N, K, M, DEGREE>, REPETITION_FACTOR>,
+        TestPolyZipTypes<K, M, DEGREE>,
+        RaaCode<TestPolyZipTypes<K, M, DEGREE>, REPETITION_FACTOR>,
     >,
-    DenseMultilinearExtension<DensePolynomial<Int<N>, DEGREE>>,
+    DenseMultilinearExtension<<TestPolyZipTypes<K, M, DEGREE> as ZipTypes>::Eval>,
 ) {
     setup_test_params_inner(num_vars, |poly_size| {
-        let eval_coeffs: Vec<_> = (1..=(poly_size * DEGREE) as i32)
-            .map(Int::from)
-            .collect_vec();
+        let eval_coeffs: Vec<_> = (1..=(poly_size * DEGREE) as i8).collect_vec();
         eval_coeffs
             .chunks_exact(DEGREE)
             .map(DensePolynomial::new)
@@ -141,9 +138,12 @@ pub fn setup_full_protocol<F, const N: usize, const K: usize, const M: usize>(
     ZipPlusProof,
 )
 where
-    F: PrimeField + for<'a> FromWithConfig<&'a Int<N>> + for<'a> MulByScalar<&'a F>,
-    F::Inner: FromRef<Uint<K>> + Transcribable,
-    Int<N>: ProjectableToField<F>,
+    F: PrimeField
+        + for<'a> FromWithConfig<&'a <TestZipTypes<N, K, M> as ZipTypes>::Chal>
+        + for<'a> MulByScalar<&'a F>,
+    F::Inner: FromRef<<TestZipTypes<N, K, M> as ZipTypes>::Fmod> + Transcribable,
+    <TestZipTypes<N, K, M> as ZipTypes>::Eval: ProjectableToField<F>,
+    <TestZipTypes<N, K, M> as ZipTypes>::Comb: ProjectableToField<F>,
 {
     setup_full_protocol_inner::<_, _, _, N>(num_vars, setup_test_params, || {
         (0..num_vars).map(|i| Int::from(i as i32 + 2)).collect()
@@ -160,8 +160,8 @@ pub fn setup_full_protocol_poly<
     num_vars: usize,
 ) -> (
     ZipPlusParams<
-        TestPolyZipTypes<N, K, M, DEGREE>,
-        RaaCode<TestPolyZipTypes<N, K, M, DEGREE>, REPETITION_FACTOR>,
+        TestPolyZipTypes<K, M, DEGREE>,
+        RaaCode<TestPolyZipTypes<K, M, DEGREE>, REPETITION_FACTOR>,
     >,
     ZipPlusCommitment,
     Vec<F>,
@@ -169,12 +169,15 @@ pub fn setup_full_protocol_poly<
     ZipPlusProof,
 )
 where
-    F: PrimeField + for<'a> FromWithConfig<&'a Int<N>> + for<'a> MulByScalar<&'a F>,
-    F::Inner: FromRef<Uint<K>> + Transcribable,
-    DensePolynomial<Int<N>, DEGREE>: ProjectableToField<F>,
+    F: PrimeField
+        + for<'a> FromWithConfig<&'a <TestPolyZipTypes<K, M, DEGREE> as ZipTypes>::Chal>
+        + for<'a> MulByScalar<&'a F>,
+    F::Inner: FromRef<<TestPolyZipTypes<K, M, DEGREE> as ZipTypes>::Fmod> + Transcribable,
+    <TestPolyZipTypes<K, M, DEGREE> as ZipTypes>::Eval: ProjectableToField<F>,
+    <TestPolyZipTypes<K, M, DEGREE> as ZipTypes>::Comb: ProjectableToField<F>,
 {
     setup_full_protocol_inner::<_, _, _, N>(num_vars, setup_poly_test_params, || {
-        (0..num_vars).map(|i| Int::from(i as i32 + 2)).collect()
+        (0..num_vars).map(|i| i as i128 + 2).collect()
     })
 }
 
@@ -191,7 +194,6 @@ fn setup_full_protocol_inner<Zt, Lc, F, const N: usize>(
 )
 where
     Zt: ZipTypes,
-    Zt::Eval: for<'a> MulByScalar<&'a Zt::Pt>,
     Lc: LinearCode<Zt>,
     F: PrimeField
         + for<'a> FromWithConfig<&'a Zt::Chal>
@@ -199,6 +201,7 @@ where
         + for<'a> MulByScalar<&'a F>,
     F::Inner: FromRef<Zt::Fmod> + Transcribable,
     Zt::Eval: ProjectableToField<F>,
+    Zt::Comb: ProjectableToField<F> + for<'a> MulByScalar<&'a Zt::Pt>,
 {
     let (pp, poly) = setup(num_vars);
 
@@ -225,10 +228,19 @@ where
 
     // Verify the evaluation is done correctly
     {
+        // Widen up polynomial for evaluation
+        let poly = DenseMultilinearExtension {
+            evaluations: poly
+                .evaluations
+                .iter()
+                .map(Zt::Comb::from_ref)
+                .collect_vec(),
+            num_vars,
+        };
         let expected_eval = poly
             .evaluate(&point, Zero::zero())
             .expect("failed to evaluate polynomial");
-        let project = Zt::Eval::prepare_projection(&projecting_element);
+        let project = Zt::Comb::prepare_projection(&projecting_element);
         assert_eq!(eval_f, project(&expected_eval));
     }
 

--- a/zip-plus/src/pcs/utils.rs
+++ b/zip-plus/src/pcs/utils.rs
@@ -35,19 +35,19 @@ pub(super) fn validate_input<'a, Zt: ZipTypes + 'a, Lc: LinearCode<Zt>, Pt: 'a>(
         // being encoded - so num_vars / 2
         let d = div!(param_num_vars, 2);
         let codeword_bits = ilog_round_up!(mul!(Lc::REPETITION_FACTOR, d), usize);
-        let mut challenge_bits = mul!(Zt::Chal::NUM_BYTES, 8);
+        let mut challenge_bits = Zt::Chal::NUM_BITS;
         if Zt::Comb::DEGREE_BOUND > 0 {
             // This means we also draft alphas (multiplied with coeffs), which
             // doubles the number of challenge bits
             challenge_bits = mul!(challenge_bits, 2);
         }
-        let max_lc_bits = mul!(Zt::CombR::NUM_BYTES, 8);
+        let max_lc_bits = Zt::CombR::NUM_BITS;
         let actual_lc_bits: usize = add!(
             add!(
                 add!(mul!(codeword_bits, 2), ilog_round_up!(d, usize)),
                 challenge_bits
             ),
-            sub!(mul!(Zt::EvalR::NUM_BYTES, 8), 1)
+            sub!(Zt::EvalR::NUM_BITS, 1)
         );
         assert!(
             actual_lc_bits <= max_lc_bits,

--- a/zip-plus/src/poly.rs
+++ b/zip-plus/src/poly.rs
@@ -3,15 +3,15 @@ pub mod mle;
 mod zero_degree;
 
 use crate::pcs::structs::MulByScalar;
-use crypto_primitives::Ring;
+use crypto_primitives::Semiring;
 use thiserror::Error;
 
-pub trait Polynomial<R: Ring> {
+pub trait Polynomial<R: Semiring> {
     /// The (max) degree of the polynomial - one less than a number of
     /// coefficients.
     const DEGREE_BOUND: usize;
 
-    fn map<R2: Ring>(&self, f: impl Fn(&R) -> R2) -> impl Polynomial<R2>;
+    fn map<R2: Semiring>(&self, f: impl Fn(&R) -> R2) -> impl Polynomial<R2>;
 
     /// Evaluates the polynomial at the given point, treating point `[p_0, p_1,
     /// p_2, ...]` as `[x, x^2, x^3, ..., x^DEGREE_BOUND]`, thus it returns

--- a/zip-plus/src/poly.rs
+++ b/zip-plus/src/poly.rs
@@ -11,8 +11,6 @@ pub trait Polynomial<R: Semiring> {
     /// coefficients.
     const DEGREE_BOUND: usize;
 
-    fn map<R2: Semiring>(&self, f: impl Fn(&R) -> R2) -> impl Polynomial<R2>;
-
     /// Evaluates the polynomial at the given point, treating point `[p_0, p_1,
     /// p_2, ...]` as `[x, x^2, x^3, ..., x^DEGREE_BOUND]`, thus it returns
     /// `a_0 + (a_1 * p_0) + (a_2 * p_1) + ... + (a_DEGREE_BOUND *

--- a/zip-plus/src/poly/dense.rs
+++ b/zip-plus/src/poly/dense.rs
@@ -28,7 +28,7 @@ pub struct DensePolynomial<R, const DEGREE: usize> {
     coeffs: [R; DEGREE],
 }
 
-impl<R: Ring + Zero, const DEGREE: usize> DensePolynomial<R, DEGREE> {
+impl<R: Semiring + Zero, const DEGREE: usize> DensePolynomial<R, DEGREE> {
     /// Create a new polynomial with the given coefficients.
     /// If the input has fewer than N+1 coefficients, the remaining slots will
     /// be filled with zeros. If the input has more than N+1 coefficients,
@@ -56,10 +56,10 @@ impl<R: Ring + Zero, const DEGREE: usize> DensePolynomial<R, DEGREE> {
     }
 }
 
-impl<R: Ring, const DEGREE: usize> Polynomial<R> for DensePolynomial<R, DEGREE> {
+impl<R: Semiring, const DEGREE: usize> Polynomial<R> for DensePolynomial<R, DEGREE> {
     const DEGREE_BOUND: usize = DEGREE;
 
-    fn map<R2: Ring>(&self, f: impl Fn(&R) -> R2) -> impl Polynomial<R2> {
+    fn map<R2: Semiring>(&self, f: impl Fn(&R) -> R2) -> impl Polynomial<R2> {
         let coeff_0 = f(&self.coeff_0);
         let coeffs: [R2; DEGREE] = self
             .coeffs
@@ -127,7 +127,7 @@ impl<R: Hash, const DEGREE: usize> Hash for DensePolynomial<R, DEGREE> {
     }
 }
 
-impl<R: Ring + Zero, const DEGREE: usize> Zero for DensePolynomial<R, DEGREE> {
+impl<R: Semiring + Zero, const DEGREE: usize> Zero for DensePolynomial<R, DEGREE> {
     fn zero() -> Self {
         Self {
             coeff_0: R::zero(),
@@ -140,7 +140,7 @@ impl<R: Ring + Zero, const DEGREE: usize> Zero for DensePolynomial<R, DEGREE> {
     }
 }
 
-impl<R: Ring + Zero + One, const DEGREE: usize> One for DensePolynomial<R, DEGREE> {
+impl<R: Semiring + Zero + One, const DEGREE: usize> One for DensePolynomial<R, DEGREE> {
     fn one() -> Self {
         Self {
             coeff_0: R::one(),
@@ -160,7 +160,7 @@ impl<R: Ring + Neg<Output = R>, const DEGREE: usize> Neg for DensePolynomial<R, 
     }
 }
 
-impl<R: Ring, const DEGREE: usize> Add for DensePolynomial<R, DEGREE> {
+impl<R: Semiring, const DEGREE: usize> Add for DensePolynomial<R, DEGREE> {
     type Output = Self;
 
     #[allow(clippy::arithmetic_side_effects, clippy::op_ref)]
@@ -170,7 +170,7 @@ impl<R: Ring, const DEGREE: usize> Add for DensePolynomial<R, DEGREE> {
     }
 }
 
-impl<'a, R: Ring, const DEGREE: usize> Add<&'a Self> for DensePolynomial<R, DEGREE> {
+impl<'a, R: Semiring, const DEGREE: usize> Add<&'a Self> for DensePolynomial<R, DEGREE> {
     type Output = Self;
 
     #[allow(clippy::arithmetic_side_effects)]
@@ -181,7 +181,7 @@ impl<'a, R: Ring, const DEGREE: usize> Add<&'a Self> for DensePolynomial<R, DEGR
     }
 }
 
-impl<R: Ring, const DEGREE: usize> Sub for DensePolynomial<R, DEGREE> {
+impl<R: Semiring, const DEGREE: usize> Sub for DensePolynomial<R, DEGREE> {
     type Output = Self;
 
     #[allow(clippy::arithmetic_side_effects, clippy::op_ref)]
@@ -191,7 +191,7 @@ impl<R: Ring, const DEGREE: usize> Sub for DensePolynomial<R, DEGREE> {
     }
 }
 
-impl<'a, R: Ring, const DEGREE: usize> Sub<&'a Self> for DensePolynomial<R, DEGREE> {
+impl<'a, R: Semiring, const DEGREE: usize> Sub<&'a Self> for DensePolynomial<R, DEGREE> {
     type Output = Self;
 
     #[allow(clippy::arithmetic_side_effects)]
@@ -202,7 +202,7 @@ impl<'a, R: Ring, const DEGREE: usize> Sub<&'a Self> for DensePolynomial<R, DEGR
     }
 }
 
-impl<R: Ring, const DEGREE: usize> Mul for DensePolynomial<R, DEGREE> {
+impl<R: Semiring, const DEGREE: usize> Mul for DensePolynomial<R, DEGREE> {
     type Output = Self;
 
     #[allow(clippy::arithmetic_side_effects, clippy::op_ref)]
@@ -212,7 +212,7 @@ impl<R: Ring, const DEGREE: usize> Mul for DensePolynomial<R, DEGREE> {
     }
 }
 
-impl<'a, R: Ring, const DEGREE: usize> Mul<&'a Self> for DensePolynomial<R, DEGREE> {
+impl<'a, R: Semiring, const DEGREE: usize> Mul<&'a Self> for DensePolynomial<R, DEGREE> {
     type Output = Self;
 
     fn mul(self, _rhs: &'a Self) -> Self::Output {
@@ -220,7 +220,7 @@ impl<'a, R: Ring, const DEGREE: usize> Mul<&'a Self> for DensePolynomial<R, DEGR
     }
 }
 
-impl<R: Ring, const DEGREE: usize> AddAssign for DensePolynomial<R, DEGREE> {
+impl<R: Semiring, const DEGREE: usize> AddAssign for DensePolynomial<R, DEGREE> {
     #[allow(clippy::arithmetic_side_effects)]
     #[inline(always)]
     fn add_assign(&mut self, rhs: Self) {
@@ -228,7 +228,7 @@ impl<R: Ring, const DEGREE: usize> AddAssign for DensePolynomial<R, DEGREE> {
     }
 }
 
-impl<'a, R: Ring, const DEGREE: usize> AddAssign<&'a Self> for DensePolynomial<R, DEGREE> {
+impl<'a, R: Semiring, const DEGREE: usize> AddAssign<&'a Self> for DensePolynomial<R, DEGREE> {
     #[allow(clippy::arithmetic_side_effects)]
     #[inline(always)]
     fn add_assign(&mut self, rhs: &'a Self) {
@@ -239,7 +239,7 @@ impl<'a, R: Ring, const DEGREE: usize> AddAssign<&'a Self> for DensePolynomial<R
     }
 }
 
-impl<R: Ring, const DEGREE: usize> SubAssign for DensePolynomial<R, DEGREE> {
+impl<R: Semiring, const DEGREE: usize> SubAssign for DensePolynomial<R, DEGREE> {
     #[allow(clippy::arithmetic_side_effects)]
     #[inline(always)]
     fn sub_assign(&mut self, rhs: Self) {
@@ -247,7 +247,7 @@ impl<R: Ring, const DEGREE: usize> SubAssign for DensePolynomial<R, DEGREE> {
     }
 }
 
-impl<'a, R: Ring, const DEGREE: usize> SubAssign<&'a Self> for DensePolynomial<R, DEGREE> {
+impl<'a, R: Semiring, const DEGREE: usize> SubAssign<&'a Self> for DensePolynomial<R, DEGREE> {
     #[allow(clippy::arithmetic_side_effects)]
     #[inline(always)]
     fn sub_assign(&mut self, rhs: &'a Self) {
@@ -258,7 +258,7 @@ impl<'a, R: Ring, const DEGREE: usize> SubAssign<&'a Self> for DensePolynomial<R
     }
 }
 
-impl<R: Ring, const DEGREE: usize> MulAssign for DensePolynomial<R, DEGREE> {
+impl<R: Semiring, const DEGREE: usize> MulAssign for DensePolynomial<R, DEGREE> {
     #[allow(clippy::arithmetic_side_effects)]
     #[inline(always)]
     fn mul_assign(&mut self, rhs: Self) {
@@ -266,7 +266,7 @@ impl<R: Ring, const DEGREE: usize> MulAssign for DensePolynomial<R, DEGREE> {
     }
 }
 
-impl<'a, R: Ring, const DEGREE: usize> MulAssign<&'a Self> for DensePolynomial<R, DEGREE> {
+impl<'a, R: Semiring, const DEGREE: usize> MulAssign<&'a Self> for DensePolynomial<R, DEGREE> {
     fn mul_assign(&mut self, _rhs: &'a Self) {
         unimplemented!("Polynomial multiplication is not implemented")
     }
@@ -282,7 +282,7 @@ impl<R: Ring, const DEGREE: usize> CheckedNeg for DensePolynomial<R, DEGREE> {
     }
 }
 
-impl<R: Ring, const DEGREE: usize> CheckedAdd for DensePolynomial<R, DEGREE> {
+impl<R: Semiring, const DEGREE: usize> CheckedAdd for DensePolynomial<R, DEGREE> {
     fn checked_add(&self, other: &Self) -> Option<Self> {
         let coeffs: Option<Vec<R>> = self
             .coeffs
@@ -297,7 +297,7 @@ impl<R: Ring, const DEGREE: usize> CheckedAdd for DensePolynomial<R, DEGREE> {
     }
 }
 
-impl<R: Ring, const DEGREE: usize> CheckedSub for DensePolynomial<R, DEGREE> {
+impl<R: Semiring, const DEGREE: usize> CheckedSub for DensePolynomial<R, DEGREE> {
     fn checked_sub(&self, other: &Self) -> Option<Self> {
         let coeffs: Option<Vec<R>> = self
             .coeffs
@@ -312,13 +312,13 @@ impl<R: Ring, const DEGREE: usize> CheckedSub for DensePolynomial<R, DEGREE> {
     }
 }
 
-impl<R: Ring, const DEGREE: usize> CheckedMul for DensePolynomial<R, DEGREE> {
+impl<R: Semiring, const DEGREE: usize> CheckedMul for DensePolynomial<R, DEGREE> {
     fn checked_mul(&self, _other: &Self) -> Option<Self> {
         unimplemented!("Polynomial multiplication is not implemented")
     }
 }
 
-impl<R: Ring, const DEGREE: usize> Sum for DensePolynomial<R, DEGREE> {
+impl<R: Semiring, const DEGREE: usize> Sum for DensePolynomial<R, DEGREE> {
     fn sum<I: Iterator<Item = Self>>(mut iter: I) -> Self {
         let Some(first) = iter.next() else {
             panic!("Sum of an empty iterator is not defined for DensePolynomial");
@@ -329,7 +329,7 @@ impl<R: Ring, const DEGREE: usize> Sum for DensePolynomial<R, DEGREE> {
     }
 }
 
-impl<'a, R: Ring, const DEGREE: usize> Sum<&'a Self> for DensePolynomial<R, DEGREE> {
+impl<'a, R: Semiring, const DEGREE: usize> Sum<&'a Self> for DensePolynomial<R, DEGREE> {
     fn sum<I: Iterator<Item = &'a Self>>(mut iter: I) -> Self {
         let Some(first) = iter.next() else {
             panic!("Sum of an empty iterator is not defined for DensePolynomial");
@@ -340,7 +340,7 @@ impl<'a, R: Ring, const DEGREE: usize> Sum<&'a Self> for DensePolynomial<R, DEGR
     }
 }
 
-impl<R: Ring, const DEGREE: usize> Product for DensePolynomial<R, DEGREE> {
+impl<R: Semiring, const DEGREE: usize> Product for DensePolynomial<R, DEGREE> {
     fn product<I: Iterator<Item = Self>>(mut iter: I) -> Self {
         let Some(first) = iter.next() else {
             panic!("Product of an empty iterator is not defined for DensePolynomial");
@@ -351,7 +351,7 @@ impl<R: Ring, const DEGREE: usize> Product for DensePolynomial<R, DEGREE> {
     }
 }
 
-impl<'a, R: Ring, const DEGREE: usize> Product<&'a Self> for DensePolynomial<R, DEGREE> {
+impl<'a, R: Semiring, const DEGREE: usize> Product<&'a Self> for DensePolynomial<R, DEGREE> {
     fn product<I: Iterator<Item = &'a Self>>(mut iter: I) -> Self {
         let Some(first) = iter.next() else {
             panic!("Product of an empty iterator is not defined for DensePolynomial");
@@ -362,11 +362,11 @@ impl<'a, R: Ring, const DEGREE: usize> Product<&'a Self> for DensePolynomial<R, 
     }
 }
 
-impl<R: Ring, const DEGREE: usize> Semiring for DensePolynomial<R, DEGREE> {}
+impl<R: Semiring, const DEGREE: usize> Semiring for DensePolynomial<R, DEGREE> {}
 
 impl<R: Ring, const DEGREE: usize> Ring for DensePolynomial<R, DEGREE> {}
 
-impl<R: Ring, const DEGREE: usize> Distribution<DensePolynomial<R, DEGREE>> for StandardUniform
+impl<R: Semiring, const DEGREE: usize> Distribution<DensePolynomial<R, DEGREE>> for StandardUniform
 where
     StandardUniform: Distribution<R>,
     StandardUniform: Distribution<[R; DEGREE]>, // This one we get for free
@@ -382,7 +382,7 @@ where
 // Zip-specific traits
 //
 
-impl<R: Ring + Named, const DEGREE: usize> Named for DensePolynomial<R, DEGREE> {
+impl<R: Semiring + Named, const DEGREE: usize> Named for DensePolynomial<R, DEGREE> {
     fn type_name() -> String {
         format!("Poly<{}, {DEGREE}>", R::type_name())
     }
@@ -427,7 +427,7 @@ impl<R: ConstTranscribable + Default, const DEGREE: usize> ConstTranscribable
 
 impl<R, S, const DEGREE: usize> FromRef<DensePolynomial<S, DEGREE>> for DensePolynomial<R, DEGREE>
 where
-    R: Ring + FromRef<S> + Default,
+    R: Semiring + FromRef<S> + Default,
 {
     fn from_ref(value: &DensePolynomial<S, DEGREE>) -> Self {
         let coeff_0 = R::from_ref(&value.coeff_0);
@@ -444,7 +444,7 @@ where
 
 impl<R, S, const DEGREE: usize> From<&DensePolynomial<S, DEGREE>> for DensePolynomial<R, DEGREE>
 where
-    R: Ring + FromRef<S> + Default,
+    R: Semiring + FromRef<S> + Default,
 {
     fn from(value: &DensePolynomial<S, DEGREE>) -> Self {
         Self::from_ref(value)
@@ -453,7 +453,7 @@ where
 
 impl<'a, R, S, const DEGREE: usize> MulByScalar<&'a S> for DensePolynomial<R, DEGREE>
 where
-    R: Ring + MulByScalar<&'a S>,
+    R: Semiring + MulByScalar<&'a S>,
 {
     fn mul_by_scalar(&self, rhs: &'a S) -> Option<Self> {
         let coeff_0 = self.coeff_0.mul_by_scalar(rhs)?;
@@ -468,7 +468,7 @@ where
 
 impl<R, F, const DEGREE: usize> ProjectableToField<F> for DensePolynomial<R, DEGREE>
 where
-    R: Ring,
+    R: Semiring,
     F: PrimeField + for<'a> FromWithConfig<&'a R> + for<'a> MulByScalar<&'a F> + 'static,
 {
     #![allow(clippy::arithmetic_side_effects)] // False alert, field operations are safe

--- a/zip-plus/src/poly/dense.rs
+++ b/zip-plus/src/poly/dense.rs
@@ -73,12 +73,16 @@ impl<R: Semiring, const DEGREE: usize> Polynomial<R> for DensePolynomial<R, DEGR
 
         // A trivial implementation of a polynomial evaluation at a given point.
         let mut result = self.coeff_0.clone();
-        for (coeff, scalar) in self.coeffs.iter().zip(point.iter()) {
-            let term = coeff
-                .mul_by_scalar(scalar)
-                .ok_or(EvaluationError::Overflow)?;
-            result = result.checked_add(&term).ok_or(EvaluationError::Overflow)?;
+        // Safety: We know that both `self.coeffs` and `point` have length DEGREE.
+        unsafe {
+            for i in 0..DEGREE {
+                let coeff = self.coeffs.get_unchecked(i);
+                let s = point.get_unchecked(i);
+                let t = coeff.mul_by_scalar(s).ok_or(EvaluationError::Overflow)?;
+                result = result.checked_add(&t).ok_or(EvaluationError::Overflow)?;
+            }
         }
+
         Ok(result)
     }
 }

--- a/zip-plus/src/poly/dense.rs
+++ b/zip-plus/src/poly/dense.rs
@@ -4,6 +4,7 @@ use crate::{
     traits::{ConstTranscribable, FromRef, Named},
 };
 use crypto_primitives::{FromWithConfig, IntoWithConfig, PrimeField, Ring, Semiring};
+use itertools::Itertools;
 use num_traits::{CheckedAdd, CheckedMul, CheckedNeg, CheckedSub, One, Zero};
 use rand::{distr::StandardUniform, prelude::*};
 use std::{
@@ -14,7 +15,7 @@ use std::{
     iter::{Product, Sum},
     ops::{Add, AddAssign, Mul, MulAssign, Neg, Sub, SubAssign},
 };
-// TODO: rename rename to univariate
+// TODO: rename to univariate?
 
 // Sadly, we cannot use [R; DEGREE + 1] in stable Rust yet, so we use separate
 // coeff_0.
@@ -58,18 +59,6 @@ impl<R: Semiring + Zero, const DEGREE: usize> DensePolynomial<R, DEGREE> {
 
 impl<R: Semiring, const DEGREE: usize> Polynomial<R> for DensePolynomial<R, DEGREE> {
     const DEGREE_BOUND: usize = DEGREE;
-
-    fn map<R2: Semiring>(&self, f: impl Fn(&R) -> R2) -> impl Polynomial<R2> {
-        let coeff_0 = f(&self.coeff_0);
-        let coeffs: [R2; DEGREE] = self
-            .coeffs
-            .iter()
-            .map(f)
-            .collect::<Vec<R2>>()
-            .try_into()
-            .expect("unreachable");
-        DensePolynomial { coeff_0, coeffs }
-    }
 
     fn evaluate_at_point<C>(&self, point: &[C]) -> Result<R, EvaluationError>
     where
@@ -480,7 +469,16 @@ where
         let field_cfg = sampled_value.cfg().clone();
 
         move |poly: &Self| {
-            poly.map(|v: &R| v.into_with_cfg(&field_cfg))
+            let coeff_0 = (&poly.coeff_0).into_with_cfg(&field_cfg);
+            let coeffs: [F; DEGREE] = poly
+                .coeffs
+                .iter()
+                .map(|v| v.into_with_cfg(&field_cfg))
+                .collect_array()
+                .expect("unreachable");
+
+            let poly2 = DensePolynomial { coeff_0, coeffs };
+            poly2
                 .evaluate_at_point(&r_powers)
                 .expect("Failed to evaluate polynomial at point")
         }

--- a/zip-plus/src/poly/mle.rs
+++ b/zip-plus/src/poly/mle.rs
@@ -6,7 +6,7 @@ use crate::pcs::structs::MulByScalar;
 use rand::prelude::*;
 use std::{
     fmt::Debug,
-    ops::{Add, AddAssign, Index, Neg, SubAssign},
+    ops::{Add, AddAssign, Index, SubAssign},
 };
 
 /// This trait describes an interface for the multilinear extension
@@ -23,7 +23,6 @@ pub trait MultilinearExtension<T>:
     + PartialEq
     + Eq
     + Add
-    + Neg
     + for<'a> AddAssign<&'a Self>
     + for<'a> AddAssign<(T, &'a Self)>
     + for<'a> SubAssign<&'a Self>

--- a/zip-plus/src/poly/mle/dense.rs
+++ b/zip-plus/src/poly/mle/dense.rs
@@ -10,7 +10,7 @@ use crate::{
     sub,
 };
 use ark_std::log2;
-use crypto_primitives::{Matrix, Ring};
+use crypto_primitives::{Matrix, Ring, Semiring};
 use rand::{distr::StandardUniform, prelude::*};
 use rand_core::RngCore;
 
@@ -22,7 +22,7 @@ pub struct DenseMultilinearExtension<F> {
     pub num_vars: usize,
 }
 
-impl<R: Ring> DenseMultilinearExtension<R> {
+impl<R: Semiring> DenseMultilinearExtension<R> {
     pub fn zero_vars(evaluation: R) -> Self {
         Self {
             evaluations: vec![evaluation],
@@ -135,7 +135,7 @@ impl<R: Ring> DenseMultilinearExtension<R> {
 
 impl<R> MultilinearExtension<R> for DenseMultilinearExtension<R>
 where
-    R: Ring,
+    R: Semiring,
 {
     #[allow(clippy::arithmetic_side_effects)]
     fn fix_variables<S>(&mut self, partial_point: &[S], zero: R)
@@ -184,7 +184,7 @@ where
 
 impl<R> MultilinearExtensionRand<R> for DenseMultilinearExtension<R>
 where
-    R: Ring,
+    R: Semiring,
     StandardUniform: Distribution<R>,
 {
     fn rand<Rng: RngCore + ?Sized>(num_vars: usize, rng: &mut Rng, zero: R) -> Self {
@@ -219,7 +219,7 @@ impl<R: Ring> Neg for DenseMultilinearExtension<R> {
     }
 }
 
-impl<R: Ring> Add for DenseMultilinearExtension<R> {
+impl<R: Semiring> Add for DenseMultilinearExtension<R> {
     type Output = Self;
 
     #[allow(clippy::arithmetic_side_effects)]
@@ -228,7 +228,7 @@ impl<R: Ring> Add for DenseMultilinearExtension<R> {
     }
 }
 
-impl<R: Ring> Add<&Self> for DenseMultilinearExtension<R> {
+impl<R: Semiring> Add<&Self> for DenseMultilinearExtension<R> {
     type Output = Self;
 
     #[allow(clippy::arithmetic_side_effects)]
@@ -238,7 +238,7 @@ impl<R: Ring> Add<&Self> for DenseMultilinearExtension<R> {
     }
 }
 
-impl<R: Ring> Sub<&Self> for DenseMultilinearExtension<R> {
+impl<R: Semiring> Sub<&Self> for DenseMultilinearExtension<R> {
     type Output = Self;
 
     #[allow(clippy::arithmetic_side_effects)]
@@ -248,7 +248,7 @@ impl<R: Ring> Sub<&Self> for DenseMultilinearExtension<R> {
     }
 }
 
-impl<R: Ring> Mul<&Self> for DenseMultilinearExtension<R> {
+impl<R: Semiring> Mul<&Self> for DenseMultilinearExtension<R> {
     type Output = Self;
 
     #[allow(clippy::arithmetic_side_effects)]
@@ -258,7 +258,7 @@ impl<R: Ring> Mul<&Self> for DenseMultilinearExtension<R> {
     }
 }
 
-impl<R: Ring> Mul<R> for DenseMultilinearExtension<R> {
+impl<R: Semiring> Mul<R> for DenseMultilinearExtension<R> {
     type Output = Self;
 
     #[allow(clippy::arithmetic_side_effects)]
@@ -268,28 +268,28 @@ impl<R: Ring> Mul<R> for DenseMultilinearExtension<R> {
     }
 }
 
-impl<R: Ring> AddAssign<&Self> for DenseMultilinearExtension<R> {
+impl<R: Semiring> AddAssign<&Self> for DenseMultilinearExtension<R> {
     #[allow(clippy::arithmetic_side_effects)]
     fn add_assign(&mut self, rhs: &Self) {
         self.binary(rhs, |a, b| *a += b);
     }
 }
 
-impl<R: Ring> SubAssign<&Self> for DenseMultilinearExtension<R> {
+impl<R: Semiring> SubAssign<&Self> for DenseMultilinearExtension<R> {
     #[allow(clippy::arithmetic_side_effects)]
     fn sub_assign(&mut self, rhs: &Self) {
         self.binary(rhs, |a, b| *a -= b);
     }
 }
 
-impl<R: Ring> MulAssign<&Self> for DenseMultilinearExtension<R> {
+impl<R: Semiring> MulAssign<&Self> for DenseMultilinearExtension<R> {
     #[allow(clippy::arithmetic_side_effects)]
     fn mul_assign(&mut self, rhs: &Self) {
         self.binary(rhs, |a, b| *a *= b);
     }
 }
 
-impl<R: Ring> AddAssign<(R, &Self)> for DenseMultilinearExtension<R> {
+impl<R: Semiring> AddAssign<(R, &Self)> for DenseMultilinearExtension<R> {
     #[allow(clippy::arithmetic_side_effects)]
     fn add_assign(&mut self, rhs: (R, &Self)) {
         let coeff = rhs.0;

--- a/zip-plus/src/poly/mle/dense.rs
+++ b/zip-plus/src/poly/mle/dense.rs
@@ -15,9 +15,9 @@ use rand::{distr::StandardUniform, prelude::*};
 use rand_core::RngCore;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub struct DenseMultilinearExtension<F> {
+pub struct DenseMultilinearExtension<T> {
     /// The evaluation over {0,1}^`num_vars`
-    pub evaluations: Vec<F>,
+    pub evaluations: Vec<T>,
     /// Number of variables
     pub num_vars: usize,
 }

--- a/zip-plus/src/poly/zero_degree.rs
+++ b/zip-plus/src/poly/zero_degree.rs
@@ -5,10 +5,6 @@ use crypto_primitives::Semiring;
 impl<R: Semiring> Polynomial<Self> for R {
     const DEGREE_BOUND: usize = 0;
 
-    fn map<R2: Semiring>(&self, f: impl Fn(&Self) -> R2) -> impl Polynomial<R2> {
-        f(self)
-    }
-
     fn evaluate_at_point<C>(&self, point: &[C]) -> Result<R, EvaluationError>
     where
         Self: for<'a> MulByScalar<&'a C>,

--- a/zip-plus/src/poly/zero_degree.rs
+++ b/zip-plus/src/poly/zero_degree.rs
@@ -1,11 +1,11 @@
 use super::{EvaluationError, Polynomial};
 use crate::pcs::structs::MulByScalar;
-use crypto_primitives::Ring;
+use crypto_primitives::Semiring;
 
-impl<R: Ring> Polynomial<Self> for R {
+impl<R: Semiring> Polynomial<Self> for R {
     const DEGREE_BOUND: usize = 0;
 
-    fn map<R2: Ring>(&self, f: impl Fn(&Self) -> R2) -> impl Polynomial<R2> {
+    fn map<R2: Semiring>(&self, f: impl Fn(&Self) -> R2) -> impl Polynomial<R2> {
         f(self)
     }
 

--- a/zip-plus/src/traits.rs
+++ b/zip-plus/src/traits.rs
@@ -1,5 +1,6 @@
 use crate::primality::PrimalityTest;
-use crypto_primitives::{ConstIntSemiring, crypto_bigint_int::Int};
+use crypto_primitives::{ConstIntSemiring, boolean::Boolean, crypto_bigint_int::Int};
+use num_traits::{ConstOne, ConstZero};
 //
 // FromRef
 //
@@ -29,6 +30,25 @@ impl_from_ref_for_primitive!(i32, [i32, i16, i8]);
 impl_from_ref_for_primitive!(i16, [i16, i8]);
 impl_from_ref_for_primitive!(i8, [i8]);
 
+macro_rules! impl_from_boolean_ref_for_primitive {
+    ($($dst:ty),+) => {
+        $(
+            impl FromRef<Boolean> for $dst {
+                fn from_ref(value: &Boolean) -> Self {
+                    if **value {
+                        ConstOne::ONE
+                    } else {
+                        ConstZero::ZERO
+                    }
+                }
+            }
+        )+
+    };
+}
+
+impl_from_boolean_ref_for_primitive!(i8, i16, i32, i64, i128);
+impl_from_boolean_ref_for_primitive!(u8, u16, u32, u64, u128);
+
 macro_rules! impl_int_from_primitive_ref {
     ($($t:ty),+) => {
         $(
@@ -43,6 +63,16 @@ macro_rules! impl_int_from_primitive_ref {
 }
 
 impl_int_from_primitive_ref!(i8, i16, i32, i64, i128);
+
+impl<const LIMBS: usize> FromRef<Boolean> for Int<LIMBS> {
+    fn from_ref(value: &Boolean) -> Self {
+        if **value {
+            ConstOne::ONE
+        } else {
+            ConstZero::ZERO
+        }
+    }
+}
 
 impl<const LIMBS: usize, const LIMBS2: usize> FromRef<Int<LIMBS2>> for Int<LIMBS> {
     #[inline]
@@ -93,6 +123,7 @@ pub trait Transcribable {
 pub trait ConstTranscribable {
     /// Number of bytes required to represent this type.
     const NUM_BYTES: usize;
+    /// Number of bits actually used to store data.
     const NUM_BITS: usize = Self::NUM_BYTES * 8;
 
     /// Creates a new instance from a byte buffer.

--- a/zip-plus/src/utils.rs
+++ b/zip-plus/src/utils.rs
@@ -10,6 +10,7 @@ use rand::{rngs::StdRng, seq::SliceRandom};
 use rand_core::SeedableRng;
 use std::iter::Iterator;
 
+use crypto_primitives::boolean::Boolean;
 #[cfg(feature = "parallel")]
 use rayon::prelude::*;
 
@@ -269,6 +270,12 @@ impl<const LIMBS: usize> Named for Uint<LIMBS> {
     }
 }
 
+impl Named for Boolean {
+    fn type_name() -> String {
+        "b".to_owned()
+    }
+}
+
 //
 // Transcribable implementations
 //
@@ -294,6 +301,19 @@ macro_rules! impl_transcribable_for_primitives {
 
 impl_transcribable_for_primitives!(u8, u16, u32, u64, u128);
 impl_transcribable_for_primitives!(i8, i16, i32, i64, i128);
+
+impl ConstTranscribable for Boolean {
+    const NUM_BYTES: usize = 1;
+    const NUM_BITS: usize = 1;
+
+    fn read_transcription_bytes(bytes: &[u8]) -> Self {
+        (bytes[0] != 0).into()
+    }
+
+    fn write_transcription_bytes(&self, buf: &mut [u8]) {
+        buf[0] = self.to_u8();
+    }
+}
 
 impl<const LIMBS: usize> ConstTranscribable for Uint<LIMBS> {
     const NUM_BYTES: usize = 8 * LIMBS / WORD_FACTOR;


### PR DESCRIPTION
(This is mostly a preparation PR to using binary decomposed polynomials)
* Switched Zip structs and traits to use semirings instead of rings where appropriate.
* RAA code has been split onto RAA and sign-flipping RAA. This is because sign-flipping version require `Neg` trait to be implemented, so it won't work on semirings.
* Zip+ benches changed to use `Boolean` instead of `i8` for evaluation coefficients.
* Additionally, test types for polynomials were changed to match benchmark types of Zip+. (Note that for int test types it's still more convenient to use types that differ to benchmarks)