### PR TITLE
Introduce binary polynomials

### DIFF
--- a/poly/Cargo.toml
+++ b/poly/Cargo.toml
@@ -37,5 +37,9 @@ workspace = true
 parallel = ["dep:rayon"]
 
 [[bench]]
+name = "binary_vs_ordinary"
+harness = false
+
+[[bench]]
 name = "nat_evaluation"
 harness = false

--- a/poly/benches/binary_vs_ordinary.rs
+++ b/poly/benches/binary_vs_ordinary.rs
@@ -1,0 +1,124 @@
+use std::hint::black_box;
+
+use criterion::{
+    AxisScale, BenchmarkId, Criterion, PlotConfiguration, criterion_group, criterion_main,
+};
+use crypto_bigint::{Odd, modular::MontyParams};
+use crypto_primitives::{FromWithConfig, PrimeField, crypto_bigint_monty::F256};
+use itertools::Itertools;
+use zinc_poly::{
+    EvaluatablePolynomial,
+    univariate::{binary::BinaryPoly, dense::DensePolynomial},
+};
+use zinc_utils::projectable_to_field::ProjectableToField;
+
+const LIMBS: usize = 4;
+
+type F = F256;
+
+fn bench_config() -> MontyParams<LIMBS> {
+    let modulus = crypto_bigint::Uint::<LIMBS>::from_be_hex(
+        "0000000000000000000000000000000000860995AE68FC80E1B1BD1E39D54B33",
+    );
+    let modulus = Odd::new(modulus).expect("modulus should be odd");
+    MontyParams::new(modulus)
+}
+
+#[allow(clippy::arithmetic_side_effects)]
+fn bench_dense_poly_projection(
+    group: &mut criterion::BenchmarkGroup<criterion::measurement::WallTime>,
+) {
+    let v: Vec<DensePolynomial<u32, 32>> = (0..1024)
+        .map(|i| {
+            DensePolynomial::new(
+                (0..32)
+                    .map(|j| if i & (1 << j) == 0 { 0u32 } else { 1 })
+                    .collect_vec(),
+            )
+        })
+        .collect_vec();
+
+    let project = DensePolynomial::prepare_projection(&F::from_with_cfg(235325, &bench_config()));
+
+    group.bench_with_input(BenchmarkId::new("Project", "Dense version"), &v, |b, v| {
+        b.iter(|| {
+            for x in v {
+                let _ = black_box(project(x));
+            }
+        });
+    });
+
+    let v: Vec<BinaryPoly<u32>> = (0..1024).map(|i| i.into()).collect_vec();
+
+    let project = BinaryPoly::<u32>::prepare_projection(&F::from_with_cfg(235325, &bench_config()));
+
+    group.bench_with_input(BenchmarkId::new("Project", "Binary version"), &v, |b, v| {
+        b.iter(|| {
+            for x in v {
+                let _ = black_box(project(x));
+            }
+        });
+    });
+}
+
+#[allow(clippy::arithmetic_side_effects)]
+fn bench_dense_poly_evaluation(
+    group: &mut criterion::BenchmarkGroup<criterion::measurement::WallTime>,
+) {
+    let zero = F::zero_with_cfg(&bench_config());
+    let one = F::one_with_cfg(&bench_config());
+    let v: Vec<DensePolynomial<F, 32>> = (0..1024)
+        .map(|i| {
+            DensePolynomial::new_with_zero(
+                (0..32)
+                    .map(|j| {
+                        if i & (1 << j) == 0 {
+                            zero.clone()
+                        } else {
+                            one.clone()
+                        }
+                    })
+                    .collect_vec(),
+                zero.clone(),
+            )
+        })
+        .collect_vec();
+
+    let point = F::from_with_cfg(235325, &bench_config());
+
+    group.bench_with_input(BenchmarkId::new("Evaluate", "Dense version"), &v, |b, v| {
+        b.iter(|| {
+            for x in v {
+                let _ = black_box(x.evaluate_at_point(&point));
+            }
+        });
+    });
+
+    let v: Vec<BinaryPoly<u32>> = (0..1024).map(|i| i.into()).collect_vec();
+
+    group.bench_with_input(
+        BenchmarkId::new("Evaluate", "Binary version"),
+        &v,
+        |b, v| {
+            b.iter(|| {
+                for x in v {
+                    let _ = black_box(x.evaluate_at_point(&point));
+                }
+            });
+        },
+    );
+}
+
+pub fn binary_poly_benchmarks(c: &mut Criterion) {
+    let plot_config = PlotConfiguration::default().summary_scale(AxisScale::Logarithmic);
+
+    let mut group = c.benchmark_group("Binary poly benches");
+    group.plot_config(plot_config);
+
+    bench_dense_poly_projection(&mut group);
+    bench_dense_poly_evaluation(&mut group);
+    group.finish();
+}
+
+criterion_group!(benches, binary_poly_benchmarks);
+criterion_main!(benches);

--- a/poly/src/lib.rs
+++ b/poly/src/lib.rs
@@ -11,10 +11,11 @@ pub trait Polynomial<C> {
     const DEGREE_BOUND: usize;
 }
 
+// TODO: Remove the bogus type parameter `S`.
 pub trait EvaluatablePolynomial<C, S, Out>: Polynomial<C> {
     /// The type of points a polynomial can be evaluated on.
-    /// For univariate polynomials this typically is `C`,
-    /// for multivariate this is `[C]`.
+    /// For univariate polynomials this typically is `S`,
+    /// for multivariate this is `[S]`.
     type EvaluationPoint: ?Sized;
 
     /// Evaluates the polynomial at the given point.

--- a/poly/src/univariate.rs
+++ b/poly/src/univariate.rs
@@ -1,2 +1,3 @@
+pub mod binary;
 pub mod dense;
 pub mod nat_evaluation;

--- a/poly/src/univariate/binary.rs
+++ b/poly/src/univariate/binary.rs
@@ -72,7 +72,7 @@ impl<T: BinaryPolyCarrier, F: PrimeField> EvaluatablePolynomial<bool, F, F> for 
             })
             .fold(F::zero_with_cfg(point.cfg()), |mut acc, coeff| {
                 acc *= point;
-                if coeff != T::ZERO { acc + &one } else { acc }
+                if !coeff.is_zero() { acc + &one } else { acc }
             }))
     }
 }

--- a/poly/src/univariate/binary.rs
+++ b/poly/src/univariate/binary.rs
@@ -1,0 +1,193 @@
+//! Dense polynomial with binary coefficients.
+use std::{fmt::Debug, ops::BitAnd};
+
+use crypto_primitives::PrimeField;
+use num_traits::ConstZero;
+use zinc_utils::projectable_to_field::ProjectableToField;
+
+use crate::{EvaluatablePolynomial, EvaluationError, Polynomial};
+
+// A type used to store the coefficients of
+// the binary polynomials. In our case, it is
+// either `u32` or `u64`.
+pub trait BinaryPolyCarrier:
+    ConstZero + TryFrom<u64, Error: Debug> + for<'a> BitAnd<&'a Self, Output = Self> + Sized + Eq
+{
+    /// The bit size of the type.
+    const BIT_SIZE: u32;
+}
+
+impl BinaryPolyCarrier for u32 {
+    const BIT_SIZE: u32 = 32;
+}
+
+impl BinaryPolyCarrier for u64 {
+    const BIT_SIZE: u32 = 64;
+}
+
+pub struct BinaryPoly<T> {
+    pub coeffs: T,
+}
+
+impl<T: BinaryPolyCarrier> Polynomial<bool> for BinaryPoly<T> {
+    const DEGREE_BOUND: usize = T::BIT_SIZE as usize;
+}
+
+impl<T: BinaryPolyCarrier> BinaryPoly<T> {
+    /// Create a polynomial of the form `X^pow_of_x`.
+    /// If `pow_of_x` exceeds the maximum degree of polynomials
+    /// of this type `None` is returned.
+    #[inline(always)]
+    pub fn single_term(pow_of_x: u32) -> Option<Self> {
+        if pow_of_x >= T::BIT_SIZE {
+            return None;
+        }
+
+        let coeffs = (1 << pow_of_x)
+            .try_into()
+            .expect("1 << pow_of_x is always less than the max T, since T::BIT_SIZE < pow_of_x");
+        Some(Self { coeffs })
+    }
+}
+
+impl<T: BinaryPolyCarrier> From<T> for BinaryPoly<T> {
+    #[inline(always)]
+    fn from(x: T) -> Self {
+        Self { coeffs: x }
+    }
+}
+
+impl<T: BinaryPolyCarrier, F: PrimeField> EvaluatablePolynomial<bool, F, F> for BinaryPoly<T> {
+    type EvaluationPoint = F;
+
+    #[allow(clippy::arithmetic_side_effects)] // (T::BIT_SIZE - 1) - i is fine if 0 <= i < T::BIT_SIZE.
+    fn evaluate_at_point(&self, point: &Self::EvaluationPoint) -> Result<F, EvaluationError> {
+        // Horner's method.
+        let one = F::one_with_cfg(point.cfg());
+        Ok((0..T::BIT_SIZE)
+            .map(|i| {
+                T::try_from(1u64 << ((T::BIT_SIZE - 1) - i))
+                    .expect("T is either u32 or u64 and this should always go through.")
+                    & &self.coeffs
+            })
+            .fold(F::zero_with_cfg(point.cfg()), |mut acc, coeff| {
+                acc *= point;
+                if coeff != T::ZERO { acc + &one } else { acc }
+            }))
+    }
+}
+
+impl<T: BinaryPolyCarrier, F: PrimeField + 'static> ProjectableToField<F> for BinaryPoly<T> {
+    #[allow(clippy::arithmetic_side_effects)]
+    fn prepare_projection(sampled_value: &F) -> impl Fn(&Self) -> F + 'static {
+        let field_cfg = sampled_value.cfg().clone();
+        let r_powers = {
+            // It makes sense to preprocess the powers here
+            // since the evaluation procedure
+            // will reduce to additions only in that case.
+            let mut r_powers = Vec::with_capacity(T::BIT_SIZE as usize);
+
+            let mut curr = F::one_with_cfg(&field_cfg);
+            r_powers.push(curr.clone());
+
+            for _ in 1..32 {
+                curr *= sampled_value;
+                r_powers.push(curr.clone());
+            }
+
+            r_powers
+        };
+
+        move |Self { coeffs, .. }| {
+            (0..T::BIT_SIZE)
+                .filter(|i| {
+                    !(T::try_from(1 << i)
+                        .expect("If T is u32 i is 31 at most. If T is u64 i is 63 at most.")
+                        & coeffs)
+                        .is_zero()
+                })
+                .fold(F::zero_with_cfg(&field_cfg), |acc, i| {
+                    acc + &r_powers[i as usize]
+                })
+        }
+    }
+}
+
+#[cfg(test)]
+mod test {
+
+    use crypto_bigint::{Odd, U128, const_monty_params, modular::MontyParams};
+
+    use crypto_primitives::{
+        FromWithConfig, crypto_bigint_const_monty::ConstMontyField, crypto_bigint_monty::F256,
+    };
+    use itertools::Itertools;
+    use zinc_utils::projectable_to_field::ProjectableToField;
+
+    use crate::{EvaluatablePolynomial, univariate::binary::BinaryPoly};
+
+    const N: usize = 2;
+
+    const_monty_params!(Params, U128, "00000000b933426489189cb5b47d567f");
+
+    type F = ConstMontyField<Params, N>;
+
+    #[test]
+    fn test_evaluate_binary_poly() {
+        for i in 0..u32::from(u16::MAX) {
+            // A u32 treated as a binary poly should give
+            // its own value when evaluated on 2.
+            let x = BinaryPoly::<u32>::from(i);
+
+            let x_val_on_1 = x.evaluate_at_point(&F::from(2)).unwrap();
+
+            assert_eq!(x_val_on_1, F::from(i));
+        }
+    }
+
+    #[test]
+    fn test_project_onto_field() {
+        let project = BinaryPoly::<u32>::prepare_projection(&F::from(2));
+        for i in 0..u32::from(u16::MAX) {
+            assert_eq!(project(&BinaryPoly::from(i)), F::from(i));
+        }
+    }
+
+    #[test]
+    fn x_value_on_2() {
+        for i in 0..64 {
+            let x = BinaryPoly::<u64>::single_term(i).unwrap();
+            let x_val = x.evaluate_at_point(&F::from(2)).unwrap();
+            // 1u64 to not fall into i64.
+            assert_eq!(x_val, F::from(1u64 << i));
+        }
+    }
+
+    const LIMBS: usize = 4;
+    type FMonty = F256;
+
+    fn test_monty_config() -> MontyParams<LIMBS> {
+        // Using a 256-bit prime 2^256 - 2^32 - 977 (secp256k1 field prime)
+        let modulus = crypto_bigint::Uint::<LIMBS>::from_be_hex(
+            "fffffffffffffffffffffffffffffffffffffffffffffffffffffffefffffc2f",
+        );
+        let modulus = Odd::new(modulus).expect("modulus should be odd");
+        MontyParams::new(modulus)
+    }
+
+    #[test]
+    fn test_projection_monty() {
+        let x = FMonty::from_with_cfg(2, &test_monty_config());
+
+        let v = (0..1024).map(BinaryPoly::<u32>::from).collect_vec();
+
+        let project = BinaryPoly::<u32>::prepare_projection(&x);
+
+        for (i, el) in v.iter().enumerate() {
+            assert_eq!(
+                project(el),
+                FMonty::from_with_cfg(i as u64, &test_monty_config())
+            );
+        }
+    }
+}

--- a/poly/src/univariate/dense.rs
+++ b/poly/src/univariate/dense.rs
@@ -53,6 +53,29 @@ impl<R: Semiring + Zero, const DEGREE_PLUS_ONE: usize> DensePolynomial<R, DEGREE
     }
 }
 
+impl<R: Semiring, const DEGREE_PLUS_ONE: usize> DensePolynomial<R, DEGREE_PLUS_ONE> {
+    /// Create a new polynomial with the given coefficients.
+    /// If the input has fewer than N+1 coefficients, the remaining slots will
+    /// be filled with zeros. If the input has more than N+1 coefficients,
+    /// it will panic.
+    #[allow(clippy::arithmetic_side_effects)]
+    pub fn new_with_zero(coeffs: impl AsRef<[R]>, zero: R) -> Self {
+        let coeffs = coeffs.as_ref();
+        assert!(
+            coeffs.len() <= DEGREE_PLUS_ONE,
+            "Too many coefficients provided: expected at most {}, got {}",
+            DEGREE_PLUS_ONE,
+            coeffs.len()
+        );
+
+        let mut coeffs = coeffs.to_vec();
+        coeffs.resize(DEGREE_PLUS_ONE, zero);
+        let coeffs = coeffs.try_into().expect("unreachable");
+
+        DensePolynomial { coeffs }
+    }
+}
+
 impl<R: Copy, const DEGREE_PLUS_ONE: usize> Copy for DensePolynomial<R, DEGREE_PLUS_ONE> {}
 
 impl<R: Default, const DEGREE_PLUS_ONE: usize> Default for DensePolynomial<R, DEGREE_PLUS_ONE> {
@@ -373,18 +396,20 @@ where
     where
         R: for<'a> MulByScalar<&'a C>,
     {
-        // A trivial implementation of a polynomial evaluation at a given point.
+        // Horner's method.
         let mut result = self
             .coeffs
             .last()
             .ok_or(EvaluationError::EmptyPolynomial)?
             .clone();
+
         for coeff in self.coeffs.iter().rev().skip(1) {
             let term = result
                 .mul_by_scalar(point)
                 .ok_or(EvaluationError::Overflow)?;
             result = term.checked_add(coeff).ok_or(EvaluationError::Overflow)?;
         }
+
         Ok(result)
     }
 }


### PR DESCRIPTION
A binary polynomial is represeneted as `u32` (degree at most 31) or `u64` (degree at most 63).

The conversion from a number to its bit polynomial is super cheap.

The projection function for binary polynomials benefits from preprocessing the powers of the random challenge as then the evaluation becomes just a sum of field elements.

Added a couple benchmarks to compare ordinary (`DensePolynomial`) and the newly inroduced binary polynomials. Evaluation of binaries is slightly faster than that of dense polynomials. Projection is massively faster. 