### PR TITLE
Better parallelism

### DIFF
--- a/zip-plus/src/merkle.rs
+++ b/zip-plus/src/merkle.rs
@@ -1,5 +1,5 @@
 use crate::{add, traits::ConstTranscribable};
-use ark_std::cfg_into_iter;
+use ark_std::cfg_iter_mut;
 use itertools::Itertools;
 use std::{
     fmt,
@@ -8,7 +8,6 @@ use std::{
 };
 use thiserror::Error;
 
-use crate::utils::parallelize;
 #[cfg(feature = "parallel")]
 use rayon::prelude::*;
 
@@ -103,9 +102,9 @@ where
 {
     let mut res = Vec::with_capacity(m_cols);
 
-    parallelize(res.spare_capacity_mut(), |(chunk, chunk_start)| {
-        for (j, v) in chunk.iter_mut().enumerate() {
-            let i = chunk_start + j;
+    cfg_iter_mut!(res.spare_capacity_mut())
+        .enumerate()
+        .for_each(|(i, v)| {
             let mut hasher = blake3::Hasher::new();
             let mut buf = vec![0_u8; S::NUM_BYTES];
             for row in rows.iter() {
@@ -114,8 +113,7 @@ where
                 hasher.update(&buf);
             }
             *v = MaybeUninit::new(hasher.finalize().into());
-        }
-    });
+        });
 
     // SAFETY: We filled the entire capacity of `res` with initialized values
     unsafe {

--- a/zip-plus/src/merkle.rs
+++ b/zip-plus/src/merkle.rs
@@ -1,10 +1,16 @@
-use crate::{add, traits::ConstTranscribable, utils::parallelize_into_iter_map_collect};
+use crate::{add, traits::ConstTranscribable};
+use ark_std::cfg_into_iter;
 use itertools::Itertools;
 use std::{
     fmt,
     fmt::{Display, Formatter},
+    mem::MaybeUninit,
 };
 use thiserror::Error;
+
+use crate::utils::parallelize;
+#[cfg(feature = "parallel")]
+use rayon::prelude::*;
 
 pub const HASH_OUT_LEN: usize = blake3::OUT_LEN;
 
@@ -95,16 +101,28 @@ fn hash_leaves<S>(rows: &[&[S]], m_cols: usize) -> Vec<MtHash>
 where
     S: ConstTranscribable + Send + Sync,
 {
-    parallelize_into_iter_map_collect(0..m_cols, |i| {
-        let mut hasher = blake3::Hasher::new();
-        let mut buf = vec![0_u8; S::NUM_BYTES];
-        for row in rows.iter() {
-            let v = &row[i];
-            v.write_transcription_bytes(&mut buf);
-            hasher.update(&buf);
+    let mut res = Vec::with_capacity(m_cols);
+
+    parallelize(res.spare_capacity_mut(), |(chunk, chunk_start)| {
+        for (j, v) in chunk.iter_mut().enumerate() {
+            let i = chunk_start + j;
+            let mut hasher = blake3::Hasher::new();
+            let mut buf = vec![0_u8; S::NUM_BYTES];
+            for row in rows.iter() {
+                let value = &row[i];
+                value.write_transcription_bytes(&mut buf);
+                hasher.update(&buf);
+            }
+            *v = MaybeUninit::new(hasher.finalize().into());
         }
-        hasher.finalize().into()
-    })
+    });
+
+    // SAFETY: We filled the entire capacity of `res` with initialized values
+    unsafe {
+        res.set_len(m_cols);
+    }
+
+    res
 }
 
 #[allow(clippy::unwrap_used)] // Using unwrap here never panics

--- a/zip-plus/src/pcs/phase_commit.rs
+++ b/zip-plus/src/pcs/phase_commit.rs
@@ -7,7 +7,6 @@ use crate::{
         utils::validate_input,
     },
     poly::mle::DenseMultilinearExtension,
-    utils::num_threads,
 };
 use ark_std::{cfg_chunks, cfg_chunks_mut};
 use crypto_primitives::DenseRowMatrix;
@@ -168,21 +167,16 @@ impl<Zt: ZipTypes<DEGREE>, Lc: LinearCode<Zt, DEGREE>, const DEGREE: usize>
         evals: &[Zt::Eval],
     ) -> DenseRowMatrix<Zt::Cw> {
         let codeword_len = pp.linear_code.codeword_len();
-        let rows_per_thread = pp.num_rows.div_ceil(num_threads());
+
         // Performance: Using DenseRowMatrix's linearized row in an uninit form
         // is much more performant that using Vec<Vec<_>>.
         let mut encoded_matrix = DenseRowMatrix::<Zt::Cw>::uninit(pp.num_rows, codeword_len);
 
-        cfg_chunks_mut!(encoded_matrix.data, rows_per_thread * codeword_len)
-            .zip(cfg_chunks!(evals, rows_per_thread * row_len))
-            .for_each(|(encoded_chunk, evals)| {
-                for (row, evals) in encoded_chunk
-                    .chunks_exact_mut(codeword_len)
-                    .zip(evals.chunks_exact(row_len))
-                {
-                    let encoded: Vec<Zt::Cw> = pp.linear_code.encode(evals);
-                    Out::from(row).copy_from_slice(encoded.as_slice());
-                }
+        cfg_chunks_mut!(encoded_matrix.data, codeword_len)
+            .zip(cfg_chunks!(evals, row_len))
+            .for_each(|(row, evals)| {
+                let encoded: Vec<Zt::Cw> = pp.linear_code.encode(evals);
+                Out::from(row).copy_from_slice(encoded.as_slice());
             });
 
         // Safe because we have just initialized all elements.

--- a/zip-plus/src/pcs/phase_commit.rs
+++ b/zip-plus/src/pcs/phase_commit.rs
@@ -7,10 +7,14 @@ use crate::{
         utils::validate_input,
     },
     poly::mle::DenseMultilinearExtension,
-    utils::{num_threads, parallelize_for_each},
+    utils::num_threads,
 };
+use ark_std::{cfg_chunks, cfg_chunks_mut};
 use crypto_primitives::DenseRowMatrix;
 use uninit::out_ref::Out;
+
+#[cfg(feature = "parallel")]
+use rayon::prelude::*;
 
 impl<Zt: ZipTypes<DEGREE>, Lc: LinearCode<Zt, DEGREE>, const DEGREE: usize>
     ZipPlus<Zt, Lc, DEGREE>
@@ -169,12 +173,9 @@ impl<Zt: ZipTypes<DEGREE>, Lc: LinearCode<Zt, DEGREE>, const DEGREE: usize>
         // is much more performant that using Vec<Vec<_>>.
         let mut encoded_matrix = DenseRowMatrix::<Zt::Cw>::uninit(pp.num_rows, codeword_len);
 
-        parallelize_for_each(
-            encoded_matrix
-                .data
-                .chunks_mut(rows_per_thread * codeword_len)
-                .zip(evals.chunks(rows_per_thread * row_len)),
-            |(encoded_chunk, evals)| {
+        cfg_chunks_mut!(encoded_matrix.data, rows_per_thread * codeword_len)
+            .zip(cfg_chunks!(evals, rows_per_thread * row_len))
+            .for_each(|(encoded_chunk, evals)| {
                 for (row, evals) in encoded_chunk
                     .chunks_exact_mut(codeword_len)
                     .zip(evals.chunks_exact(row_len))
@@ -182,8 +183,7 @@ impl<Zt: ZipTypes<DEGREE>, Lc: LinearCode<Zt, DEGREE>, const DEGREE: usize>
                     let encoded: Vec<Zt::Cw> = pp.linear_code.encode(evals);
                     Out::from(row).copy_from_slice(encoded.as_slice());
                 }
-            },
-        );
+            });
 
         // Safe because we have just initialized all elements.
         unsafe { encoded_matrix.init() }

--- a/zip-plus/src/pcs/phase_evaluate.rs
+++ b/zip-plus/src/pcs/phase_evaluate.rs
@@ -62,8 +62,7 @@ impl<Zt: ZipTypes<DEGREE>, Lc: LinearCode<Zt, DEGREE>, const DEGREE: usize>
 
         let q_0_combined_row = if num_rows > 1 {
             // Return the evaluation row combination
-            let combined_row =
-                combine_rows(&q_0, &evaluations, row_len, F::zero_with_cfg(&field_cfg));
+            let combined_row = combine_rows(&q_0, &evaluations, row_len);
             Cow::<Vec<F>>::Owned(combined_row)
         } else {
             // If there is only one row, we have no need to take linear combinations

--- a/zip-plus/src/pcs/phase_test.rs
+++ b/zip-plus/src/pcs/phase_test.rs
@@ -12,7 +12,6 @@ use crate::{
     utils::combine_rows,
 };
 use itertools::Itertools;
-use num_traits::ConstZero;
 
 impl<Zt: ZipTypes<DEGREE>, Lc: LinearCode<Zt, DEGREE>, const DEGREE: usize>
     ZipPlus<Zt, Lc, DEGREE>
@@ -48,8 +47,7 @@ impl<Zt: ZipTypes<DEGREE>, Lc: LinearCode<Zt, DEGREE>, const DEGREE: usize>
                 .collect_vec();
 
             // u' in the Zinc paper
-            let combined_row =
-                combine_rows(&coeffs, &evals, pp.linear_code.row_len(), Zt::CombR::ZERO);
+            let combined_row = combine_rows(&coeffs, &evals, pp.linear_code.row_len());
 
             transcript.write_const_many(&combined_row)?;
         }

--- a/zip-plus/src/pcs/utils.rs
+++ b/zip-plus/src/pcs/utils.rs
@@ -1,17 +1,20 @@
+use crate::{
+    ZipError, add,
+    code::LinearCode,
+    div, ilog_round_up,
+    merkle::{MerkleError, MerkleProof, MtHash},
+    mul,
+    pcs::structs::{ZipPlusHint, ZipTypes},
+    pcs_transcript::PcsTranscript,
+    poly::{ConstCoeffBitWidth, mle::DenseMultilinearExtension},
+    sub,
+    traits::ConstTranscribable,
+    utils::parallelize,
+};
 use ark_std::{cfg_iter_mut, iterable::Iterable};
 use crypto_primitives::PrimeField;
 use thiserror::Error;
 
-use crate::{ZipError, add, div, ilog_round_up, mul, poly::mle::DenseMultilinearExtension, sub};
-
-use crate::{
-    code::LinearCode,
-    merkle::{MerkleError, MerkleProof, MtHash},
-    pcs::structs::{ZipPlusHint, ZipTypes},
-    pcs_transcript::PcsTranscript,
-    poly::ConstCoeffBitWidth,
-    traits::ConstTranscribable,
-};
 #[cfg(feature = "parallel")]
 use rayon::prelude::*;
 

--- a/zip-plus/src/pcs/utils.rs
+++ b/zip-plus/src/pcs/utils.rs
@@ -9,7 +9,6 @@ use crate::{
     poly::{ConstCoeffBitWidth, mle::DenseMultilinearExtension},
     sub,
     traits::ConstTranscribable,
-    utils::parallelize,
 };
 use ark_std::{cfg_iter_mut, iterable::Iterable};
 use crypto_primitives::PrimeField;

--- a/zip-plus/src/utils.rs
+++ b/zip-plus/src/utils.rs
@@ -3,14 +3,13 @@ use crate::{
     traits::{ConstTranscribable, Named, Transcribable},
 };
 use crypto_bigint::{BitOps, BoxedUint, Word};
-use crypto_primitives::{crypto_bigint_int::Int, crypto_bigint_uint::Uint};
+use crypto_primitives::{boolean::Boolean, crypto_bigint_int::Int, crypto_bigint_uint::Uint};
 use itertools::Itertools;
 use num_traits::CheckedAdd;
 use rand::{rngs::StdRng, seq::SliceRandom};
 use rand_core::SeedableRng;
 use std::iter::Iterator;
 
-use crypto_primitives::boolean::Boolean;
 #[cfg(feature = "parallel")]
 use rayon::prelude::*;
 
@@ -116,48 +115,6 @@ pub(crate) fn num_threads() -> usize {
     return 1;
 }
 
-#[cfg(not(feature = "parallel"))]
-pub(crate) fn parallelize_into_iter_map_collect<I, T, F, R, C>(iterable: I, f: F) -> C
-where
-    I: Send + IntoIterator<Item = T>,
-    T: Send,
-    R: Send,
-    F: Fn(T) -> R + Send + Sync + Clone,
-    C: FromIterator<R>,
-{
-    iterable.into_iter().map(f).collect()
-}
-
-#[cfg(feature = "parallel")]
-pub(crate) fn parallelize_into_iter_map_collect<I, T, F, R, C>(iterable: I, f: F) -> C
-where
-    I: Send + IntoParallelIterator<Item = T>,
-    T: Send,
-    R: Send,
-    F: Fn(T) -> R + Send + Sync + Clone,
-    C: FromParallelIterator<R>,
-{
-    iterable.into_par_iter().map(f).collect()
-}
-
-pub(crate) fn parallelize_for_each<I, T, F>(iter: I, f: F)
-where
-    I: Send + Iterator<Item = T>,
-    T: Send,
-    F: Fn(T) + Send + Sync + Clone,
-{
-    #[cfg(feature = "parallel")]
-    rayon::scope(|scope| {
-        iter.for_each(|item| {
-            let f = &f;
-            scope.spawn(move |_| f(item))
-        })
-    });
-
-    #[cfg(not(feature = "parallel"))]
-    iter.for_each(f);
-}
-
 pub(crate) fn parallelize<T, F>(v: &mut [T], f: F)
 where
     T: Send,
@@ -170,7 +127,9 @@ where
         if chunk_size < num_threads {
             f((v, 0));
         } else {
-            parallelize_for_each(v.chunks_mut(chunk_size).zip((0..).step_by(chunk_size)), f);
+            v.par_chunks_mut(chunk_size)
+                .enumerate()
+                .for_each(|(i, chunk)| f((chunk, i * chunk_size)));
         }
     }
 

--- a/zip-plus/src/utils.rs
+++ b/zip-plus/src/utils.rs
@@ -2,13 +2,17 @@ use crate::{
     pcs::structs::MulByScalar,
     traits::{ConstTranscribable, Named, Transcribable},
 };
+use ark_std::cfg_iter_mut;
 use crypto_bigint::{BitOps, BoxedUint, Word};
 use crypto_primitives::{boolean::Boolean, crypto_bigint_int::Int, crypto_bigint_uint::Uint};
 use itertools::Itertools;
 use num_traits::CheckedAdd;
 use rand::{rngs::StdRng, seq::SliceRandom};
 use rand_core::SeedableRng;
-use std::iter::Iterator;
+use std::{
+    iter::{Iterator, Sum},
+    mem::MaybeUninit,
+};
 
 #[cfg(feature = "parallel")]
 use rayon::prelude::*;
@@ -107,36 +111,6 @@ where
         .unwrap_or(zero)
 }
 
-pub(crate) fn num_threads() -> usize {
-    #[cfg(feature = "parallel")]
-    return rayon::current_num_threads();
-
-    #[cfg(not(feature = "parallel"))]
-    return 1;
-}
-
-pub(crate) fn parallelize<T, F>(v: &mut [T], f: F)
-where
-    T: Send,
-    F: Fn((&mut [T], usize)) + Send + Sync + Clone,
-{
-    #[cfg(feature = "parallel")]
-    {
-        let num_threads = num_threads();
-        let chunk_size = v.len().div_ceil(num_threads);
-        if chunk_size < num_threads {
-            f((v, 0));
-        } else {
-            v.par_chunks_mut(chunk_size)
-                .enumerate()
-                .for_each(|(i, chunk)| f((chunk, i * chunk_size)));
-        }
-    }
-
-    #[cfg(not(feature = "parallel"))]
-    f((v, 0));
-}
-
 /// Computes a linear combination of multiple evaluation rows into a single
 /// combined row.
 ///
@@ -163,31 +137,32 @@ pub(super) fn combine_rows<Coeff, El>(
     coeffs: &[Coeff],
     evaluations: &[El],
     row_len: usize,
-    zero: El,
 ) -> Vec<El>
 where
     Coeff: Send + Sync,
-    El: Clone + CheckedAdd + for<'z> MulByScalar<&'z Coeff> + Send + Sync,
+    El: Clone + Sum + for<'z> MulByScalar<&'z Coeff> + Send + Sync,
 {
-    let mut combined_row = vec![zero; row_len];
-    parallelize(&mut combined_row, |(combined_row, offset)| {
-        combined_row
-            .iter_mut()
-            .zip(offset..)
-            .for_each(|(combined, column)| {
+    let mut combined_row = Vec::with_capacity(row_len);
+
+    cfg_iter_mut!(combined_row.spare_capacity_mut())
+        .enumerate()
+        .for_each(|(column, combined)| {
+            *combined = MaybeUninit::new(
                 coeffs
                     .iter()
                     .zip(evaluations.iter().skip(column).step_by(row_len))
-                    .for_each(|(coeff, eval)| {
-                        *combined = add!(
-                            combined,
-                            &eval
-                                .mul_by_scalar(coeff)
-                                .expect("Cannot multiply evaluation by coefficient")
-                        );
-                    });
-            })
-    });
+                    .map(|(coeff, eval)| {
+                        eval.mul_by_scalar(coeff)
+                            .expect("Cannot multiply evaluation by coefficient")
+                    })
+                    .sum(),
+            );
+        });
+
+    // Safety: We initialized all elements in the combined_row.
+    unsafe {
+        combined_row.set_len(row_len);
+    }
 
     combined_row
 }
@@ -380,7 +355,7 @@ mod test {
         let evaluations = vec![3, 4, 5, 6];
         let row_len = 2;
 
-        let result = combine_rows(&coeffs, &evaluations, row_len, 0);
+        let result = combine_rows(&coeffs, &evaluations, row_len);
 
         assert_eq!(result, vec![(3 + 2 * 5), (4 + 2 * 6)]);
     }
@@ -391,7 +366,7 @@ mod test {
         let evaluations = vec![2, 4, 6, 8];
         let row_len = 2;
 
-        let result = combine_rows(&coeffs, &evaluations, row_len, 0);
+        let result = combine_rows(&coeffs, &evaluations, row_len);
 
         assert_eq!(result, vec![(3 * 2 + 4 * 6), (3 * 4 + 4 * 8)]);
     }
@@ -401,7 +376,7 @@ mod test {
         let evaluations = vec![2000, -3000, 4000, -5000];
         let row_len = 2;
 
-        let result = combine_rows(&coeffs, &evaluations, row_len, 0);
+        let result = combine_rows(&coeffs, &evaluations, row_len);
 
         assert_eq!(
             result,


### PR DESCRIPTION
Turns out that thread limiting approach used in `parallelize` adds more overhead than it removes.
Replaced our `parallelize` and `parallelize_*` methods with `cfg_*` macros from `ark-std`.
As a result, code was simplified and `encode` performace for primitive types improved by ~40% with `parallel` feature enabled.

Fixes #17 