### PR TITLE
Remove coeff_0 in DensePolynomial and DEGREE from ZipTypes

### DIFF
--- a/zip-plus/benches/zip_benches.rs
+++ b/zip-plus/benches/zip_benches.rs
@@ -17,7 +17,7 @@ use zip_plus::{
 const INT_LIMBS: usize = U64::LIMBS;
 
 struct BenchZipTypes {}
-impl ZipTypes<0> for BenchZipTypes {
+impl ZipTypes for BenchZipTypes {
     const NUM_COLUMN_OPENINGS: usize = 650;
     type Eval = i32;
     type Cw = i64;
@@ -28,7 +28,7 @@ impl ZipTypes<0> for BenchZipTypes {
     type CombR = Int<{ INT_LIMBS * 3 }>;
     type Comb = Self::CombR;
 }
-type Code = RaaCode<BenchZipTypes, 4, 0>;
+type Code = RaaCode<BenchZipTypes, 4>;
 
 const RAA_CONFIG: RaaConfig = RaaConfig {
     check_for_overflows: false,
@@ -37,7 +37,7 @@ const RAA_CONFIG: RaaConfig = RaaConfig {
 
 fn zip_benchmarks(c: &mut Criterion) {
     let mut group = c.benchmark_group("Zip+");
-    do_bench::<BenchZipTypes, Code, _>(&mut group, RAA_CONFIG);
+    do_bench::<BenchZipTypes, Code>(&mut group, RAA_CONFIG);
     group.finish();
 }
 

--- a/zip-plus/benches/zip_common.rs
+++ b/zip-plus/benches/zip_common.rs
@@ -26,7 +26,7 @@ use zip_plus::{
 
 type F = BoxedMontyField;
 
-pub fn do_bench<Zt: ZipTypes<DEGREE>, Lc: LinearCode<Zt, DEGREE>, const DEGREE: usize>(
+pub fn do_bench<Zt: ZipTypes, Lc: LinearCode<Zt>>(
     group: &mut BenchmarkGroup<WallTime>,
     code_config: Lc::Config,
 ) where
@@ -36,54 +36,49 @@ pub fn do_bench<Zt: ZipTypes<DEGREE>, Lc: LinearCode<Zt, DEGREE>, const DEGREE: 
     Zt::Eval: ProjectableToField<F>,
     Zt::Cw: ProjectableToField<F>,
 {
-    encode_rows::<Zt, Lc, DEGREE, 12>(group, code_config);
-    encode_rows::<Zt, Lc, DEGREE, 13>(group, code_config);
-    encode_rows::<Zt, Lc, DEGREE, 14>(group, code_config);
-    encode_rows::<Zt, Lc, DEGREE, 15>(group, code_config);
-    encode_rows::<Zt, Lc, DEGREE, 16>(group, code_config);
+    encode_rows::<Zt, Lc, 12>(group, code_config);
+    encode_rows::<Zt, Lc, 13>(group, code_config);
+    encode_rows::<Zt, Lc, 14>(group, code_config);
+    encode_rows::<Zt, Lc, 15>(group, code_config);
+    encode_rows::<Zt, Lc, 16>(group, code_config);
 
-    encode_single_row::<Zt, Lc, DEGREE, 128>(group, code_config);
-    encode_single_row::<Zt, Lc, DEGREE, 256>(group, code_config);
-    encode_single_row::<Zt, Lc, DEGREE, 512>(group, code_config);
-    encode_single_row::<Zt, Lc, DEGREE, 1024>(group, code_config);
+    encode_single_row::<Zt, Lc, 128>(group, code_config);
+    encode_single_row::<Zt, Lc, 256>(group, code_config);
+    encode_single_row::<Zt, Lc, 512>(group, code_config);
+    encode_single_row::<Zt, Lc, 1024>(group, code_config);
 
-    merkle_root::<Zt, DEGREE, 12>(group);
-    merkle_root::<Zt, DEGREE, 13>(group);
-    merkle_root::<Zt, DEGREE, 14>(group);
-    merkle_root::<Zt, DEGREE, 15>(group);
-    merkle_root::<Zt, DEGREE, 16>(group);
+    merkle_root::<Zt, 12>(group);
+    merkle_root::<Zt, 13>(group);
+    merkle_root::<Zt, 14>(group);
+    merkle_root::<Zt, 15>(group);
+    merkle_root::<Zt, 16>(group);
 
-    commit::<Zt, Lc, DEGREE, 12>(group, code_config);
-    commit::<Zt, Lc, DEGREE, 13>(group, code_config);
-    commit::<Zt, Lc, DEGREE, 14>(group, code_config);
-    commit::<Zt, Lc, DEGREE, 15>(group, code_config);
-    commit::<Zt, Lc, DEGREE, 16>(group, code_config);
+    commit::<Zt, Lc, 12>(group, code_config);
+    commit::<Zt, Lc, 13>(group, code_config);
+    commit::<Zt, Lc, 14>(group, code_config);
+    commit::<Zt, Lc, 15>(group, code_config);
+    commit::<Zt, Lc, 16>(group, code_config);
 
-    test::<Zt, Lc, DEGREE, 12>(group, code_config);
-    test::<Zt, Lc, DEGREE, 13>(group, code_config);
-    test::<Zt, Lc, DEGREE, 14>(group, code_config);
-    test::<Zt, Lc, DEGREE, 15>(group, code_config);
-    test::<Zt, Lc, DEGREE, 16>(group, code_config);
+    test::<Zt, Lc, 12>(group, code_config);
+    test::<Zt, Lc, 13>(group, code_config);
+    test::<Zt, Lc, 14>(group, code_config);
+    test::<Zt, Lc, 15>(group, code_config);
+    test::<Zt, Lc, 16>(group, code_config);
 
-    evaluate::<Zt, Lc, DEGREE, 12>(group, code_config);
-    evaluate::<Zt, Lc, DEGREE, 13>(group, code_config);
-    evaluate::<Zt, Lc, DEGREE, 14>(group, code_config);
-    evaluate::<Zt, Lc, DEGREE, 15>(group, code_config);
-    evaluate::<Zt, Lc, DEGREE, 16>(group, code_config);
+    evaluate::<Zt, Lc, 12>(group, code_config);
+    evaluate::<Zt, Lc, 13>(group, code_config);
+    evaluate::<Zt, Lc, 14>(group, code_config);
+    evaluate::<Zt, Lc, 15>(group, code_config);
+    evaluate::<Zt, Lc, 16>(group, code_config);
 
-    verify::<Zt, Lc, DEGREE, 12>(group, code_config);
-    verify::<Zt, Lc, DEGREE, 13>(group, code_config);
-    verify::<Zt, Lc, DEGREE, 14>(group, code_config);
-    verify::<Zt, Lc, DEGREE, 15>(group, code_config);
-    verify::<Zt, Lc, DEGREE, 16>(group, code_config);
+    verify::<Zt, Lc, 12>(group, code_config);
+    verify::<Zt, Lc, 13>(group, code_config);
+    verify::<Zt, Lc, 14>(group, code_config);
+    verify::<Zt, Lc, 15>(group, code_config);
+    verify::<Zt, Lc, 16>(group, code_config);
 }
 
-pub fn encode_rows<
-    Zt: ZipTypes<DEGREE>,
-    Lc: LinearCode<Zt, DEGREE>,
-    const DEGREE: usize,
-    const P: usize,
->(
+pub fn encode_rows<Zt: ZipTypes, Lc: LinearCode<Zt>, const P: usize>(
     group: &mut BenchmarkGroup<WallTime>,
     code_config: Lc::Config,
 ) where
@@ -101,7 +96,7 @@ pub fn encode_rows<
             let linear_code = Lc::new(poly_size, code_config);
             let params = ZipPlus::setup(poly_size, linear_code);
             let row_len = params.linear_code.row_len();
-            let poly = DenseMultilinearExtension::<<Zt as ZipTypes<_>>::Eval>::rand(
+            let poly = DenseMultilinearExtension::<<Zt as ZipTypes>::Eval>::rand(
                 P,
                 &mut rng,
                 Zero::zero(),
@@ -114,12 +109,7 @@ pub fn encode_rows<
     );
 }
 
-pub fn encode_single_row<
-    Zt: ZipTypes<DEGREE>,
-    Lc: LinearCode<Zt, DEGREE>,
-    const DEGREE: usize,
-    const ROW_LEN: usize,
->(
+pub fn encode_single_row<Zt: ZipTypes, Lc: LinearCode<Zt>, const ROW_LEN: usize>(
     group: &mut BenchmarkGroup<WallTime>,
     code_config: Lc::Config,
 ) where
@@ -136,26 +126,25 @@ pub fn encode_single_row<
             let poly_size = ROW_LEN * ROW_LEN;
             let linear_code = Lc::new(poly_size, code_config);
             assert_eq!(linear_code.row_len(), ROW_LEN, "Unexpected row_len");
-            let message: Vec<<Zt as ZipTypes<_>>::Eval> =
+            let message: Vec<<Zt as ZipTypes>::Eval> =
                 (0..ROW_LEN).map(|_i| rng.random()).collect();
             b.iter(|| {
-                let encoded_row: Vec<<Zt as ZipTypes<_>>::Cw> = linear_code.encode(&message);
+                let encoded_row: Vec<<Zt as ZipTypes>::Cw> = linear_code.encode(&message);
                 black_box(encoded_row);
             })
         },
     );
 }
 
-pub fn merkle_root<Zt: ZipTypes<DEGREE>, const DEGREE: usize, const P: usize>(
-    group: &mut BenchmarkGroup<WallTime>,
-) where
+pub fn merkle_root<Zt: ZipTypes, const P: usize>(group: &mut BenchmarkGroup<WallTime>)
+where
     StandardUniform: Distribution<Zt::Cw>,
 {
     let mut rng = ThreadRng::default();
 
     let num_leaves = 1 << P;
     let leaves = (0..num_leaves)
-        .map(|_| rng.random::<<Zt as ZipTypes<_>>::Cw>())
+        .map(|_| rng.random::<<Zt as ZipTypes>::Cw>())
         .collect_vec();
     let matrix: DenseRowMatrix<_> = vec![leaves.clone()].into();
     let rows = matrix.to_rows_slices();
@@ -171,12 +160,7 @@ pub fn merkle_root<Zt: ZipTypes<DEGREE>, const DEGREE: usize, const P: usize>(
     );
 }
 
-pub fn commit<
-    Zt: ZipTypes<DEGREE>,
-    Lc: LinearCode<Zt, DEGREE>,
-    const DEGREE: usize,
-    const P: usize,
->(
+pub fn commit<Zt: ZipTypes, Lc: LinearCode<Zt>, const P: usize>(
     group: &mut BenchmarkGroup<WallTime>,
     code_config: Lc::Config,
 ) where
@@ -211,7 +195,7 @@ pub fn commit<
     );
 }
 
-pub fn test<Zt: ZipTypes<DEGREE>, Lc: LinearCode<Zt, DEGREE>, const DEGREE: usize, const P: usize>(
+pub fn test<Zt: ZipTypes, Lc: LinearCode<Zt>, const P: usize>(
     group: &mut BenchmarkGroup<WallTime>,
     code_config: Lc::Config,
 ) where
@@ -243,12 +227,7 @@ pub fn test<Zt: ZipTypes<DEGREE>, Lc: LinearCode<Zt, DEGREE>, const DEGREE: usiz
     );
 }
 
-pub fn evaluate<
-    Zt: ZipTypes<DEGREE>,
-    Lc: LinearCode<Zt, DEGREE>,
-    const DEGREE: usize,
-    const P: usize,
->(
+pub fn evaluate<Zt: ZipTypes, Lc: LinearCode<Zt>, const P: usize>(
     group: &mut BenchmarkGroup<WallTime>,
     code_config: Lc::Config,
 ) where
@@ -294,12 +273,7 @@ pub fn evaluate<
     );
 }
 
-pub fn verify<
-    Zt: ZipTypes<DEGREE>,
-    Lc: LinearCode<Zt, DEGREE>,
-    const DEGREE: usize,
-    const P: usize,
->(
+pub fn verify<Zt: ZipTypes, Lc: LinearCode<Zt>, const P: usize>(
     group: &mut BenchmarkGroup<WallTime>,
     code_config: Lc::Config,
 ) where

--- a/zip-plus/benches/zip_plus_benches.rs
+++ b/zip-plus/benches/zip_plus_benches.rs
@@ -17,19 +17,19 @@ use zip_plus::{
 
 const INT_LIMBS: usize = U64::LIMBS;
 
-struct BenchZipPlusTypes<const D: usize> {}
-impl<const D: usize> ZipTypes<D> for BenchZipPlusTypes<D> {
+struct BenchZipPlusTypes<const D_PLUS_ONE: usize> {}
+impl<const D_PLUS_ONE: usize> ZipTypes for BenchZipPlusTypes<D_PLUS_ONE> {
     const NUM_COLUMN_OPENINGS: usize = 650;
-    type Eval = DensePolynomial<Boolean, D>;
-    type Cw = DensePolynomial<i32, D>;
+    type Eval = DensePolynomial<Boolean, D_PLUS_ONE>;
+    type Cw = DensePolynomial<i32, D_PLUS_ONE>;
     type Fmod = Uint<{ INT_LIMBS * 4 }>;
     type PrimeTest = MillerRabin;
     type Chal = i128;
     type Pt = i128;
     type CombR = Int<{ INT_LIMBS * 5 }>;
-    type Comb = DensePolynomial<Self::CombR, D>;
+    type Comb = DensePolynomial<Self::CombR, D_PLUS_ONE>;
 }
-type Code<const D: usize> = RaaCode<BenchZipPlusTypes<D>, 4, D>;
+type Code<const D_PLUS_ONE: usize> = RaaCode<BenchZipPlusTypes<D_PLUS_ONE>, 4>;
 
 const RAA_CONFIG: RaaConfig = RaaConfig {
     check_for_overflows: false,
@@ -39,8 +39,8 @@ const RAA_CONFIG: RaaConfig = RaaConfig {
 fn zip_plus_benchmarks(c: &mut Criterion) {
     let mut group = c.benchmark_group("Zip+");
 
-    do_bench::<BenchZipPlusTypes<31>, Code<_>, _>(&mut group, RAA_CONFIG);
-    do_bench::<BenchZipPlusTypes<63>, Code<_>, _>(&mut group, RAA_CONFIG);
+    do_bench::<BenchZipPlusTypes<32>, Code<_>>(&mut group, RAA_CONFIG);
+    do_bench::<BenchZipPlusTypes<64>, Code<_>>(&mut group, RAA_CONFIG);
 
     group.finish();
 }

--- a/zip-plus/src/code.rs
+++ b/zip-plus/src/code.rs
@@ -4,7 +4,7 @@ pub mod raa_sign_flip;
 use crate::{pcs::structs::ZipTypes, traits::FromRef};
 use crypto_primitives::PrimeField;
 
-pub trait LinearCode<Zt: ZipTypes<DEGREE>, const DEGREE: usize = 1>: Sync + Send {
+pub trait LinearCode<Zt: ZipTypes>: Sync + Send {
     type Config: Copy;
 
     /// Repetition factor, a.k.a. inverse rate, the ratio of codeword length to

--- a/zip-plus/src/code/raa.rs
+++ b/zip-plus/src/code/raa.rs
@@ -9,7 +9,7 @@ use std::{marker::PhantomData, ops::AddAssign};
 /// Implementation of a repeat-accumulate-accumulate (RAA) codes over the binary
 /// field, as defined by the Blaze paper (https://eprint.iacr.org/2024/1609)
 #[derive(Debug, Clone)]
-pub struct RaaCode<Zt: ZipTypes<DEGREE>, const REP: usize, const DEGREE: usize> {
+pub struct RaaCode<Zt: ZipTypes, const REP: usize> {
     pub(crate) cfg: RaaConfig,
 
     pub(crate) row_len: usize,
@@ -38,7 +38,7 @@ pub struct RaaConfig {
     pub permute_in_place: bool,
 }
 
-impl<Zt: ZipTypes<DEGREE>, const REP: usize, const DEGREE: usize> RaaCode<Zt, REP, DEGREE> {
+impl<Zt: ZipTypes, const REP: usize> RaaCode<Zt, REP> {
     /// Do the actual encoding, as per RAA spec
     fn encode_inner<In, Out>(&self, row: &[In]) -> Vec<Out>
     where
@@ -76,9 +76,7 @@ impl<Zt: ZipTypes<DEGREE>, const REP: usize, const DEGREE: usize> RaaCode<Zt, RE
     }
 }
 
-impl<Zt: ZipTypes<DEGREE>, const REP: usize, const DEGREE: usize> LinearCode<Zt, DEGREE>
-    for RaaCode<Zt, REP, DEGREE>
-{
+impl<Zt: ZipTypes, const REP: usize> LinearCode<Zt> for RaaCode<Zt, REP> {
     type Config = RaaConfig;
 
     const REPETITION_FACTOR: usize = REP;
@@ -251,12 +249,12 @@ mod tests {
 
     fn test_raa<Zt, F>(poly_size: usize, f: F)
     where
-        Zt: ZipTypes<0>,
-        F: Fn(&RaaCode<Zt, REPETITION_FACTOR, 0>),
+        Zt: ZipTypes,
+        F: Fn(&RaaCode<Zt, REPETITION_FACTOR>),
     {
         for check_for_overflows in [true, false] {
             for permute_in_place in [true, false] {
-                let code = RaaCode::<Zt, REPETITION_FACTOR, 0>::new(
+                let code = RaaCode::<Zt, REPETITION_FACTOR>::new(
                     poly_size,
                     RaaConfig {
                         check_for_overflows,
@@ -381,7 +379,7 @@ mod tests {
 
         for check_for_overflows in [true, false] {
             for permute_in_place in [true, false] {
-                let code = RaaCode::<TestZipTypes<N, K, M>, REPETITION_FACTOR, 0>::new(
+                let code = RaaCode::<TestZipTypes<N, K, M>, REPETITION_FACTOR>::new(
                     16,
                     RaaConfig {
                         check_for_overflows,
@@ -422,7 +420,7 @@ mod tests {
         let data: Vec<Int<N>> = (1..=1024).map(Int::<N>::from).collect();
         let poly_size = data.len() * data.len();
         let codeword_1: Vec<Int<K>> = {
-            let code_in_place = RaaCode::<TestZipTypes<N, K, M>, REPETITION_FACTOR, 0>::new(
+            let code_in_place = RaaCode::<TestZipTypes<N, K, M>, REPETITION_FACTOR>::new(
                 poly_size,
                 RaaConfig {
                     check_for_overflows: true,
@@ -433,7 +431,7 @@ mod tests {
         };
 
         let codeword_2: Vec<Int<K>> = {
-            let code_cloning = RaaCode::<TestZipTypes<N, K, M>, REPETITION_FACTOR, 0>::new(
+            let code_cloning = RaaCode::<TestZipTypes<N, K, M>, REPETITION_FACTOR>::new(
                 poly_size,
                 RaaConfig {
                     check_for_overflows: true,
@@ -454,7 +452,7 @@ mod tests {
         const N: usize = 1;
         const K: usize = 1;
 
-        let _code = RaaCode::<TestZipTypes<N, K, N>, REPETITION_FACTOR, 0>::new(
+        let _code = RaaCode::<TestZipTypes<N, K, N>, REPETITION_FACTOR>::new(
             1 << 30,
             RaaConfig {
                 check_for_overflows: true,

--- a/zip-plus/src/code/raa_sign_flip.rs
+++ b/zip-plus/src/code/raa_sign_flip.rs
@@ -10,15 +10,14 @@ use std::ops::{AddAssign, Neg};
 /// Flips signs of every second entry in the codeword, starting from the second
 /// one.
 #[derive(Debug, Clone)]
-pub struct RaaSignFlippingCode<Zt: ZipTypes<DEGREE>, const REP: usize, const DEGREE: usize>
+pub struct RaaSignFlippingCode<Zt: ZipTypes, const REP: usize>
 where
     Zt::Cw: Ring,
 {
-    raa: RaaCode<Zt, REP, DEGREE>,
+    raa: RaaCode<Zt, REP>,
 }
 
-impl<Zt: ZipTypes<DEGREE>, const REP: usize, const DEGREE: usize>
-    RaaSignFlippingCode<Zt, REP, DEGREE>
+impl<Zt: ZipTypes, const REP: usize> RaaSignFlippingCode<Zt, REP>
 where
     Zt::Cw: Ring,
 {
@@ -66,12 +65,11 @@ where
     }
 }
 
-impl<Zt: ZipTypes<DEGREE>, const REP: usize, const DEGREE: usize> LinearCode<Zt, DEGREE>
-    for RaaSignFlippingCode<Zt, REP, DEGREE>
+impl<Zt: ZipTypes, const REP: usize> LinearCode<Zt> for RaaSignFlippingCode<Zt, REP>
 where
     Zt::Cw: Ring,
 {
-    type Config = <RaaCode<Zt, REP, DEGREE> as LinearCode<Zt, DEGREE>>::Config;
+    type Config = <RaaCode<Zt, REP> as LinearCode<Zt>>::Config;
 
     const REPETITION_FACTOR: usize = REP;
 

--- a/zip-plus/src/field/const_monty.rs
+++ b/zip-plus/src/field/const_monty.rs
@@ -114,7 +114,7 @@ mod tests {
 
     #[test]
     fn prepare_projection_for_polynomial() {
-        type Poly = DensePolynomial<Int<{ U128::LIMBS }>, 3>;
+        type Poly = DensePolynomial<Int<{ U128::LIMBS }>, 4>;
 
         // 1 - 2x + 3x^2
         let poly = Poly::new([Int::from(1_i64), Int::from(-2_i64), Int::from(3_i64)]);

--- a/zip-plus/src/pcs/phase_commit.rs
+++ b/zip-plus/src/pcs/phase_commit.rs
@@ -15,9 +15,7 @@ use uninit::out_ref::Out;
 #[cfg(feature = "parallel")]
 use rayon::prelude::*;
 
-impl<Zt: ZipTypes<DEGREE>, Lc: LinearCode<Zt, DEGREE>, const DEGREE: usize>
-    ZipPlus<Zt, Lc, DEGREE>
-{
+impl<Zt: ZipTypes, Lc: LinearCode<Zt>> ZipPlus<Zt, Lc> {
     /// Creates a commitment to a multilinear polynomial using the ZIP PCS
     /// scheme.
     ///
@@ -66,10 +64,10 @@ impl<Zt: ZipTypes<DEGREE>, Lc: LinearCode<Zt, DEGREE>, const DEGREE: usize>
     ///   `pp.num_rows`, indicating an internal logic error.
     #[allow(clippy::arithmetic_side_effects)]
     pub fn commit(
-        pp: &ZipPlusParams<Zt, Lc, DEGREE>,
+        pp: &ZipPlusParams<Zt, Lc>,
         poly: &DenseMultilinearExtension<Zt::Eval>,
     ) -> Result<(ZipPlusHint<Zt::Cw>, ZipPlusCommitment), ZipError> {
-        validate_input::<Zt, Lc, bool, DEGREE>("commit", pp.num_vars, [poly], None)?;
+        validate_input::<Zt, Lc, bool>("commit", pp.num_vars, [poly], None)?;
 
         let expected_num_evals = pp.num_rows * pp.linear_code.row_len();
         assert_eq!(
@@ -110,10 +108,10 @@ impl<Zt: ZipTypes<DEGREE>, Lc: LinearCode<Zt, DEGREE>, const DEGREE: usize>
     /// vector of roots.
     #[allow(dead_code)]
     pub fn commit_no_merkle(
-        pp: &ZipPlusParams<Zt, Lc, DEGREE>,
+        pp: &ZipPlusParams<Zt, Lc>,
         poly: &DenseMultilinearExtension<Zt::Eval>,
     ) -> Result<DenseRowMatrix<Zt::Cw>, ZipError> {
-        validate_input::<Zt, Lc, bool, DEGREE>("commit", pp.num_vars, [poly], None)?;
+        validate_input::<Zt, Lc, bool>("commit", pp.num_vars, [poly], None)?;
 
         let row_len = pp.linear_code.row_len();
 
@@ -137,7 +135,7 @@ impl<Zt: ZipTypes<DEGREE>, Lc: LinearCode<Zt, DEGREE>, const DEGREE: usize>
     /// corresponds to a polynomial in the input slice.
     #[allow(clippy::type_complexity)]
     pub fn batch_commit(
-        pp: &ZipPlusParams<Zt, Lc, DEGREE>,
+        pp: &ZipPlusParams<Zt, Lc>,
         polys: &[DenseMultilinearExtension<Zt::Eval>],
     ) -> Result<Vec<(ZipPlusHint<Zt::Cw>, ZipPlusCommitment)>, ZipError> {
         polys.iter().map(|poly| Self::commit(pp, poly)).collect()
@@ -162,7 +160,7 @@ impl<Zt: ZipTypes<DEGREE>, Lc: LinearCode<Zt, DEGREE>, const DEGREE: usize>
     /// A `Vec<Int<K>>` containing all the encoded rows concatenated together.
     #[allow(clippy::arithmetic_side_effects)]
     pub fn encode_rows(
-        pp: &ZipPlusParams<Zt, Lc, DEGREE>,
+        pp: &ZipPlusParams<Zt, Lc>,
         row_len: usize,
         evals: &[Zt::Eval],
     ) -> DenseRowMatrix<Zt::Cw> {
@@ -216,16 +214,16 @@ mod tests {
     const N: usize = INT_LIMBS;
     const K: usize = INT_LIMBS * 4;
     const M: usize = INT_LIMBS * 8;
-    const DEGREE: usize = 2;
+    const DEGREE_PLUS_ONE: usize = 3;
 
     type Zt = TestZipTypes<N, K, M>;
-    type C = RaaSignFlippingCode<Zt, 4, 0>;
+    type C = RaaSignFlippingCode<Zt, 4>;
 
-    type PolyZt = TestPolyZipTypes<K, M, DEGREE>;
-    type PolyC = RaaCode<PolyZt, 4, DEGREE>;
+    type PolyZt = TestPolyZipTypes<K, M, DEGREE_PLUS_ONE>;
+    type PolyC = RaaCode<PolyZt, 4>;
 
-    type TestZip = ZipPlus<Zt, C, 0>;
-    type TestPolyZip = ZipPlus<PolyZt, PolyC, DEGREE>;
+    type TestZip = ZipPlus<Zt, C>;
+    type TestPolyZip = ZipPlus<PolyZt, PolyC>;
 
     #[test]
     fn commit_rejects_too_many_variables() {
@@ -584,7 +582,7 @@ mod tests {
 
     #[test]
     fn proof_size_is_correct_for_parameters() {
-        fn calculate_expected_test_transcript_size_bytes(pp: &ZipPlusParams<Zt, C, 0>) -> usize {
+        fn calculate_expected_test_transcript_size_bytes(pp: &ZipPlusParams<Zt, C>) -> usize {
             let size_of_zt_k = K * size_of::<Word>();
             let size_of_zt_m = M * size_of::<Word>();
             let size_of_path_len = size_of::<u64>();
@@ -605,7 +603,7 @@ mod tests {
             proximity_phase_size + column_opening_phase_size
         }
 
-        fn calculate_expected_proof_size_bytes(pp: &ZipPlusParams<Zt, C, 0>) -> usize {
+        fn calculate_expected_proof_size_bytes(pp: &ZipPlusParams<Zt, C>) -> usize {
             // F stored as `(value, modulus)` where both `value` and `modulus` are of
             // length `len`.
             // `len` itself is stored only once at the beginning of the F list.
@@ -624,12 +622,12 @@ mod tests {
         let linear_code = C::new(poly_size, RAA_CFG);
         let param = TestZip::setup(poly_size, linear_code);
         let evaluations: Vec<_> = (0..poly_size)
-            .map(|_| <Zt as ZipTypes<_>>::Eval::from(rng.random::<i8>()))
+            .map(|_| <Zt as ZipTypes>::Eval::from(rng.random::<i8>()))
             .collect();
         let mle =
             DenseMultilinearExtension::from_evaluations_slice(num_vars, &evaluations, Zero::zero());
         let point: Vec<_> = (0..num_vars)
-            .map(|_| <Zt as ZipTypes<_>>::Pt::random(&mut rng))
+            .map(|_| <Zt as ZipTypes>::Pt::random(&mut rng))
             .collect();
 
         let (hint, _) = TestZip::commit(&param, &mle).unwrap();

--- a/zip-plus/src/pcs/phase_evaluate.rs
+++ b/zip-plus/src/pcs/phase_evaluate.rs
@@ -16,11 +16,9 @@ use crate::{
 use crypto_primitives::{FromWithConfig, IntoWithConfig, PrimeField};
 use itertools::Itertools;
 
-impl<Zt: ZipTypes<DEGREE>, Lc: LinearCode<Zt, DEGREE>, const DEGREE: usize>
-    ZipPlus<Zt, Lc, DEGREE>
-{
+impl<Zt: ZipTypes, Lc: LinearCode<Zt>> ZipPlus<Zt, Lc> {
     pub fn evaluate<F>(
-        pp: &ZipPlusParams<Zt, Lc, DEGREE>,
+        pp: &ZipPlusParams<Zt, Lc>,
         poly: &DenseMultilinearExtension<Zt::Eval>,
         point: &[Zt::Pt],
         test_transcript: ZipPlusTestTranscript,
@@ -33,7 +31,7 @@ impl<Zt: ZipTypes<DEGREE>, Lc: LinearCode<Zt, DEGREE>, const DEGREE: usize>
         F::Inner: FromRef<Zt::Fmod> + Transcribable,
         Zt::Eval: ProjectableToField<F>,
     {
-        validate_input::<Zt, Lc, _, DEGREE>("evaluate", pp.num_vars, [poly], [point])?;
+        validate_input::<Zt, Lc, _>("evaluate", pp.num_vars, [poly], [point])?;
 
         let mut transcript: PcsTranscript = test_transcript.into();
 

--- a/zip-plus/src/pcs/phase_test.rs
+++ b/zip-plus/src/pcs/phase_test.rs
@@ -7,28 +7,28 @@ use crate::{
         utils::{ColumnOpening, validate_input},
     },
     pcs_transcript::PcsTranscript,
-    poly::{EvaluatablePolynomial, mle::DenseMultilinearExtension},
+    poly::{EvaluatablePolynomial, Polynomial, mle::DenseMultilinearExtension},
     traits::{FromRef, Transcript},
     utils::combine_rows,
 };
 use itertools::Itertools;
 
-impl<Zt: ZipTypes<DEGREE>, Lc: LinearCode<Zt, DEGREE>, const DEGREE: usize>
-    ZipPlus<Zt, Lc, DEGREE>
-{
+impl<Zt: ZipTypes, Lc: LinearCode<Zt>> ZipPlus<Zt, Lc> {
     pub fn test(
-        pp: &ZipPlusParams<Zt, Lc, DEGREE>,
+        pp: &ZipPlusParams<Zt, Lc>,
         poly: &DenseMultilinearExtension<Zt::Eval>,
         commit_hint: &ZipPlusHint<Zt::Cw>,
     ) -> Result<ZipPlusTestTranscript, ZipError> {
-        validate_input::<Zt, Lc, bool, DEGREE>("test", pp.num_vars, [poly], None)?;
+        validate_input::<Zt, Lc, bool>("test", pp.num_vars, [poly], None)?;
 
         let mut transcript = PcsTranscript::new();
 
         // If we can take linear combinations, perform the proximity test
         if pp.num_rows > 1 {
             // Values to evaluate the coefficients at
-            let alphas = transcript.fs_transcript.get_challenges::<Zt::Chal>(DEGREE);
+            let alphas = transcript
+                .fs_transcript
+                .get_challenges::<Zt::Chal>(Zt::Comb::DEGREE_BOUND);
 
             // Coefficients for the linear combination of polynomial with evaluated
             // coefficients
@@ -103,16 +103,16 @@ mod tests {
     const N: usize = INT_LIMBS;
     const K: usize = INT_LIMBS * 4;
     const M: usize = INT_LIMBS * 8;
-    const DEGREE: usize = 2;
+    const DEGREE_PLUS_ONE: usize = 3;
 
     type Zt = TestZipTypes<N, K, M>;
-    type C = RaaSignFlippingCode<Zt, 4, 0>;
+    type C = RaaSignFlippingCode<Zt, 4>;
 
-    type PolyZt = TestPolyZipTypes<K, M, DEGREE>;
-    type PolyC = RaaCode<PolyZt, 4, DEGREE>;
+    type PolyZt = TestPolyZipTypes<K, M, DEGREE_PLUS_ONE>;
+    type PolyC = RaaCode<PolyZt, 4>;
 
-    type TestZip = ZipPlus<Zt, C, 0>;
-    type TestPolyZip = ZipPlus<PolyZt, PolyC, DEGREE>;
+    type TestZip = ZipPlus<Zt, C>;
+    type TestPolyZip = ZipPlus<PolyZt, PolyC>;
 
     #[test]
     fn successful_testing_with_correct_polynomial_and_hint() {

--- a/zip-plus/src/pcs/phase_verify.rs
+++ b/zip-plus/src/pcs/phase_verify.rs
@@ -367,11 +367,12 @@ mod tests {
                 setup_full_protocol_poly::<F, N, K, M, DEGREE_PLUS_ONE>(num_vars);
 
             let different_evals = {
-                let different_eval_coeffs: Vec<_> = (1..=((1 << num_vars) * DEGREE_PLUS_ONE as i8))
+                let different_eval_coeffs: Vec<_> = (1..=((1 << num_vars)
+                    * (DEGREE_PLUS_ONE - 1) as i8))
                     .map(|x| (x % 3 == 0).into())
                     .collect_vec();
                 different_eval_coeffs
-                    .chunks_exact(DEGREE_PLUS_ONE)
+                    .chunks_exact(DEGREE_PLUS_ONE - 1)
                     .map(DensePolynomial::new)
                     .collect_vec()
             };

--- a/zip-plus/src/pcs/phase_verify.rs
+++ b/zip-plus/src/pcs/phase_verify.rs
@@ -10,7 +10,7 @@ use crate::{
         utils::{ColumnOpening, point_to_tensor, validate_input},
     },
     pcs_transcript::PcsTranscript,
-    poly::EvaluatablePolynomial,
+    poly::{EvaluatablePolynomial, Polynomial},
     traits::{FromRef, Transcribable, Transcript},
     utils::inner_product,
 };
@@ -18,11 +18,9 @@ use crypto_primitives::{FromWithConfig, IntoWithConfig, PrimeField};
 use itertools::Itertools;
 use num_traits::ConstZero;
 
-impl<Zt: ZipTypes<DEGREE>, Lc: LinearCode<Zt, DEGREE>, const DEGREE: usize>
-    ZipPlus<Zt, Lc, DEGREE>
-{
+impl<Zt: ZipTypes, Lc: LinearCode<Zt>> ZipPlus<Zt, Lc> {
     pub fn verify<F>(
-        vp: &ZipPlusParams<Zt, Lc, DEGREE>,
+        vp: &ZipPlusParams<Zt, Lc>,
         comm: &ZipPlusCommitment,
         point_f: &[F],
         eval_f: &F,
@@ -36,7 +34,7 @@ impl<Zt: ZipTypes<DEGREE>, Lc: LinearCode<Zt, DEGREE>, const DEGREE: usize>
         F::Inner: FromRef<Zt::Fmod> + Transcribable,
         Zt::Cw: ProjectableToField<F>,
     {
-        validate_input::<Zt, Lc, _, DEGREE>("verify", vp.num_vars, &[], [point_f])?;
+        validate_input::<Zt, Lc, _>("verify", vp.num_vars, &[], [point_f])?;
 
         let mut transcript: PcsTranscript = proof.clone().into();
 
@@ -66,7 +64,7 @@ impl<Zt: ZipTypes<DEGREE>, Lc: LinearCode<Zt, DEGREE>, const DEGREE: usize>
 
     #[allow(clippy::type_complexity)]
     pub(super) fn verify_testing(
-        vp: &ZipPlusParams<Zt, Lc, DEGREE>,
+        vp: &ZipPlusParams<Zt, Lc>,
         root: &MtHash,
         transcript: &mut PcsTranscript,
     ) -> Result<Vec<(usize, Vec<Zt::Cw>)>, ZipError> {
@@ -74,7 +72,9 @@ impl<Zt: ZipTypes<DEGREE>, Lc: LinearCode<Zt, DEGREE>, const DEGREE: usize>
         let encoded_combined_rows: Option<(Vec<Zt::Chal>, Vec<Zt::Chal>, Vec<Zt::CombR>)> = {
             if vp.num_rows > 1 {
                 // Values to evaluate the coefficients at
-                let alphas = transcript.fs_transcript.get_challenges(DEGREE);
+                let alphas = transcript
+                    .fs_transcript
+                    .get_challenges(Zt::Comb::DEGREE_BOUND);
 
                 // Coefficients for the linear combination of polynomial with evaluated
                 // coefficients
@@ -146,7 +146,7 @@ impl<Zt: ZipTypes<DEGREE>, Lc: LinearCode<Zt, DEGREE>, const DEGREE: usize>
     }
 
     fn verify_evaluation<F>(
-        vp: &ZipPlusParams<Zt, Lc, DEGREE>,
+        vp: &ZipPlusParams<Zt, Lc>,
         point_f: &[F],
         eval_f: &F,
         columns_opened: &[(usize, Vec<Zt::Cw>)],
@@ -191,7 +191,7 @@ impl<Zt: ZipTypes<DEGREE>, Lc: LinearCode<Zt, DEGREE>, const DEGREE: usize>
         column_entries: &[Zt::Cw],
         column: usize,
         num_rows: usize,
-        project: &impl Fn(&<Zt as ZipTypes<DEGREE>>::Cw) -> F,
+        project: &impl Fn(&<Zt as ZipTypes>::Cw) -> F,
         field_cfg: &F::Config,
     ) -> Result<(), ZipError>
     where
@@ -249,18 +249,18 @@ mod tests {
     const N: usize = INT_LIMBS;
     const K: usize = INT_LIMBS * 4;
     const M: usize = INT_LIMBS * 8;
-    const DEGREE: usize = 2;
+    const DEGREE_PLUS_ONE: usize = 3;
 
     type F = BoxedMontyField;
 
     type Zt = TestZipTypes<N, K, M>;
-    type C = RaaSignFlippingCode<Zt, 4, 0>;
+    type C = RaaSignFlippingCode<Zt, 4>;
 
-    type PolyZt = TestPolyZipTypes<K, M, DEGREE>;
-    type PolyC = RaaCode<PolyZt, 4, DEGREE>;
+    type PolyZt = TestPolyZipTypes<K, M, DEGREE_PLUS_ONE>;
+    type PolyC = RaaCode<PolyZt, 4>;
 
-    type TestZip = ZipPlus<Zt, C, 0>;
-    type TestPolyZip = ZipPlus<PolyZt, PolyC, DEGREE>;
+    type TestZip = ZipPlus<Zt, C>;
+    type TestPolyZip = ZipPlus<PolyZt, PolyC>;
 
     #[test]
     fn successful_verification_of_valid_proof() {
@@ -273,7 +273,7 @@ mod tests {
         };
         {
             let (pp, comm, point_f, eval_f, proof) =
-                setup_full_protocol_poly::<F, N, K, M, DEGREE>(num_vars);
+                setup_full_protocol_poly::<F, N, K, M, DEGREE_PLUS_ONE>(num_vars);
 
             let result = TestPolyZip::verify(&pp, &comm, &point_f, &eval_f, &proof);
 
@@ -302,7 +302,7 @@ mod tests {
 
         {
             let (pp, comm, point_f, eval_f, proof) =
-                setup_full_protocol_poly::<F, N, K, M, DEGREE>(num_vars);
+                setup_full_protocol_poly::<F, N, K, M, DEGREE_PLUS_ONE>(num_vars);
             let cfg = eval_f.cfg().clone();
 
             let result = TestPolyZip::verify(
@@ -335,7 +335,7 @@ mod tests {
 
         {
             let (pp, comm, point_f, eval_f, proof) =
-                setup_full_protocol_poly::<F, N, K, M, DEGREE>(num_vars);
+                setup_full_protocol_poly::<F, N, K, M, DEGREE_PLUS_ONE>(num_vars);
             let tampered = tamper(proof);
             let result = TestPolyZip::verify(&pp, &comm, &point_f, &eval_f, &tampered);
             assert!(result.is_err());
@@ -364,14 +364,14 @@ mod tests {
 
         {
             let (pp, _comm_poly1, point_f, eval_f, proof_poly1) =
-                setup_full_protocol_poly::<F, N, K, M, DEGREE>(num_vars);
+                setup_full_protocol_poly::<F, N, K, M, DEGREE_PLUS_ONE>(num_vars);
 
             let different_evals = {
-                let different_eval_coeffs: Vec<_> = (1..=((1 << num_vars) * DEGREE as i8))
+                let different_eval_coeffs: Vec<_> = (1..=((1 << num_vars) * DEGREE_PLUS_ONE as i8))
                     .map(|x| (x % 3 == 0).into())
                     .collect_vec();
                 different_eval_coeffs
-                    .chunks_exact(DEGREE)
+                    .chunks_exact(DEGREE_PLUS_ONE)
                     .map(DensePolynomial::new)
                     .collect_vec()
             };
@@ -403,7 +403,7 @@ mod tests {
 
         {
             let (pp, comm, _point_f, eval_f, proof) =
-                setup_full_protocol_poly::<F, N, K, M, DEGREE>(num_vars);
+                setup_full_protocol_poly::<F, N, K, M, DEGREE_PLUS_ONE>(num_vars);
             let invalid_point = make_invalid_point(eval_f.cfg());
 
             let result = TestPolyZip::verify(&pp, &comm, &invalid_point, &eval_f, &proof);
@@ -435,7 +435,7 @@ mod tests {
             Zero::zero(),
         );
 
-        let point: Vec<<Zt as ZipTypes<_>>::Pt> =
+        let point: Vec<<Zt as ZipTypes>::Pt> =
             (0..num_vars).map(|i| Int::from(i as i32 + 2)).collect();
 
         let test_mle2_proof = TestZip::test(&pp, &mle2, &data).expect("test phase should succeed");
@@ -478,7 +478,7 @@ mod tests {
         let corrupted_merkle_tree = MerkleTree::new(&corrupted_data.to_rows_slices());
         let corrupted_data = ZipPlusHint::new(corrupted_data, corrupted_merkle_tree);
 
-        let point: Vec<<Zt as ZipTypes<_>>::Pt> =
+        let point: Vec<<Zt as ZipTypes>::Pt> =
             (0..num_vars).map(|i| Int::from(i as i32 + 2)).collect();
 
         let test_transcript =
@@ -506,7 +506,7 @@ mod tests {
 
         let (data, comm) = TestZip::commit(&pp, &mle).unwrap();
 
-        let point: Vec<<Zt as ZipTypes<_>>::Pt> =
+        let point: Vec<<Zt as ZipTypes>::Pt> =
             (0..num_vars).map(|i| Int::from(i as i32 + 2)).collect();
 
         let test_transcript = TestZip::test(&pp, &mle, &data).expect("test phase should succeed");
@@ -537,7 +537,7 @@ mod tests {
         let pp = TestZip::setup(poly_size, linear_code);
 
         let evaluations: Vec<_> = (0..poly_size as i32)
-            .map(<Zt as ZipTypes<_>>::Eval::from)
+            .map(<Zt as ZipTypes>::Eval::from)
             .collect();
         let mle = DenseMultilinearExtension::from_evaluations_slice(n, &evaluations, Zero::zero());
 
@@ -619,11 +619,11 @@ mod tests {
         let linear_code: C = C::new(poly_size, RAA_CFG);
         let pp = TestZip::setup(poly_size, linear_code);
         let evaluations: Vec<_> = (0..poly_size)
-            .map(|_| <Zt as ZipTypes<_>>::Eval::from(rng.random::<i8>()))
+            .map(|_| <Zt as ZipTypes>::Eval::from(rng.random::<i8>()))
             .collect();
         let mle = DenseMultilinearExtension::from_evaluations_slice(n, &evaluations, Zero::zero());
         let point: Vec<_> = (0..n)
-            .map(|_| <Zt as ZipTypes<_>>::Pt::random(&mut rng))
+            .map(|_| <Zt as ZipTypes>::Pt::random(&mut rng))
             .collect();
 
         let (mut data, comm) = TestZip::commit(&pp, &mle).unwrap();
@@ -655,7 +655,7 @@ mod tests {
 
         let (data, comm) = TestZip::commit(&pp, &mle).expect("commit should succeed");
 
-        let point: Vec<<Zt as ZipTypes<_>>::Pt> =
+        let point: Vec<<Zt as ZipTypes>::Pt> =
             [0i64, 0i64, 0i64].into_iter().map(Int::from).collect_vec();
 
         let test_transcript = TestZip::test(&pp, &mle, &data).unwrap();
@@ -701,7 +701,7 @@ mod tests {
 
         let (data, comm) = TestZip::commit(&pp, &mle).expect("commit should succeed");
 
-        let point: Vec<<Zt as ZipTypes<_>>::Pt> =
+        let point: Vec<<Zt as ZipTypes>::Pt> =
             [0i64, 0i64, 0i64].into_iter().map(Int::from).collect_vec();
 
         let test_transcript = TestZip::test(&pp, &mle, &data).unwrap();
@@ -732,7 +732,7 @@ mod tests {
 
         let (data, comm) = TestZip::commit(&pp, &mle).expect("commit should succeed");
 
-        let point: Vec<<Zt as ZipTypes<_>>::Pt> = vec![Int::ZERO; num_vars];
+        let point: Vec<<Zt as ZipTypes>::Pt> = vec![Int::ZERO; num_vars];
 
         let test_transcript = TestZip::test(&pp, &mle, &data).unwrap();
         let (real_eval_f, proof) =
@@ -754,7 +754,7 @@ mod tests {
         let num_vars = 4;
         let (pp, _) = setup_test_params(num_vars);
 
-        let mut evals: Vec<<Zt as ZipTypes<_>>::Eval> =
+        let mut evals: Vec<<Zt as ZipTypes>::Eval> =
             (0..1 << num_vars as i32).map(Int::from).collect();
         evals[1] = Int::from(i64::MAX);
         let poly = DenseMultilinearExtension::from_evaluations_vec(num_vars, evals, Zero::zero());
@@ -762,8 +762,8 @@ mod tests {
         let (data, comm) = TestZip::commit(&pp, &poly).unwrap();
 
         // A point of [1, 0, 0, 0] will evaluate to poly.evaluations[1].
-        let mut point = vec![<Zt as ZipTypes<_>>::Pt::ZERO; num_vars];
-        point[0] = <Zt as ZipTypes<_>>::Pt::ONE;
+        let mut point = vec![<Zt as ZipTypes>::Pt::ZERO; num_vars];
+        point[0] = <Zt as ZipTypes>::Pt::ONE;
 
         let test_transcript = TestZip::test(&pp, &poly, &data).unwrap();
         let (eval_f, proof) = TestZip::evaluate::<F>(&pp, &poly, &point, test_transcript).unwrap();
@@ -791,7 +791,7 @@ mod tests {
 
         let (hint, comm) = TestZip::commit(&pp, &poly).unwrap();
 
-        let point: Vec<<Zt as ZipTypes<_>>::Pt> = vec![Int::from(1), Int::from(2)];
+        let point: Vec<<Zt as ZipTypes>::Pt> = vec![Int::from(1), Int::from(2)];
 
         let test_transcript = TestZip::test(&pp, &poly, &hint).unwrap();
         let (eval_f, proof) = TestZip::evaluate::<F>(&pp, &poly, &point, test_transcript).unwrap();
@@ -821,7 +821,7 @@ mod tests {
 
         let (data, comm) = TestZip::commit(&pp, &mle).expect("commit should succeed");
 
-        let point: Vec<<Zt as ZipTypes<_>>::Pt> =
+        let point: Vec<<Zt as ZipTypes>::Pt> =
             [0i64, 0i64, 0i64].into_iter().map(Int::from).collect_vec();
 
         let test_transcript = TestZip::test(&pp, &mle, &data).unwrap();

--- a/zip-plus/src/pcs/structs.rs
+++ b/zip-plus/src/pcs/structs.rs
@@ -12,7 +12,7 @@ use crypto_primitives::{
 use num_traits::CheckedMul;
 use std::{marker::PhantomData, ops::Neg};
 
-pub trait ZipTypes<const DEGREE: usize>: Send + Sync {
+pub trait ZipTypes: Send + Sync {
     const NUM_COLUMN_OPENINGS: usize;
 
     /// Semiring of witness/polynomial evaluations on boolean hypercube
@@ -46,7 +46,7 @@ pub trait ZipTypes<const DEGREE: usize>: Send + Sync {
     /// Ring of elements in the linear combination of codewords, at least as
     /// wide as the evaluation, codeword, and challenge rings.
     type Comb: FixedSemiring
-        + EvaluatablePolynomial<Self::Chal, Self::CombR>
+        + EvaluatablePolynomial<Self::CombR, Self::Chal, Self::CombR>
         + FromRef<Self::Eval>
         + FromRef<Self::Cw>
         + Named;
@@ -54,17 +54,15 @@ pub trait ZipTypes<const DEGREE: usize>: Send + Sync {
 
 /// Zip is a Polynomial Commitment Scheme (PCS) that supports committing to
 /// multilinear polynomials.
-pub struct ZipPlus<Zt: ZipTypes<DEGREE>, Lc: LinearCode<Zt, DEGREE>, const DEGREE: usize>(
-    PhantomData<(Zt, Lc)>,
-);
+pub struct ZipPlus<Zt: ZipTypes, Lc: LinearCode<Zt>>(PhantomData<(Zt, Lc)>);
 
-impl<Zt, Lc, const DEGREE: usize> ZipPlus<Zt, Lc, DEGREE>
+impl<Zt, Lc> ZipPlus<Zt, Lc>
 where
-    Zt: ZipTypes<DEGREE>,
-    Lc: LinearCode<Zt, DEGREE>,
+    Zt: ZipTypes,
+    Lc: LinearCode<Zt>,
 {
     #[allow(clippy::arithmetic_side_effects)]
-    pub fn setup(poly_size: usize, linear_code: Lc) -> ZipPlusParams<Zt, Lc, DEGREE> {
+    pub fn setup(poly_size: usize, linear_code: Lc) -> ZipPlusParams<Zt, Lc> {
         assert!(poly_size.is_power_of_two());
         let num_vars = poly_size.ilog2() as usize;
         let num_rows = ((1 << num_vars) / linear_code.row_len()).next_power_of_two();
@@ -74,16 +72,14 @@ where
 
 /// Parameters for the Zip+ PCS.
 #[derive(Clone, Debug)]
-pub struct ZipPlusParams<Zt: ZipTypes<DEGREE>, Lc: LinearCode<Zt, DEGREE>, const DEGREE: usize> {
+pub struct ZipPlusParams<Zt: ZipTypes, Lc: LinearCode<Zt>> {
     pub num_vars: usize,
     pub num_rows: usize,
     pub linear_code: Lc,
     phantom_data: PhantomData<Zt>,
 }
 
-impl<Zt: ZipTypes<DEGREE>, Lc: LinearCode<Zt, DEGREE>, const DEGREE: usize>
-    ZipPlusParams<Zt, Lc, DEGREE>
-{
+impl<Zt: ZipTypes, Lc: LinearCode<Zt>> ZipPlusParams<Zt, Lc> {
     pub fn new(num_vars: usize, num_rows: usize, linear_code: Lc) -> Self {
         Self {
             num_vars,

--- a/zip-plus/src/pcs/test_utils.rs
+++ b/zip-plus/src/pcs/test_utils.rs
@@ -96,7 +96,7 @@ pub fn setup_poly_test_params<const K: usize, const M: usize, const DEGREE_PLUS_
             .map(|v| v.is_odd().into())
             .collect_vec();
         eval_coeffs
-            .chunks_exact(DEGREE_PLUS_ONE)
+            .chunks_exact(DEGREE_PLUS_ONE - 1)
             .map(DensePolynomial::new)
             .collect_vec()
     })

--- a/zip-plus/src/pcs/test_utils.rs
+++ b/zip-plus/src/pcs/test_utils.rs
@@ -39,7 +39,7 @@ pub const RAA_CFG: RaaConfig = RaaConfig {
 };
 
 pub struct TestZipTypes<const N: usize, const K: usize, const M: usize> {}
-impl<const N: usize, const K: usize, const M: usize> ZipTypes<0> for TestZipTypes<N, K, M> {
+impl<const N: usize, const K: usize, const M: usize> ZipTypes for TestZipTypes<N, K, M> {
     const NUM_COLUMN_OPENINGS: usize = 650;
     type Eval = Int<N>;
     type Cw = Int<K>;
@@ -51,19 +51,19 @@ impl<const N: usize, const K: usize, const M: usize> ZipTypes<0> for TestZipType
     type Comb = Self::CombR;
 }
 
-pub struct TestPolyZipTypes<const K: usize, const M: usize, const DEGREE: usize> {}
-impl<const K: usize, const M: usize, const DEGREE: usize> ZipTypes<DEGREE>
-    for TestPolyZipTypes<K, M, DEGREE>
+pub struct TestPolyZipTypes<const K: usize, const M: usize, const DEGREE_PLUS_ONE: usize> {}
+impl<const K: usize, const M: usize, const DEGREE_PLUS_ONE: usize> ZipTypes
+    for TestPolyZipTypes<K, M, DEGREE_PLUS_ONE>
 {
     const NUM_COLUMN_OPENINGS: usize = 650;
-    type Eval = DensePolynomial<Boolean, DEGREE>;
-    type Cw = DensePolynomial<i32, DEGREE>;
+    type Eval = DensePolynomial<Boolean, DEGREE_PLUS_ONE>;
+    type Cw = DensePolynomial<i32, DEGREE_PLUS_ONE>;
     type Fmod = Uint<K>;
     type PrimeTest = MillerRabin;
     type Chal = i128;
     type Pt = i128;
     type CombR = Int<M>;
-    type Comb = DensePolynomial<Self::CombR, DEGREE>;
+    type Comb = DensePolynomial<Self::CombR, DEGREE_PLUS_ONE>;
 }
 
 /// Helper function to set up common parameters for tests.
@@ -72,10 +72,9 @@ pub fn setup_test_params<const N: usize, const K: usize, const M: usize>(
 ) -> (
     ZipPlusParams<
         TestZipTypes<N, K, M>,
-        RaaSignFlippingCode<TestZipTypes<N, K, M>, REPETITION_FACTOR, 0>,
-        0,
+        RaaSignFlippingCode<TestZipTypes<N, K, M>, REPETITION_FACTOR>,
     >,
-    DenseMultilinearExtension<<TestZipTypes<N, K, M> as ZipTypes<0>>::Eval>,
+    DenseMultilinearExtension<<TestZipTypes<N, K, M> as ZipTypes>::Eval>,
 ) {
     setup_test_params_inner(num_vars, |poly_size| {
         (1..=poly_size as i32).map(Int::from).collect()
@@ -83,38 +82,30 @@ pub fn setup_test_params<const N: usize, const K: usize, const M: usize>(
 }
 
 /// Helper function to set up common parameters for tests.
-pub fn setup_poly_test_params<const K: usize, const M: usize, const DEGREE: usize>(
+pub fn setup_poly_test_params<const K: usize, const M: usize, const DEGREE_PLUS_ONE: usize>(
     num_vars: usize,
 ) -> (
     ZipPlusParams<
-        TestPolyZipTypes<K, M, DEGREE>,
-        RaaCode<TestPolyZipTypes<K, M, DEGREE>, REPETITION_FACTOR, DEGREE>,
-        DEGREE,
+        TestPolyZipTypes<K, M, DEGREE_PLUS_ONE>,
+        RaaCode<TestPolyZipTypes<K, M, DEGREE_PLUS_ONE>, REPETITION_FACTOR>,
     >,
-    DenseMultilinearExtension<<TestPolyZipTypes<K, M, DEGREE> as ZipTypes<DEGREE>>::Eval>,
+    DenseMultilinearExtension<<TestPolyZipTypes<K, M, DEGREE_PLUS_ONE> as ZipTypes>::Eval>,
 ) {
     setup_test_params_inner(num_vars, |poly_size| {
-        let eval_coeffs: Vec<_> = (1..=(poly_size * DEGREE) as i8)
+        let eval_coeffs: Vec<_> = (1..=(poly_size * (DEGREE_PLUS_ONE - 1)) as i8)
             .map(|v| v.is_odd().into())
             .collect_vec();
         eval_coeffs
-            .chunks_exact(DEGREE)
+            .chunks_exact(DEGREE_PLUS_ONE)
             .map(DensePolynomial::new)
             .collect_vec()
     })
 }
 
-fn setup_test_params_inner<
-    Zt: ZipTypes<DEGREE>,
-    Lc: LinearCode<Zt, DEGREE, Config = RaaConfig>,
-    const DEGREE: usize,
->(
+fn setup_test_params_inner<Zt: ZipTypes, Lc: LinearCode<Zt, Config = RaaConfig>>(
     num_vars: usize,
     prepare_evaluations: impl FnOnce(usize) -> Vec<Zt::Eval>,
-) -> (
-    ZipPlusParams<Zt, Lc, DEGREE>,
-    DenseMultilinearExtension<Zt::Eval>,
-) {
+) -> (ZipPlusParams<Zt, Lc>, DenseMultilinearExtension<Zt::Eval>) {
     let poly_size = 1 << num_vars;
     let num_rows = 1 << num_vars.div_ceil(2);
 
@@ -132,8 +123,7 @@ pub fn setup_full_protocol<F, const N: usize, const K: usize, const M: usize>(
 ) -> (
     ZipPlusParams<
         TestZipTypes<N, K, M>,
-        RaaSignFlippingCode<TestZipTypes<N, K, M>, REPETITION_FACTOR, 0>,
-        0,
+        RaaSignFlippingCode<TestZipTypes<N, K, M>, REPETITION_FACTOR>,
     >,
     ZipPlusCommitment,
     Vec<F>,
@@ -142,13 +132,13 @@ pub fn setup_full_protocol<F, const N: usize, const K: usize, const M: usize>(
 )
 where
     F: PrimeField
-        + for<'a> FromWithConfig<&'a <TestZipTypes<N, K, M> as ZipTypes<0>>::Chal>
+        + for<'a> FromWithConfig<&'a <TestZipTypes<N, K, M> as ZipTypes>::Chal>
         + for<'a> MulByScalar<&'a F>,
-    F::Inner: FromRef<<TestZipTypes<N, K, M> as ZipTypes<0>>::Fmod> + Transcribable,
-    <TestZipTypes<N, K, M> as ZipTypes<0>>::Eval: ProjectableToField<F>,
-    <TestZipTypes<N, K, M> as ZipTypes<0>>::Comb: ProjectableToField<F>,
+    F::Inner: FromRef<<TestZipTypes<N, K, M> as ZipTypes>::Fmod> + Transcribable,
+    <TestZipTypes<N, K, M> as ZipTypes>::Eval: ProjectableToField<F>,
+    <TestZipTypes<N, K, M> as ZipTypes>::Comb: ProjectableToField<F>,
 {
-    setup_full_protocol_inner::<_, _, _, N, 0>(num_vars, setup_test_params, || {
+    setup_full_protocol_inner::<_, _, _, N>(num_vars, setup_test_params, || {
         (0..num_vars).map(|i| Int::from(i as i32 + 2)).collect()
     })
 }
@@ -158,14 +148,13 @@ pub fn setup_full_protocol_poly<
     const N: usize,
     const K: usize,
     const M: usize,
-    const DEGREE: usize,
+    const DEGREE_PLUS_ONE: usize,
 >(
     num_vars: usize,
 ) -> (
     ZipPlusParams<
-        TestPolyZipTypes<K, M, DEGREE>,
-        RaaCode<TestPolyZipTypes<K, M, DEGREE>, REPETITION_FACTOR, DEGREE>,
-        DEGREE,
+        TestPolyZipTypes<K, M, DEGREE_PLUS_ONE>,
+        RaaCode<TestPolyZipTypes<K, M, DEGREE_PLUS_ONE>, REPETITION_FACTOR>,
     >,
     ZipPlusCommitment,
     Vec<F>,
@@ -174,36 +163,31 @@ pub fn setup_full_protocol_poly<
 )
 where
     F: PrimeField
-        + for<'a> FromWithConfig<&'a <TestPolyZipTypes<K, M, DEGREE> as ZipTypes<DEGREE>>::Chal>
+        + for<'a> FromWithConfig<&'a <TestPolyZipTypes<K, M, DEGREE_PLUS_ONE> as ZipTypes>::Chal>
         + for<'a> MulByScalar<&'a F>,
-    F::Inner: FromRef<<TestPolyZipTypes<K, M, DEGREE> as ZipTypes<DEGREE>>::Fmod> + Transcribable,
-    <TestPolyZipTypes<K, M, DEGREE> as ZipTypes<DEGREE>>::Eval: ProjectableToField<F>,
-    <TestPolyZipTypes<K, M, DEGREE> as ZipTypes<DEGREE>>::Comb: ProjectableToField<F>,
+    F::Inner: FromRef<<TestPolyZipTypes<K, M, DEGREE_PLUS_ONE> as ZipTypes>::Fmod> + Transcribable,
+    <TestPolyZipTypes<K, M, DEGREE_PLUS_ONE> as ZipTypes>::Eval: ProjectableToField<F>,
+    <TestPolyZipTypes<K, M, DEGREE_PLUS_ONE> as ZipTypes>::Comb: ProjectableToField<F>,
 {
-    setup_full_protocol_inner::<_, _, _, N, DEGREE>(num_vars, setup_poly_test_params, || {
+    setup_full_protocol_inner::<_, _, _, N>(num_vars, setup_poly_test_params, || {
         (0..num_vars).map(|i| i as i128 + 2).collect()
     })
 }
 
-fn setup_full_protocol_inner<Zt, Lc, F, const N: usize, const DEGREE: usize>(
+fn setup_full_protocol_inner<Zt, Lc, F, const N: usize>(
     num_vars: usize,
-    setup: impl FnOnce(
-        usize,
-    ) -> (
-        ZipPlusParams<Zt, Lc, DEGREE>,
-        DenseMultilinearExtension<Zt::Eval>,
-    ),
+    setup: impl FnOnce(usize) -> (ZipPlusParams<Zt, Lc>, DenseMultilinearExtension<Zt::Eval>),
     prepare_evaluation_point: impl FnOnce() -> Vec<Zt::Pt>,
 ) -> (
-    ZipPlusParams<Zt, Lc, DEGREE>,
+    ZipPlusParams<Zt, Lc>,
     ZipPlusCommitment,
     Vec<F>,
     F,
     ZipPlusProof,
 )
 where
-    Zt: ZipTypes<DEGREE>,
-    Lc: LinearCode<Zt, DEGREE>,
+    Zt: ZipTypes,
+    Lc: LinearCode<Zt>,
     F: PrimeField
         + for<'a> FromWithConfig<&'a Zt::Chal>
         + for<'a> FromWithConfig<&'a Zt::Pt>

--- a/zip-plus/src/pcs/utils.rs
+++ b/zip-plus/src/pcs/utils.rs
@@ -14,6 +14,7 @@ use ark_std::{cfg_iter_mut, iterable::Iterable};
 use crypto_primitives::PrimeField;
 use thiserror::Error;
 
+use crate::poly::Polynomial;
 #[cfg(feature = "parallel")]
 use rayon::prelude::*;
 
@@ -24,13 +25,7 @@ fn err_too_many_variates(function: &str, upto: usize, got: usize) -> ZipError {
 }
 
 // Ensures that polynomials and evaluation points are of appropriate size
-pub(super) fn validate_input<
-    'a,
-    Zt: ZipTypes<DEGREE> + 'a,
-    Lc: LinearCode<Zt, DEGREE>,
-    Pt: 'a,
-    const DEGREE: usize,
->(
+pub(super) fn validate_input<'a, Zt: ZipTypes + 'a, Lc: LinearCode<Zt>, Pt: 'a>(
     function: &str,
     param_num_vars: usize,
     polys: impl Iterable<Item = &'a DenseMultilinearExtension<Zt::Eval>>,
@@ -44,7 +39,7 @@ pub(super) fn validate_input<
         let d = div!(param_num_vars, 2);
         let codeword_bits = ilog_round_up!(mul!(Lc::REPETITION_FACTOR, d), usize);
         let mut challenge_bits = Zt::Chal::NUM_BITS;
-        if DEGREE > 0 {
+        if Zt::Comb::DEGREE_BOUND > 0 {
             // This means we also draft alphas (multiplied with coeffs), which
             // doubles the number of challenge bits
             challenge_bits = mul!(challenge_bits, 2);

--- a/zip-plus/src/poly.rs
+++ b/zip-plus/src/poly.rs
@@ -4,7 +4,13 @@ pub mod zero_degree;
 
 use thiserror::Error;
 
-pub trait EvaluatablePolynomial<S, Out> {
+/// Polynomial with coefficients of type `C` and degree bounded by
+/// `DEGREE_BOUND`.
+pub trait Polynomial<C> {
+    const DEGREE_BOUND: usize;
+}
+
+pub trait EvaluatablePolynomial<C, S, Out>: Polynomial<C> {
     /// Evaluates the polynomial at the given point, treating point `[p_0, p_1,
     /// p_2, ...]` as `[x, x^2, x^3, ..., x^DEGREE_BOUND]`, thus it returns
     /// `a_0 + (a_1 * p_0) + (a_2 * p_1) + ... + (a_DEGREE_BOUND *

--- a/zip-plus/src/poly/dense.rs
+++ b/zip-plus/src/poly/dense.rs
@@ -1,6 +1,7 @@
-use super::{ConstCoeffBitWidth, EvaluatablePolynomial, EvaluationError};
+use super::{ConstCoeffBitWidth, EvaluatablePolynomial, EvaluationError, Polynomial};
 use crate::{
     pcs::structs::{MulByScalar, ProjectableToField},
+    sub,
     traits::{ConstTranscribable, FromRef, Named},
 };
 use crypto_primitives::{FromWithConfig, IntoWithConfig, PrimeField, Ring, Semiring};
@@ -11,25 +12,18 @@ use std::{
     array,
     fmt::Display,
     hash::Hash,
-    iter,
     iter::{Product, Sum},
     ops::{Add, AddAssign, Mul, MulAssign, Neg, Sub, SubAssign},
 };
 // TODO: rename to univariate?
 
-// Sadly, we cannot use [R; DEGREE + 1] in stable Rust yet, so we use separate
-// coeff_0.
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub struct DensePolynomial<R, const DEGREE: usize> {
-    /// Coefficient of the polynomial of degree 0.
-    coeff_0: R,
-
-    /// Coefficients of the polynomial, lowest degree first, starting with
-    /// degree 1.
-    coeffs: [R; DEGREE],
+pub struct DensePolynomial<R, const DEGREE_PLUS_ONE: usize> {
+    /// Coefficients of the polynomial, lowest degree first
+    pub coeffs: [R; DEGREE_PLUS_ONE],
 }
 
-impl<R: Semiring + Zero, const DEGREE: usize> DensePolynomial<R, DEGREE> {
+impl<R: Semiring + Zero, const DEGREE_PLUS_ONE: usize> DensePolynomial<R, DEGREE_PLUS_ONE> {
     /// Create a new polynomial with the given coefficients.
     /// If the input has fewer than N+1 coefficients, the remaining slots will
     /// be filled with zeros. If the input has more than N+1 coefficients,
@@ -38,9 +32,9 @@ impl<R: Semiring + Zero, const DEGREE: usize> DensePolynomial<R, DEGREE> {
     pub fn new(coeffs: impl AsRef<[R]>) -> Self {
         let coeffs = coeffs.as_ref();
         assert!(
-            coeffs.len() <= DEGREE + 1,
+            coeffs.len() <= DEGREE_PLUS_ONE,
             "Too many coefficients provided: expected at most {}, got {}",
-            DEGREE + 1,
+            DEGREE_PLUS_ONE,
             coeffs.len()
         );
 
@@ -48,43 +42,34 @@ impl<R: Semiring + Zero, const DEGREE: usize> DensePolynomial<R, DEGREE> {
             return Self::zero();
         }
 
-        let coeff_0 = coeffs[0].clone();
-        let mut coeffs = coeffs[1..].to_vec();
-        coeffs.resize(DEGREE, R::zero());
+        let mut coeffs = coeffs.to_vec();
+        coeffs.resize(DEGREE_PLUS_ONE, R::zero());
         let coeffs = coeffs.try_into().expect("unreachable");
 
-        DensePolynomial { coeff_0, coeffs }
-    }
-
-    /// Return all coefficients as a vector.
-    /// The result contains DEGREE+1 elements: [coeff_0, coeffs[0], ...,
-    /// coeffs[DEGREE-1]].
-    #[allow(clippy::arithmetic_side_effects)]
-    pub fn to_coeffs(&self) -> Vec<R> {
-        let mut result = Vec::with_capacity(DEGREE + 1);
-        result.push(self.coeff_0.clone());
-        result.extend_from_slice(&self.coeffs);
-        result
+        DensePolynomial { coeffs }
     }
 }
 
-impl<R: Copy, const DEGREE: usize> Copy for DensePolynomial<R, DEGREE> {}
+impl<R: Copy, const DEGREE_PLUS_ONE: usize> Copy for DensePolynomial<R, DEGREE_PLUS_ONE> {}
 
-impl<R: Default, const DEGREE: usize> Default for DensePolynomial<R, DEGREE> {
+impl<R: Default, const DEGREE_PLUS_ONE: usize> Default for DensePolynomial<R, DEGREE_PLUS_ONE> {
     fn default() -> Self {
         DensePolynomial {
-            coeff_0: R::default(),
-            coeffs: array::from_fn::<_, DEGREE, _>(|_| R::default()),
+            coeffs: array::from_fn::<_, DEGREE_PLUS_ONE, _>(|_| R::default()),
         }
     }
 }
 
-impl<R: Display, const DEGREE: usize> Display for DensePolynomial<R, DEGREE> {
+impl<R: Display, const DEGREE_PLUS_ONE: usize> Display for DensePolynomial<R, DEGREE_PLUS_ONE> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "[")?;
-        write!(f, "{}", self.coeff_0)?;
+        let mut first = true;
         for coeff in self.coeffs.iter() {
-            write!(f, ", ")?;
+            if first {
+                first = false;
+            } else {
+                write!(f, ", ")?;
+            }
             write!(f, "{}", coeff)?;
         }
         write!(f, "]")?;
@@ -92,49 +77,51 @@ impl<R: Display, const DEGREE: usize> Display for DensePolynomial<R, DEGREE> {
     }
 }
 
-impl<R: Hash, const DEGREE: usize> Hash for DensePolynomial<R, DEGREE> {
+impl<R: Hash, const DEGREE_PLUS_ONE: usize> Hash for DensePolynomial<R, DEGREE_PLUS_ONE> {
     fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
-        self.coeff_0.hash(state);
         for coeff in self.coeffs.iter() {
             coeff.hash(state);
         }
     }
 }
 
-impl<R: Semiring + Zero, const DEGREE: usize> Zero for DensePolynomial<R, DEGREE> {
+impl<R: Semiring + Zero, const DEGREE_PLUS_ONE: usize> Zero
+    for DensePolynomial<R, DEGREE_PLUS_ONE>
+{
     fn zero() -> Self {
         Self {
-            coeff_0: R::zero(),
-            coeffs: array::from_fn::<_, DEGREE, _>(|_| R::zero()),
+            coeffs: array::from_fn::<_, DEGREE_PLUS_ONE, _>(|_| R::zero()),
         }
     }
 
     fn is_zero(&self) -> bool {
-        self.coeff_0.is_zero() && self.coeffs.iter().all(|c| c.is_zero())
+        self.coeffs.iter().all(|c| c.is_zero())
     }
 }
 
-impl<R: Semiring + Zero + One, const DEGREE: usize> One for DensePolynomial<R, DEGREE> {
+impl<R: Semiring + Zero + One, const DEGREE_PLUS_ONE: usize> One
+    for DensePolynomial<R, DEGREE_PLUS_ONE>
+{
     fn one() -> Self {
         Self {
-            coeff_0: R::one(),
-            coeffs: array::from_fn::<_, DEGREE, _>(|_| R::zero()),
+            coeffs: array::from_fn::<_, DEGREE_PLUS_ONE, _>(|_| R::zero()),
         }
     }
 }
 
-impl<R: Ring + Neg<Output = R>, const DEGREE: usize> Neg for DensePolynomial<R, DEGREE> {
+impl<R: Ring + Neg<Output = R>, const DEGREE_PLUS_ONE: usize> Neg
+    for DensePolynomial<R, DEGREE_PLUS_ONE>
+{
     type Output = Self;
 
     #[allow(clippy::arithmetic_side_effects)] // By design
     fn neg(mut self) -> Self::Output {
-        self.coeff_0 = -self.coeff_0;
         self.coeffs.iter_mut().for_each(|c| *c = -c.clone());
         self
     }
 }
 
-impl<R: Semiring, const DEGREE: usize> Add for DensePolynomial<R, DEGREE> {
+impl<R: Semiring, const DEGREE_PLUS_ONE: usize> Add for DensePolynomial<R, DEGREE_PLUS_ONE> {
     type Output = Self;
 
     #[allow(clippy::arithmetic_side_effects, clippy::op_ref)]
@@ -144,7 +131,9 @@ impl<R: Semiring, const DEGREE: usize> Add for DensePolynomial<R, DEGREE> {
     }
 }
 
-impl<'a, R: Semiring, const DEGREE: usize> Add<&'a Self> for DensePolynomial<R, DEGREE> {
+impl<'a, R: Semiring, const DEGREE_PLUS_ONE: usize> Add<&'a Self>
+    for DensePolynomial<R, DEGREE_PLUS_ONE>
+{
     type Output = Self;
 
     #[allow(clippy::arithmetic_side_effects)]
@@ -155,7 +144,7 @@ impl<'a, R: Semiring, const DEGREE: usize> Add<&'a Self> for DensePolynomial<R, 
     }
 }
 
-impl<R: Semiring, const DEGREE: usize> Sub for DensePolynomial<R, DEGREE> {
+impl<R: Semiring, const DEGREE_PLUS_ONE: usize> Sub for DensePolynomial<R, DEGREE_PLUS_ONE> {
     type Output = Self;
 
     #[allow(clippy::arithmetic_side_effects, clippy::op_ref)]
@@ -165,7 +154,9 @@ impl<R: Semiring, const DEGREE: usize> Sub for DensePolynomial<R, DEGREE> {
     }
 }
 
-impl<'a, R: Semiring, const DEGREE: usize> Sub<&'a Self> for DensePolynomial<R, DEGREE> {
+impl<'a, R: Semiring, const DEGREE_PLUS_ONE: usize> Sub<&'a Self>
+    for DensePolynomial<R, DEGREE_PLUS_ONE>
+{
     type Output = Self;
 
     #[allow(clippy::arithmetic_side_effects)]
@@ -176,7 +167,7 @@ impl<'a, R: Semiring, const DEGREE: usize> Sub<&'a Self> for DensePolynomial<R, 
     }
 }
 
-impl<R: Semiring, const DEGREE: usize> Mul for DensePolynomial<R, DEGREE> {
+impl<R: Semiring, const DEGREE_PLUS_ONE: usize> Mul for DensePolynomial<R, DEGREE_PLUS_ONE> {
     type Output = Self;
 
     #[allow(clippy::arithmetic_side_effects, clippy::op_ref)]
@@ -186,7 +177,9 @@ impl<R: Semiring, const DEGREE: usize> Mul for DensePolynomial<R, DEGREE> {
     }
 }
 
-impl<'a, R: Semiring, const DEGREE: usize> Mul<&'a Self> for DensePolynomial<R, DEGREE> {
+impl<'a, R: Semiring, const DEGREE_PLUS_ONE: usize> Mul<&'a Self>
+    for DensePolynomial<R, DEGREE_PLUS_ONE>
+{
     type Output = Self;
 
     fn mul(self, _rhs: &'a Self) -> Self::Output {
@@ -194,7 +187,7 @@ impl<'a, R: Semiring, const DEGREE: usize> Mul<&'a Self> for DensePolynomial<R, 
     }
 }
 
-impl<R: Semiring, const DEGREE: usize> AddAssign for DensePolynomial<R, DEGREE> {
+impl<R: Semiring, const DEGREE_PLUS_ONE: usize> AddAssign for DensePolynomial<R, DEGREE_PLUS_ONE> {
     #[allow(clippy::arithmetic_side_effects)]
     #[inline(always)]
     fn add_assign(&mut self, rhs: Self) {
@@ -202,18 +195,19 @@ impl<R: Semiring, const DEGREE: usize> AddAssign for DensePolynomial<R, DEGREE> 
     }
 }
 
-impl<'a, R: Semiring, const DEGREE: usize> AddAssign<&'a Self> for DensePolynomial<R, DEGREE> {
+impl<'a, R: Semiring, const DEGREE_PLUS_ONE: usize> AddAssign<&'a Self>
+    for DensePolynomial<R, DEGREE_PLUS_ONE>
+{
     #[allow(clippy::arithmetic_side_effects)]
     #[inline(always)]
     fn add_assign(&mut self, rhs: &'a Self) {
-        self.coeff_0 += &rhs.coeff_0;
-        for i in 0..DEGREE {
+        for i in 0..DEGREE_PLUS_ONE {
             self.coeffs[i] += &rhs.coeffs[i];
         }
     }
 }
 
-impl<R: Semiring, const DEGREE: usize> SubAssign for DensePolynomial<R, DEGREE> {
+impl<R: Semiring, const DEGREE_PLUS_ONE: usize> SubAssign for DensePolynomial<R, DEGREE_PLUS_ONE> {
     #[allow(clippy::arithmetic_side_effects)]
     #[inline(always)]
     fn sub_assign(&mut self, rhs: Self) {
@@ -221,18 +215,19 @@ impl<R: Semiring, const DEGREE: usize> SubAssign for DensePolynomial<R, DEGREE> 
     }
 }
 
-impl<'a, R: Semiring, const DEGREE: usize> SubAssign<&'a Self> for DensePolynomial<R, DEGREE> {
+impl<'a, R: Semiring, const DEGREE_PLUS_ONE: usize> SubAssign<&'a Self>
+    for DensePolynomial<R, DEGREE_PLUS_ONE>
+{
     #[allow(clippy::arithmetic_side_effects)]
     #[inline(always)]
     fn sub_assign(&mut self, rhs: &'a Self) {
-        self.coeff_0 -= &rhs.coeff_0;
-        for i in 0..DEGREE {
+        for i in 0..DEGREE_PLUS_ONE {
             self.coeffs[i] -= &rhs.coeffs[i];
         }
     }
 }
 
-impl<R: Semiring, const DEGREE: usize> MulAssign for DensePolynomial<R, DEGREE> {
+impl<R: Semiring, const DEGREE_PLUS_ONE: usize> MulAssign for DensePolynomial<R, DEGREE_PLUS_ONE> {
     #[allow(clippy::arithmetic_side_effects)]
     #[inline(always)]
     fn mul_assign(&mut self, rhs: Self) {
@@ -240,23 +235,24 @@ impl<R: Semiring, const DEGREE: usize> MulAssign for DensePolynomial<R, DEGREE> 
     }
 }
 
-impl<'a, R: Semiring, const DEGREE: usize> MulAssign<&'a Self> for DensePolynomial<R, DEGREE> {
+impl<'a, R: Semiring, const DEGREE_PLUS_ONE: usize> MulAssign<&'a Self>
+    for DensePolynomial<R, DEGREE_PLUS_ONE>
+{
     fn mul_assign(&mut self, _rhs: &'a Self) {
         unimplemented!("Polynomial multiplication is not implemented")
     }
 }
 
-impl<R: Ring, const DEGREE: usize> CheckedNeg for DensePolynomial<R, DEGREE> {
+impl<R: Ring, const DEGREE_PLUS_ONE: usize> CheckedNeg for DensePolynomial<R, DEGREE_PLUS_ONE> {
     fn checked_neg(&self) -> Option<Self> {
         let coeffs: Option<Vec<R>> = self.coeffs.iter().map(|c| c.checked_neg()).collect();
         Some(Self {
-            coeff_0: self.coeff_0.checked_neg()?,
             coeffs: coeffs?.try_into().ok()?,
         })
     }
 }
 
-impl<R: Semiring, const DEGREE: usize> CheckedAdd for DensePolynomial<R, DEGREE> {
+impl<R: Semiring, const DEGREE_PLUS_ONE: usize> CheckedAdd for DensePolynomial<R, DEGREE_PLUS_ONE> {
     fn checked_add(&self, other: &Self) -> Option<Self> {
         let coeffs: Option<Vec<R>> = self
             .coeffs
@@ -265,13 +261,12 @@ impl<R: Semiring, const DEGREE: usize> CheckedAdd for DensePolynomial<R, DEGREE>
             .map(|(a, b)| a.checked_add(b))
             .collect();
         Some(Self {
-            coeff_0: self.coeff_0.checked_add(&other.coeff_0)?,
             coeffs: coeffs?.try_into().ok()?,
         })
     }
 }
 
-impl<R: Semiring, const DEGREE: usize> CheckedSub for DensePolynomial<R, DEGREE> {
+impl<R: Semiring, const DEGREE_PLUS_ONE: usize> CheckedSub for DensePolynomial<R, DEGREE_PLUS_ONE> {
     fn checked_sub(&self, other: &Self) -> Option<Self> {
         let coeffs: Option<Vec<R>> = self
             .coeffs
@@ -280,19 +275,18 @@ impl<R: Semiring, const DEGREE: usize> CheckedSub for DensePolynomial<R, DEGREE>
             .map(|(a, b)| a.checked_sub(b))
             .collect();
         Some(Self {
-            coeff_0: self.coeff_0.checked_sub(&other.coeff_0)?,
             coeffs: coeffs?.try_into().ok()?,
         })
     }
 }
 
-impl<R: Semiring, const DEGREE: usize> CheckedMul for DensePolynomial<R, DEGREE> {
+impl<R: Semiring, const DEGREE_PLUS_ONE: usize> CheckedMul for DensePolynomial<R, DEGREE_PLUS_ONE> {
     fn checked_mul(&self, _other: &Self) -> Option<Self> {
         unimplemented!("Polynomial multiplication is not implemented")
     }
 }
 
-impl<R: Semiring, const DEGREE: usize> Sum for DensePolynomial<R, DEGREE> {
+impl<R: Semiring, const DEGREE_PLUS_ONE: usize> Sum for DensePolynomial<R, DEGREE_PLUS_ONE> {
     fn sum<I: Iterator<Item = Self>>(mut iter: I) -> Self {
         let Some(first) = iter.next() else {
             panic!("Sum of an empty iterator is not defined for DensePolynomial");
@@ -303,7 +297,9 @@ impl<R: Semiring, const DEGREE: usize> Sum for DensePolynomial<R, DEGREE> {
     }
 }
 
-impl<'a, R: Semiring, const DEGREE: usize> Sum<&'a Self> for DensePolynomial<R, DEGREE> {
+impl<'a, R: Semiring, const DEGREE_PLUS_ONE: usize> Sum<&'a Self>
+    for DensePolynomial<R, DEGREE_PLUS_ONE>
+{
     fn sum<I: Iterator<Item = &'a Self>>(mut iter: I) -> Self {
         let Some(first) = iter.next() else {
             panic!("Sum of an empty iterator is not defined for DensePolynomial");
@@ -314,7 +310,7 @@ impl<'a, R: Semiring, const DEGREE: usize> Sum<&'a Self> for DensePolynomial<R, 
     }
 }
 
-impl<R: Semiring, const DEGREE: usize> Product for DensePolynomial<R, DEGREE> {
+impl<R: Semiring, const DEGREE_PLUS_ONE: usize> Product for DensePolynomial<R, DEGREE_PLUS_ONE> {
     fn product<I: Iterator<Item = Self>>(mut iter: I) -> Self {
         let Some(first) = iter.next() else {
             panic!("Product of an empty iterator is not defined for DensePolynomial");
@@ -325,7 +321,9 @@ impl<R: Semiring, const DEGREE: usize> Product for DensePolynomial<R, DEGREE> {
     }
 }
 
-impl<'a, R: Semiring, const DEGREE: usize> Product<&'a Self> for DensePolynomial<R, DEGREE> {
+impl<'a, R: Semiring, const DEGREE_PLUS_ONE: usize> Product<&'a Self>
+    for DensePolynomial<R, DEGREE_PLUS_ONE>
+{
     fn product<I: Iterator<Item = &'a Self>>(mut iter: I) -> Self {
         let Some(first) = iter.next() else {
             panic!("Product of an empty iterator is not defined for DensePolynomial");
@@ -336,27 +334,33 @@ impl<'a, R: Semiring, const DEGREE: usize> Product<&'a Self> for DensePolynomial
     }
 }
 
-impl<R: Semiring, const DEGREE: usize> Semiring for DensePolynomial<R, DEGREE> {}
+impl<R: Semiring, const DEGREE_PLUS_ONE: usize> Semiring for DensePolynomial<R, DEGREE_PLUS_ONE> {}
 
-impl<R: Ring, const DEGREE: usize> Ring for DensePolynomial<R, DEGREE> {}
+impl<R: Ring, const DEGREE_PLUS_ONE: usize> Ring for DensePolynomial<R, DEGREE_PLUS_ONE> {}
 
-impl<R: Semiring, const DEGREE: usize> Distribution<DensePolynomial<R, DEGREE>> for StandardUniform
+impl<R: Semiring, const DEGREE_PLUS_ONE: usize> Distribution<DensePolynomial<R, DEGREE_PLUS_ONE>>
+    for StandardUniform
 where
     StandardUniform: Distribution<R>,
-    StandardUniform: Distribution<[R; DEGREE]>, // This one we get for free
+    StandardUniform: Distribution<[R; DEGREE_PLUS_ONE]>, // This one we get for free
 {
-    fn sample<Gen: Rng + ?Sized>(&self, rng: &mut Gen) -> DensePolynomial<R, DEGREE> {
-        let coeff_0: R = rng.random();
-        let coeffs: [R; DEGREE] = rng.random();
-        DensePolynomial { coeff_0, coeffs }
+    fn sample<Gen: Rng + ?Sized>(&self, rng: &mut Gen) -> DensePolynomial<R, DEGREE_PLUS_ONE> {
+        let coeffs: [R; DEGREE_PLUS_ONE] = rng.random();
+        DensePolynomial { coeffs }
     }
 }
 
 //
 // Zip-specific traits
 //
+impl<R: Semiring, const DEGREE_PLUS_ONE: usize> Polynomial<R>
+    for DensePolynomial<R, DEGREE_PLUS_ONE>
+{
+    const DEGREE_BOUND: usize = DEGREE_PLUS_ONE - 1;
+}
 
-impl<R: Semiring, C, const DEGREE: usize> EvaluatablePolynomial<C, R> for DensePolynomial<R, DEGREE>
+impl<R: Semiring, C, const DEGREE_PLUS_ONE: usize> EvaluatablePolynomial<R, C, R>
+    for DensePolynomial<R, DEGREE_PLUS_ONE>
 where
     R: for<'a> MulByScalar<&'a C>,
 {
@@ -364,16 +368,16 @@ where
     where
         R: for<'a> MulByScalar<&'a C>,
     {
-        if point.len() != DEGREE {
+        if point.len() != sub!(DEGREE_PLUS_ONE, 1) {
             return Err(EvaluationError::WrongPointWidth {
-                expected: DEGREE,
+                expected: sub!(DEGREE_PLUS_ONE, 1),
                 actual: point.len(),
             });
         }
 
         // A trivial implementation of a polynomial evaluation at a given point.
-        let mut result = self.coeff_0.clone();
-        for (coeff, scalar) in self.coeffs.iter().zip(point.iter()) {
+        let mut result = self.coeffs[0].clone();
+        for (coeff, scalar) in self.coeffs.iter().skip(1).zip(point.iter()) {
             let term = coeff
                 .mul_by_scalar(scalar)
                 .ok_or(EvaluationError::Overflow)?;
@@ -383,119 +387,116 @@ where
     }
 }
 
-impl<R: Semiring + ConstTranscribable, const DEGREE: usize> ConstCoeffBitWidth
-    for DensePolynomial<R, DEGREE>
+impl<R: Semiring + ConstTranscribable, const DEGREE_PLUS_ONE: usize> ConstCoeffBitWidth
+    for DensePolynomial<R, DEGREE_PLUS_ONE>
 {
     const COEFF_BIT_WIDTH: usize = R::NUM_BITS;
 }
 
-impl<R: Semiring + Named, const DEGREE: usize> Named for DensePolynomial<R, DEGREE> {
+impl<R: Semiring + Named, const DEGREE_PLUS_ONE: usize> Named
+    for DensePolynomial<R, DEGREE_PLUS_ONE>
+{
     fn type_name() -> String {
-        format!("Poly<{}, {DEGREE}>", R::type_name())
+        format!("Poly<{}, {}>", R::type_name(), Self::DEGREE_BOUND)
     }
 }
 
-impl<R: ConstTranscribable + Default, const DEGREE: usize> ConstTranscribable
-    for DensePolynomial<R, DEGREE>
+impl<R: ConstTranscribable + Default, const DEGREE_PLUS_ONE: usize> ConstTranscribable
+    for DensePolynomial<R, DEGREE_PLUS_ONE>
 {
-    const NUM_BYTES: usize = R::NUM_BYTES * (DEGREE + 1);
+    const NUM_BYTES: usize = R::NUM_BYTES * DEGREE_PLUS_ONE;
 
     #[allow(clippy::arithmetic_side_effects)]
     fn read_transcription_bytes(bytes: &[u8]) -> Self {
         assert_eq!(
             bytes.len(),
-            R::NUM_BYTES * (DEGREE + 1),
+            R::NUM_BYTES * DEGREE_PLUS_ONE,
             "Invalid byte length for DensePolynomial: expected {}, got {}",
-            R::NUM_BYTES * (DEGREE + 1),
+            R::NUM_BYTES * DEGREE_PLUS_ONE,
             bytes.len()
         );
 
-        let coeff_0 = R::read_transcription_bytes(&bytes[0..R::NUM_BYTES]);
-
-        let mut coeffs = array::from_fn::<_, DEGREE, _>(|_| R::default());
-        for i in 1..=DEGREE {
-            let start = i * R::NUM_BYTES;
-            let end = start + R::NUM_BYTES;
-            coeffs[i - 1] = R::read_transcription_bytes(&bytes[start..end]);
-        }
-
-        Self { coeff_0, coeffs }
+        // Can't use as_chunks because generic parameters may not be used in const
+        // operations.
+        let coeffs = bytes
+            .chunks_exact(R::NUM_BYTES)
+            .map(R::read_transcription_bytes)
+            .collect_array()
+            .expect("Unreachable");
+        Self { coeffs }
     }
 
     fn write_transcription_bytes(&self, buf: &mut [u8]) {
-        for (chunk, coeff) in buf
-            .chunks_exact_mut(R::NUM_BYTES)
-            .zip(iter::once(&self.coeff_0).chain(self.coeffs.iter()))
-        {
+        for (chunk, coeff) in buf.chunks_exact_mut(R::NUM_BYTES).zip(self.coeffs.iter()) {
             coeff.write_transcription_bytes(chunk);
         }
     }
 }
 
-impl<R, S, const DEGREE: usize> FromRef<DensePolynomial<S, DEGREE>> for DensePolynomial<R, DEGREE>
+impl<R, S, const DEGREE_PLUS_ONE: usize> FromRef<DensePolynomial<S, DEGREE_PLUS_ONE>>
+    for DensePolynomial<R, DEGREE_PLUS_ONE>
 where
     R: Semiring + FromRef<S> + Default,
 {
-    fn from_ref(value: &DensePolynomial<S, DEGREE>) -> Self {
-        let coeff_0 = R::from_ref(&value.coeff_0);
-        let mut coeffs = array::from_fn::<_, DEGREE, _>(|_| R::default());
+    fn from_ref(value: &DensePolynomial<S, DEGREE_PLUS_ONE>) -> Self {
+        let mut coeffs = array::from_fn::<_, DEGREE_PLUS_ONE, _>(|_| R::default());
         coeffs
             .iter_mut()
             .zip(value.coeffs.iter())
             .for_each(|(coeff, other_coeff)| {
                 *coeff = R::from_ref(other_coeff);
             });
-        DensePolynomial { coeff_0, coeffs }
+        DensePolynomial { coeffs }
     }
 }
 
-impl<R, S, const DEGREE: usize> From<&DensePolynomial<S, DEGREE>> for DensePolynomial<R, DEGREE>
+impl<R, S, const DEGREE_PLUS_ONE: usize> From<&DensePolynomial<S, DEGREE_PLUS_ONE>>
+    for DensePolynomial<R, DEGREE_PLUS_ONE>
 where
     R: Semiring + FromRef<S> + Default,
 {
-    fn from(value: &DensePolynomial<S, DEGREE>) -> Self {
+    fn from(value: &DensePolynomial<S, DEGREE_PLUS_ONE>) -> Self {
         Self::from_ref(value)
     }
 }
 
-impl<'a, R, S, const DEGREE: usize> MulByScalar<&'a S> for DensePolynomial<R, DEGREE>
+impl<'a, R, S, const DEGREE_PLUS_ONE: usize> MulByScalar<&'a S>
+    for DensePolynomial<R, DEGREE_PLUS_ONE>
 where
     R: Semiring + MulByScalar<&'a S>,
 {
     fn mul_by_scalar(&self, rhs: &'a S) -> Option<Self> {
-        let coeff_0 = self.coeff_0.mul_by_scalar(rhs)?;
         let coeffs: Option<Vec<R>> = self.coeffs.iter().map(|c| c.mul_by_scalar(rhs)).collect();
 
         Some(Self {
-            coeff_0,
             coeffs: coeffs?.try_into().ok()?,
         })
     }
 }
 
-impl<R, F, const DEGREE: usize> ProjectableToField<F> for DensePolynomial<R, DEGREE>
+impl<R, F, const DEGREE_PLUS_ONE: usize> ProjectableToField<F>
+    for DensePolynomial<R, DEGREE_PLUS_ONE>
 where
     R: Semiring,
     F: PrimeField + for<'a> FromWithConfig<&'a R> + for<'a> MulByScalar<&'a F> + 'static,
 {
     #![allow(clippy::arithmetic_side_effects)] // False alert, field operations are safe
     fn prepare_projection(sampled_value: &F) -> impl Fn(&Self) -> F + 'static {
-        let mut r_powers = vec![sampled_value.clone(); DEGREE];
-        for i in 1..DEGREE {
+        let mut r_powers = vec![sampled_value.clone(); DEGREE_PLUS_ONE - 1];
+        for i in 1..(DEGREE_PLUS_ONE - 1) {
             r_powers[i] = r_powers[i - 1].clone() * sampled_value;
         }
         let field_cfg = sampled_value.cfg().clone();
 
         move |poly: &Self| {
-            let coeff_0 = (&poly.coeff_0).into_with_cfg(&field_cfg);
-            let coeffs: [F; DEGREE] = poly
+            let coeffs: [F; DEGREE_PLUS_ONE] = poly
                 .coeffs
                 .iter()
                 .map(|v| v.into_with_cfg(&field_cfg))
                 .collect_array()
                 .expect("unreachable");
 
-            let poly2 = DensePolynomial { coeff_0, coeffs };
+            let poly2 = DensePolynomial { coeffs };
             poly2
                 .evaluate_at_point(&r_powers)
                 .expect("Failed to evaluate polynomial at point")

--- a/zip-plus/src/poly/zero_degree.rs
+++ b/zip-plus/src/poly/zero_degree.rs
@@ -1,11 +1,15 @@
-use super::{ConstCoeffBitWidth, EvaluatablePolynomial, EvaluationError};
+use super::{ConstCoeffBitWidth, EvaluatablePolynomial, EvaluationError, Polynomial};
 use crate::traits::ConstTranscribable;
 use crypto_primitives::crypto_bigint_int::Int;
 
 macro_rules! impl_zero_degree {
     ($($t:ty),+) => {
         $(
-            impl<T> EvaluatablePolynomial<T, Self> for $t {
+            impl Polynomial<Self> for $t {
+                const DEGREE_BOUND: usize = 0;
+            }
+
+            impl<T> EvaluatablePolynomial<Self, T, Self> for $t {
                 fn evaluate_at_point(&self, point: &[T]) -> Result<Self, EvaluationError> {
                     if !point.is_empty() {
                         return Err(EvaluationError::WrongPointWidth {
@@ -27,7 +31,11 @@ macro_rules! impl_zero_degree {
 impl_zero_degree!(i8, i16, i32, i64, i128);
 impl_zero_degree!(u8, u16, u32, u64, u128);
 
-impl<T, const LIMBS: usize> EvaluatablePolynomial<T, Self> for Int<LIMBS> {
+impl<const LIMBS: usize> Polynomial<Self> for Int<LIMBS> {
+    const DEGREE_BOUND: usize = 0;
+}
+
+impl<T, const LIMBS: usize> EvaluatablePolynomial<Self, T, Self> for Int<LIMBS> {
     fn evaluate_at_point(&self, point: &[T]) -> Result<Self, EvaluationError> {
         if !point.is_empty() {
             return Err(EvaluationError::WrongPointWidth {


### PR DESCRIPTION
* Due to inability to limitation of stable rust (cannot use math operations on generic constants as array size), `DensePolynomial` used `coeff_0` and `coeffs: [_; DEGREE]`. However, using `coeffs: [_; DEGREE_PLUS_ONE]` is much more simple and convenient workaround.

* `ZipTypes`,`LinearCode` and all Zip phases were parameterized by `DEGREE`, but that was largely a leftover from a previous design iteration. The only place it was actually used was to pass it to `validate_input`. Instead, re-introduced a simplified version of `Polynomial` trait that's aware of its own degree. (Luckily, math operations on generic constants are allowed there.)

This refactoring does not affect behaviour, benchmarked performance is also largely unchanged.