### PR TITLE
Add utilitary traits implementations for `BinaryPoly`

### DIFF
--- a/poly/src/univariate/binary.rs
+++ b/poly/src/univariate/binary.rs
@@ -3,6 +3,7 @@ use std::{fmt::Debug, ops::BitAnd};
 
 use crypto_primitives::PrimeField;
 use num_traits::{CheckedAdd, ConstZero};
+use rand::distr::{Distribution, StandardUniform};
 use zinc_utils::{
     inner_product::{InnerProduct, InnerProductError},
     named::Named,
@@ -76,6 +77,16 @@ impl<T: BinaryPolyCarrier> From<T> for BinaryPoly<T> {
     #[inline(always)]
     fn from(x: T) -> Self {
         Self { coeffs: x }
+    }
+}
+
+impl<T> Distribution<BinaryPoly<T>> for StandardUniform
+where
+    T: BinaryPolyCarrier,
+    StandardUniform: Distribution<T>,
+{
+    fn sample<R: rand::Rng + ?Sized>(&self, rng: &mut R) -> BinaryPoly<T> {
+        From::from(rng.sample(self))
     }
 }
 
@@ -167,6 +178,7 @@ mod test {
         crypto_bigint_monty::F256,
     };
     use itertools::Itertools;
+    use rand::distr::{Distribution, StandardUniform};
     use zinc_utils::{inner_product::InnerProduct, projectable_to_field::ProjectableToField};
 
     use crate::{EvaluatablePolynomial, univariate::binary::BinaryPoly};
@@ -261,5 +273,13 @@ mod test {
             .sum();
 
         assert_eq!(inner_product, expected);
+    }
+
+    #[test]
+    fn ensure_distribution() {
+        fn _assert_impl<T: Distribution<BinaryPoly<u32>>>() {}
+        _assert_impl::<StandardUniform>();
+        fn _assert_impl2<T: Distribution<BinaryPoly<u64>>>() {}
+        _assert_impl2::<StandardUniform>();
     }
 }

--- a/poly/src/univariate/binary.rs
+++ b/poly/src/univariate/binary.rs
@@ -2,7 +2,8 @@
 use std::{fmt::Debug, ops::BitAnd};
 
 use crypto_primitives::PrimeField;
-use num_traits::{CheckedAdd, ConstZero};
+use itertools::Itertools;
+use num_traits::{CheckedAdd, ConstOne, ConstZero};
 use rand::distr::{Distribution, StandardUniform};
 use zinc_utils::{
     inner_product::{InnerProduct, InnerProductError},
@@ -168,6 +169,29 @@ impl<T: BinaryPolyCarrier> Named for BinaryPoly<T> {
     }
 }
 
+macro_rules! impl_from_binary_poly_for_array {
+    ($degree: literal, $carrier: ty) => {
+        impl<R: ConstZero + ConstOne> From<BinaryPoly<$carrier>> for [R; $degree] {
+            #[allow(clippy::arithmetic_side_effects)]
+            fn from(poly: BinaryPoly<$carrier>) -> Self {
+                (0..$degree)
+                    .map(|i| {
+                        if poly.is_zero_term_unchecked(i) {
+                            R::ZERO
+                        } else {
+                            R::ONE
+                        }
+                    })
+                    .collect_array()
+                    .expect("The size is always correct")
+            }
+        }
+    };
+}
+
+impl_from_binary_poly_for_array!(32, u32);
+impl_from_binary_poly_for_array!(64, u64);
+
 #[cfg(test)]
 mod test {
 
@@ -281,5 +305,25 @@ mod test {
         _assert_impl::<StandardUniform>();
         fn _assert_impl2<T: Distribution<BinaryPoly<u64>>>() {}
         _assert_impl2::<StandardUniform>();
+    }
+
+    #[test]
+    fn into_array() {
+        let poly = BinaryPoly::<u32>::from(0b10101010101010101010101010101010);
+        let expected: [u32; 32] = [
+            0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0,
+            1, 0, 1,
+        ];
+        assert_eq!(Into::<[u32; 32]>::into(poly), expected);
+
+        let poly = BinaryPoly::<u64>::from(
+            0b1010101010101010101010101010101010101010101010101010101010101010,
+        );
+        let expected: [u32; 64] = [
+            0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0,
+            1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1,
+            0, 1, 0, 1, 0, 1,
+        ];
+        assert_eq!(Into::<[u32; 64]>::into(poly), expected);
     }
 }

--- a/poly/src/univariate/binary.rs
+++ b/poly/src/univariate/binary.rs
@@ -69,8 +69,12 @@ impl<T: BinaryPolyCarrier> BinaryPoly<T> {
     }
 
     /// Is the `term` coefficient equal to 0
-    fn is_zero_term_unchecked(&self, term: u32) -> bool {
-        (T::try_from(1 << term).expect("Unchecked") & &self.coeffs).is_zero()
+    fn is_zero_term(&self, term: u32) -> bool {
+        (T::try_from(1 << term).expect(
+            "Failed to convert (1 << term) to T.\
+                                       This should not have happened normally.",
+        ) & &self.coeffs)
+            .is_zero()
     }
 }
 
@@ -101,7 +105,7 @@ impl<T: BinaryPolyCarrier, F: PrimeField> EvaluatablePolynomial<bool, F> for Bin
         Ok(
             (0..T::BIT_SIZE).fold(F::zero_with_cfg(point.cfg()), |mut acc, i| {
                 acc *= point;
-                if !self.is_zero_term_unchecked(T::BIT_SIZE - 1 - i) {
+                if !self.is_zero_term(T::BIT_SIZE - 1 - i) {
                     acc + &one
                 } else {
                     acc
@@ -134,7 +138,7 @@ impl<T: BinaryPolyCarrier, F: PrimeField + 'static> ProjectableToField<F> for Bi
 
         move |poly| {
             (0..T::BIT_SIZE)
-                .filter(|&i| !poly.is_zero_term_unchecked(i))
+                .filter(|&i| !poly.is_zero_term(i))
                 .fold(F::zero_with_cfg(&field_cfg), |acc, i| {
                     acc + &r_powers[i as usize]
                 })
@@ -155,7 +159,7 @@ where
         zero: Self::Output,
     ) -> Result<Self::Output, InnerProductError> {
         (0..T::BIT_SIZE)
-            .filter(|&i| !self.is_zero_term_unchecked(i))
+            .filter(|&i| !self.is_zero_term(i))
             .try_fold(zero, |acc, i| {
                 acc.checked_add(&rhs[i as usize])
                     .ok_or(InnerProductError::Overflow)
@@ -165,7 +169,7 @@ where
 
 impl<T: BinaryPolyCarrier> Named for BinaryPoly<T> {
     fn type_name() -> String {
-        format!("BinaryPoly<{}>", T::type_name())
+        format!("BPoly<{}>", T::type_name())
     }
 }
 
@@ -176,7 +180,7 @@ macro_rules! impl_from_binary_poly_for_array {
             fn from(poly: BinaryPoly<$carrier>) -> Self {
                 (0..$degree)
                     .map(|i| {
-                        if poly.is_zero_term_unchecked(i) {
+                        if poly.is_zero_term(i) {
                             R::ZERO
                         } else {
                             R::ONE

--- a/poly/src/univariate/binary.rs
+++ b/poly/src/univariate/binary.rs
@@ -2,16 +2,28 @@
 use std::{fmt::Debug, ops::BitAnd};
 
 use crypto_primitives::PrimeField;
-use num_traits::ConstZero;
-use zinc_utils::projectable_to_field::ProjectableToField;
+use num_traits::{CheckedAdd, ConstZero};
+use zinc_utils::{
+    inner_product::{InnerProduct, InnerProductError},
+    named::Named,
+    projectable_to_field::ProjectableToField,
+};
 
-use crate::{EvaluatablePolynomial, EvaluationError, Polynomial};
+use crate::{ConstCoeffBitWidth, EvaluatablePolynomial, EvaluationError, Polynomial};
 
 // A type used to store the coefficients of
 // the binary polynomials. In our case, it is
 // either `u32` or `u64`.
 pub trait BinaryPolyCarrier:
-    ConstZero + TryFrom<u64, Error: Debug> + for<'a> BitAnd<&'a Self, Output = Self> + Sized + Eq
+    ConstZero
+    + TryFrom<u64, Error: Debug>
+    + for<'a> BitAnd<&'a Self, Output = Self>
+    + Sized
+    + Eq
+    + Named
+    + Copy
+    + Send
+    + Sync
 {
     /// The bit size of the type.
     const BIT_SIZE: u32;
@@ -25,12 +37,17 @@ impl BinaryPolyCarrier for u64 {
     const BIT_SIZE: u32 = 64;
 }
 
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct BinaryPoly<T> {
     pub coeffs: T,
 }
 
 impl<T: BinaryPolyCarrier> Polynomial<bool> for BinaryPoly<T> {
     const DEGREE_BOUND: usize = T::BIT_SIZE as usize;
+}
+
+impl<T: BinaryPolyCarrier> ConstCoeffBitWidth for BinaryPoly<T> {
+    const COEFF_BIT_WIDTH: usize = 1;
 }
 
 impl<T: BinaryPolyCarrier> BinaryPoly<T> {
@@ -48,6 +65,11 @@ impl<T: BinaryPolyCarrier> BinaryPoly<T> {
             .expect("1 << pow_of_x is always less than the max T, since T::BIT_SIZE < pow_of_x");
         Some(Self { coeffs })
     }
+
+    /// Is the `term` coefficient equal to 0
+    fn is_zero_term_unchecked(&self, term: u32) -> bool {
+        (T::try_from(1 << term).expect("Unchecked") & &self.coeffs).is_zero()
+    }
 }
 
 impl<T: BinaryPolyCarrier> From<T> for BinaryPoly<T> {
@@ -64,16 +86,16 @@ impl<T: BinaryPolyCarrier, F: PrimeField> EvaluatablePolynomial<bool, F> for Bin
     fn evaluate_at_point(&self, point: &Self::EvaluationPoint) -> Result<F, EvaluationError> {
         // Horner's method.
         let one = F::one_with_cfg(point.cfg());
-        Ok((0..T::BIT_SIZE)
-            .map(|i| {
-                T::try_from(1u64 << ((T::BIT_SIZE - 1) - i))
-                    .expect("T is either u32 or u64 and this should always go through.")
-                    & &self.coeffs
-            })
-            .fold(F::zero_with_cfg(point.cfg()), |mut acc, coeff| {
+        Ok(
+            (0..T::BIT_SIZE).fold(F::zero_with_cfg(point.cfg()), |mut acc, i| {
                 acc *= point;
-                if !coeff.is_zero() { acc + &one } else { acc }
-            }))
+                if !self.is_zero_term_unchecked(T::BIT_SIZE - 1 - i) {
+                    acc + &one
+                } else {
+                    acc
+                }
+            }),
+        )
     }
 }
 
@@ -98,18 +120,40 @@ impl<T: BinaryPolyCarrier, F: PrimeField + 'static> ProjectableToField<F> for Bi
             r_powers
         };
 
-        move |Self { coeffs, .. }| {
+        move |poly| {
             (0..T::BIT_SIZE)
-                .filter(|i| {
-                    !(T::try_from(1 << i)
-                        .expect("If T is u32 i is 31 at most. If T is u64 i is 63 at most.")
-                        & coeffs)
-                        .is_zero()
-                })
+                .filter(|&i| !poly.is_zero_term_unchecked(i))
                 .fold(F::zero_with_cfg(&field_cfg), |acc, i| {
                     acc + &r_powers[i as usize]
                 })
         }
+    }
+}
+
+impl<T, R> InnerProduct<R> for BinaryPoly<T>
+where
+    T: BinaryPolyCarrier,
+    R: CheckedAdd,
+{
+    type Output = R;
+
+    fn inner_product(
+        &self,
+        rhs: &[R],
+        zero: Self::Output,
+    ) -> Result<Self::Output, InnerProductError> {
+        (0..T::BIT_SIZE)
+            .filter(|&i| !self.is_zero_term_unchecked(i))
+            .try_fold(zero, |acc, i| {
+                acc.checked_add(&rhs[i as usize])
+                    .ok_or(InnerProductError::Overflow)
+            })
+    }
+}
+
+impl<T: BinaryPolyCarrier> Named for BinaryPoly<T> {
+    fn type_name() -> String {
+        format!("BinaryPoly<{}>", T::type_name())
     }
 }
 
@@ -119,10 +163,11 @@ mod test {
     use crypto_bigint::{Odd, U128, const_monty_params, modular::MontyParams};
 
     use crypto_primitives::{
-        FromWithConfig, crypto_bigint_const_monty::ConstMontyField, crypto_bigint_monty::F256,
+        FromWithConfig, PrimeField, crypto_bigint_const_monty::ConstMontyField,
+        crypto_bigint_monty::F256,
     };
     use itertools::Itertools;
-    use zinc_utils::projectable_to_field::ProjectableToField;
+    use zinc_utils::{inner_product::InnerProduct, projectable_to_field::ProjectableToField};
 
     use crate::{EvaluatablePolynomial, univariate::binary::BinaryPoly};
 
@@ -189,5 +234,32 @@ mod test {
                 FMonty::from_with_cfg(i as u64, &test_monty_config())
             );
         }
+    }
+
+    #[test]
+    fn binary_poly_inner_product() {
+        let rhs = (0..32)
+            .map(|i| FMonty::from_with_cfg(i, &test_monty_config()))
+            .collect_vec();
+
+        // All odd coeffs are 1.
+        let poly = BinaryPoly::<u32>::from(0b10101010101010101010101010101010);
+
+        let inner_product = poly
+            .inner_product(&rhs, FMonty::zero_with_cfg(&test_monty_config()))
+            .unwrap();
+
+        // Sum of the odd numbers in the range [0, 31].
+        let expected: FMonty = (0..32)
+            .map(|i| {
+                if i % 2 != 0 {
+                    FMonty::from_with_cfg(i, &test_monty_config())
+                } else {
+                    FMonty::zero_with_cfg(&test_monty_config())
+                }
+            })
+            .sum();
+
+        assert_eq!(inner_product, expected);
     }
 }

--- a/poly/src/univariate/dense.rs
+++ b/poly/src/univariate/dense.rs
@@ -2,7 +2,7 @@ use crate::{ConstCoeffBitWidth, EvaluatablePolynomial, EvaluationError, Polynomi
 use core::slice;
 use crypto_primitives::{FromWithConfig, IntoWithConfig, PrimeField, Ring, Semiring};
 use itertools::Itertools;
-use num_traits::{CheckedAdd, CheckedMul, CheckedNeg, CheckedSub, One, Zero};
+use num_traits::{CheckedAdd, CheckedMul, CheckedNeg, CheckedSub, ConstOne, ConstZero, One, Zero};
 use rand::{distr::StandardUniform, prelude::*};
 use std::{
     array,
@@ -19,6 +19,8 @@ use zinc_utils::{
     named::Named,
     projectable_to_field::ProjectableToField,
 };
+
+use super::binary::BinaryPoly;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct DensePolynomial<R, const DEGREE_PLUS_ONE: usize> {
@@ -550,5 +552,37 @@ where
         zero: Self::Output,
     ) -> Result<Self::Output, InnerProductError> {
         self.as_ref().inner_product(rhs, zero)
+    }
+}
+
+impl<R: ConstZero + ConstOne> FromRef<BinaryPoly<u32>> for DensePolynomial<R, 32> {
+    fn from_ref(binary_poly: &BinaryPoly<u32>) -> Self {
+        Self {
+            coeffs: (*binary_poly).into(),
+        }
+    }
+}
+
+impl<R: ConstZero + ConstOne> FromRef<BinaryPoly<u64>> for DensePolynomial<R, 64> {
+    fn from_ref(binary_poly: &BinaryPoly<u64>) -> Self {
+        Self {
+            coeffs: (*binary_poly).into(),
+        }
+    }
+}
+
+impl<R: ConstZero + ConstOne> From<BinaryPoly<u32>> for DensePolynomial<R, 32> {
+    fn from(binary_poly: BinaryPoly<u32>) -> Self {
+        Self {
+            coeffs: binary_poly.into(),
+        }
+    }
+}
+
+impl<R: ConstZero + ConstOne> From<BinaryPoly<u64>> for DensePolynomial<R, 64> {
+    fn from(binary_poly: BinaryPoly<u64>) -> Self {
+        Self {
+            coeffs: binary_poly.into(),
+        }
     }
 }

--- a/poly/src/univariate/dense.rs
+++ b/poly/src/univariate/dense.rs
@@ -573,16 +573,12 @@ impl<R: ConstZero + ConstOne> FromRef<BinaryPoly<u64>> for DensePolynomial<R, 64
 
 impl<R: ConstZero + ConstOne> From<BinaryPoly<u32>> for DensePolynomial<R, 32> {
     fn from(binary_poly: BinaryPoly<u32>) -> Self {
-        Self {
-            coeffs: binary_poly.into(),
-        }
+        Self::from_ref(&binary_poly)
     }
 }
 
 impl<R: ConstZero + ConstOne> From<BinaryPoly<u64>> for DensePolynomial<R, 64> {
     fn from(binary_poly: BinaryPoly<u64>) -> Self {
-        Self {
-            coeffs: binary_poly.into(),
-        }
+        Self::from_ref(&binary_poly)
     }
 }


### PR DESCRIPTION
* Namely,
```rust
impl<T: BinaryPolyCarrier> Named for BinaryPoly<T>
```
```rust
impl<T, R> InnerProduct<R> for BinaryPoly<T>
where
    T: BinaryPolyCarrier,
    R: CheckedAdd,

```
and derived `#[derive(Clone, Copy, Debug, PartialEq, Eq)]`

* Make `BinaryPolyCarrier` implement `Named`, `Copy`, `Send` and `Sync`.

* Add
```rust
impl<T> Distribution<BinaryPoly<T>> for StandardUniform
where
    T: BinaryPolyCarrier,
    StandardUniform: Distribution<T>,
```

* Add
```rust
impl<R: ConstZero + ConstOne> From<BinaryPoly<u32>> for [R; 32] 
impl<R: ConstZero + ConstOne> From<BinaryPoly<u64>> for [R; 64]
```

* Add helper private method for `BinaryPoly`
```rust
fn is_zero_term_unchecked(&self, term: u32) -> bool
```

* Add conversion from binary to dense polynomials.