### PR TITLE
`MultilinearExtensionRand` doesn't have to extend `MultilinearExtension`

### DIFF
--- a/poly/src/mle.rs
+++ b/poly/src/mle.rs
@@ -41,8 +41,8 @@ pub trait MultilinearExtension<T>:
         T: for<'a> MulByScalar<&'a S>;
 }
 
-pub trait MultilinearExtensionRand<T>: MultilinearExtension<T> {
+pub trait MultilinearExtensionRand<T> {
     /// Outputs an `l`-variate multilinear extension where value of evaluations
     /// are sampled uniformly at random.
-    fn rand<R: RngCore + ?Sized>(num_vars: usize, rng: &mut R, zero: T) -> Self;
+    fn rand<R: RngCore + ?Sized>(num_vars: usize, rng: &mut R) -> Self;
 }

--- a/poly/src/mle/dense.rs
+++ b/poly/src/mle/dense.rs
@@ -168,15 +168,14 @@ where
 
 impl<R> MultilinearExtensionRand<R> for DenseMultilinearExtension<R>
 where
-    R: Semiring,
+    R: Clone,
     StandardUniform: Distribution<R>,
 {
-    fn rand<Rng: RngCore + ?Sized>(num_vars: usize, rng: &mut Rng, zero: R) -> Self {
-        Self::from_evaluations_vec(
+    fn rand<Rng: RngCore + ?Sized>(num_vars: usize, rng: &mut Rng) -> Self {
+        Self {
             num_vars,
-            (0..1 << num_vars).map(|_| rng.random::<R>()).collect(),
-            zero,
-        )
+            evaluations: (0..1 << num_vars).map(|_| rng.random::<R>()).collect(),
+        }
     }
 }
 

--- a/zip-plus/benches/zip_common.rs
+++ b/zip-plus/benches/zip_common.rs
@@ -14,7 +14,7 @@ use crypto_primitives::{
     crypto_bigint_boxed_monty::BoxedMontyField,
 };
 use itertools::Itertools;
-use num_traits::{One, Zero};
+use num_traits::One;
 use rand::{distr::StandardUniform, prelude::*};
 use zinc_poly::mle::{DenseMultilinearExtension, MultilinearExtensionRand};
 use zinc_transcript::traits::ConstTranscribable;
@@ -97,11 +97,7 @@ pub fn encode_rows<Zt: ZipTypes, Lc: LinearCode<Zt>, const P: usize>(
             let linear_code = Lc::new(poly_size, code_config);
             let params = ZipPlus::setup(poly_size, linear_code);
             let row_len = params.linear_code.row_len();
-            let poly = DenseMultilinearExtension::<<Zt as ZipTypes>::Eval>::rand(
-                P,
-                &mut rng,
-                Zero::zero(),
-            );
+            let poly = DenseMultilinearExtension::<<Zt as ZipTypes>::Eval>::rand(P, &mut rng);
             b.iter(|| {
                 let cw = ZipPlus::encode_rows(&params, row_len, &poly.evaluations);
                 black_box(cw)
@@ -183,7 +179,7 @@ pub fn commit<Zt: ZipTypes, Lc: LinearCode<Zt>, const P: usize>(
             b.iter_custom(|iters| {
                 let mut total_duration = Duration::ZERO;
                 for _ in 0..iters {
-                    let poly = DenseMultilinearExtension::rand(P, &mut rng, Zero::zero());
+                    let poly = DenseMultilinearExtension::rand(P, &mut rng);
                     let timer = Instant::now();
                     let res = ZipPlus::commit(&params, &poly).expect("Failed to commit");
                     black_box(res);
@@ -208,7 +204,7 @@ pub fn test<Zt: ZipTypes, Lc: LinearCode<Zt>, const P: usize>(
     let linear_code = Lc::new(poly_size, code_config);
     let params = ZipPlus::setup(poly_size, linear_code);
 
-    let poly = DenseMultilinearExtension::rand(P, &mut rng, Zero::zero());
+    let poly = DenseMultilinearExtension::rand(P, &mut rng);
     let (data, _) = ZipPlus::commit(&params, &poly).unwrap();
 
     group.bench_function(
@@ -243,7 +239,7 @@ pub fn evaluate<Zt: ZipTypes, Lc: LinearCode<Zt>, const P: usize>(
     let linear_code = Lc::new(poly_size, code_config);
     let params = ZipPlus::setup(poly_size, linear_code);
 
-    let poly = DenseMultilinearExtension::rand(P, &mut rng, Zero::zero());
+    let poly = DenseMultilinearExtension::rand(P, &mut rng);
     let (data, _) = ZipPlus::commit(&params, &poly).unwrap();
     let point = vec![Zt::Pt::one(); P];
 
@@ -289,7 +285,7 @@ pub fn verify<Zt: ZipTypes, Lc: LinearCode<Zt>, const P: usize>(
     let linear_code = Lc::new(poly_size, code_config);
     let params = ZipPlus::setup(poly_size, linear_code);
 
-    let poly = DenseMultilinearExtension::rand(P, &mut rng, Zero::zero());
+    let poly = DenseMultilinearExtension::rand(P, &mut rng);
     let (data, commitment) = ZipPlus::commit(&params, &poly).unwrap();
     let point = vec![Zt::Pt::one(); P];
 

--- a/zip-plus/src/pcs/phase_verify.rs
+++ b/zip-plus/src/pcs/phase_verify.rs
@@ -863,7 +863,7 @@ mod tests {
             let linear_code = C::new(poly_size, RAA_CFG);
             let pp = TestZip::setup(poly_size, linear_code);
 
-            let mle = DenseMultilinearExtension::rand(P, &mut rng, Zero::zero());
+            let mle = DenseMultilinearExtension::rand(P, &mut rng);
             let (data, commitment) = TestZip::commit(&pp, &mle).expect("commit");
 
             // Same point choice as the bench
@@ -901,7 +901,7 @@ mod tests {
             let linear_code = PolyC::new(poly_size, RAA_CFG);
             let pp = TestPolyZip::setup(poly_size, linear_code);
 
-            let mle = DenseMultilinearExtension::rand(P, &mut rng, Zero::zero());
+            let mle = DenseMultilinearExtension::rand(P, &mut rng);
             let (data, commitment) = TestPolyZip::commit(&pp, &mle).expect("commit");
 
             // Same point choice as the bench


### PR DESCRIPTION
Although the name suggests this hierarchy `MultilinearExtensionRand` doesn't rely on any evaluation stuff. It's just a constructor. So, I suggest we make it a red herring.

Also we don't need `zero` argument since we don't need to pad - the size is already a power of two!