### PR TITLE
Refactor polynomials

### DIFF
--- a/zip-plus/benches/zip_benches.rs
+++ b/zip-plus/benches/zip_benches.rs
@@ -17,12 +17,10 @@ use zip_plus::{
 const INT_LIMBS: usize = U64::LIMBS;
 
 struct BenchZipTypes {}
-impl ZipTypes for BenchZipTypes {
+impl ZipTypes<0> for BenchZipTypes {
     const NUM_COLUMN_OPENINGS: usize = 650;
-    type EvalR = i32;
-    type Eval = Self::EvalR;
-    type CwR = i64;
-    type Cw = Self::CwR;
+    type Eval = i32;
+    type Cw = i64;
     type Fmod = Uint<{ INT_LIMBS * 4 }>;
     type PrimeTest = MillerRabin;
     type Chal = i128;
@@ -30,7 +28,7 @@ impl ZipTypes for BenchZipTypes {
     type CombR = Int<{ INT_LIMBS * 3 }>;
     type Comb = Self::CombR;
 }
-type Code = RaaCode<BenchZipTypes, 4>;
+type Code = RaaCode<BenchZipTypes, 4, 0>;
 
 const RAA_CONFIG: RaaConfig = RaaConfig {
     check_for_overflows: false,
@@ -39,7 +37,7 @@ const RAA_CONFIG: RaaConfig = RaaConfig {
 
 fn zip_benchmarks(c: &mut Criterion) {
     let mut group = c.benchmark_group("Zip+");
-    do_bench::<BenchZipTypes, Code>(&mut group, RAA_CONFIG);
+    do_bench::<BenchZipTypes, Code, _>(&mut group, RAA_CONFIG);
     group.finish();
 }
 

--- a/zip-plus/benches/zip_common.rs
+++ b/zip-plus/benches/zip_common.rs
@@ -26,7 +26,7 @@ use zip_plus::{
 
 type F = BoxedMontyField;
 
-pub fn do_bench<Zt: ZipTypes, Lc: LinearCode<Zt>>(
+pub fn do_bench<Zt: ZipTypes<DEGREE>, Lc: LinearCode<Zt, DEGREE>, const DEGREE: usize>(
     group: &mut BenchmarkGroup<WallTime>,
     code_config: Lc::Config,
 ) where
@@ -36,49 +36,54 @@ pub fn do_bench<Zt: ZipTypes, Lc: LinearCode<Zt>>(
     Zt::Eval: ProjectableToField<F>,
     Zt::Cw: ProjectableToField<F>,
 {
-    encode_rows::<Zt, Lc, 12>(group, code_config);
-    encode_rows::<Zt, Lc, 13>(group, code_config);
-    encode_rows::<Zt, Lc, 14>(group, code_config);
-    encode_rows::<Zt, Lc, 15>(group, code_config);
-    encode_rows::<Zt, Lc, 16>(group, code_config);
+    encode_rows::<Zt, Lc, DEGREE, 12>(group, code_config);
+    encode_rows::<Zt, Lc, DEGREE, 13>(group, code_config);
+    encode_rows::<Zt, Lc, DEGREE, 14>(group, code_config);
+    encode_rows::<Zt, Lc, DEGREE, 15>(group, code_config);
+    encode_rows::<Zt, Lc, DEGREE, 16>(group, code_config);
 
-    encode_single_row::<Zt, Lc, 128>(group, code_config);
-    encode_single_row::<Zt, Lc, 256>(group, code_config);
-    encode_single_row::<Zt, Lc, 512>(group, code_config);
-    encode_single_row::<Zt, Lc, 1024>(group, code_config);
+    encode_single_row::<Zt, Lc, DEGREE, 128>(group, code_config);
+    encode_single_row::<Zt, Lc, DEGREE, 256>(group, code_config);
+    encode_single_row::<Zt, Lc, DEGREE, 512>(group, code_config);
+    encode_single_row::<Zt, Lc, DEGREE, 1024>(group, code_config);
 
-    merkle_root::<Zt, 12>(group);
-    merkle_root::<Zt, 13>(group);
-    merkle_root::<Zt, 14>(group);
-    merkle_root::<Zt, 15>(group);
-    merkle_root::<Zt, 16>(group);
+    merkle_root::<Zt, DEGREE, 12>(group);
+    merkle_root::<Zt, DEGREE, 13>(group);
+    merkle_root::<Zt, DEGREE, 14>(group);
+    merkle_root::<Zt, DEGREE, 15>(group);
+    merkle_root::<Zt, DEGREE, 16>(group);
 
-    commit::<Zt, Lc, 12>(group, code_config);
-    commit::<Zt, Lc, 13>(group, code_config);
-    commit::<Zt, Lc, 14>(group, code_config);
-    commit::<Zt, Lc, 15>(group, code_config);
-    commit::<Zt, Lc, 16>(group, code_config);
+    commit::<Zt, Lc, DEGREE, 12>(group, code_config);
+    commit::<Zt, Lc, DEGREE, 13>(group, code_config);
+    commit::<Zt, Lc, DEGREE, 14>(group, code_config);
+    commit::<Zt, Lc, DEGREE, 15>(group, code_config);
+    commit::<Zt, Lc, DEGREE, 16>(group, code_config);
 
-    test::<Zt, Lc, 12>(group, code_config);
-    test::<Zt, Lc, 13>(group, code_config);
-    test::<Zt, Lc, 14>(group, code_config);
-    test::<Zt, Lc, 15>(group, code_config);
-    test::<Zt, Lc, 16>(group, code_config);
+    test::<Zt, Lc, DEGREE, 12>(group, code_config);
+    test::<Zt, Lc, DEGREE, 13>(group, code_config);
+    test::<Zt, Lc, DEGREE, 14>(group, code_config);
+    test::<Zt, Lc, DEGREE, 15>(group, code_config);
+    test::<Zt, Lc, DEGREE, 16>(group, code_config);
 
-    evaluate::<Zt, Lc, 12>(group, code_config);
-    evaluate::<Zt, Lc, 13>(group, code_config);
-    evaluate::<Zt, Lc, 14>(group, code_config);
-    evaluate::<Zt, Lc, 15>(group, code_config);
-    evaluate::<Zt, Lc, 16>(group, code_config);
+    evaluate::<Zt, Lc, DEGREE, 12>(group, code_config);
+    evaluate::<Zt, Lc, DEGREE, 13>(group, code_config);
+    evaluate::<Zt, Lc, DEGREE, 14>(group, code_config);
+    evaluate::<Zt, Lc, DEGREE, 15>(group, code_config);
+    evaluate::<Zt, Lc, DEGREE, 16>(group, code_config);
 
-    verify::<Zt, Lc, 12>(group, code_config);
-    verify::<Zt, Lc, 13>(group, code_config);
-    verify::<Zt, Lc, 14>(group, code_config);
-    verify::<Zt, Lc, 15>(group, code_config);
-    verify::<Zt, Lc, 16>(group, code_config);
+    verify::<Zt, Lc, DEGREE, 12>(group, code_config);
+    verify::<Zt, Lc, DEGREE, 13>(group, code_config);
+    verify::<Zt, Lc, DEGREE, 14>(group, code_config);
+    verify::<Zt, Lc, DEGREE, 15>(group, code_config);
+    verify::<Zt, Lc, DEGREE, 16>(group, code_config);
 }
 
-pub fn encode_rows<Zt: ZipTypes, Lc: LinearCode<Zt>, const P: usize>(
+pub fn encode_rows<
+    Zt: ZipTypes<DEGREE>,
+    Lc: LinearCode<Zt, DEGREE>,
+    const DEGREE: usize,
+    const P: usize,
+>(
     group: &mut BenchmarkGroup<WallTime>,
     code_config: Lc::Config,
 ) where
@@ -96,7 +101,7 @@ pub fn encode_rows<Zt: ZipTypes, Lc: LinearCode<Zt>, const P: usize>(
             let linear_code = Lc::new(poly_size, code_config);
             let params = ZipPlus::setup(poly_size, linear_code);
             let row_len = params.linear_code.row_len();
-            let poly = DenseMultilinearExtension::<<Zt as ZipTypes>::Eval>::rand(
+            let poly = DenseMultilinearExtension::<<Zt as ZipTypes<_>>::Eval>::rand(
                 P,
                 &mut rng,
                 Zero::zero(),
@@ -109,7 +114,12 @@ pub fn encode_rows<Zt: ZipTypes, Lc: LinearCode<Zt>, const P: usize>(
     );
 }
 
-pub fn encode_single_row<Zt: ZipTypes, Lc: LinearCode<Zt>, const ROW_LEN: usize>(
+pub fn encode_single_row<
+    Zt: ZipTypes<DEGREE>,
+    Lc: LinearCode<Zt, DEGREE>,
+    const DEGREE: usize,
+    const ROW_LEN: usize,
+>(
     group: &mut BenchmarkGroup<WallTime>,
     code_config: Lc::Config,
 ) where
@@ -126,25 +136,26 @@ pub fn encode_single_row<Zt: ZipTypes, Lc: LinearCode<Zt>, const ROW_LEN: usize>
             let poly_size = ROW_LEN * ROW_LEN;
             let linear_code = Lc::new(poly_size, code_config);
             assert_eq!(linear_code.row_len(), ROW_LEN, "Unexpected row_len");
-            let message: Vec<<Zt as ZipTypes>::Eval> =
+            let message: Vec<<Zt as ZipTypes<_>>::Eval> =
                 (0..ROW_LEN).map(|_i| rng.random()).collect();
             b.iter(|| {
-                let encoded_row: Vec<<Zt as ZipTypes>::Cw> = linear_code.encode(&message);
+                let encoded_row: Vec<<Zt as ZipTypes<_>>::Cw> = linear_code.encode(&message);
                 black_box(encoded_row);
             })
         },
     );
 }
 
-pub fn merkle_root<Zt: ZipTypes, const P: usize>(group: &mut BenchmarkGroup<WallTime>)
-where
+pub fn merkle_root<Zt: ZipTypes<DEGREE>, const DEGREE: usize, const P: usize>(
+    group: &mut BenchmarkGroup<WallTime>,
+) where
     StandardUniform: Distribution<Zt::Cw>,
 {
     let mut rng = ThreadRng::default();
 
     let num_leaves = 1 << P;
     let leaves = (0..num_leaves)
-        .map(|_| rng.random::<<Zt as ZipTypes>::Cw>())
+        .map(|_| rng.random::<<Zt as ZipTypes<_>>::Cw>())
         .collect_vec();
     let matrix: DenseRowMatrix<_> = vec![leaves.clone()].into();
     let rows = matrix.to_rows_slices();
@@ -160,7 +171,12 @@ where
     );
 }
 
-pub fn commit<Zt: ZipTypes, Lc: LinearCode<Zt>, const P: usize>(
+pub fn commit<
+    Zt: ZipTypes<DEGREE>,
+    Lc: LinearCode<Zt, DEGREE>,
+    const DEGREE: usize,
+    const P: usize,
+>(
     group: &mut BenchmarkGroup<WallTime>,
     code_config: Lc::Config,
 ) where
@@ -195,7 +211,7 @@ pub fn commit<Zt: ZipTypes, Lc: LinearCode<Zt>, const P: usize>(
     );
 }
 
-pub fn test<Zt: ZipTypes, Lc: LinearCode<Zt>, const P: usize>(
+pub fn test<Zt: ZipTypes<DEGREE>, Lc: LinearCode<Zt, DEGREE>, const DEGREE: usize, const P: usize>(
     group: &mut BenchmarkGroup<WallTime>,
     code_config: Lc::Config,
 ) where
@@ -227,7 +243,12 @@ pub fn test<Zt: ZipTypes, Lc: LinearCode<Zt>, const P: usize>(
     );
 }
 
-pub fn evaluate<Zt: ZipTypes, Lc: LinearCode<Zt>, const P: usize>(
+pub fn evaluate<
+    Zt: ZipTypes<DEGREE>,
+    Lc: LinearCode<Zt, DEGREE>,
+    const DEGREE: usize,
+    const P: usize,
+>(
     group: &mut BenchmarkGroup<WallTime>,
     code_config: Lc::Config,
 ) where
@@ -273,7 +294,12 @@ pub fn evaluate<Zt: ZipTypes, Lc: LinearCode<Zt>, const P: usize>(
     );
 }
 
-pub fn verify<Zt: ZipTypes, Lc: LinearCode<Zt>, const P: usize>(
+pub fn verify<
+    Zt: ZipTypes<DEGREE>,
+    Lc: LinearCode<Zt, DEGREE>,
+    const DEGREE: usize,
+    const P: usize,
+>(
     group: &mut BenchmarkGroup<WallTime>,
     code_config: Lc::Config,
 ) where

--- a/zip-plus/benches/zip_plus_benches.rs
+++ b/zip-plus/benches/zip_plus_benches.rs
@@ -18,12 +18,10 @@ use zip_plus::{
 const INT_LIMBS: usize = U64::LIMBS;
 
 struct BenchZipPlusTypes<const D: usize> {}
-impl<const D: usize> ZipTypes for BenchZipPlusTypes<D> {
+impl<const D: usize> ZipTypes<D> for BenchZipPlusTypes<D> {
     const NUM_COLUMN_OPENINGS: usize = 650;
-    type EvalR = Boolean;
-    type Eval = DensePolynomial<Self::EvalR, D>;
-    type CwR = i32;
-    type Cw = DensePolynomial<Self::CwR, D>;
+    type Eval = DensePolynomial<Boolean, D>;
+    type Cw = DensePolynomial<i32, D>;
     type Fmod = Uint<{ INT_LIMBS * 4 }>;
     type PrimeTest = MillerRabin;
     type Chal = i128;
@@ -31,7 +29,7 @@ impl<const D: usize> ZipTypes for BenchZipPlusTypes<D> {
     type CombR = Int<{ INT_LIMBS * 5 }>;
     type Comb = DensePolynomial<Self::CombR, D>;
 }
-type Code<const D: usize> = RaaCode<BenchZipPlusTypes<D>, 4>;
+type Code<const D: usize> = RaaCode<BenchZipPlusTypes<D>, 4, D>;
 
 const RAA_CONFIG: RaaConfig = RaaConfig {
     check_for_overflows: false,
@@ -41,8 +39,8 @@ const RAA_CONFIG: RaaConfig = RaaConfig {
 fn zip_plus_benchmarks(c: &mut Criterion) {
     let mut group = c.benchmark_group("Zip+");
 
-    do_bench::<BenchZipPlusTypes<31>, Code<31>>(&mut group, RAA_CONFIG);
-    do_bench::<BenchZipPlusTypes<63>, Code<63>>(&mut group, RAA_CONFIG);
+    do_bench::<BenchZipPlusTypes<31>, Code<_>, _>(&mut group, RAA_CONFIG);
+    do_bench::<BenchZipPlusTypes<63>, Code<_>, _>(&mut group, RAA_CONFIG);
 
     group.finish();
 }

--- a/zip-plus/src/code.rs
+++ b/zip-plus/src/code.rs
@@ -4,7 +4,7 @@ pub mod raa_sign_flip;
 use crate::{pcs::structs::ZipTypes, traits::FromRef};
 use crypto_primitives::PrimeField;
 
-pub trait LinearCode<Zt: ZipTypes>: Sync + Send {
+pub trait LinearCode<Zt: ZipTypes<DEGREE>, const DEGREE: usize = 1>: Sync + Send {
     type Config: Copy;
 
     /// Repetition factor, a.k.a. inverse rate, the ratio of codeword length to

--- a/zip-plus/src/code/raa.rs
+++ b/zip-plus/src/code/raa.rs
@@ -1,9 +1,5 @@
 use crate::{
-    add,
-    code::LinearCode,
-    mul,
-    pcs::structs::ZipTypes,
-    traits::{ConstTranscribable, FromRef},
+    add, code::LinearCode, mul, pcs::structs::ZipTypes, poly::ConstCoeffBitWidth, traits::FromRef,
     utils::shuffle_seeded,
 };
 use crypto_primitives::PrimeField;
@@ -13,7 +9,7 @@ use std::{marker::PhantomData, ops::AddAssign};
 /// Implementation of a repeat-accumulate-accumulate (RAA) codes over the binary
 /// field, as defined by the Blaze paper (https://eprint.iacr.org/2024/1609)
 #[derive(Debug, Clone)]
-pub struct RaaCode<Zt: ZipTypes, const REP: usize> {
+pub struct RaaCode<Zt: ZipTypes<DEGREE>, const REP: usize, const DEGREE: usize> {
     pub(crate) cfg: RaaConfig,
 
     pub(crate) row_len: usize,
@@ -42,7 +38,7 @@ pub struct RaaConfig {
     pub permute_in_place: bool,
 }
 
-impl<Zt: ZipTypes, const REP: usize> RaaCode<Zt, REP> {
+impl<Zt: ZipTypes<DEGREE>, const REP: usize, const DEGREE: usize> RaaCode<Zt, REP, DEGREE> {
     /// Do the actual encoding, as per RAA spec
     fn encode_inner<In, Out>(&self, row: &[In]) -> Vec<Out>
     where
@@ -80,7 +76,9 @@ impl<Zt: ZipTypes, const REP: usize> RaaCode<Zt, REP> {
     }
 }
 
-impl<Zt: ZipTypes, const REP: usize> LinearCode<Zt> for RaaCode<Zt, REP> {
+impl<Zt: ZipTypes<DEGREE>, const REP: usize, const DEGREE: usize> LinearCode<Zt, DEGREE>
+    for RaaCode<Zt, REP, DEGREE>
+{
     type Config = RaaConfig;
 
     const REPETITION_FACTOR: usize = REP;
@@ -105,7 +103,7 @@ impl<Zt: ZipTypes, const REP: usize> LinearCode<Zt> for RaaCode<Zt, REP> {
         // For RAA it's initial_bits + 2*log(repetition_factor) + num_variables
         let codeword_width_bits = {
             let initial_bits =
-                u32::try_from(Zt::EvalR::NUM_BITS).expect("Size of EvalR type is too large");
+                u32::try_from(Zt::Eval::COEFF_BIT_WIDTH).expect("Size of EvalR type is too large");
 
             let rep_factor_log = REP.ilog2();
             let num_vars_even = if num_vars.is_multiple_of(2) {
@@ -116,7 +114,7 @@ impl<Zt: ZipTypes, const REP: usize> LinearCode<Zt> for RaaCode<Zt, REP> {
             add!(initial_bits, add!(num_vars_even, mul!(rep_factor_log, 2)))
         };
         let codeword_type_bits =
-            u32::try_from(Zt::CwR::NUM_BITS).expect("Size of CwR type is too large");
+            u32::try_from(Zt::Cw::COEFF_BIT_WIDTH).expect("Size of CwR type is too large");
         assert!(
             codeword_type_bits >= codeword_width_bits,
             "Cannot fit {codeword_width_bits}-bit wide codeword entries in {} bits entries",
@@ -253,12 +251,12 @@ mod tests {
 
     fn test_raa<Zt, F>(poly_size: usize, f: F)
     where
-        Zt: ZipTypes,
-        F: Fn(&RaaCode<Zt, REPETITION_FACTOR>),
+        Zt: ZipTypes<0>,
+        F: Fn(&RaaCode<Zt, REPETITION_FACTOR, 0>),
     {
         for check_for_overflows in [true, false] {
             for permute_in_place in [true, false] {
-                let code = RaaCode::<Zt, REPETITION_FACTOR>::new(
+                let code = RaaCode::<Zt, REPETITION_FACTOR, 0>::new(
                     poly_size,
                     RaaConfig {
                         check_for_overflows,
@@ -383,7 +381,7 @@ mod tests {
 
         for check_for_overflows in [true, false] {
             for permute_in_place in [true, false] {
-                let code = RaaCode::<TestZipTypes<N, K, M>, REPETITION_FACTOR>::new(
+                let code = RaaCode::<TestZipTypes<N, K, M>, REPETITION_FACTOR, 0>::new(
                     16,
                     RaaConfig {
                         check_for_overflows,
@@ -424,7 +422,7 @@ mod tests {
         let data: Vec<Int<N>> = (1..=1024).map(Int::<N>::from).collect();
         let poly_size = data.len() * data.len();
         let codeword_1: Vec<Int<K>> = {
-            let code_in_place = RaaCode::<TestZipTypes<N, K, M>, REPETITION_FACTOR>::new(
+            let code_in_place = RaaCode::<TestZipTypes<N, K, M>, REPETITION_FACTOR, 0>::new(
                 poly_size,
                 RaaConfig {
                     check_for_overflows: true,
@@ -435,7 +433,7 @@ mod tests {
         };
 
         let codeword_2: Vec<Int<K>> = {
-            let code_cloning = RaaCode::<TestZipTypes<N, K, M>, REPETITION_FACTOR>::new(
+            let code_cloning = RaaCode::<TestZipTypes<N, K, M>, REPETITION_FACTOR, 0>::new(
                 poly_size,
                 RaaConfig {
                     check_for_overflows: true,
@@ -456,7 +454,7 @@ mod tests {
         const N: usize = 1;
         const K: usize = 1;
 
-        let _code = RaaCode::<TestZipTypes<N, K, N>, REPETITION_FACTOR>::new(
+        let _code = RaaCode::<TestZipTypes<N, K, N>, REPETITION_FACTOR, 0>::new(
             1 << 30,
             RaaConfig {
                 check_for_overflows: true,

--- a/zip-plus/src/code/raa_sign_flip.rs
+++ b/zip-plus/src/code/raa_sign_flip.rs
@@ -10,14 +10,15 @@ use std::ops::{AddAssign, Neg};
 /// Flips signs of every second entry in the codeword, starting from the second
 /// one.
 #[derive(Debug, Clone)]
-pub struct RaaSignFlippingCode<Zt: ZipTypes, const REP: usize>
+pub struct RaaSignFlippingCode<Zt: ZipTypes<DEGREE>, const REP: usize, const DEGREE: usize>
 where
     Zt::Cw: Ring,
 {
-    raa: RaaCode<Zt, REP>,
+    raa: RaaCode<Zt, REP, DEGREE>,
 }
 
-impl<Zt: ZipTypes, const REP: usize> RaaSignFlippingCode<Zt, REP>
+impl<Zt: ZipTypes<DEGREE>, const REP: usize, const DEGREE: usize>
+    RaaSignFlippingCode<Zt, REP, DEGREE>
 where
     Zt::Cw: Ring,
 {
@@ -65,11 +66,12 @@ where
     }
 }
 
-impl<Zt: ZipTypes, const REP: usize> LinearCode<Zt> for RaaSignFlippingCode<Zt, REP>
+impl<Zt: ZipTypes<DEGREE>, const REP: usize, const DEGREE: usize> LinearCode<Zt, DEGREE>
+    for RaaSignFlippingCode<Zt, REP, DEGREE>
 where
     Zt::Cw: Ring,
 {
-    type Config = <RaaCode<Zt, REP> as LinearCode<Zt>>::Config;
+    type Config = <RaaCode<Zt, REP, DEGREE> as LinearCode<Zt, DEGREE>>::Config;
 
     const REPETITION_FACTOR: usize = REP;
 

--- a/zip-plus/src/pcs/phase_commit.rs
+++ b/zip-plus/src/pcs/phase_commit.rs
@@ -12,7 +12,9 @@ use crate::{
 use crypto_primitives::DenseRowMatrix;
 use uninit::out_ref::Out;
 
-impl<Zt: ZipTypes, Lc: LinearCode<Zt>> ZipPlus<Zt, Lc> {
+impl<Zt: ZipTypes<DEGREE>, Lc: LinearCode<Zt, DEGREE>, const DEGREE: usize>
+    ZipPlus<Zt, Lc, DEGREE>
+{
     /// Creates a commitment to a multilinear polynomial using the ZIP PCS
     /// scheme.
     ///
@@ -61,10 +63,10 @@ impl<Zt: ZipTypes, Lc: LinearCode<Zt>> ZipPlus<Zt, Lc> {
     ///   `pp.num_rows`, indicating an internal logic error.
     #[allow(clippy::arithmetic_side_effects)]
     pub fn commit(
-        pp: &ZipPlusParams<Zt, Lc>,
+        pp: &ZipPlusParams<Zt, Lc, DEGREE>,
         poly: &DenseMultilinearExtension<Zt::Eval>,
     ) -> Result<(ZipPlusHint<Zt::Cw>, ZipPlusCommitment), ZipError> {
-        validate_input::<Zt, Lc, bool>("commit", pp.num_vars, [poly], None)?;
+        validate_input::<Zt, Lc, bool, DEGREE>("commit", pp.num_vars, [poly], None)?;
 
         let expected_num_evals = pp.num_rows * pp.linear_code.row_len();
         assert_eq!(
@@ -105,10 +107,10 @@ impl<Zt: ZipTypes, Lc: LinearCode<Zt>> ZipPlus<Zt, Lc> {
     /// vector of roots.
     #[allow(dead_code)]
     pub fn commit_no_merkle(
-        pp: &ZipPlusParams<Zt, Lc>,
+        pp: &ZipPlusParams<Zt, Lc, DEGREE>,
         poly: &DenseMultilinearExtension<Zt::Eval>,
     ) -> Result<DenseRowMatrix<Zt::Cw>, ZipError> {
-        validate_input::<Zt, Lc, bool>("commit", pp.num_vars, [poly], None)?;
+        validate_input::<Zt, Lc, bool, DEGREE>("commit", pp.num_vars, [poly], None)?;
 
         let row_len = pp.linear_code.row_len();
 
@@ -132,7 +134,7 @@ impl<Zt: ZipTypes, Lc: LinearCode<Zt>> ZipPlus<Zt, Lc> {
     /// corresponds to a polynomial in the input slice.
     #[allow(clippy::type_complexity)]
     pub fn batch_commit(
-        pp: &ZipPlusParams<Zt, Lc>,
+        pp: &ZipPlusParams<Zt, Lc, DEGREE>,
         polys: &[DenseMultilinearExtension<Zt::Eval>],
     ) -> Result<Vec<(ZipPlusHint<Zt::Cw>, ZipPlusCommitment)>, ZipError> {
         polys.iter().map(|poly| Self::commit(pp, poly)).collect()
@@ -157,7 +159,7 @@ impl<Zt: ZipTypes, Lc: LinearCode<Zt>> ZipPlus<Zt, Lc> {
     /// A `Vec<Int<K>>` containing all the encoded rows concatenated together.
     #[allow(clippy::arithmetic_side_effects)]
     pub fn encode_rows(
-        pp: &ZipPlusParams<Zt, Lc>,
+        pp: &ZipPlusParams<Zt, Lc, DEGREE>,
         row_len: usize,
         evals: &[Zt::Eval],
     ) -> DenseRowMatrix<Zt::Cw> {
@@ -223,13 +225,13 @@ mod tests {
     const DEGREE: usize = 2;
 
     type Zt = TestZipTypes<N, K, M>;
-    type C = RaaSignFlippingCode<Zt, 4>;
+    type C = RaaSignFlippingCode<Zt, 4, 0>;
 
     type PolyZt = TestPolyZipTypes<K, M, DEGREE>;
-    type PolyC = RaaCode<PolyZt, 4>;
+    type PolyC = RaaCode<PolyZt, 4, DEGREE>;
 
-    type TestZip = ZipPlus<Zt, C>;
-    type TestPolyZip = ZipPlus<PolyZt, PolyC>;
+    type TestZip = ZipPlus<Zt, C, 0>;
+    type TestPolyZip = ZipPlus<PolyZt, PolyC, DEGREE>;
 
     #[test]
     fn commit_rejects_too_many_variables() {
@@ -588,7 +590,7 @@ mod tests {
 
     #[test]
     fn proof_size_is_correct_for_parameters() {
-        fn calculate_expected_test_transcript_size_bytes(pp: &ZipPlusParams<Zt, C>) -> usize {
+        fn calculate_expected_test_transcript_size_bytes(pp: &ZipPlusParams<Zt, C, 0>) -> usize {
             let size_of_zt_k = K * size_of::<Word>();
             let size_of_zt_m = M * size_of::<Word>();
             let size_of_path_len = size_of::<u64>();
@@ -609,7 +611,7 @@ mod tests {
             proximity_phase_size + column_opening_phase_size
         }
 
-        fn calculate_expected_proof_size_bytes(pp: &ZipPlusParams<Zt, C>) -> usize {
+        fn calculate_expected_proof_size_bytes(pp: &ZipPlusParams<Zt, C, 0>) -> usize {
             // F stored as `(value, modulus)` where both `value` and `modulus` are of
             // length `len`.
             // `len` itself is stored only once at the beginning of the F list.
@@ -628,12 +630,12 @@ mod tests {
         let linear_code = C::new(poly_size, RAA_CFG);
         let param = TestZip::setup(poly_size, linear_code);
         let evaluations: Vec<_> = (0..poly_size)
-            .map(|_| <Zt as ZipTypes>::Eval::from(rng.random::<i8>()))
+            .map(|_| <Zt as ZipTypes<_>>::Eval::from(rng.random::<i8>()))
             .collect();
         let mle =
             DenseMultilinearExtension::from_evaluations_slice(num_vars, &evaluations, Zero::zero());
         let point: Vec<_> = (0..num_vars)
-            .map(|_| <Zt as ZipTypes>::Pt::random(&mut rng))
+            .map(|_| <Zt as ZipTypes<_>>::Pt::random(&mut rng))
             .collect();
 
         let (hint, _) = TestZip::commit(&param, &mle).unwrap();

--- a/zip-plus/src/pcs/phase_evaluate.rs
+++ b/zip-plus/src/pcs/phase_evaluate.rs
@@ -16,9 +16,11 @@ use crate::{
 use crypto_primitives::{FromWithConfig, IntoWithConfig, PrimeField};
 use itertools::Itertools;
 
-impl<Zt: ZipTypes, Lc: LinearCode<Zt>> ZipPlus<Zt, Lc> {
+impl<Zt: ZipTypes<DEGREE>, Lc: LinearCode<Zt, DEGREE>, const DEGREE: usize>
+    ZipPlus<Zt, Lc, DEGREE>
+{
     pub fn evaluate<F>(
-        pp: &ZipPlusParams<Zt, Lc>,
+        pp: &ZipPlusParams<Zt, Lc, DEGREE>,
         poly: &DenseMultilinearExtension<Zt::Eval>,
         point: &[Zt::Pt],
         test_transcript: ZipPlusTestTranscript,
@@ -31,7 +33,7 @@ impl<Zt: ZipTypes, Lc: LinearCode<Zt>> ZipPlus<Zt, Lc> {
         F::Inner: FromRef<Zt::Fmod> + Transcribable,
         Zt::Eval: ProjectableToField<F>,
     {
-        validate_input::<Zt, Lc, _>("evaluate", pp.num_vars, [poly], [point])?;
+        validate_input::<Zt, Lc, _, DEGREE>("evaluate", pp.num_vars, [poly], [point])?;
 
         let mut transcript: PcsTranscript = test_transcript.into();
 

--- a/zip-plus/src/pcs/phase_test.rs
+++ b/zip-plus/src/pcs/phase_test.rs
@@ -7,29 +7,29 @@ use crate::{
         utils::{ColumnOpening, validate_input},
     },
     pcs_transcript::PcsTranscript,
-    poly::{Polynomial, mle::DenseMultilinearExtension},
+    poly::{EvaluatablePolynomial, mle::DenseMultilinearExtension},
     traits::{FromRef, Transcript},
     utils::combine_rows,
 };
 use itertools::Itertools;
 use num_traits::ConstZero;
 
-impl<Zt: ZipTypes, Lc: LinearCode<Zt>> ZipPlus<Zt, Lc> {
+impl<Zt: ZipTypes<DEGREE>, Lc: LinearCode<Zt, DEGREE>, const DEGREE: usize>
+    ZipPlus<Zt, Lc, DEGREE>
+{
     pub fn test(
-        pp: &ZipPlusParams<Zt, Lc>,
+        pp: &ZipPlusParams<Zt, Lc, DEGREE>,
         poly: &DenseMultilinearExtension<Zt::Eval>,
         commit_hint: &ZipPlusHint<Zt::Cw>,
     ) -> Result<ZipPlusTestTranscript, ZipError> {
-        validate_input::<Zt, Lc, bool>("test", pp.num_vars, [poly], None)?;
+        validate_input::<Zt, Lc, bool, DEGREE>("test", pp.num_vars, [poly], None)?;
 
         let mut transcript = PcsTranscript::new();
 
         // If we can take linear combinations, perform the proximity test
         if pp.num_rows > 1 {
             // Values to evaluate the coefficients at
-            let alphas = transcript
-                .fs_transcript
-                .get_challenges::<Zt::Chal>(Zt::Comb::DEGREE_BOUND);
+            let alphas = transcript.fs_transcript.get_challenges::<Zt::Chal>(DEGREE);
 
             // Coefficients for the linear combination of polynomial with evaluated
             // coefficients
@@ -108,13 +108,13 @@ mod tests {
     const DEGREE: usize = 2;
 
     type Zt = TestZipTypes<N, K, M>;
-    type C = RaaSignFlippingCode<Zt, 4>;
+    type C = RaaSignFlippingCode<Zt, 4, 0>;
 
     type PolyZt = TestPolyZipTypes<K, M, DEGREE>;
-    type PolyC = RaaCode<PolyZt, 4>;
+    type PolyC = RaaCode<PolyZt, 4, DEGREE>;
 
-    type TestZip = ZipPlus<Zt, C>;
-    type TestPolyZip = ZipPlus<PolyZt, PolyC>;
+    type TestZip = ZipPlus<Zt, C, 0>;
+    type TestPolyZip = ZipPlus<PolyZt, PolyC, DEGREE>;
 
     #[test]
     fn successful_testing_with_correct_polynomial_and_hint() {

--- a/zip-plus/src/pcs/phase_verify.rs
+++ b/zip-plus/src/pcs/phase_verify.rs
@@ -10,7 +10,7 @@ use crate::{
         utils::{ColumnOpening, point_to_tensor, validate_input},
     },
     pcs_transcript::PcsTranscript,
-    poly::Polynomial,
+    poly::EvaluatablePolynomial,
     traits::{FromRef, Transcribable, Transcript},
     utils::inner_product,
 };
@@ -18,9 +18,11 @@ use crypto_primitives::{FromWithConfig, IntoWithConfig, PrimeField};
 use itertools::Itertools;
 use num_traits::ConstZero;
 
-impl<Zt: ZipTypes, Lc: LinearCode<Zt>> ZipPlus<Zt, Lc> {
+impl<Zt: ZipTypes<DEGREE>, Lc: LinearCode<Zt, DEGREE>, const DEGREE: usize>
+    ZipPlus<Zt, Lc, DEGREE>
+{
     pub fn verify<F>(
-        vp: &ZipPlusParams<Zt, Lc>,
+        vp: &ZipPlusParams<Zt, Lc, DEGREE>,
         comm: &ZipPlusCommitment,
         point_f: &[F],
         eval_f: &F,
@@ -34,7 +36,7 @@ impl<Zt: ZipTypes, Lc: LinearCode<Zt>> ZipPlus<Zt, Lc> {
         F::Inner: FromRef<Zt::Fmod> + Transcribable,
         Zt::Cw: ProjectableToField<F>,
     {
-        validate_input::<Zt, Lc, _>("verify", vp.num_vars, &[], [point_f])?;
+        validate_input::<Zt, Lc, _, DEGREE>("verify", vp.num_vars, &[], [point_f])?;
 
         let mut transcript: PcsTranscript = proof.clone().into();
 
@@ -64,7 +66,7 @@ impl<Zt: ZipTypes, Lc: LinearCode<Zt>> ZipPlus<Zt, Lc> {
 
     #[allow(clippy::type_complexity)]
     pub(super) fn verify_testing(
-        vp: &ZipPlusParams<Zt, Lc>,
+        vp: &ZipPlusParams<Zt, Lc, DEGREE>,
         root: &MtHash,
         transcript: &mut PcsTranscript,
     ) -> Result<Vec<(usize, Vec<Zt::Cw>)>, ZipError> {
@@ -72,9 +74,7 @@ impl<Zt: ZipTypes, Lc: LinearCode<Zt>> ZipPlus<Zt, Lc> {
         let encoded_combined_rows: Option<(Vec<Zt::Chal>, Vec<Zt::Chal>, Vec<Zt::CombR>)> = {
             if vp.num_rows > 1 {
                 // Values to evaluate the coefficients at
-                let alphas = transcript
-                    .fs_transcript
-                    .get_challenges(Zt::Comb::DEGREE_BOUND);
+                let alphas = transcript.fs_transcript.get_challenges(DEGREE);
 
                 // Coefficients for the linear combination of polynomial with evaluated
                 // coefficients
@@ -146,7 +146,7 @@ impl<Zt: ZipTypes, Lc: LinearCode<Zt>> ZipPlus<Zt, Lc> {
     }
 
     fn verify_evaluation<F>(
-        vp: &ZipPlusParams<Zt, Lc>,
+        vp: &ZipPlusParams<Zt, Lc, DEGREE>,
         point_f: &[F],
         eval_f: &F,
         columns_opened: &[(usize, Vec<Zt::Cw>)],
@@ -191,7 +191,7 @@ impl<Zt: ZipTypes, Lc: LinearCode<Zt>> ZipPlus<Zt, Lc> {
         column_entries: &[Zt::Cw],
         column: usize,
         num_rows: usize,
-        project: &impl Fn(&<Zt as ZipTypes>::Cw) -> F,
+        project: &impl Fn(&<Zt as ZipTypes<DEGREE>>::Cw) -> F,
         field_cfg: &F::Config,
     ) -> Result<(), ZipError>
     where
@@ -254,13 +254,13 @@ mod tests {
     type F = BoxedMontyField;
 
     type Zt = TestZipTypes<N, K, M>;
-    type C = RaaSignFlippingCode<Zt, 4>;
+    type C = RaaSignFlippingCode<Zt, 4, 0>;
 
     type PolyZt = TestPolyZipTypes<K, M, DEGREE>;
-    type PolyC = RaaCode<PolyZt, 4>;
+    type PolyC = RaaCode<PolyZt, 4, DEGREE>;
 
-    type TestZip = ZipPlus<Zt, C>;
-    type TestPolyZip = ZipPlus<PolyZt, PolyC>;
+    type TestZip = ZipPlus<Zt, C, 0>;
+    type TestPolyZip = ZipPlus<PolyZt, PolyC, DEGREE>;
 
     #[test]
     fn successful_verification_of_valid_proof() {
@@ -435,7 +435,7 @@ mod tests {
             Zero::zero(),
         );
 
-        let point: Vec<<Zt as ZipTypes>::Pt> =
+        let point: Vec<<Zt as ZipTypes<_>>::Pt> =
             (0..num_vars).map(|i| Int::from(i as i32 + 2)).collect();
 
         let test_mle2_proof = TestZip::test(&pp, &mle2, &data).expect("test phase should succeed");
@@ -478,7 +478,7 @@ mod tests {
         let corrupted_merkle_tree = MerkleTree::new(&corrupted_data.to_rows_slices());
         let corrupted_data = ZipPlusHint::new(corrupted_data, corrupted_merkle_tree);
 
-        let point: Vec<<Zt as ZipTypes>::Pt> =
+        let point: Vec<<Zt as ZipTypes<_>>::Pt> =
             (0..num_vars).map(|i| Int::from(i as i32 + 2)).collect();
 
         let test_transcript =
@@ -506,7 +506,7 @@ mod tests {
 
         let (data, comm) = TestZip::commit(&pp, &mle).unwrap();
 
-        let point: Vec<<Zt as ZipTypes>::Pt> =
+        let point: Vec<<Zt as ZipTypes<_>>::Pt> =
             (0..num_vars).map(|i| Int::from(i as i32 + 2)).collect();
 
         let test_transcript = TestZip::test(&pp, &mle, &data).expect("test phase should succeed");
@@ -537,7 +537,7 @@ mod tests {
         let pp = TestZip::setup(poly_size, linear_code);
 
         let evaluations: Vec<_> = (0..poly_size as i32)
-            .map(<Zt as ZipTypes>::Eval::from)
+            .map(<Zt as ZipTypes<_>>::Eval::from)
             .collect();
         let mle = DenseMultilinearExtension::from_evaluations_slice(n, &evaluations, Zero::zero());
 
@@ -619,11 +619,11 @@ mod tests {
         let linear_code: C = C::new(poly_size, RAA_CFG);
         let pp = TestZip::setup(poly_size, linear_code);
         let evaluations: Vec<_> = (0..poly_size)
-            .map(|_| <Zt as ZipTypes>::Eval::from(rng.random::<i8>()))
+            .map(|_| <Zt as ZipTypes<_>>::Eval::from(rng.random::<i8>()))
             .collect();
         let mle = DenseMultilinearExtension::from_evaluations_slice(n, &evaluations, Zero::zero());
         let point: Vec<_> = (0..n)
-            .map(|_| <Zt as ZipTypes>::Pt::random(&mut rng))
+            .map(|_| <Zt as ZipTypes<_>>::Pt::random(&mut rng))
             .collect();
 
         let (mut data, comm) = TestZip::commit(&pp, &mle).unwrap();
@@ -655,7 +655,7 @@ mod tests {
 
         let (data, comm) = TestZip::commit(&pp, &mle).expect("commit should succeed");
 
-        let point: Vec<<Zt as ZipTypes>::Pt> =
+        let point: Vec<<Zt as ZipTypes<_>>::Pt> =
             [0i64, 0i64, 0i64].into_iter().map(Int::from).collect_vec();
 
         let test_transcript = TestZip::test(&pp, &mle, &data).unwrap();
@@ -701,7 +701,7 @@ mod tests {
 
         let (data, comm) = TestZip::commit(&pp, &mle).expect("commit should succeed");
 
-        let point: Vec<<Zt as ZipTypes>::Pt> =
+        let point: Vec<<Zt as ZipTypes<_>>::Pt> =
             [0i64, 0i64, 0i64].into_iter().map(Int::from).collect_vec();
 
         let test_transcript = TestZip::test(&pp, &mle, &data).unwrap();
@@ -732,7 +732,7 @@ mod tests {
 
         let (data, comm) = TestZip::commit(&pp, &mle).expect("commit should succeed");
 
-        let point: Vec<<Zt as ZipTypes>::Pt> = vec![Int::ZERO; num_vars];
+        let point: Vec<<Zt as ZipTypes<_>>::Pt> = vec![Int::ZERO; num_vars];
 
         let test_transcript = TestZip::test(&pp, &mle, &data).unwrap();
         let (real_eval_f, proof) =
@@ -754,7 +754,7 @@ mod tests {
         let num_vars = 4;
         let (pp, _) = setup_test_params(num_vars);
 
-        let mut evals: Vec<<Zt as ZipTypes>::Eval> =
+        let mut evals: Vec<<Zt as ZipTypes<_>>::Eval> =
             (0..1 << num_vars as i32).map(Int::from).collect();
         evals[1] = Int::from(i64::MAX);
         let poly = DenseMultilinearExtension::from_evaluations_vec(num_vars, evals, Zero::zero());
@@ -762,8 +762,8 @@ mod tests {
         let (data, comm) = TestZip::commit(&pp, &poly).unwrap();
 
         // A point of [1, 0, 0, 0] will evaluate to poly.evaluations[1].
-        let mut point = vec![<Zt as ZipTypes>::Pt::ZERO; num_vars];
-        point[0] = <Zt as ZipTypes>::Pt::ONE;
+        let mut point = vec![<Zt as ZipTypes<_>>::Pt::ZERO; num_vars];
+        point[0] = <Zt as ZipTypes<_>>::Pt::ONE;
 
         let test_transcript = TestZip::test(&pp, &poly, &data).unwrap();
         let (eval_f, proof) = TestZip::evaluate::<F>(&pp, &poly, &point, test_transcript).unwrap();
@@ -791,7 +791,7 @@ mod tests {
 
         let (hint, comm) = TestZip::commit(&pp, &poly).unwrap();
 
-        let point: Vec<<Zt as ZipTypes>::Pt> = vec![Int::from(1), Int::from(2)];
+        let point: Vec<<Zt as ZipTypes<_>>::Pt> = vec![Int::from(1), Int::from(2)];
 
         let test_transcript = TestZip::test(&pp, &poly, &hint).unwrap();
         let (eval_f, proof) = TestZip::evaluate::<F>(&pp, &poly, &point, test_transcript).unwrap();
@@ -821,7 +821,7 @@ mod tests {
 
         let (data, comm) = TestZip::commit(&pp, &mle).expect("commit should succeed");
 
-        let point: Vec<<Zt as ZipTypes>::Pt> =
+        let point: Vec<<Zt as ZipTypes<_>>::Pt> =
             [0i64, 0i64, 0i64].into_iter().map(Int::from).collect_vec();
 
         let test_transcript = TestZip::test(&pp, &mle, &data).unwrap();

--- a/zip-plus/src/pcs/structs.rs
+++ b/zip-plus/src/pcs/structs.rs
@@ -1,7 +1,7 @@
 use crate::{
     code::LinearCode,
     merkle::{MerkleTree, MtHash},
-    poly::Polynomial,
+    poly::{ConstCoeffBitWidth, EvaluatablePolynomial, Polynomial},
     primality::PrimalityTest,
     traits::{ConstTranscribable, FromRef, Named},
 };
@@ -12,19 +12,16 @@ use crypto_primitives::{
 use num_traits::CheckedMul;
 use std::{marker::PhantomData, ops::Neg};
 
-pub trait ZipTypes: Send + Sync {
+pub trait ZipTypes<const DEGREE: usize>: Send + Sync {
     const NUM_COLUMN_OPENINGS: usize;
 
-    /// Coefficient ring of evaluation polynomial [Self::Eval]
-    type EvalR: ConstIntSemiring + ConstTranscribable + Named;
     /// Semiring of witness/polynomial evaluations on boolean hypercube
-    type Eval: FixedSemiring + Named + Polynomial<Self::EvalR>;
+    type Eval: FixedSemiring + Named + Polynomial<DEGREE> + ConstCoeffBitWidth;
 
-    /// Coefficient semiring of codeword polynomial [Self::Cw]
-    type CwR: ConstIntSemiring + ConstTranscribable + Named;
     /// Semiring of codeword elements, at least as wide as the evaluation ring
     type Cw: FixedSemiring
-        + Polynomial<Self::CwR>
+        + Polynomial<DEGREE>
+        + ConstCoeffBitWidth
         + ConstTranscribable
         + FromRef<Self::Eval>
         + Named
@@ -49,20 +46,27 @@ pub trait ZipTypes: Send + Sync {
         + for<'a> MulByScalar<&'a Self::Chal>;
     /// Ring of elements in the linear combination of codewords, at least as
     /// wide as the evaluation, codeword, and challenge rings.
-    type Comb: FixedRing + Polynomial<Self::CombR> + FromRef<Self::Eval> + FromRef<Self::Cw> + Named;
+    type Comb: FixedRing
+        + Polynomial<DEGREE>
+        + EvaluatablePolynomial<Self::Chal, Output = Self::CombR>
+        + FromRef<Self::Eval>
+        + FromRef<Self::Cw>
+        + Named;
 }
 
 /// Zip is a Polynomial Commitment Scheme (PCS) that supports committing to
 /// multilinear polynomials.
-pub struct ZipPlus<Zt: ZipTypes, Lc: LinearCode<Zt>>(PhantomData<(Zt, Lc)>);
+pub struct ZipPlus<Zt: ZipTypes<DEGREE>, Lc: LinearCode<Zt, DEGREE>, const DEGREE: usize>(
+    PhantomData<(Zt, Lc)>,
+);
 
-impl<Zt, Lc> ZipPlus<Zt, Lc>
+impl<Zt, Lc, const DEGREE: usize> ZipPlus<Zt, Lc, DEGREE>
 where
-    Zt: ZipTypes,
-    Lc: LinearCode<Zt>,
+    Zt: ZipTypes<DEGREE>,
+    Lc: LinearCode<Zt, DEGREE>,
 {
     #[allow(clippy::arithmetic_side_effects)]
-    pub fn setup(poly_size: usize, linear_code: Lc) -> ZipPlusParams<Zt, Lc> {
+    pub fn setup(poly_size: usize, linear_code: Lc) -> ZipPlusParams<Zt, Lc, DEGREE> {
         assert!(poly_size.is_power_of_two());
         let num_vars = poly_size.ilog2() as usize;
         let num_rows = ((1 << num_vars) / linear_code.row_len()).next_power_of_two();
@@ -72,14 +76,16 @@ where
 
 /// Parameters for the Zip+ PCS.
 #[derive(Clone, Debug)]
-pub struct ZipPlusParams<Zt: ZipTypes, Lc: LinearCode<Zt>> {
+pub struct ZipPlusParams<Zt: ZipTypes<DEGREE>, Lc: LinearCode<Zt, DEGREE>, const DEGREE: usize> {
     pub num_vars: usize,
     pub num_rows: usize,
     pub linear_code: Lc,
     phantom_data: PhantomData<Zt>,
 }
 
-impl<Zt: ZipTypes, Lc: LinearCode<Zt>> ZipPlusParams<Zt, Lc> {
+impl<Zt: ZipTypes<DEGREE>, Lc: LinearCode<Zt, DEGREE>, const DEGREE: usize>
+    ZipPlusParams<Zt, Lc, DEGREE>
+{
     pub fn new(num_vars: usize, num_rows: usize, linear_code: Lc) -> Self {
         Self {
             num_vars,

--- a/zip-plus/src/pcs/structs.rs
+++ b/zip-plus/src/pcs/structs.rs
@@ -1,7 +1,7 @@
 use crate::{
     code::LinearCode,
     merkle::{MerkleTree, MtHash},
-    poly::{ConstCoeffBitWidth, EvaluatablePolynomial, Polynomial},
+    poly::{ConstCoeffBitWidth, EvaluatablePolynomial},
     primality::PrimalityTest,
     traits::{ConstTranscribable, FromRef, Named},
 };
@@ -16,11 +16,10 @@ pub trait ZipTypes<const DEGREE: usize>: Send + Sync {
     const NUM_COLUMN_OPENINGS: usize;
 
     /// Semiring of witness/polynomial evaluations on boolean hypercube
-    type Eval: FixedSemiring + Named + Polynomial<DEGREE> + ConstCoeffBitWidth;
+    type Eval: FixedSemiring + Named + ConstCoeffBitWidth;
 
     /// Semiring of codeword elements, at least as wide as the evaluation ring
     type Cw: FixedSemiring
-        + Polynomial<DEGREE>
         + ConstCoeffBitWidth
         + ConstTranscribable
         + FromRef<Self::Eval>
@@ -47,7 +46,6 @@ pub trait ZipTypes<const DEGREE: usize>: Send + Sync {
     /// Ring of elements in the linear combination of codewords, at least as
     /// wide as the evaluation, codeword, and challenge rings.
     type Comb: FixedRing
-        + Polynomial<DEGREE>
         + EvaluatablePolynomial<Self::Chal, Output = Self::CombR>
         + FromRef<Self::Eval>
         + FromRef<Self::Cw>

--- a/zip-plus/src/pcs/structs.rs
+++ b/zip-plus/src/pcs/structs.rs
@@ -6,7 +6,7 @@ use crate::{
     traits::{ConstTranscribable, FromRef, Named},
 };
 use crypto_primitives::{
-    ConstIntRing, ConstIntSemiring, DenseRowMatrix, FixedRing, FixedSemiring, PrimeField,
+    ConstIntRing, ConstIntSemiring, DenseRowMatrix, FixedSemiring, PrimeField,
     crypto_bigint_int::Int,
 };
 use num_traits::CheckedMul;
@@ -45,8 +45,8 @@ pub trait ZipTypes<const DEGREE: usize>: Send + Sync {
         + for<'a> MulByScalar<&'a Self::Chal>;
     /// Ring of elements in the linear combination of codewords, at least as
     /// wide as the evaluation, codeword, and challenge rings.
-    type Comb: FixedRing
-        + EvaluatablePolynomial<Self::Chal, Output = Self::CombR>
+    type Comb: FixedSemiring
+        + EvaluatablePolynomial<Self::Chal, Self::CombR>
         + FromRef<Self::Eval>
         + FromRef<Self::Cw>
         + Named;

--- a/zip-plus/src/pcs/test_utils.rs
+++ b/zip-plus/src/pcs/test_utils.rs
@@ -39,12 +39,10 @@ pub const RAA_CFG: RaaConfig = RaaConfig {
 };
 
 pub struct TestZipTypes<const N: usize, const K: usize, const M: usize> {}
-impl<const N: usize, const K: usize, const M: usize> ZipTypes for TestZipTypes<N, K, M> {
+impl<const N: usize, const K: usize, const M: usize> ZipTypes<0> for TestZipTypes<N, K, M> {
     const NUM_COLUMN_OPENINGS: usize = 650;
-    type EvalR = Int<N>;
-    type Eval = Self::EvalR;
-    type CwR = Int<K>;
-    type Cw = Self::CwR;
+    type Eval = Int<N>;
+    type Cw = Int<K>;
     type Fmod = Uint<K>;
     type PrimeTest = MillerRabin;
     type Chal = Int<N>;
@@ -54,14 +52,12 @@ impl<const N: usize, const K: usize, const M: usize> ZipTypes for TestZipTypes<N
 }
 
 pub struct TestPolyZipTypes<const K: usize, const M: usize, const DEGREE: usize> {}
-impl<const K: usize, const M: usize, const DEGREE: usize> ZipTypes
+impl<const K: usize, const M: usize, const DEGREE: usize> ZipTypes<DEGREE>
     for TestPolyZipTypes<K, M, DEGREE>
 {
     const NUM_COLUMN_OPENINGS: usize = 650;
-    type EvalR = Boolean;
-    type Eval = DensePolynomial<Self::EvalR, DEGREE>;
-    type CwR = i32;
-    type Cw = DensePolynomial<Self::CwR, DEGREE>;
+    type Eval = DensePolynomial<Boolean, DEGREE>;
+    type Cw = DensePolynomial<i32, DEGREE>;
     type Fmod = Uint<K>;
     type PrimeTest = MillerRabin;
     type Chal = i128;
@@ -76,9 +72,10 @@ pub fn setup_test_params<const N: usize, const K: usize, const M: usize>(
 ) -> (
     ZipPlusParams<
         TestZipTypes<N, K, M>,
-        RaaSignFlippingCode<TestZipTypes<N, K, M>, REPETITION_FACTOR>,
+        RaaSignFlippingCode<TestZipTypes<N, K, M>, REPETITION_FACTOR, 0>,
+        0,
     >,
-    DenseMultilinearExtension<<TestZipTypes<N, K, M> as ZipTypes>::Eval>,
+    DenseMultilinearExtension<<TestZipTypes<N, K, M> as ZipTypes<0>>::Eval>,
 ) {
     setup_test_params_inner(num_vars, |poly_size| {
         (1..=poly_size as i32).map(Int::from).collect()
@@ -91,9 +88,10 @@ pub fn setup_poly_test_params<const K: usize, const M: usize, const DEGREE: usiz
 ) -> (
     ZipPlusParams<
         TestPolyZipTypes<K, M, DEGREE>,
-        RaaCode<TestPolyZipTypes<K, M, DEGREE>, REPETITION_FACTOR>,
+        RaaCode<TestPolyZipTypes<K, M, DEGREE>, REPETITION_FACTOR, DEGREE>,
+        DEGREE,
     >,
-    DenseMultilinearExtension<<TestPolyZipTypes<K, M, DEGREE> as ZipTypes>::Eval>,
+    DenseMultilinearExtension<<TestPolyZipTypes<K, M, DEGREE> as ZipTypes<DEGREE>>::Eval>,
 ) {
     setup_test_params_inner(num_vars, |poly_size| {
         let eval_coeffs: Vec<_> = (1..=(poly_size * DEGREE) as i8)
@@ -106,10 +104,17 @@ pub fn setup_poly_test_params<const K: usize, const M: usize, const DEGREE: usiz
     })
 }
 
-fn setup_test_params_inner<Zt: ZipTypes, Lc: LinearCode<Zt, Config = RaaConfig>>(
+fn setup_test_params_inner<
+    Zt: ZipTypes<DEGREE>,
+    Lc: LinearCode<Zt, DEGREE, Config = RaaConfig>,
+    const DEGREE: usize,
+>(
     num_vars: usize,
     prepare_evaluations: impl FnOnce(usize) -> Vec<Zt::Eval>,
-) -> (ZipPlusParams<Zt, Lc>, DenseMultilinearExtension<Zt::Eval>) {
+) -> (
+    ZipPlusParams<Zt, Lc, DEGREE>,
+    DenseMultilinearExtension<Zt::Eval>,
+) {
     let poly_size = 1 << num_vars;
     let num_rows = 1 << num_vars.div_ceil(2);
 
@@ -127,7 +132,8 @@ pub fn setup_full_protocol<F, const N: usize, const K: usize, const M: usize>(
 ) -> (
     ZipPlusParams<
         TestZipTypes<N, K, M>,
-        RaaSignFlippingCode<TestZipTypes<N, K, M>, REPETITION_FACTOR>,
+        RaaSignFlippingCode<TestZipTypes<N, K, M>, REPETITION_FACTOR, 0>,
+        0,
     >,
     ZipPlusCommitment,
     Vec<F>,
@@ -136,13 +142,13 @@ pub fn setup_full_protocol<F, const N: usize, const K: usize, const M: usize>(
 )
 where
     F: PrimeField
-        + for<'a> FromWithConfig<&'a <TestZipTypes<N, K, M> as ZipTypes>::Chal>
+        + for<'a> FromWithConfig<&'a <TestZipTypes<N, K, M> as ZipTypes<0>>::Chal>
         + for<'a> MulByScalar<&'a F>,
-    F::Inner: FromRef<<TestZipTypes<N, K, M> as ZipTypes>::Fmod> + Transcribable,
-    <TestZipTypes<N, K, M> as ZipTypes>::Eval: ProjectableToField<F>,
-    <TestZipTypes<N, K, M> as ZipTypes>::Comb: ProjectableToField<F>,
+    F::Inner: FromRef<<TestZipTypes<N, K, M> as ZipTypes<0>>::Fmod> + Transcribable,
+    <TestZipTypes<N, K, M> as ZipTypes<0>>::Eval: ProjectableToField<F>,
+    <TestZipTypes<N, K, M> as ZipTypes<0>>::Comb: ProjectableToField<F>,
 {
-    setup_full_protocol_inner::<_, _, _, N>(num_vars, setup_test_params, || {
+    setup_full_protocol_inner::<_, _, _, N, 0>(num_vars, setup_test_params, || {
         (0..num_vars).map(|i| Int::from(i as i32 + 2)).collect()
     })
 }
@@ -158,7 +164,8 @@ pub fn setup_full_protocol_poly<
 ) -> (
     ZipPlusParams<
         TestPolyZipTypes<K, M, DEGREE>,
-        RaaCode<TestPolyZipTypes<K, M, DEGREE>, REPETITION_FACTOR>,
+        RaaCode<TestPolyZipTypes<K, M, DEGREE>, REPETITION_FACTOR, DEGREE>,
+        DEGREE,
     >,
     ZipPlusCommitment,
     Vec<F>,
@@ -167,31 +174,36 @@ pub fn setup_full_protocol_poly<
 )
 where
     F: PrimeField
-        + for<'a> FromWithConfig<&'a <TestPolyZipTypes<K, M, DEGREE> as ZipTypes>::Chal>
+        + for<'a> FromWithConfig<&'a <TestPolyZipTypes<K, M, DEGREE> as ZipTypes<DEGREE>>::Chal>
         + for<'a> MulByScalar<&'a F>,
-    F::Inner: FromRef<<TestPolyZipTypes<K, M, DEGREE> as ZipTypes>::Fmod> + Transcribable,
-    <TestPolyZipTypes<K, M, DEGREE> as ZipTypes>::Eval: ProjectableToField<F>,
-    <TestPolyZipTypes<K, M, DEGREE> as ZipTypes>::Comb: ProjectableToField<F>,
+    F::Inner: FromRef<<TestPolyZipTypes<K, M, DEGREE> as ZipTypes<DEGREE>>::Fmod> + Transcribable,
+    <TestPolyZipTypes<K, M, DEGREE> as ZipTypes<DEGREE>>::Eval: ProjectableToField<F>,
+    <TestPolyZipTypes<K, M, DEGREE> as ZipTypes<DEGREE>>::Comb: ProjectableToField<F>,
 {
-    setup_full_protocol_inner::<_, _, _, N>(num_vars, setup_poly_test_params, || {
+    setup_full_protocol_inner::<_, _, _, N, DEGREE>(num_vars, setup_poly_test_params, || {
         (0..num_vars).map(|i| i as i128 + 2).collect()
     })
 }
 
-fn setup_full_protocol_inner<Zt, Lc, F, const N: usize>(
+fn setup_full_protocol_inner<Zt, Lc, F, const N: usize, const DEGREE: usize>(
     num_vars: usize,
-    setup: impl FnOnce(usize) -> (ZipPlusParams<Zt, Lc>, DenseMultilinearExtension<Zt::Eval>),
+    setup: impl FnOnce(
+        usize,
+    ) -> (
+        ZipPlusParams<Zt, Lc, DEGREE>,
+        DenseMultilinearExtension<Zt::Eval>,
+    ),
     prepare_evaluation_point: impl FnOnce() -> Vec<Zt::Pt>,
 ) -> (
-    ZipPlusParams<Zt, Lc>,
+    ZipPlusParams<Zt, Lc, DEGREE>,
     ZipPlusCommitment,
     Vec<F>,
     F,
     ZipPlusProof,
 )
 where
-    Zt: ZipTypes,
-    Lc: LinearCode<Zt>,
+    Zt: ZipTypes<DEGREE>,
+    Lc: LinearCode<Zt, DEGREE>,
     F: PrimeField
         + for<'a> FromWithConfig<&'a Zt::Chal>
         + for<'a> FromWithConfig<&'a Zt::Pt>

--- a/zip-plus/src/pcs/utils.rs
+++ b/zip-plus/src/pcs/utils.rs
@@ -9,7 +9,7 @@ use crate::{
     merkle::{MerkleError, MerkleProof, MtHash},
     pcs::structs::{ZipPlusHint, ZipTypes},
     pcs_transcript::PcsTranscript,
-    poly::Polynomial,
+    poly::ConstCoeffBitWidth,
     traits::ConstTranscribable,
 };
 #[cfg(feature = "parallel")]
@@ -22,7 +22,13 @@ fn err_too_many_variates(function: &str, upto: usize, got: usize) -> ZipError {
 }
 
 // Ensures that polynomials and evaluation points are of appropriate size
-pub(super) fn validate_input<'a, Zt: ZipTypes + 'a, Lc: LinearCode<Zt>, Pt: 'a>(
+pub(super) fn validate_input<
+    'a,
+    Zt: ZipTypes<DEGREE> + 'a,
+    Lc: LinearCode<Zt, DEGREE>,
+    Pt: 'a,
+    const DEGREE: usize,
+>(
     function: &str,
     param_num_vars: usize,
     polys: impl Iterable<Item = &'a DenseMultilinearExtension<Zt::Eval>>,
@@ -36,7 +42,7 @@ pub(super) fn validate_input<'a, Zt: ZipTypes + 'a, Lc: LinearCode<Zt>, Pt: 'a>(
         let d = div!(param_num_vars, 2);
         let codeword_bits = ilog_round_up!(mul!(Lc::REPETITION_FACTOR, d), usize);
         let mut challenge_bits = Zt::Chal::NUM_BITS;
-        if Zt::Comb::DEGREE_BOUND > 0 {
+        if DEGREE > 0 {
             // This means we also draft alphas (multiplied with coeffs), which
             // doubles the number of challenge bits
             challenge_bits = mul!(challenge_bits, 2);
@@ -47,7 +53,7 @@ pub(super) fn validate_input<'a, Zt: ZipTypes + 'a, Lc: LinearCode<Zt>, Pt: 'a>(
                 add!(mul!(codeword_bits, 2), ilog_round_up!(d, usize)),
                 challenge_bits
             ),
-            sub!(Zt::EvalR::NUM_BITS, 1)
+            sub!(Zt::Eval::COEFF_BIT_WIDTH, 1)
         );
         assert!(
             actual_lc_bits <= max_lc_bits,

--- a/zip-plus/src/poly.rs
+++ b/zip-plus/src/poly.rs
@@ -4,16 +4,14 @@ pub mod zero_degree;
 
 use thiserror::Error;
 
-pub trait EvaluatablePolynomial<S> {
-    type Output;
-
+pub trait EvaluatablePolynomial<S, Out> {
     /// Evaluates the polynomial at the given point, treating point `[p_0, p_1,
     /// p_2, ...]` as `[x, x^2, x^3, ..., x^DEGREE_BOUND]`, thus it returns
     /// `a_0 + (a_1 * p_0) + (a_2 * p_1) + ... + (a_DEGREE_BOUND *
     /// p_{DEGREE_BOUND - 1})`.
     // Note: we can't reference Self::DEGREE_BOUND here, type parameters may not be
     // used in const expressions. As such, no point in declaring Self: Polynomial.
-    fn evaluate_at_point(&self, point: &[S]) -> Result<Self::Output, EvaluationError>;
+    fn evaluate_at_point(&self, point: &[S]) -> Result<Out, EvaluationError>;
 }
 
 pub trait ConstCoeffBitWidth {

--- a/zip-plus/src/poly.rs
+++ b/zip-plus/src/poly.rs
@@ -1,25 +1,27 @@
 pub mod dense;
 pub mod mle;
-mod zero_degree;
+pub mod zero_degree;
 
-use crate::pcs::structs::MulByScalar;
-use crypto_primitives::Semiring;
 use thiserror::Error;
 
-pub trait Polynomial<R: Semiring> {
-    /// The (max) degree of the polynomial - one less than a number of
-    /// coefficients.
-    const DEGREE_BOUND: usize;
+/// * `DEGREE_BOUND`: The (max) degree of the polynomial - one less than a
+///   number of coefficients.
+pub trait Polynomial<const DEGREE_BOUND: usize> {}
+
+pub trait EvaluatablePolynomial<S> {
+    type Output;
 
     /// Evaluates the polynomial at the given point, treating point `[p_0, p_1,
     /// p_2, ...]` as `[x, x^2, x^3, ..., x^DEGREE_BOUND]`, thus it returns
     /// `a_0 + (a_1 * p_0) + (a_2 * p_1) + ... + (a_DEGREE_BOUND *
     /// p_{DEGREE_BOUND - 1})`.
-    // Note: we can't reference Self::DEGREE_BOUND here type parameters may not be
-    // used in const expressions
-    fn evaluate_at_point<C>(&self, point: &[C]) -> Result<R, EvaluationError>
-    where
-        R: for<'a> MulByScalar<&'a C>;
+    // Note: we can't reference Self::DEGREE_BOUND here, type parameters may not be
+    // used in const expressions. As such, no point in declaring Self: Polynomial.
+    fn evaluate_at_point(&self, point: &[S]) -> Result<Self::Output, EvaluationError>;
+}
+
+pub trait ConstCoeffBitWidth {
+    const COEFF_BIT_WIDTH: usize;
 }
 
 #[derive(Clone, Debug, PartialEq, Error)]

--- a/zip-plus/src/poly.rs
+++ b/zip-plus/src/poly.rs
@@ -4,10 +4,6 @@ pub mod zero_degree;
 
 use thiserror::Error;
 
-/// * `DEGREE_BOUND`: The (max) degree of the polynomial - one less than a
-///   number of coefficients.
-pub trait Polynomial<const DEGREE_BOUND: usize> {}
-
 pub trait EvaluatablePolynomial<S> {
     type Output;
 

--- a/zip-plus/src/poly/dense.rs
+++ b/zip-plus/src/poly/dense.rs
@@ -1,4 +1,4 @@
-use super::{EvaluationError, Polynomial};
+use super::{EvaluatablePolynomial, EvaluationError, Polynomial};
 use crate::{
     pcs::structs::{MulByScalar, ProjectableToField},
     traits::{ConstTranscribable, FromRef, Named},
@@ -55,12 +55,28 @@ impl<R: Semiring + Zero, const DEGREE: usize> DensePolynomial<R, DEGREE> {
 
         DensePolynomial { coeff_0, coeffs }
     }
+
+    /// Return all coefficients as a vector.
+    /// The result contains DEGREE+1 elements: [coeff_0, coeffs[0], ...,
+    /// coeffs[DEGREE-1]].
+    #[allow(clippy::arithmetic_side_effects)]
+    pub fn to_coeffs(&self) -> Vec<R> {
+        let mut result = Vec::with_capacity(DEGREE + 1);
+        result.push(self.coeff_0.clone());
+        result.extend_from_slice(&self.coeffs);
+        result
+    }
 }
 
-impl<R: Semiring, const DEGREE: usize> Polynomial<R> for DensePolynomial<R, DEGREE> {
-    const DEGREE_BOUND: usize = DEGREE;
+impl<R: Semiring, const DEGREE: usize> Polynomial<DEGREE> for DensePolynomial<R, DEGREE> {}
 
-    fn evaluate_at_point<C>(&self, point: &[C]) -> Result<R, EvaluationError>
+impl<R: Semiring, C, const DEGREE: usize> EvaluatablePolynomial<C> for DensePolynomial<R, DEGREE>
+where
+    R: for<'a> MulByScalar<&'a C>,
+{
+    type Output = R;
+
+    fn evaluate_at_point(&self, point: &[C]) -> Result<R, EvaluationError>
     where
         R: for<'a> MulByScalar<&'a C>,
     {

--- a/zip-plus/src/poly/dense.rs
+++ b/zip-plus/src/poly/dense.rs
@@ -356,12 +356,10 @@ where
 // Zip-specific traits
 //
 
-impl<R: Semiring, C, const DEGREE: usize> EvaluatablePolynomial<C> for DensePolynomial<R, DEGREE>
+impl<R: Semiring, C, const DEGREE: usize> EvaluatablePolynomial<C, R> for DensePolynomial<R, DEGREE>
 where
     R: for<'a> MulByScalar<&'a C>,
 {
-    type Output = R;
-
     fn evaluate_at_point(&self, point: &[C]) -> Result<R, EvaluationError>
     where
         R: for<'a> MulByScalar<&'a C>,

--- a/zip-plus/src/poly/dense.rs
+++ b/zip-plus/src/poly/dense.rs
@@ -1,4 +1,4 @@
-use super::{EvaluatablePolynomial, EvaluationError, Polynomial};
+use super::{EvaluatablePolynomial, EvaluationError};
 use crate::{
     pcs::structs::{MulByScalar, ProjectableToField},
     traits::{ConstTranscribable, FromRef, Named},
@@ -67,8 +67,6 @@ impl<R: Semiring + Zero, const DEGREE: usize> DensePolynomial<R, DEGREE> {
         result
     }
 }
-
-impl<R: Semiring, const DEGREE: usize> Polynomial<DEGREE> for DensePolynomial<R, DEGREE> {}
 
 impl<R: Semiring, C, const DEGREE: usize> EvaluatablePolynomial<C> for DensePolynomial<R, DEGREE>
 where

--- a/zip-plus/src/poly/dense.rs
+++ b/zip-plus/src/poly/dense.rs
@@ -1,4 +1,4 @@
-use super::{EvaluatablePolynomial, EvaluationError};
+use super::{ConstCoeffBitWidth, EvaluatablePolynomial, EvaluationError};
 use crate::{
     pcs::structs::{MulByScalar, ProjectableToField},
     traits::{ConstTranscribable, FromRef, Named},
@@ -65,35 +65,6 @@ impl<R: Semiring + Zero, const DEGREE: usize> DensePolynomial<R, DEGREE> {
         result.push(self.coeff_0.clone());
         result.extend_from_slice(&self.coeffs);
         result
-    }
-}
-
-impl<R: Semiring, C, const DEGREE: usize> EvaluatablePolynomial<C> for DensePolynomial<R, DEGREE>
-where
-    R: for<'a> MulByScalar<&'a C>,
-{
-    type Output = R;
-
-    fn evaluate_at_point(&self, point: &[C]) -> Result<R, EvaluationError>
-    where
-        R: for<'a> MulByScalar<&'a C>,
-    {
-        if point.len() != DEGREE {
-            return Err(EvaluationError::WrongPointWidth {
-                expected: DEGREE,
-                actual: point.len(),
-            });
-        }
-
-        // A trivial implementation of a polynomial evaluation at a given point.
-        let mut result = self.coeff_0.clone();
-        for (coeff, scalar) in self.coeffs.iter().zip(point.iter()) {
-            let term = coeff
-                .mul_by_scalar(scalar)
-                .ok_or(EvaluationError::Overflow)?;
-            result = result.checked_add(&term).ok_or(EvaluationError::Overflow)?;
-        }
-        Ok(result)
     }
 }
 
@@ -384,6 +355,41 @@ where
 //
 // Zip-specific traits
 //
+
+impl<R: Semiring, C, const DEGREE: usize> EvaluatablePolynomial<C> for DensePolynomial<R, DEGREE>
+where
+    R: for<'a> MulByScalar<&'a C>,
+{
+    type Output = R;
+
+    fn evaluate_at_point(&self, point: &[C]) -> Result<R, EvaluationError>
+    where
+        R: for<'a> MulByScalar<&'a C>,
+    {
+        if point.len() != DEGREE {
+            return Err(EvaluationError::WrongPointWidth {
+                expected: DEGREE,
+                actual: point.len(),
+            });
+        }
+
+        // A trivial implementation of a polynomial evaluation at a given point.
+        let mut result = self.coeff_0.clone();
+        for (coeff, scalar) in self.coeffs.iter().zip(point.iter()) {
+            let term = coeff
+                .mul_by_scalar(scalar)
+                .ok_or(EvaluationError::Overflow)?;
+            result = result.checked_add(&term).ok_or(EvaluationError::Overflow)?;
+        }
+        Ok(result)
+    }
+}
+
+impl<R: Semiring + ConstTranscribable, const DEGREE: usize> ConstCoeffBitWidth
+    for DensePolynomial<R, DEGREE>
+{
+    const COEFF_BIT_WIDTH: usize = R::NUM_BITS;
+}
 
 impl<R: Semiring + Named, const DEGREE: usize> Named for DensePolynomial<R, DEGREE> {
     fn type_name() -> String {

--- a/zip-plus/src/poly/zero_degree.rs
+++ b/zip-plus/src/poly/zero_degree.rs
@@ -5,9 +5,7 @@ use crypto_primitives::crypto_bigint_int::Int;
 macro_rules! impl_zero_degree {
     ($($t:ty),+) => {
         $(
-            impl<T> EvaluatablePolynomial<T> for $t {
-                type Output = Self;
-
+            impl<T> EvaluatablePolynomial<T, Self> for $t {
                 fn evaluate_at_point(&self, point: &[T]) -> Result<Self, EvaluationError> {
                     if !point.is_empty() {
                         return Err(EvaluationError::WrongPointWidth {
@@ -29,9 +27,7 @@ macro_rules! impl_zero_degree {
 impl_zero_degree!(i8, i16, i32, i64, i128);
 impl_zero_degree!(u8, u16, u32, u64, u128);
 
-impl<T, const LIMBS: usize> EvaluatablePolynomial<T> for Int<LIMBS> {
-    type Output = Self;
-
+impl<T, const LIMBS: usize> EvaluatablePolynomial<T, Self> for Int<LIMBS> {
     fn evaluate_at_point(&self, point: &[T]) -> Result<Self, EvaluationError> {
         if !point.is_empty() {
             return Err(EvaluationError::WrongPointWidth {

--- a/zip-plus/src/poly/zero_degree.rs
+++ b/zip-plus/src/poly/zero_degree.rs
@@ -1,12 +1,10 @@
-use super::{ConstCoeffBitWidth, EvaluatablePolynomial, EvaluationError, Polynomial};
+use super::{ConstCoeffBitWidth, EvaluatablePolynomial, EvaluationError};
 use crate::traits::ConstTranscribable;
 use crypto_primitives::{Semiring, crypto_bigint_int::Int};
 
 macro_rules! impl_zero_degree {
     ($($t:ty),+) => {
         $(
-            impl Polynomial<0> for $t {}
-
             impl<T> EvaluatablePolynomial<T> for $t {
                 type Output = Self;
 
@@ -26,8 +24,6 @@ macro_rules! impl_zero_degree {
 
 impl_zero_degree!(i8, i16, i32, i64, i128);
 impl_zero_degree!(u8, u16, u32, u64, u128);
-
-impl<const LIMBS: usize> Polynomial<0> for Int<LIMBS> {}
 
 impl<T, const LIMBS: usize> EvaluatablePolynomial<T> for Int<LIMBS> {
     type Output = Self;

--- a/zip-plus/src/poly/zero_degree.rs
+++ b/zip-plus/src/poly/zero_degree.rs
@@ -1,6 +1,6 @@
 use super::{ConstCoeffBitWidth, EvaluatablePolynomial, EvaluationError};
 use crate::traits::ConstTranscribable;
-use crypto_primitives::{Semiring, crypto_bigint_int::Int};
+use crypto_primitives::crypto_bigint_int::Int;
 
 macro_rules! impl_zero_degree {
     ($($t:ty),+) => {
@@ -17,6 +17,10 @@ macro_rules! impl_zero_degree {
                     }
                     Ok(self.clone())
                 }
+            }
+
+            impl ConstCoeffBitWidth for $t {
+                const COEFF_BIT_WIDTH: usize = <$t>::BITS as usize;
             }
         )*
     };
@@ -39,6 +43,6 @@ impl<T, const LIMBS: usize> EvaluatablePolynomial<T> for Int<LIMBS> {
     }
 }
 
-impl<R: Semiring + ConstTranscribable> ConstCoeffBitWidth for R {
-    const COEFF_BIT_WIDTH: usize = R::NUM_BITS;
+impl<const LIMBS: usize> ConstCoeffBitWidth for Int<LIMBS> {
+    const COEFF_BIT_WIDTH: usize = Self::NUM_BITS;
 }

--- a/zip-plus/src/poly/zero_degree.rs
+++ b/zip-plus/src/poly/zero_degree.rs
@@ -1,20 +1,48 @@
-use super::{EvaluationError, Polynomial};
-use crate::pcs::structs::MulByScalar;
-use crypto_primitives::Semiring;
+use super::{ConstCoeffBitWidth, EvaluatablePolynomial, EvaluationError, Polynomial};
+use crate::traits::ConstTranscribable;
+use crypto_primitives::{Semiring, crypto_bigint_int::Int};
 
-impl<R: Semiring> Polynomial<Self> for R {
-    const DEGREE_BOUND: usize = 0;
+macro_rules! impl_zero_degree {
+    ($($t:ty),+) => {
+        $(
+            impl Polynomial<0> for $t {}
 
-    fn evaluate_at_point<C>(&self, point: &[C]) -> Result<R, EvaluationError>
-    where
-        Self: for<'a> MulByScalar<&'a C>,
-    {
+            impl<T> EvaluatablePolynomial<T> for $t {
+                type Output = Self;
+
+                fn evaluate_at_point(&self, point: &[T]) -> Result<Self, EvaluationError> {
+                    if !point.is_empty() {
+                        return Err(EvaluationError::WrongPointWidth {
+                            expected: 0,
+                            actual: point.len(),
+                        });
+                    }
+                    Ok(self.clone())
+                }
+            }
+        )*
+    };
+}
+
+impl_zero_degree!(i8, i16, i32, i64, i128);
+impl_zero_degree!(u8, u16, u32, u64, u128);
+
+impl<const LIMBS: usize> Polynomial<0> for Int<LIMBS> {}
+
+impl<T, const LIMBS: usize> EvaluatablePolynomial<T> for Int<LIMBS> {
+    type Output = Self;
+
+    fn evaluate_at_point(&self, point: &[T]) -> Result<Self, EvaluationError> {
         if !point.is_empty() {
             return Err(EvaluationError::WrongPointWidth {
                 expected: 0,
                 actual: point.len(),
             });
         }
-        Ok(self.clone())
+        Ok(*self)
     }
+}
+
+impl<R: Semiring + ConstTranscribable> ConstCoeffBitWidth for R {
+    const COEFF_BIT_WIDTH: usize = R::NUM_BITS;
 }


### PR DESCRIPTION
Removed `EvalR` and `CwR` types from `ZipTypes`. Instead, `ZipTypes` is now parameterized by polynomial degree. Added separate trait `ConstCoeffBitWidth` for polynomials that need to know their coefficient bit width (`Eval` and `Cw`)
Also replaced trait `Polynomial` with `EvaluatablePolynomial` with different type signature and intentions. It can be implemented multiple times if needed.