### PR TITLE
Introduce traits `InnerProduct` and `InnerProductWithConfig`

### DIFF
--- a/poly/src/lib.rs
+++ b/poly/src/lib.rs
@@ -12,13 +12,13 @@ pub trait Polynomial<C> {
 }
 
 pub trait EvaluatablePolynomial<C, S, Out>: Polynomial<C> {
-    /// Evaluates the polynomial at the given point, treating point `[p_0, p_1,
-    /// p_2, ...]` as `[x, x^2, x^3, ..., x^DEGREE_BOUND]`, thus it returns
-    /// `a_0 + (a_1 * p_0) + (a_2 * p_1) + ... + (a_DEGREE_BOUND *
-    /// p_{DEGREE_BOUND - 1})`.
-    // Note: we can't reference Self::DEGREE_BOUND here, type parameters may not be
-    // used in const expressions. As such, no point in declaring Self: Polynomial.
-    fn evaluate_at_point(&self, point: &[S]) -> Result<Out, EvaluationError>;
+    /// The type of points a polynomial can be evaluated on.
+    /// For univariate polynomials this typically is `C`,
+    /// for multivariate this is `[C]`.
+    type EvaluationPoint: ?Sized;
+
+    /// Evaluates the polynomial at the given point.
+    fn evaluate_at_point(&self, point: &Self::EvaluationPoint) -> Result<Out, EvaluationError>;
 }
 
 pub trait ConstCoeffBitWidth {
@@ -31,4 +31,6 @@ pub enum EvaluationError {
     WrongPointWidth { expected: usize, actual: usize },
     #[error("Evaluation failed due to overflow")]
     Overflow,
+    #[error("Empty polynomials are not allowed to be evaluate")]
+    EmptyPolynomial,
 }

--- a/poly/src/lib.rs
+++ b/poly/src/lib.rs
@@ -1,5 +1,5 @@
-pub mod dense;
 pub mod mle;
+pub mod univariate;
 pub mod utils;
 pub mod zero_degree;
 

--- a/poly/src/univariate.rs
+++ b/poly/src/univariate.rs
@@ -1,0 +1,1 @@
+pub mod dense;

--- a/poly/src/univariate/dense.rs
+++ b/poly/src/univariate/dense.rs
@@ -1,5 +1,4 @@
-use super::{ConstCoeffBitWidth, EvaluatablePolynomial, EvaluationError};
-use crate::Polynomial;
+use crate::{ConstCoeffBitWidth, EvaluatablePolynomial, EvaluationError, Polynomial};
 use crypto_primitives::{FromWithConfig, IntoWithConfig, PrimeField, Ring, Semiring};
 use itertools::Itertools;
 use num_traits::{CheckedAdd, CheckedMul, CheckedNeg, CheckedSub, One, Zero};
@@ -16,7 +15,6 @@ use zinc_utils::{
     from_ref::FromRef, mul_by_scalar::MulByScalar, named::Named,
     projectable_to_field::ProjectableToField, sub,
 };
-// TODO: rename to univariate?
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct DensePolynomial<R, const DEGREE_PLUS_ONE: usize> {

--- a/poly/src/univariate/dense.rs
+++ b/poly/src/univariate/dense.rs
@@ -1,4 +1,5 @@
 use crate::{ConstCoeffBitWidth, EvaluatablePolynomial, EvaluationError, Polynomial};
+use core::slice;
 use crypto_primitives::{FromWithConfig, IntoWithConfig, PrimeField, Ring, Semiring};
 use itertools::Itertools;
 use num_traits::{CheckedAdd, CheckedMul, CheckedNeg, CheckedSub, One, Zero};
@@ -12,8 +13,8 @@ use std::{
 };
 use zinc_transcript::traits::ConstTranscribable;
 use zinc_utils::{
-    from_ref::FromRef, mul_by_scalar::MulByScalar, named::Named,
-    projectable_to_field::ProjectableToField, sub,
+    from_ref::FromRef, inner_product::InnerProduct, mul_by_scalar::MulByScalar, named::Named,
+    projectable_to_field::ProjectableToField,
 };
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -363,24 +364,23 @@ impl<R: Semiring, C, const DEGREE_PLUS_ONE: usize> EvaluatablePolynomial<R, C, R
 where
     R: for<'a> MulByScalar<&'a C>,
 {
-    fn evaluate_at_point(&self, point: &[C]) -> Result<R, EvaluationError>
+    type EvaluationPoint = C;
+
+    fn evaluate_at_point(&self, point: &C) -> Result<R, EvaluationError>
     where
         R: for<'a> MulByScalar<&'a C>,
     {
-        if point.len() != sub!(DEGREE_PLUS_ONE, 1) {
-            return Err(EvaluationError::WrongPointWidth {
-                expected: sub!(DEGREE_PLUS_ONE, 1),
-                actual: point.len(),
-            });
-        }
-
         // A trivial implementation of a polynomial evaluation at a given point.
-        let mut result = self.coeffs[0].clone();
-        for (coeff, scalar) in self.coeffs.iter().skip(1).zip(point.iter()) {
-            let term = coeff
-                .mul_by_scalar(scalar)
+        let mut result = self
+            .coeffs
+            .last()
+            .ok_or(EvaluationError::EmptyPolynomial)?
+            .clone();
+        for coeff in self.coeffs.iter().rev().skip(1) {
+            let term = result
+                .mul_by_scalar(point)
                 .ok_or(EvaluationError::Overflow)?;
-            result = result.checked_add(&term).ok_or(EvaluationError::Overflow)?;
+            result = term.checked_add(coeff).ok_or(EvaluationError::Overflow)?;
         }
         Ok(result)
     }
@@ -481,10 +481,7 @@ where
 {
     #![allow(clippy::arithmetic_side_effects)] // False alert, field operations are safe
     fn prepare_projection(sampled_value: &F) -> impl Fn(&Self) -> F + 'static {
-        let mut r_powers = vec![sampled_value.clone(); DEGREE_PLUS_ONE - 1];
-        for i in 1..(DEGREE_PLUS_ONE - 1) {
-            r_powers[i] = r_powers[i - 1].clone() * sampled_value;
-        }
+        let sampled_value = sampled_value.clone();
         let field_cfg = sampled_value.cfg().clone();
 
         move |poly: &Self| {
@@ -497,8 +494,36 @@ where
 
             let poly2 = DensePolynomial { coeffs };
             poly2
-                .evaluate_at_point(&r_powers)
+                .evaluate_at_point(&sampled_value)
                 .expect("Failed to evaluate polynomial at point")
         }
+    }
+}
+
+impl<'a, R, const DEGREE_PLUS_ONE: usize> IntoIterator for &'a DensePolynomial<R, DEGREE_PLUS_ONE> {
+    type Item = &'a R;
+
+    type IntoIter = slice::Iter<'a, R>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.coeffs.iter()
+    }
+}
+
+impl<R, const DEGREE_PLUS_ONE: usize> AsRef<[R]> for DensePolynomial<R, DEGREE_PLUS_ONE> {
+    fn as_ref(&self) -> &[R] {
+        self.coeffs.as_slice()
+    }
+}
+
+impl<R, Rhs, Out, const DEGREE_PLUS_ONE: usize> InnerProduct<Rhs>
+    for DensePolynomial<R, DEGREE_PLUS_ONE>
+where
+    for<'a> &'a [R]: InnerProduct<Rhs, Output = Out>,
+{
+    type Output = Out;
+
+    fn inner_product(&self, rhs: &[Rhs]) -> Self::Output {
+        self.as_ref().inner_product(rhs)
     }
 }

--- a/poly/src/univariate/dense.rs
+++ b/poly/src/univariate/dense.rs
@@ -13,7 +13,10 @@ use std::{
 };
 use zinc_transcript::traits::ConstTranscribable;
 use zinc_utils::{
-    from_ref::FromRef, inner_product::InnerProduct, mul_by_scalar::MulByScalar, named::Named,
+    from_ref::FromRef,
+    inner_product::{InnerProduct, InnerProductError},
+    mul_by_scalar::MulByScalar,
+    named::Named,
     projectable_to_field::ProjectableToField,
 };
 
@@ -523,7 +526,11 @@ where
 {
     type Output = Out;
 
-    fn inner_product(&self, rhs: &[Rhs]) -> Self::Output {
-        self.as_ref().inner_product(rhs)
+    fn inner_product(
+        &self,
+        rhs: &[Rhs],
+        zero: Self::Output,
+    ) -> Result<Self::Output, InnerProductError> {
+        self.as_ref().inner_product(rhs, zero)
     }
 }

--- a/poly/src/zero_degree.rs
+++ b/poly/src/zero_degree.rs
@@ -11,6 +11,8 @@ macro_rules! impl_zero_degree {
             }
 
             impl<T> EvaluatablePolynomial<Self, T, Self> for $t {
+                type EvaluationPoint = [T];
+
                 fn evaluate_at_point(&self, point: &[T]) -> Result<Self, EvaluationError> {
                     if !point.is_empty() {
                         return Err(EvaluationError::WrongPointWidth {
@@ -37,6 +39,8 @@ impl<const LIMBS: usize> Polynomial<Self> for Int<LIMBS> {
 }
 
 impl<T, const LIMBS: usize> EvaluatablePolynomial<Self, T, Self> for Int<LIMBS> {
+    type EvaluationPoint = [T];
+
     fn evaluate_at_point(&self, point: &[T]) -> Result<Self, EvaluationError> {
         if !point.is_empty() {
             return Err(EvaluationError::WrongPointWidth {

--- a/utils/Cargo.toml
+++ b/utils/Cargo.toml
@@ -12,10 +12,8 @@ bench = false
 [dependencies]
 crypto-primitives = { workspace = true }
 
-ark-std = { workspace = true }
 crypto-bigint = { workspace = true }
 num-traits = { workspace = true }
-rayon = { workspace = true, optional = true }
 thiserror = { workspace = true }
 
 [dev-dependencies]
@@ -24,5 +22,3 @@ proptest = { workspace = true }
 [lints]
 workspace = true
 
-[features]
-parallel = ["dep:rayon"]

--- a/utils/Cargo.toml
+++ b/utils/Cargo.toml
@@ -12,11 +12,16 @@ bench = false
 [dependencies]
 crypto-primitives = { workspace = true }
 
+ark-std = { workspace = true }
 crypto-bigint = { workspace = true }
 num-traits = { workspace = true }
+rayon = { workspace = true, optional = true }
 
 [dev-dependencies]
 proptest = { workspace = true }
 
 [lints]
 workspace = true
+
+[features]
+parallel = ["dep:rayon"]

--- a/utils/Cargo.toml
+++ b/utils/Cargo.toml
@@ -16,6 +16,7 @@ ark-std = { workspace = true }
 crypto-bigint = { workspace = true }
 num-traits = { workspace = true }
 rayon = { workspace = true, optional = true }
+thiserror = { workspace = true }
 
 [dev-dependencies]
 proptest = { workspace = true }

--- a/utils/src/inner_product.rs
+++ b/utils/src/inner_product.rs
@@ -1,9 +1,11 @@
-use crypto_primitives::{PrimeField, crypto_bigint_int::Int};
-use num_traits::{CheckedAdd, Zero};
+use ark_std::cfg_iter;
+use crypto_primitives::crypto_bigint_int::Int;
+use num_traits::CheckedAdd;
 #[cfg(feature = "parallel")]
 use rayon::prelude::*;
+use thiserror::Error;
 
-use crate::{add, mul_by_scalar::MulByScalar};
+use crate::mul_by_scalar::MulByScalar;
 
 /// A trait for types that can be dot-multiplied.
 pub trait InnerProduct<Rhs> {
@@ -11,18 +13,49 @@ pub trait InnerProduct<Rhs> {
     type Output;
 
     /// The main entry point for the inner product.
-    fn inner_product(&self, rhs: &[Rhs]) -> Self::Output;
+    fn inner_product(
+        &self,
+        rhs: &[Rhs],
+        zero: Self::Output,
+    ) -> Result<Self::Output, InnerProductError>;
+}
+
+#[derive(Clone, Debug, PartialEq, Error)]
+pub enum InnerProductError {
+    #[error("The length of LHS and RHS does not match: LHS={lhs}, RHS={rhs}")]
+    LengthMismatch { lhs: usize, rhs: usize },
+    #[error("Arithmetic overflow")]
+    Overflow,
 }
 
 impl<Lhs, Rhs> InnerProduct<Rhs> for &[Lhs]
 where
-    Lhs: Clone + Zero + CheckedAdd + for<'z> MulByScalar<&'z Rhs> + Send + Sync,
+    Lhs: Clone + CheckedAdd + for<'z> MulByScalar<&'z Rhs> + Send + Sync,
     Rhs: Send + Sync,
 {
     type Output = Lhs;
 
-    fn inner_product(&self, rhs: &[Rhs]) -> Self::Output {
-        inner_product_aux(self, rhs, Lhs::zero)
+    fn inner_product(&self, rhs: &[Rhs], zero: Lhs) -> Result<Self::Output, InnerProductError> {
+        let half_baked = cfg_iter!(self)
+            .zip(rhs)
+            .map(|(lhs, rhs)| lhs.mul_by_scalar(rhs).ok_or(InnerProductError::Overflow));
+
+        #[cfg(not(feature = "parallel"))]
+        return half_baked
+            .reduce(|acc, product| {
+                acc?.checked_add(&product?)
+                    .ok_or(InnerProductError::Overflow)
+            })
+            .unwrap_or(Ok(zero));
+
+        #[cfg(feature = "parallel")]
+        half_baked.reduce(
+            || Ok(zero.clone()),
+            |acc, product| {
+                acc?.checked_add(&product?)
+                    .ok_or(InnerProductError::Overflow)
+            },
+        )
     }
 }
 
@@ -32,8 +65,9 @@ where
 {
     type Output = Lhs;
 
-    fn inner_product(&self, rhs: &[Rhs]) -> Self::Output {
-        self.as_slice().inner_product(rhs)
+    #[inline]
+    fn inner_product(&self, rhs: &[Rhs], zero: Lhs) -> Result<Self::Output, InnerProductError> {
+        self.as_slice().inner_product(rhs, zero)
     }
 }
 
@@ -43,91 +77,27 @@ where
 {
     type Output = Lhs;
 
-    fn inner_product(&self, rhs: &[Rhs]) -> Self::Output {
-        self.as_slice().inner_product(rhs)
+    #[inline]
+    fn inner_product(&self, rhs: &[Rhs], zero: Lhs) -> Result<Self::Output, InnerProductError> {
+        self.as_slice().inner_product(rhs, zero)
     }
 }
 
 impl<T, const LIMBS: usize> InnerProduct<T> for Int<LIMBS> {
     type Output = Self;
 
-    fn inner_product(&self, point: &[T]) -> Self::Output {
+    fn inner_product(&self, point: &[T], _zero: Self) -> Result<Self::Output, InnerProductError> {
         if !point.is_empty() {
             // TODO: Do we really want the RHS be empty?
             //       Or do we want it to be one point?
-            panic!("The RHS should be empty");
+            Err(InnerProductError::LengthMismatch {
+                lhs: 0,
+                rhs: point.len(),
+            })
+        } else {
+            Ok(*self)
         }
-        *self
     }
-}
-
-/// A trait for types can be dot-multiplied
-/// but with a catch: they need a config for
-/// getting the zero (e.g. `PrimeField`s).
-pub trait InnerProductWithConfig<Rhs> {
-    type Output;
-    type Config;
-
-    fn inner_product(&self, rhs: &[Rhs], config: &Self::Config) -> Self::Output;
-}
-
-impl<Lhs, Rhs> InnerProductWithConfig<Rhs> for &[Lhs]
-where
-    Lhs: PrimeField + CheckedAdd + for<'z> MulByScalar<&'z Rhs>,
-    Rhs: Send + Sync,
-{
-    type Output = Lhs;
-    type Config = Lhs::Config;
-
-    fn inner_product(&self, rhs: &[Rhs], config: &Lhs::Config) -> Self::Output {
-        inner_product_aux(self, rhs, || Lhs::zero_with_cfg(config))
-    }
-}
-
-impl<Lhs: PrimeField, Rhs> InnerProductWithConfig<Rhs> for Vec<Lhs>
-where
-    for<'a> &'a [Lhs]: InnerProductWithConfig<Rhs, Output = Lhs, Config = Lhs::Config>,
-{
-    type Output = Lhs;
-    type Config = Lhs::Config;
-
-    fn inner_product(&self, rhs: &[Rhs], config: &Lhs::Config) -> Self::Output {
-        self.as_slice().inner_product(rhs, config)
-    }
-}
-
-// TODO: can these two merged into one?
-
-#[cfg(not(feature = "parallel"))]
-fn inner_product_aux<Lhs, Rhs, Z>(lhs: &[Lhs], rhs: &[Rhs], zero: Z) -> Lhs
-where
-    Lhs: Clone + CheckedAdd + for<'z> MulByScalar<&'z Rhs>,
-    Z: Fn() -> Lhs,
-{
-    lhs.iter()
-        .zip(rhs)
-        .map(|(lhs, rhs)| {
-            lhs.mul_by_scalar(rhs)
-                .expect("Cannot multiply an element by a coefficient")
-        })
-        .reduce(|acc, product| add!(acc, &product))
-        .unwrap_or(zero())
-}
-
-#[cfg(feature = "parallel")]
-fn inner_product_aux<Lhs, Rhs, Z>(lhs: &[Lhs], rhs: &[Rhs], zero: Z) -> Lhs
-where
-    Lhs: Clone + Sync + Send + CheckedAdd + for<'z> MulByScalar<&'z Rhs>,
-    Rhs: Send + Sync,
-    Z: Fn() -> Lhs + Send + Sync,
-{
-    lhs.par_iter()
-        .zip(rhs)
-        .map(|(lhs, rhs)| {
-            lhs.mul_by_scalar(rhs)
-                .expect("Cannot multiply an element by a coefficient")
-        })
-        .reduce(zero, |acc, product| add!(acc, &product))
 }
 
 #[cfg(test)]
@@ -138,6 +108,6 @@ mod test {
     fn test_inner_product_basic() {
         let lhs = [1, 2, 3];
         let rhs = [4, 5, 6];
-        assert_eq!(lhs.inner_product(&rhs), 4 + 2 * 5 + 3 * 6);
+        assert_eq!(lhs.inner_product(&rhs, 0), Ok(4 + 2 * 5 + 3 * 6));
     }
 }

--- a/utils/src/inner_product.rs
+++ b/utils/src/inner_product.rs
@@ -32,12 +32,9 @@ where
     type Output = Lhs;
 
     fn inner_product(&self, rhs: &[Rhs], zero: Lhs) -> Result<Self::Output, InnerProductError> {
-        let half_baked = self
-            .iter()
+        self.iter()
             .zip(rhs)
-            .map(|(lhs, rhs)| lhs.mul_by_scalar(rhs).ok_or(InnerProductError::Overflow));
-
-        half_baked
+            .map(|(lhs, rhs)| lhs.mul_by_scalar(rhs).ok_or(InnerProductError::Overflow))
             .reduce(|acc, product| {
                 acc?.checked_add(&product?)
                     .ok_or(InnerProductError::Overflow)

--- a/utils/src/inner_product.rs
+++ b/utils/src/inner_product.rs
@@ -1,0 +1,143 @@
+use crypto_primitives::{PrimeField, crypto_bigint_int::Int};
+use num_traits::{CheckedAdd, Zero};
+#[cfg(feature = "parallel")]
+use rayon::prelude::*;
+
+use crate::{add, mul_by_scalar::MulByScalar};
+
+/// A trait for types that can be dot-multiplied.
+pub trait InnerProduct<Rhs> {
+    /// The resulting type we get after the inner product.
+    type Output;
+
+    /// The main entry point for the inner product.
+    fn inner_product(&self, rhs: &[Rhs]) -> Self::Output;
+}
+
+impl<Lhs, Rhs> InnerProduct<Rhs> for &[Lhs]
+where
+    Lhs: Clone + Zero + CheckedAdd + for<'z> MulByScalar<&'z Rhs> + Send + Sync,
+    Rhs: Send + Sync,
+{
+    type Output = Lhs;
+
+    fn inner_product(&self, rhs: &[Rhs]) -> Self::Output {
+        inner_product_aux(self, rhs, Lhs::zero)
+    }
+}
+
+impl<Lhs, Rhs> InnerProduct<Rhs> for Vec<Lhs>
+where
+    for<'a> &'a [Lhs]: InnerProduct<Rhs, Output = Lhs>,
+{
+    type Output = Lhs;
+
+    fn inner_product(&self, rhs: &[Rhs]) -> Self::Output {
+        self.as_slice().inner_product(rhs)
+    }
+}
+
+impl<Lhs, Rhs, const N: usize> InnerProduct<Rhs> for [Lhs; N]
+where
+    for<'a> &'a [Lhs]: InnerProduct<Rhs, Output = Lhs>,
+{
+    type Output = Lhs;
+
+    fn inner_product(&self, rhs: &[Rhs]) -> Self::Output {
+        self.as_slice().inner_product(rhs)
+    }
+}
+
+impl<T, const LIMBS: usize> InnerProduct<T> for Int<LIMBS> {
+    type Output = Self;
+
+    fn inner_product(&self, point: &[T]) -> Self::Output {
+        if !point.is_empty() {
+            // TODO: Do we really want the RHS be empty?
+            //       Or do we want it to be one point?
+            panic!("The RHS should be empty");
+        }
+        *self
+    }
+}
+
+/// A trait for types can be dot-multiplied
+/// but with a catch: they need a config for
+/// getting the zero (e.g. `PrimeField`s).
+pub trait InnerProductWithConfig<Rhs> {
+    type Output;
+    type Config;
+
+    fn inner_product(&self, rhs: &[Rhs], config: &Self::Config) -> Self::Output;
+}
+
+impl<Lhs, Rhs> InnerProductWithConfig<Rhs> for &[Lhs]
+where
+    Lhs: PrimeField + CheckedAdd + for<'z> MulByScalar<&'z Rhs>,
+    Rhs: Send + Sync,
+{
+    type Output = Lhs;
+    type Config = Lhs::Config;
+
+    fn inner_product(&self, rhs: &[Rhs], config: &Lhs::Config) -> Self::Output {
+        inner_product_aux(self, rhs, || Lhs::zero_with_cfg(config))
+    }
+}
+
+impl<Lhs: PrimeField, Rhs> InnerProductWithConfig<Rhs> for Vec<Lhs>
+where
+    for<'a> &'a [Lhs]: InnerProductWithConfig<Rhs, Output = Lhs, Config = Lhs::Config>,
+{
+    type Output = Lhs;
+    type Config = Lhs::Config;
+
+    fn inner_product(&self, rhs: &[Rhs], config: &Lhs::Config) -> Self::Output {
+        self.as_slice().inner_product(rhs, config)
+    }
+}
+
+// TODO: can these two merged into one?
+
+#[cfg(not(feature = "parallel"))]
+fn inner_product_aux<Lhs, Rhs, Z>(lhs: &[Lhs], rhs: &[Rhs], zero: Z) -> Lhs
+where
+    Lhs: Clone + CheckedAdd + for<'z> MulByScalar<&'z Rhs>,
+    Z: Fn() -> Lhs,
+{
+    lhs.iter()
+        .zip(rhs)
+        .map(|(lhs, rhs)| {
+            lhs.mul_by_scalar(rhs)
+                .expect("Cannot multiply an element by a coefficient")
+        })
+        .reduce(|acc, product| add!(acc, &product))
+        .unwrap_or(zero())
+}
+
+#[cfg(feature = "parallel")]
+fn inner_product_aux<Lhs, Rhs, Z>(lhs: &[Lhs], rhs: &[Rhs], zero: Z) -> Lhs
+where
+    Lhs: Clone + Sync + Send + CheckedAdd + for<'z> MulByScalar<&'z Rhs>,
+    Rhs: Send + Sync,
+    Z: Fn() -> Lhs + Send + Sync,
+{
+    lhs.par_iter()
+        .zip(rhs)
+        .map(|(lhs, rhs)| {
+            lhs.mul_by_scalar(rhs)
+                .expect("Cannot multiply an element by a coefficient")
+        })
+        .reduce(zero, |acc, product| add!(acc, &product))
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn test_inner_product_basic() {
+        let lhs = [1, 2, 3];
+        let rhs = [4, 5, 6];
+        assert_eq!(lhs.inner_product(&rhs), 4 + 2 * 5 + 3 * 6);
+    }
+}

--- a/utils/src/inner_product.rs
+++ b/utils/src/inner_product.rs
@@ -1,8 +1,5 @@
-use ark_std::cfg_iter;
 use crypto_primitives::crypto_bigint_int::Int;
 use num_traits::CheckedAdd;
-#[cfg(feature = "parallel")]
-use rayon::prelude::*;
 use thiserror::Error;
 
 use crate::mul_by_scalar::MulByScalar;
@@ -30,32 +27,22 @@ pub enum InnerProductError {
 
 impl<Lhs, Rhs> InnerProduct<Rhs> for &[Lhs]
 where
-    Lhs: Clone + CheckedAdd + for<'z> MulByScalar<&'z Rhs> + Send + Sync,
-    Rhs: Send + Sync,
+    Lhs: Clone + CheckedAdd + for<'z> MulByScalar<&'z Rhs>,
 {
     type Output = Lhs;
 
     fn inner_product(&self, rhs: &[Rhs], zero: Lhs) -> Result<Self::Output, InnerProductError> {
-        let half_baked = cfg_iter!(self)
+        let half_baked = self
+            .iter()
             .zip(rhs)
             .map(|(lhs, rhs)| lhs.mul_by_scalar(rhs).ok_or(InnerProductError::Overflow));
 
-        #[cfg(not(feature = "parallel"))]
-        return half_baked
+        half_baked
             .reduce(|acc, product| {
                 acc?.checked_add(&product?)
                     .ok_or(InnerProductError::Overflow)
             })
-            .unwrap_or(Ok(zero));
-
-        #[cfg(feature = "parallel")]
-        half_baked.reduce(
-            || Ok(zero.clone()),
-            |acc, product| {
-                acc?.checked_add(&product?)
-                    .ok_or(InnerProductError::Overflow)
-            },
-        )
+            .unwrap_or(Ok(zero))
     }
 }
 

--- a/utils/src/lib.rs
+++ b/utils/src/lib.rs
@@ -1,5 +1,6 @@
 pub mod field;
 pub mod from_ref;
+pub mod inner_product;
 pub mod mul_by_scalar;
 pub mod named;
 pub mod ops_macros;

--- a/zip-plus/Cargo.toml
+++ b/zip-plus/Cargo.toml
@@ -37,7 +37,7 @@ proptest = { workspace = true }
 workspace = true
 
 [features]
-parallel = ["dep:rayon", "zinc-poly/parallel", "zinc-utils/parallel"]
+parallel = ["dep:rayon", "zinc-poly/parallel"]
 asm = ["zinc-transcript/asm"]
 
 [[bench]]

--- a/zip-plus/Cargo.toml
+++ b/zip-plus/Cargo.toml
@@ -37,7 +37,7 @@ proptest = { workspace = true }
 workspace = true
 
 [features]
-parallel = ["dep:rayon", "zinc-poly/parallel"]
+parallel = ["dep:rayon", "zinc-poly/parallel", "zinc-utils/parallel"]
 asm = ["zinc-transcript/asm"]
 
 [[bench]]

--- a/zip-plus/benches/zip_plus_benches.rs
+++ b/zip-plus/benches/zip_plus_benches.rs
@@ -3,7 +3,7 @@
 
 mod zip_common;
 
-use zinc_poly::dense::DensePolynomial;
+use zinc_poly::univariate::dense::DensePolynomial;
 use zinc_primality::MillerRabin;
 use zip_common::*;
 

--- a/zip-plus/src/lib.rs
+++ b/zip-plus/src/lib.rs
@@ -23,6 +23,8 @@ pub enum ZipError {
     Transcript(ark_std::io::ErrorKind, String),
     #[error("Error during polynomial evaluation: {0}")]
     PolynomialEvaluationError(zinc_poly::EvaluationError),
+    #[error("Error during inner product computation: {0}")]
+    InnerProductError(zinc_utils::inner_product::InnerProductError),
 }
 
 impl From<zinc_poly::EvaluationError> for ZipError {
@@ -34,5 +36,11 @@ impl From<zinc_poly::EvaluationError> for ZipError {
 impl From<FieldError> for ZipError {
     fn from(err: FieldError) -> Self {
         ZipError::InvalidSnark(format!("Field error: {err}"))
+    }
+}
+
+impl From<zinc_utils::inner_product::InnerProductError> for ZipError {
+    fn from(err: zinc_utils::inner_product::InnerProductError) -> Self {
+        ZipError::InnerProductError(err)
     }
 }

--- a/zip-plus/src/pcs/phase_commit.rs
+++ b/zip-plus/src/pcs/phase_commit.rs
@@ -207,7 +207,7 @@ mod tests {
     use itertools::Itertools;
     use num_traits::Zero;
     use rand::{Rng, rng};
-    use zinc_poly::{dense::DensePolynomial, mle::DenseMultilinearExtension};
+    use zinc_poly::{mle::DenseMultilinearExtension, univariate::dense::DensePolynomial};
 
     const INT_LIMBS: usize = U64::LIMBS;
 

--- a/zip-plus/src/pcs/phase_evaluate.rs
+++ b/zip-plus/src/pcs/phase_evaluate.rs
@@ -16,7 +16,7 @@ use itertools::Itertools;
 use zinc_poly::mle::DenseMultilinearExtension;
 use zinc_transcript::traits::{Transcribable, Transcript};
 use zinc_utils::{
-    from_ref::FromRef, inner_product::InnerProductWithConfig, mul_by_scalar::MulByScalar,
+    from_ref::FromRef, inner_product::InnerProduct, mul_by_scalar::MulByScalar,
     projectable_to_field::ProjectableToField,
 };
 
@@ -73,7 +73,7 @@ impl<Zt: ZipTypes, Lc: LinearCode<Zt>> ZipPlus<Zt, Lc> {
         };
 
         transcript.write_field_elements(&q_0_combined_row)?;
-        let eval_f = (&q_0_combined_row[..]).inner_product(&q_1, &field_cfg);
+        let eval_f = (&q_0_combined_row[..]).inner_product(&q_1, F::zero_with_cfg(&field_cfg))?;
         Ok((eval_f, transcript.into()))
     }
 }

--- a/zip-plus/src/pcs/phase_evaluate.rs
+++ b/zip-plus/src/pcs/phase_evaluate.rs
@@ -9,14 +9,15 @@ use crate::{
         utils::{point_to_tensor, validate_input},
     },
     pcs_transcript::PcsTranscript,
-    utils::{combine_rows, inner_product},
+    utils::combine_rows,
 };
 use crypto_primitives::{FromWithConfig, IntoWithConfig, PrimeField};
 use itertools::Itertools;
 use zinc_poly::mle::DenseMultilinearExtension;
 use zinc_transcript::traits::{Transcribable, Transcript};
 use zinc_utils::{
-    from_ref::FromRef, mul_by_scalar::MulByScalar, projectable_to_field::ProjectableToField,
+    from_ref::FromRef, inner_product::InnerProductWithConfig, mul_by_scalar::MulByScalar,
+    projectable_to_field::ProjectableToField,
 };
 
 impl<Zt: ZipTypes, Lc: LinearCode<Zt>> ZipPlus<Zt, Lc> {
@@ -72,7 +73,7 @@ impl<Zt: ZipTypes, Lc: LinearCode<Zt>> ZipPlus<Zt, Lc> {
         };
 
         transcript.write_field_elements(&q_0_combined_row)?;
-        let eval_f = inner_product(&q_0_combined_row[..], &q_1, F::zero_with_cfg(&field_cfg));
+        let eval_f = (&q_0_combined_row[..]).inner_product(&q_1, &field_cfg);
         Ok((eval_f, transcript.into()))
     }
 }

--- a/zip-plus/src/pcs/phase_test.rs
+++ b/zip-plus/src/pcs/phase_test.rs
@@ -37,12 +37,12 @@ impl<Zt: ZipTypes, Lc: LinearCode<Zt>> ZipPlus<Zt, Lc> {
                 .fs_transcript
                 .get_challenges::<Zt::Chal>(pp.num_rows);
 
-            let evals = poly
+            let evals: Vec<_> = poly
                 .evaluations
                 .iter()
                 .map(Zt::Comb::from_ref)
-                .map(|p| p.inner_product(&alphas))
-                .collect_vec();
+                .map(|p| p.inner_product(&alphas, Zt::CombR::from(0)))
+                .try_collect()?;
 
             // u' in the Zinc paper
             let combined_row = combine_rows(&coeffs, &evals, pp.linear_code.row_len());

--- a/zip-plus/src/pcs/phase_test.rs
+++ b/zip-plus/src/pcs/phase_test.rs
@@ -10,9 +10,9 @@ use crate::{
     utils::combine_rows,
 };
 use itertools::Itertools;
-use zinc_poly::{EvaluatablePolynomial, Polynomial, mle::DenseMultilinearExtension};
+use zinc_poly::{Polynomial, mle::DenseMultilinearExtension};
 use zinc_transcript::traits::Transcript;
-use zinc_utils::from_ref::FromRef;
+use zinc_utils::{from_ref::FromRef, inner_product::InnerProduct};
 
 impl<Zt: ZipTypes, Lc: LinearCode<Zt>> ZipPlus<Zt, Lc> {
     pub fn test(
@@ -41,10 +41,7 @@ impl<Zt: ZipTypes, Lc: LinearCode<Zt>> ZipPlus<Zt, Lc> {
                 .evaluations
                 .iter()
                 .map(Zt::Comb::from_ref)
-                .map(|p| {
-                    p.evaluate_at_point(&alphas)
-                        .expect("Failed to evaluate polynomial")
-                })
+                .map(|p| p.inner_product(&alphas))
                 .collect_vec();
 
             // u' in the Zinc paper

--- a/zip-plus/src/pcs/phase_verify.rs
+++ b/zip-plus/src/pcs/phase_verify.rs
@@ -14,9 +14,7 @@ use itertools::Itertools;
 use zinc_poly::Polynomial;
 use zinc_transcript::traits::{Transcribable, Transcript};
 use zinc_utils::{
-    from_ref::FromRef,
-    inner_product::{InnerProduct, InnerProductWithConfig},
-    mul_by_scalar::MulByScalar,
+    from_ref::FromRef, inner_product::InnerProduct, mul_by_scalar::MulByScalar,
     projectable_to_field::ProjectableToField,
 };
 
@@ -131,14 +129,14 @@ impl<Zt: ZipTypes, Lc: LinearCode<Zt>> ZipPlus<Zt, Lc> {
         num_rows: usize,
     ) -> Result<(), ZipError> {
         let column_entries_comb: Zt::CombR = if num_rows > 1 {
-            let column_entries = column_entries
+            let column_entries: Vec<_> = column_entries
                 .iter()
                 .map(Zt::Comb::from_ref)
-                .map(|p| p.inner_product(alphas))
-                .collect_vec();
-            column_entries.inner_product(coeffs)
+                .map(|p| p.inner_product(alphas, Zt::CombR::from(0)))
+                .try_collect()?;
+            column_entries.inner_product(coeffs, Zt::CombR::from(0))?
         } else {
-            Zt::Comb::from_ref(&column_entries[0]).inner_product(alphas)
+            Zt::Comb::from_ref(&column_entries[0]).inner_product(alphas, Zt::CombR::from(0))?
         };
 
         if column_entries_comb != encoded_combined_row[column] {
@@ -166,7 +164,7 @@ impl<Zt: ZipTypes, Lc: LinearCode<Zt>> ZipPlus<Zt, Lc> {
 
         let (q_0, q_1) = point_to_tensor(vp.num_rows, point_f, field_cfg)?;
 
-        if InnerProductWithConfig::inner_product(&q_0_combined_row, &q_1, field_cfg) != *eval_f {
+        if q_0_combined_row.inner_product(&q_1, F::zero_with_cfg(field_cfg))? != *eval_f {
             return Err(ZipError::InvalidPcsOpen(
                 "Evaluation consistency failure".into(),
             ));
@@ -202,7 +200,7 @@ impl<Zt: ZipTypes, Lc: LinearCode<Zt>> ZipPlus<Zt, Lc> {
     {
         let column_entries_comb = if num_rows > 1 {
             let column_entries = column_entries.iter().map(project).collect_vec();
-            q_0.inner_product(&column_entries, field_cfg)
+            q_0.inner_product(&column_entries, F::zero_with_cfg(field_cfg))?
             // TODO: this inner product is taking a long time.
         } else {
             project(column_entries.first().expect("No column entries"))

--- a/zip-plus/src/pcs/phase_verify.rs
+++ b/zip-plus/src/pcs/phase_verify.rs
@@ -240,8 +240,8 @@ mod tests {
     use num_traits::{ConstOne, ConstZero, Zero};
     use rand::prelude::*;
     use zinc_poly::{
-        dense::DensePolynomial,
         mle::{DenseMultilinearExtension, MultilinearExtensionRand},
+        univariate::dense::DensePolynomial,
     };
     use zinc_transcript::traits::Transcribable;
 

--- a/zip-plus/src/pcs/phase_verify.rs
+++ b/zip-plus/src/pcs/phase_verify.rs
@@ -8,15 +8,16 @@ use crate::{
         utils::{ColumnOpening, point_to_tensor, validate_input},
     },
     pcs_transcript::PcsTranscript,
-    utils::inner_product,
 };
 use crypto_primitives::{FromWithConfig, IntoWithConfig, PrimeField};
 use itertools::Itertools;
-use num_traits::ConstZero;
-use zinc_poly::{EvaluatablePolynomial, Polynomial};
+use zinc_poly::Polynomial;
 use zinc_transcript::traits::{Transcribable, Transcript};
 use zinc_utils::{
-    from_ref::FromRef, mul_by_scalar::MulByScalar, projectable_to_field::ProjectableToField,
+    from_ref::FromRef,
+    inner_product::{InnerProduct, InnerProductWithConfig},
+    mul_by_scalar::MulByScalar,
+    projectable_to_field::ProjectableToField,
 };
 
 impl<Zt: ZipTypes, Lc: LinearCode<Zt>> ZipPlus<Zt, Lc> {
@@ -130,14 +131,14 @@ impl<Zt: ZipTypes, Lc: LinearCode<Zt>> ZipPlus<Zt, Lc> {
         num_rows: usize,
     ) -> Result<(), ZipError> {
         let column_entries_comb: Zt::CombR = if num_rows > 1 {
-            let column_entries: Result<Vec<Zt::CombR>, _> = column_entries
+            let column_entries = column_entries
                 .iter()
                 .map(Zt::Comb::from_ref)
-                .map(|p| p.evaluate_at_point(alphas))
-                .collect();
-            inner_product(coeffs.iter(), column_entries?.iter(), Zt::CombR::ZERO)
+                .map(|p| p.inner_product(alphas))
+                .collect_vec();
+            column_entries.inner_product(coeffs)
         } else {
-            Zt::Comb::from_ref(&column_entries[0]).evaluate_at_point(alphas)?
+            Zt::Comb::from_ref(&column_entries[0]).inner_product(alphas)
         };
 
         if column_entries_comb != encoded_combined_row[column] {
@@ -165,7 +166,7 @@ impl<Zt: ZipTypes, Lc: LinearCode<Zt>> ZipPlus<Zt, Lc> {
 
         let (q_0, q_1) = point_to_tensor(vp.num_rows, point_f, field_cfg)?;
 
-        if inner_product(&q_0_combined_row, &q_1, F::zero_with_cfg(field_cfg)) != *eval_f {
+        if InnerProductWithConfig::inner_product(&q_0_combined_row, &q_1, field_cfg) != *eval_f {
             return Err(ZipError::InvalidPcsOpen(
                 "Evaluation consistency failure".into(),
             ));
@@ -201,7 +202,7 @@ impl<Zt: ZipTypes, Lc: LinearCode<Zt>> ZipPlus<Zt, Lc> {
     {
         let column_entries_comb = if num_rows > 1 {
             let column_entries = column_entries.iter().map(project).collect_vec();
-            inner_product(q_0, &column_entries, F::zero_with_cfg(field_cfg))
+            q_0.inner_product(&column_entries, field_cfg)
             // TODO: this inner product is taking a long time.
         } else {
             project(column_entries.first().expect("No column entries"))

--- a/zip-plus/src/pcs/phase_verify.rs
+++ b/zip-plus/src/pcs/phase_verify.rs
@@ -9,6 +9,7 @@ use crate::{
     },
     pcs_transcript::PcsTranscript,
 };
+use crypto_bigint::ConstZero;
 use crypto_primitives::{FromWithConfig, IntoWithConfig, PrimeField};
 use itertools::Itertools;
 use zinc_poly::Polynomial;
@@ -132,11 +133,11 @@ impl<Zt: ZipTypes, Lc: LinearCode<Zt>> ZipPlus<Zt, Lc> {
             let column_entries: Vec<_> = column_entries
                 .iter()
                 .map(Zt::Comb::from_ref)
-                .map(|p| p.inner_product(alphas, Zt::CombR::from(0)))
+                .map(|p| p.inner_product(alphas, Zt::CombR::ZERO))
                 .try_collect()?;
-            column_entries.inner_product(coeffs, Zt::CombR::from(0))?
+            column_entries.inner_product(coeffs, Zt::CombR::ZERO)?
         } else {
-            Zt::Comb::from_ref(&column_entries[0]).inner_product(alphas, Zt::CombR::from(0))?
+            Zt::Comb::from_ref(&column_entries[0]).inner_product(alphas, Zt::CombR::ZERO)?
         };
 
         if column_entries_comb != encoded_combined_row[column] {
@@ -696,7 +697,7 @@ mod tests {
         let linear_code = C::new(poly_size, RAA_CFG);
         let pp = TestZip::setup(poly_size, linear_code);
 
-        let evaluations: Vec<_> = vec![Int::<INT_LIMBS>::from(0); poly_size];
+        let evaluations: Vec<_> = vec![Int::<INT_LIMBS>::ZERO; poly_size];
         let n = 3;
         let mle = DenseMultilinearExtension::from_evaluations_slice(n, &evaluations, Zero::zero());
 

--- a/zip-plus/src/pcs/structs.rs
+++ b/zip-plus/src/pcs/structs.rs
@@ -4,10 +4,12 @@ use crate::{
 };
 use crypto_primitives::{ConstIntRing, ConstIntSemiring, DenseRowMatrix, FixedSemiring};
 use std::{marker::PhantomData, ops::Neg};
-use zinc_poly::{ConstCoeffBitWidth, EvaluatablePolynomial};
+use zinc_poly::{ConstCoeffBitWidth, Polynomial};
 use zinc_primality::PrimalityTest;
 use zinc_transcript::traits::ConstTranscribable;
-use zinc_utils::{from_ref::FromRef, mul_by_scalar::MulByScalar, named::Named};
+use zinc_utils::{
+    from_ref::FromRef, inner_product::InnerProduct, mul_by_scalar::MulByScalar, named::Named,
+};
 
 pub trait ZipTypes: Send + Sync {
     const NUM_COLUMN_OPENINGS: usize;
@@ -43,7 +45,8 @@ pub trait ZipTypes: Send + Sync {
     /// Ring of elements in the linear combination of codewords, at least as
     /// wide as the evaluation, codeword, and challenge rings.
     type Comb: FixedSemiring
-        + EvaluatablePolynomial<Self::CombR, Self::Chal, Self::CombR>
+        + Polynomial<Self::CombR>
+        + InnerProduct<Self::Chal, Output = Self::CombR>
         + FromRef<Self::Eval>
         + FromRef<Self::Cw>
         + Named;

--- a/zip-plus/src/pcs/test_utils.rs
+++ b/zip-plus/src/pcs/test_utils.rs
@@ -24,7 +24,7 @@ use crypto_primitives::{
 };
 use itertools::Itertools;
 use num_traits::Zero;
-use zinc_poly::{dense::DensePolynomial, mle::DenseMultilinearExtension};
+use zinc_poly::{mle::DenseMultilinearExtension, univariate::dense::DensePolynomial};
 use zinc_primality::MillerRabin;
 use zinc_transcript::traits::{Transcribable, Transcript};
 use zinc_utils::{

--- a/zip-plus/src/utils.rs
+++ b/zip-plus/src/utils.rs
@@ -1,32 +1,14 @@
 use ark_std::cfg_iter_mut;
-use num_traits::CheckedAdd;
 use rand::{rngs::StdRng, seq::SliceRandom};
 use rand_core::SeedableRng;
 use std::{
     iter::{Iterator, Sum},
     mem::MaybeUninit,
 };
-use zinc_utils::{add, mul_by_scalar::MulByScalar};
+use zinc_utils::mul_by_scalar::MulByScalar;
 
 #[cfg(feature = "parallel")]
 use rayon::prelude::*;
-
-pub(crate) fn inner_product<'a, 'b, Coeff, El, L, R>(lhs: L, rhs: R, zero: El) -> El
-where
-    Coeff: Clone + 'a + 'b,
-    El: Clone + CheckedAdd + for<'z> MulByScalar<&'z Coeff> + 'a + 'b,
-    L: IntoIterator<Item = &'a Coeff>,
-    R: IntoIterator<Item = &'b El>,
-{
-    lhs.into_iter()
-        .zip(rhs)
-        .map(|(lhs, rhs)| {
-            rhs.mul_by_scalar(lhs)
-                .expect("Cannot multiply a codeword element by a coefficient")
-        })
-        .reduce(|acc, product| add!(acc, &product))
-        .unwrap_or(zero)
-}
 
 /// Computes a linear combination of multiple evaluation rows into a single
 /// combined row.
@@ -93,13 +75,6 @@ pub(super) fn shuffle_seeded<T>(slice: &mut [T], seed: u64) {
 #[cfg(test)]
 mod test {
     use super::*;
-
-    #[test]
-    fn test_inner_product_basic() {
-        let lhs = [1, 2, 3];
-        let rhs = [4, 5, 6];
-        assert_eq!(inner_product(lhs.iter(), rhs.iter(), 0), 4 + 2 * 5 + 3 * 6);
-    }
 
     #[test]
     fn test_basic_combination() {


### PR DESCRIPTION
There's a loose abstraction in both the paper and the implementation of evaluating a univariate polynomial on a vector of points instead of denoting it as an inner product. This PR fixes that in the code and unifies various kinds of inner products by introducing the trait `InnerProduct`.

Along the way, the dense univariate polys are moved into `univariate::dense` module and the interface of the univariate evaluation is slightly changed. Now, it doesn't expect a slice for evaluation which typically was a slice of powers but rather a single point whose powers it computes under the hood.