### PR TITLE
Remove `crypto-primes` dependency from workspace

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,6 @@ publish = false
 crypto-primitives = { git = "https://github.com/NethermindEth/crypto-primitives.git", branch = "main", features = ["std", "ark_std", "crypto_bigint", "rand"]  }
 
 crypto-bigint = { version = "0.7.0-rc.10", features = ["zeroize"] }
-crypto-primes = { version = "0.7.0-pre.4" }
 ark-std = "0.5"
 criterion = "0.7.0"
 itertools = "0.14"

--- a/poly/Cargo.toml
+++ b/poly/Cargo.toml
@@ -24,7 +24,6 @@ num-traits = { workspace = true }
 rand = { workspace = true }
 rand_core = { workspace = true }
 rayon = { workspace = true, optional = true }
-crypto-primes = { workspace = true }
 
 [dev-dependencies]
 criterion = { workspace = true }

--- a/primality/Cargo.toml
+++ b/primality/Cargo.toml
@@ -12,7 +12,7 @@ bench = false
 [dependencies]
 crypto-primitives = { workspace = true }
 crypto-bigint = { workspace = true }
-crypto-primes = { workspace = true }
+crypto-primes = { version = "0.7.0-pre.4" }
 
 [lints]
 workspace = true

--- a/zip-plus/Cargo.toml
+++ b/zip-plus/Cargo.toml
@@ -27,7 +27,6 @@ rand_core = { workspace = true }
 rayon = { workspace = true, optional = true }
 blake3 = "1.8.2"
 uninit = "0.6.2"
-crypto-primes = { workspace = true }
 
 [dev-dependencies]
 criterion = { workspace = true }


### PR DESCRIPTION
It's only a dependency for primality crate and it should depend on it directly.