### PR TITLE
Unsafe projection onto `Field::Inner`

### DIFF
--- a/poly/src/univariate/binary.rs
+++ b/poly/src/univariate/binary.rs
@@ -1,8 +1,8 @@
 //! Dense polynomial with binary coefficients.
 use std::{fmt::Debug, ops::BitAnd};
 
-use crypto_primitives::PrimeField;
-use zinc_utils::projectable_to_field::ProjectableToField;
+use crypto_primitives::{Field, PrimeField, crypto_bigint_monty::MontyField};
+use zinc_utils::projectable_to_field::{ProjectableToField, ProjectableToFieldInner};
 
 use crate::{EvaluatablePolynomial, EvaluationError, Polynomial};
 
@@ -157,16 +157,38 @@ define_binary_poly!(BinaryPoly64, 0);
 define_binary_poly!(BinaryPoly128, 8);
 define_binary_poly!(BinaryPoly256, 24);
 
+macro_rules! impl_projectable_to_field_inner {
+    ($for:ident, $field:ty) => {
+        unsafe impl<T: BinaryPolyCarrier> ProjectableToFieldInner<$field> for $for<T> {
+            fn prepare_projection_to_inner(sampled_value: &$field) -> impl Fn(*mut Self) + 'static {
+                let project = Self::prepare_projection(sampled_value);
+                move |p| unsafe {
+                    let val = project(p.as_ref().expect("A correct pointer was expected here"));
+                    let p = p as *mut <$field as Field>::Inner;
+                    *p = val.into_inner();
+                }
+            }
+        }
+    };
+}
+
+// TODO: this is not ideal for 32bit target architectures.
+impl_projectable_to_field_inner!(BinaryPoly64, MontyField<1>);
+impl_projectable_to_field_inner!(BinaryPoly128, MontyField<2>);
+impl_projectable_to_field_inner!(BinaryPoly256, MontyField<4>);
+
 #[cfg(test)]
 mod test {
-
     use crypto_bigint::{Odd, U128, const_monty_params, modular::MontyParams};
 
     use crypto_primitives::{
         FromWithConfig, crypto_bigint_const_monty::ConstMontyField, crypto_bigint_monty::F256,
+        crypto_bigint_uint::Uint,
     };
     use itertools::Itertools;
-    use zinc_utils::projectable_to_field::ProjectableToField;
+    use zinc_utils::projectable_to_field::{
+        ProjectableToField, ProjectableToFieldInner, project_vec_in_place,
+    };
 
     use crate::{
         EvaluatablePolynomial,
@@ -245,6 +267,27 @@ mod test {
                 project(el),
                 FMonty::from_with_cfg(i as u64, &test_monty_config())
             );
+        }
+    }
+
+    #[test]
+    fn test_vec_projection() {
+        let vec = (0..(1 << 20))
+            .map(|i: u32| BinaryPoly256::from(i))
+            .collect_vec();
+
+        let config = test_monty_config();
+
+        let project =
+            BinaryPoly256::<u32>::prepare_projection_to_inner(&FMonty::from_with_cfg(2, &config));
+
+        let vec: Vec<Uint<4>> = unsafe { project_vec_in_place(vec, project) };
+
+        for (i, x) in vec.into_iter().enumerate() {
+            assert_eq!(
+                FMonty::from_montgomery(x, &config).retrieve(),
+                Uint::from(i as u64)
+            )
         }
     }
 }

--- a/utils/Cargo.toml
+++ b/utils/Cargo.toml
@@ -10,11 +10,13 @@ license.workspace = true
 bench = false
 
 [dependencies]
+ark-std = {workspace = true}
 crypto-primitives = { workspace = true }
 
 crypto-bigint = { workspace = true }
 num-traits = { workspace = true }
 thiserror = { workspace = true }
+rayon = {workspace = true, optional = true}
 
 [dev-dependencies]
 proptest = { workspace = true }
@@ -22,3 +24,5 @@ proptest = { workspace = true }
 [lints]
 workspace = true
 
+[features]
+parallel = ["dep:rayon"]

--- a/utils/src/projectable_to_field.rs
+++ b/utils/src/projectable_to_field.rs
@@ -1,4 +1,7 @@
+use ark_std::cfg_iter_mut;
 use crypto_primitives::PrimeField;
+#[cfg(feature = "parallel")]
+use rayon::prelude::*;
 
 /// Trait for preparing a projection function to a field element from a current
 /// type.
@@ -6,4 +9,56 @@ pub trait ProjectableToField<F: PrimeField> {
     /// Prepare a projection function that will project the current type
     /// to a prime field using the given sampled value.
     fn prepare_projection(sampled_value: &F) -> impl Fn(&Self) -> F + 'static;
+}
+
+/// An unsafe trait for types that can be projected onto a field's
+/// inner type. We expect that this projected element is in a correct
+/// Montgomery form representation that corresponds to the config of
+/// `sampled_value`.
+///
+/// # Safety
+/// The returned closure expects to receive a non-null pointer to
+/// an element of the type and should modify its content to a correct
+/// Montgomery representation of an element of `F`.
+pub unsafe trait ProjectableToFieldInner<F: PrimeField> {
+    fn prepare_projection_to_inner(sampled_value: &F) -> impl Fn(*mut Self) + 'static;
+}
+
+/// Apply a projection to each element of the vector
+/// to obtain a vector of projected elements.
+/// No intermediate vector allocations.
+///
+/// # Safety
+/// The closure `project` is expected to write a correct representation
+/// of an object of type `F` into a given pointer.
+///
+/// # Panics
+/// The function asserts if the sizes of the types `T` and `F` are the same.
+pub unsafe fn project_vec_in_place<T, F, P>(mut vec: Vec<T>, project: P) -> Vec<F>
+where
+    T: Send + Sync,
+    F: Send + Sync,
+    P: Fn(*mut T) + Send + Sync,
+{
+    assert_eq!(size_of::<T>(), size_of::<F>());
+
+    cfg_iter_mut!(vec).for_each(|x| {
+        project(x);
+    });
+
+    unsafe { std::mem::transmute(vec) }
+}
+
+#[cfg(test)]
+mod test {
+    use crate::projectable_to_field::project_vec_in_place;
+
+    #[test]
+    fn project_vec_in_place_i32_u32() {
+        let x: Vec<i32> = vec![-2, -1, 0, 1, 2];
+
+        let y: Vec<u32> = unsafe { project_vec_in_place(x, |_| {}) };
+
+        assert_eq!(y, vec![4294967294, 4294967295, 0, 1, 2]);
+    }
 }


### PR DESCRIPTION
When projecting a lot of elements onto a field (think of projecting a `DenseMultilinearExtension<BinaryPoly<u32>>`) it gets quite expensive to drag a field config with each. Instead we can project onto the field and only store the inner Montgomery representation. For that we introduce the unsafe trait:
```rust
pub unsafe trait ProjectableToFieldInner<F: PrimeField> {
    fn prepare_projection_to_inner(sampled_value: &F) -> impl Fn(*mut Self) + 'static;
}
```
The returned closure is supposed to perform the transformation above and store the result in the place.

We also define this utilitary function:
```rust
pub unsafe fn project_vec_in_place<T, F, P>(mut vec: Vec<T>, project: P) -> Vec<F>
where
    T: Send + Sync,
    F: Send + Sync,
    P: Fn(*mut T) + Send + Sync,
```
that can be used to batch-project vectors.