### PR TITLE
Lift `Output` in `InnerProduct` to generic parameters

### DIFF
--- a/poly/src/univariate/binary.rs
+++ b/poly/src/univariate/binary.rs
@@ -1,9 +1,12 @@
 //! Dense polynomial with binary coefficients.
-use std::{fmt::Debug, ops::BitAnd};
+use std::{
+    fmt::Debug,
+    ops::{Add, BitAnd},
+};
 
 use crypto_primitives::PrimeField;
 use itertools::Itertools;
-use num_traits::{CheckedAdd, ConstOne, ConstZero};
+use num_traits::{ConstOne, ConstZero};
 use rand::distr::{Distribution, StandardUniform};
 use zinc_utils::{
     inner_product::{InnerProduct, InnerProductError},
@@ -146,24 +149,23 @@ impl<T: BinaryPolyCarrier, F: PrimeField + 'static> ProjectableToField<F> for Bi
     }
 }
 
-impl<T, R> InnerProduct<R> for BinaryPoly<T>
+impl<T, R, Out> InnerProduct<R, Out> for BinaryPoly<T>
 where
     T: BinaryPolyCarrier,
-    R: CheckedAdd,
+    R: Clone,
+    Out: for<'a> Add<&'a Out, Output = Out> + From<R>,
 {
-    type Output = R;
+    fn inner_product(&self, rhs: &[R], zero: Out) -> Result<Out, InnerProductError> {
+        if rhs.len() != T::BIT_SIZE as usize {
+            return Err(InnerProductError::LengthMismatch {
+                lhs: T::BIT_SIZE as usize,
+                rhs: rhs.len(),
+            });
+        }
 
-    fn inner_product(
-        &self,
-        rhs: &[R],
-        zero: Self::Output,
-    ) -> Result<Self::Output, InnerProductError> {
-        (0..T::BIT_SIZE)
+        Ok((0..T::BIT_SIZE)
             .filter(|&i| !self.is_zero_term(i))
-            .try_fold(zero, |acc, i| {
-                acc.checked_add(&rhs[i as usize])
-                    .ok_or(InnerProductError::Overflow)
-            })
+            .fold(zero, |acc, i| acc.add(&(rhs[i as usize].clone().into()))))
     }
 }
 

--- a/poly/src/univariate/dense.rs
+++ b/poly/src/univariate/dense.rs
@@ -539,18 +539,13 @@ impl<R, const DEGREE_PLUS_ONE: usize> AsRef<[R]> for DensePolynomial<R, DEGREE_P
     }
 }
 
-impl<R, Rhs, Out, const DEGREE_PLUS_ONE: usize> InnerProduct<Rhs>
+impl<R, Rhs, Out, const DEGREE_PLUS_ONE: usize> InnerProduct<Rhs, Out>
     for DensePolynomial<R, DEGREE_PLUS_ONE>
 where
-    for<'a> &'a [R]: InnerProduct<Rhs, Output = Out>,
+    for<'a> &'a [R]: InnerProduct<Rhs, Out>,
 {
-    type Output = Out;
-
-    fn inner_product(
-        &self,
-        rhs: &[Rhs],
-        zero: Self::Output,
-    ) -> Result<Self::Output, InnerProductError> {
+    #[inline]
+    fn inner_product(&self, rhs: &[Rhs], zero: Out) -> Result<Out, InnerProductError> {
         self.as_ref().inner_product(rhs, zero)
     }
 }

--- a/utils/src/inner_product.rs
+++ b/utils/src/inner_product.rs
@@ -1,20 +1,13 @@
-use crypto_primitives::crypto_bigint_int::Int;
+use crypto_primitives::{boolean::Boolean, crypto_bigint_int::Int};
 use num_traits::CheckedAdd;
 use thiserror::Error;
 
-use crate::mul_by_scalar::MulByScalar;
+use crate::{from_ref::FromRef, mul_by_scalar::MulByScalar};
 
 /// A trait for types that can be dot-multiplied.
-pub trait InnerProduct<Rhs> {
-    /// The resulting type we get after the inner product.
-    type Output;
-
+pub trait InnerProduct<Rhs, Output> {
     /// The main entry point for the inner product.
-    fn inner_product(
-        &self,
-        rhs: &[Rhs],
-        zero: Self::Output,
-    ) -> Result<Self::Output, InnerProductError>;
+    fn inner_product(&self, rhs: &[Rhs], zero: Output) -> Result<Output, InnerProductError>;
 }
 
 #[derive(Clone, Debug, PartialEq, Error)]
@@ -25,62 +18,80 @@ pub enum InnerProductError {
     Overflow,
 }
 
-impl<Lhs, Rhs> InnerProduct<Rhs> for &[Lhs]
+impl<Lhs, Rhs, Out> InnerProduct<Rhs, Out> for &[Lhs]
 where
-    Lhs: Clone + CheckedAdd + for<'z> MulByScalar<&'z Rhs>,
+    Lhs: CheckedAdd + for<'a> MulByScalar<&'a Rhs>,
+    Out: From<Lhs> + CheckedAdd,
 {
-    type Output = Lhs;
-
-    fn inner_product(&self, rhs: &[Rhs], zero: Lhs) -> Result<Self::Output, InnerProductError> {
+    fn inner_product(&self, rhs: &[Rhs], zero: Out) -> Result<Out, InnerProductError> {
         self.iter()
             .zip(rhs)
             .map(|(lhs, rhs)| lhs.mul_by_scalar(rhs).ok_or(InnerProductError::Overflow))
-            .reduce(|acc, product| {
-                acc?.checked_add(&product?)
+            .try_fold(zero, |acc, product| {
+                acc.checked_add(&product?.into())
                     .ok_or(InnerProductError::Overflow)
             })
-            .unwrap_or(Ok(zero))
     }
 }
 
-impl<Lhs, Rhs> InnerProduct<Rhs> for Vec<Lhs>
+impl<Lhs, Rhs, Out> InnerProduct<Rhs, Out> for Vec<Lhs>
 where
-    for<'a> &'a [Lhs]: InnerProduct<Rhs, Output = Lhs>,
+    for<'a> &'a [Lhs]: InnerProduct<Rhs, Out>,
 {
-    type Output = Lhs;
-
     #[inline]
-    fn inner_product(&self, rhs: &[Rhs], zero: Lhs) -> Result<Self::Output, InnerProductError> {
+    fn inner_product(&self, rhs: &[Rhs], zero: Out) -> Result<Out, InnerProductError> {
         self.as_slice().inner_product(rhs, zero)
     }
 }
 
-impl<Lhs, Rhs, const N: usize> InnerProduct<Rhs> for [Lhs; N]
+impl<Lhs, Rhs, Out, const N: usize> InnerProduct<Rhs, Out> for [Lhs; N]
 where
-    for<'a> &'a [Lhs]: InnerProduct<Rhs, Output = Lhs>,
+    for<'a> &'a [Lhs]: InnerProduct<Rhs, Out>,
 {
-    type Output = Lhs;
-
     #[inline]
-    fn inner_product(&self, rhs: &[Rhs], zero: Lhs) -> Result<Self::Output, InnerProductError> {
+    fn inner_product(&self, rhs: &[Rhs], zero: Out) -> Result<Out, InnerProductError> {
         self.as_slice().inner_product(rhs, zero)
     }
 }
 
-impl<T, const LIMBS: usize> InnerProduct<T> for Int<LIMBS> {
-    type Output = Self;
-
-    fn inner_product(&self, point: &[T], _zero: Self) -> Result<Self::Output, InnerProductError> {
-        if !point.is_empty() {
-            // TODO: Do we really want the RHS be empty?
-            //       Or do we want it to be one point?
+impl<T, Out, const LIMBS: usize> InnerProduct<T, Out> for Int<LIMBS>
+where
+    Int<LIMBS>: for<'a> MulByScalar<&'a T>,
+    Out: FromRef<Self>,
+{
+    fn inner_product(&self, point: &[T], _zero: Out) -> Result<Out, InnerProductError> {
+        if point.len() != 1 {
             Err(InnerProductError::LengthMismatch {
-                lhs: 0,
+                lhs: 1,
                 rhs: point.len(),
             })
         } else {
-            Ok(*self)
+            Ok(Out::from_ref(
+                &self
+                    .mul_by_scalar(&point[0])
+                    .ok_or(InnerProductError::Overflow)?,
+            ))
         }
+    }
+}
+
+impl<const M: usize> InnerProduct<i128, Int<M>> for &[Boolean] {
+    /// If we have a slice of booleans we do not need to multiply at all.
+    /// The inner product is just a sum!
+    fn inner_product(&self, rhs: &[i128], zero: Int<M>) -> Result<Int<M>, InnerProductError> {
+        if self.len() != rhs.len() {
+            return Err(InnerProductError::LengthMismatch {
+                lhs: self.len(),
+                rhs: rhs.len(),
+            });
+        }
+
+        (0..self.len())
+            .filter(|&i| self[i].into_inner())
+            .try_fold(zero, |acc, i| {
+                acc.checked_add(&Int::from(rhs[i]))
+                    .ok_or(InnerProductError::Overflow)
+            })
     }
 }
 

--- a/utils/src/inner_product.rs
+++ b/utils/src/inner_product.rs
@@ -24,6 +24,13 @@ where
     Out: From<Lhs> + CheckedAdd,
 {
     fn inner_product(&self, rhs: &[Rhs], zero: Out) -> Result<Out, InnerProductError> {
+        if self.len() != rhs.len() {
+            return Err(InnerProductError::LengthMismatch {
+                lhs: self.len(),
+                rhs: rhs.len(),
+            });
+        }
+
         self.iter()
             .zip(rhs)
             .map(|(lhs, rhs)| lhs.mul_by_scalar(rhs).ok_or(InnerProductError::Overflow))
@@ -75,10 +82,13 @@ where
     }
 }
 
-impl<const M: usize> InnerProduct<i128, Int<M>> for &[Boolean] {
+impl<Out> InnerProduct<i128, Out> for &[Boolean]
+where
+    Out: CheckedAdd + From<i128>,
+{
     /// If we have a slice of booleans we do not need to multiply at all.
     /// The inner product is just a sum!
-    fn inner_product(&self, rhs: &[i128], zero: Int<M>) -> Result<Int<M>, InnerProductError> {
+    fn inner_product(&self, rhs: &[i128], zero: Out) -> Result<Out, InnerProductError> {
         if self.len() != rhs.len() {
             return Err(InnerProductError::LengthMismatch {
                 lhs: self.len(),
@@ -89,7 +99,7 @@ impl<const M: usize> InnerProduct<i128, Int<M>> for &[Boolean] {
         (0..self.len())
             .filter(|&i| self[i].into_inner())
             .try_fold(zero, |acc, i| {
-                acc.checked_add(&Int::from(rhs[i]))
+                acc.checked_add(&Out::from(rhs[i]))
                     .ok_or(InnerProductError::Overflow)
             })
     }

--- a/zip-plus/src/pcs/phase_test.rs
+++ b/zip-plus/src/pcs/phase_test.rs
@@ -10,11 +10,13 @@ use crate::{
     utils::combine_rows,
 };
 use itertools::Itertools;
+use num_traits::{ConstOne, ConstZero, Zero};
 use zinc_poly::{Polynomial, mle::DenseMultilinearExtension};
 use zinc_transcript::traits::Transcript;
 use zinc_utils::{from_ref::FromRef, inner_product::InnerProduct};
 
 impl<Zt: ZipTypes, Lc: LinearCode<Zt>> ZipPlus<Zt, Lc> {
+    #[allow(clippy::arithmetic_side_effects)]
     pub fn test(
         pp: &ZipPlusParams<Zt, Lc>,
         poly: &DenseMultilinearExtension<Zt::Eval>,
@@ -27,9 +29,19 @@ impl<Zt: ZipTypes, Lc: LinearCode<Zt>> ZipPlus<Zt, Lc> {
         // If we can take linear combinations, perform the proximity test
         if pp.num_rows > 1 {
             // Values to evaluate the coefficients at
-            let alphas = transcript
-                .fs_transcript
-                .get_challenges::<Zt::Chal>(Zt::Comb::DEGREE_BOUND);
+            let alphas = if Zt::Comb::DEGREE_BOUND.is_zero() {
+                // If we have just one coefficient
+                // we don't take an RLC.
+                vec![Zt::Chal::ONE]
+            } else {
+                transcript
+                    .fs_transcript
+                    // NB: To take an inner product of coeffs
+                    // of a polynomial with the non-strict degree bound B
+                    // with a slice of challenges
+                    // we need to sample B + 1 challenges.
+                    .get_challenges::<Zt::Chal>(Zt::Comb::DEGREE_BOUND + 1)
+            };
 
             // Coefficients for the linear combination of polynomial with evaluated
             // coefficients
@@ -41,7 +53,7 @@ impl<Zt: ZipTypes, Lc: LinearCode<Zt>> ZipPlus<Zt, Lc> {
                 .evaluations
                 .iter()
                 .map(Zt::Comb::from_ref)
-                .map(|p| p.inner_product(&alphas, Zt::CombR::from(0)))
+                .map(|p| p.inner_product(&alphas, Zt::CombR::ZERO))
                 .try_collect()?;
 
             // u' in the Zinc paper

--- a/zip-plus/src/pcs/phase_verify.rs
+++ b/zip-plus/src/pcs/phase_verify.rs
@@ -9,9 +9,9 @@ use crate::{
     },
     pcs_transcript::PcsTranscript,
 };
-use crypto_bigint::ConstZero;
 use crypto_primitives::{FromWithConfig, IntoWithConfig, PrimeField};
 use itertools::Itertools;
+use num_traits::{ConstOne, ConstZero, Zero};
 use zinc_poly::Polynomial;
 use zinc_transcript::traits::{Transcribable, Transcript};
 use zinc_utils::{
@@ -63,7 +63,7 @@ impl<Zt: ZipTypes, Lc: LinearCode<Zt>> ZipPlus<Zt, Lc> {
         Ok(())
     }
 
-    #[allow(clippy::type_complexity)]
+    #[allow(clippy::arithmetic_side_effects, clippy::type_complexity)]
     pub(super) fn verify_testing(
         vp: &ZipPlusParams<Zt, Lc>,
         root: &MtHash,
@@ -73,9 +73,19 @@ impl<Zt: ZipTypes, Lc: LinearCode<Zt>> ZipPlus<Zt, Lc> {
         let encoded_combined_rows: Option<(Vec<Zt::Chal>, Vec<Zt::Chal>, Vec<Zt::CombR>)> = {
             if vp.num_rows > 1 {
                 // Values to evaluate the coefficients at
-                let alphas = transcript
-                    .fs_transcript
-                    .get_challenges(Zt::Comb::DEGREE_BOUND);
+                let alphas = if Zt::Comb::DEGREE_BOUND.is_zero() {
+                    // If we have just one coefficient
+                    // we don't take an RLC.
+                    vec![Zt::Chal::ONE]
+                } else {
+                    transcript
+                        .fs_transcript
+                        // NB: To take an inner product of coeffs
+                        // of a polynomial with the non-strict degree bound B
+                        // with a slice of challenges
+                        // we need to sample B + 1 challenges.
+                        .get_challenges::<Zt::Chal>(Zt::Comb::DEGREE_BOUND + 1)
+                };
 
                 // Coefficients for the linear combination of polynomial with evaluated
                 // coefficients

--- a/zip-plus/src/pcs/structs.rs
+++ b/zip-plus/src/pcs/structs.rs
@@ -46,7 +46,7 @@ pub trait ZipTypes: Send + Sync {
     /// wide as the evaluation, codeword, and challenge rings.
     type Comb: FixedSemiring
         + Polynomial<Self::CombR>
-        + InnerProduct<Self::Chal, Output = Self::CombR>
+        + InnerProduct<Self::Chal, Self::CombR>
         + FromRef<Self::Eval>
         + FromRef<Self::Cw>
         + Named;


### PR DESCRIPTION
* Now it's possible to define inner products with different resulting types for the same input arguments. It's convenient when we want to enlarge the bit width of the result (e.g. `i128` -> `Int<M>`).

* IMPORTANT: this PR also increments the number of `alphas` drawn at the testing phase. Previously, we would take the linear combination `1 * p_0 + \alpha_0 * p_1 + ... + \alpha_{DEGREE_BOUND - 1} * p_{DEGREE_BOUND}`. Now we do `\alpha_0 * p_0 + \alpha_1 * p_1 + ... + \alpha_{DEGREE_BOUND} * p_{DEGREE_BOUND}`.