### PR TITLE
Fix bug in `prepare_projection` for `BinaryPoly<u64>`

### DIFF
--- a/poly/src/univariate/binary.rs
+++ b/poly/src/univariate/binary.rs
@@ -277,6 +277,24 @@ mod test {
     }
 
     #[test]
+    fn test_projection_64() {
+        let x = FMonty::from_with_cfg(2, &test_monty_config());
+
+        let v = ((u64::MAX - 1024)..u64::MAX)
+            .map(BinaryPoly::<u64>::from)
+            .collect_vec();
+
+        let project = BinaryPoly::<u64>::prepare_projection(&x);
+
+        for (i, el) in v.iter().enumerate() {
+            assert_eq!(
+                project(el),
+                FMonty::from_with_cfg((u64::MAX - 1024) + i as u64, &test_monty_config())
+            );
+        }
+    }
+
+    #[test]
     fn binary_poly_inner_product() {
         let rhs = (0..32)
             .map(|i| FMonty::from_with_cfg(i, &test_monty_config()))

--- a/poly/src/univariate/binary.rs
+++ b/poly/src/univariate/binary.rs
@@ -128,7 +128,7 @@ impl<T: BinaryPolyCarrier, F: PrimeField + 'static> ProjectableToField<F> for Bi
             let mut curr = F::one_with_cfg(&field_cfg);
             r_powers.push(curr.clone());
 
-            for _ in 1..32 {
+            for _ in 1..T::BIT_SIZE {
                 curr *= sampled_value;
                 r_powers.push(curr.clone());
             }


### PR DESCRIPTION
The `prepare_projection` method didn't take into account the degree of the polynomial - `32` was hardcoded. 