### PR TITLE
Test phase optimisation

### DIFF
--- a/utils/src/inner_product.rs
+++ b/utils/src/inner_product.rs
@@ -1,5 +1,5 @@
 use crypto_primitives::{boolean::Boolean, crypto_bigint_int::Int};
-use num_traits::{CheckedAdd, CheckedMul};
+use num_traits::{CheckedAdd, CheckedMul, One, Zero};
 use thiserror::Error;
 
 use crate::{from_ref::FromRef, mul_by_scalar::MulByScalar};
@@ -66,18 +66,29 @@ macro_rules! impl_inner_product_for_primitives {
        $(
            impl<T, Out> InnerProduct<T, Out> for $t
            where
-               Out: From<$t> + for<'a> From<&'a T>,
-               Out: CheckedMul,
+               T: Zero + One + PartialEq,
+               Out: Zero + One + From<$t> + for<'a> From<&'a T> + CheckedMul,
            {
                 fn inner_product(&self, point: &[T], _zero: Out) -> Result<Out, InnerProductError> {
                         if point.len() != 1 {
-                            Err(InnerProductError::LengthMismatch {
+                            return Err(InnerProductError::LengthMismatch {
                                 lhs: 1,
                                 rhs: point.len(),
-                            })
-                        } else {
-                            Ok(Out::from(*self).checked_mul(&Out::from(&point[0])).ok_or(InnerProductError::Overflow)?)
+                            });
                         }
+
+                        if point[0].is_one() {
+                            return Ok(Out::from(*self))
+                        }
+
+
+                        if point[0].is_zero() {
+                            return Ok(Out::zero());
+                        }
+
+
+                        Out::from(*self).checked_mul(&Out::from(&point[0])).ok_or(InnerProductError::Overflow)
+
                     }
            }
        )*

--- a/utils/src/inner_product.rs
+++ b/utils/src/inner_product.rs
@@ -1,5 +1,5 @@
 use crypto_primitives::{boolean::Boolean, crypto_bigint_int::Int};
-use num_traits::CheckedAdd;
+use num_traits::{CheckedAdd, CheckedMul};
 use thiserror::Error;
 
 use crate::{from_ref::FromRef, mul_by_scalar::MulByScalar};
@@ -60,6 +60,31 @@ where
         self.as_slice().inner_product(rhs, zero)
     }
 }
+
+macro_rules! impl_inner_product_for_primitives {
+    ($($t:ty),*) => {
+       $(
+           impl<T, Out> InnerProduct<T, Out> for $t
+           where
+               Out: From<$t> + for<'a> From<&'a T>,
+               Out: CheckedMul,
+           {
+                fn inner_product(&self, point: &[T], _zero: Out) -> Result<Out, InnerProductError> {
+                        if point.len() != 1 {
+                            Err(InnerProductError::LengthMismatch {
+                                lhs: 1,
+                                rhs: point.len(),
+                            })
+                        } else {
+                            Ok(Out::from(*self).checked_mul(&Out::from(&point[0])).ok_or(InnerProductError::Overflow)?)
+                        }
+                    }
+           }
+       )*
+    };
+}
+
+impl_inner_product_for_primitives!(i8, i16, i32, i64, i128);
 
 impl<T, Out, const LIMBS: usize> InnerProduct<T, Out> for Int<LIMBS>
 where

--- a/utils/src/mul_by_scalar.rs
+++ b/utils/src/mul_by_scalar.rs
@@ -1,6 +1,6 @@
 use crate::from_ref::FromRef;
 use crypto_primitives::{boolean::Boolean, crypto_bigint_int::Int};
-use num_traits::CheckedMul;
+use num_traits::{CheckedMul, ConstZero};
 
 pub trait MulByScalar<Rhs>: Sized {
     /// Multiplies the current element by a scalar from the right (usually - a
@@ -46,8 +46,15 @@ macro_rules! impl_mul_int_by_primitive_scalar {
 
 impl_mul_int_by_primitive_scalar!(i8, i16, i32, i64, i128);
 
-impl MulByScalar<&Boolean> for i128 {
+impl<T> MulByScalar<&Boolean> for T
+where
+    T: Clone + ConstZero + From<Boolean>,
+{
     fn mul_by_scalar(&self, rhs: &Boolean) -> Option<Self> {
-        Some(if rhs.into_inner() { *self } else { 0 })
+        Some(if rhs.into_inner() {
+            self.clone()
+        } else {
+            ConstZero::ZERO
+        })
     }
 }

--- a/utils/src/mul_by_scalar.rs
+++ b/utils/src/mul_by_scalar.rs
@@ -1,5 +1,5 @@
 use crate::from_ref::FromRef;
-use crypto_primitives::crypto_bigint_int::Int;
+use crypto_primitives::{boolean::Boolean, crypto_bigint_int::Int};
 use num_traits::CheckedMul;
 
 pub trait MulByScalar<Rhs>: Sized {
@@ -45,3 +45,9 @@ macro_rules! impl_mul_int_by_primitive_scalar {
 }
 
 impl_mul_int_by_primitive_scalar!(i8, i16, i32, i64, i128);
+
+impl MulByScalar<&Boolean> for i128 {
+    fn mul_by_scalar(&self, rhs: &Boolean) -> Option<Self> {
+        Some(if rhs.into_inner() { *self } else { 0 })
+    }
+}

--- a/zip-plus/src/pcs/phase_test.rs
+++ b/zip-plus/src/pcs/phase_test.rs
@@ -13,7 +13,7 @@ use itertools::Itertools;
 use num_traits::{ConstOne, ConstZero, Zero};
 use zinc_poly::{Polynomial, mle::DenseMultilinearExtension};
 use zinc_transcript::traits::Transcript;
-use zinc_utils::{from_ref::FromRef, inner_product::InnerProduct};
+use zinc_utils::inner_product::InnerProduct;
 
 impl<Zt: ZipTypes, Lc: LinearCode<Zt>> ZipPlus<Zt, Lc> {
     #[allow(clippy::arithmetic_side_effects)]
@@ -52,7 +52,6 @@ impl<Zt: ZipTypes, Lc: LinearCode<Zt>> ZipPlus<Zt, Lc> {
             let evals: Vec<_> = poly
                 .evaluations
                 .iter()
-                .map(Zt::Comb::from_ref)
                 .map(|p| p.inner_product(&alphas, Zt::CombR::ZERO))
                 .try_collect()?;
 

--- a/zip-plus/src/pcs/structs.rs
+++ b/zip-plus/src/pcs/structs.rs
@@ -15,7 +15,12 @@ pub trait ZipTypes: Send + Sync {
     const NUM_COLUMN_OPENINGS: usize;
 
     /// Semiring of witness/polynomial evaluations on boolean hypercube
-    type Eval: FixedSemiring + Named + ConstCoeffBitWidth;
+    type Eval: Clone
+        + Send
+        + Sync
+        + Named
+        + ConstCoeffBitWidth
+        + InnerProduct<Self::Chal, Self::CombR>;
 
     /// Semiring of codeword elements, at least as wide as the evaluation ring
     type Cw: FixedSemiring

--- a/zip-plus/src/pcs/test_utils.rs
+++ b/zip-plus/src/pcs/test_utils.rs
@@ -113,7 +113,11 @@ fn setup_test_params_inner<Zt: ZipTypes, Lc: LinearCode<Zt, Config = RaaConfig>>
     let pp = ZipPlusParams::new(num_vars, num_rows, code);
 
     let evaluations = prepare_evaluations(poly_size);
-    let poly = DenseMultilinearExtension::from_evaluations_vec(num_vars, evaluations, Zero::zero());
+    // We know the length of the evaluations is a power of two.
+    let poly = DenseMultilinearExtension {
+        num_vars,
+        evaluations,
+    };
 
     (pp, poly)
 }


### PR DESCRIPTION
* Remove `.map(Zt::Comb::from_ref)` in
```rust
let evals: Vec<_> = poly
                .evaluations
                .iter()
                .map(Zt::Comb::from_ref)
                .map(|p| p.inner_product(&alphas, Zt::CombR::ZERO))
                .try_collect()?;
```
that regresses performance of the test phase. In the main benchmark, `Zt::Comb` is `DensePolynomial<Int<5>, D_PLUS_ONE>` and `Zt::Eval` is `DensePolynomial<Boolean, D_PLUS_ONE>`. So the conversion would erase the information that the coefficients of the polynomial are 0s or 1s, and a less optimal `inner_product` implementation would be used.

* Optimise trait constraints for `Eval` of `ZipTypes`. Now it's the bare minimum of what we need to know about `Eval`.