### PR TITLE
`InnerProduct` and `ProjectableToField` traits reworked

### DIFF
--- a/poly/benches/binary_vs_ordinary.rs
+++ b/poly/benches/binary_vs_ordinary.rs
@@ -8,9 +8,12 @@ use crypto_primitives::{FromWithConfig, PrimeField, crypto_bigint_monty::F256};
 use itertools::Itertools;
 use zinc_poly::{
     EvaluatablePolynomial,
-    univariate::{binary::BinaryPoly, dense::DensePolynomial},
+    univariate::{
+        binary::{BinaryPoly, BinaryPolyProjectionToField},
+        dense::{DensePolynomial, HornerProjection},
+    },
 };
-use zinc_utils::projectable_to_field::ProjectableToField;
+use zinc_utils::projection_to_field::ProjectionToField;
 
 const LIMBS: usize = 4;
 
@@ -38,7 +41,7 @@ fn bench_dense_poly_projection(
         })
         .collect_vec();
 
-    let project = DensePolynomial::prepare_projection(&F::from_with_cfg(235325, &bench_config()));
+    let project = HornerProjection::prepare_projection(&F::from_with_cfg(235325, &bench_config()));
 
     group.bench_with_input(BenchmarkId::new("Project", "Dense version"), &v, |b, v| {
         b.iter(|| {
@@ -50,7 +53,8 @@ fn bench_dense_poly_projection(
 
     let v: Vec<BinaryPoly<u32>> = (0..1024).map(|i| i.into()).collect_vec();
 
-    let project = BinaryPoly::<u32>::prepare_projection(&F::from_with_cfg(235325, &bench_config()));
+    let project =
+        BinaryPolyProjectionToField::prepare_projection(&F::from_with_cfg(235325, &bench_config()));
 
     group.bench_with_input(BenchmarkId::new("Project", "Binary version"), &v, |b, v| {
         b.iter(|| {

--- a/poly/src/univariate/binary.rs
+++ b/poly/src/univariate/binary.rs
@@ -1,6 +1,7 @@
 //! Dense polynomial with binary coefficients.
 use std::{
     fmt::Debug,
+    marker::PhantomData,
     ops::{Add, BitAnd},
 };
 
@@ -149,22 +150,28 @@ impl<T: BinaryPolyCarrier, F: PrimeField + 'static> ProjectableToField<F> for Bi
     }
 }
 
-impl<T, R, Out> InnerProduct<R, Out> for BinaryPoly<T>
+pub struct BinaryPolyInnerProduct<T>(PhantomData<T>);
+
+impl<T, Rhs, Out> InnerProduct<BinaryPoly<T>, Rhs, Out> for BinaryPolyInnerProduct<T>
 where
     T: BinaryPolyCarrier,
-    R: Clone,
-    Out: for<'a> Add<&'a Out, Output = Out> + From<R>,
+    Rhs: Clone,
+    Out: for<'a> Add<&'a Out, Output = Out> + From<Rhs>,
 {
-    fn inner_product(&self, rhs: &[R], zero: Out) -> Result<Out, InnerProductError> {
-        if rhs.len() != T::BIT_SIZE as usize {
+    fn inner_product(
+        lhs: &BinaryPoly<T>,
+        rhs: &[Rhs],
+        zero: Out,
+    ) -> Result<Out, InnerProductError> {
+        if rhs.as_ref().len() != T::BIT_SIZE as usize {
             return Err(InnerProductError::LengthMismatch {
                 lhs: T::BIT_SIZE as usize,
-                rhs: rhs.len(),
+                rhs: rhs.as_ref().len(),
             });
         }
 
         Ok((0..T::BIT_SIZE)
-            .filter(|&i| !self.is_zero_term(i))
+            .filter(|&i| !lhs.is_zero_term(i))
             .fold(zero, |acc, i| acc.add(&(rhs[i as usize].clone().into()))))
     }
 }
@@ -211,7 +218,10 @@ mod test {
     use rand::distr::{Distribution, StandardUniform};
     use zinc_utils::{inner_product::InnerProduct, projectable_to_field::ProjectableToField};
 
-    use crate::{EvaluatablePolynomial, univariate::binary::BinaryPoly};
+    use crate::{
+        EvaluatablePolynomial,
+        univariate::binary::{BinaryPoly, BinaryPolyInnerProduct},
+    };
 
     const N: usize = 2;
 
@@ -305,9 +315,12 @@ mod test {
         // All odd coeffs are 1.
         let poly = BinaryPoly::<u32>::from(0b10101010101010101010101010101010);
 
-        let inner_product = poly
-            .inner_product(&rhs, FMonty::zero_with_cfg(&test_monty_config()))
-            .unwrap();
+        let inner_product = BinaryPolyInnerProduct::inner_product(
+            &poly,
+            &rhs,
+            FMonty::zero_with_cfg(&test_monty_config()),
+        )
+        .unwrap();
 
         // Sum of the odd numbers in the range [0, 31].
         let expected: FMonty = (0..32)

--- a/poly/src/univariate/binary.rs
+++ b/poly/src/univariate/binary.rs
@@ -12,7 +12,7 @@ use rand::distr::{Distribution, StandardUniform};
 use zinc_utils::{
     inner_product::{InnerProduct, InnerProductError},
     named::Named,
-    projectable_to_field::ProjectableToField,
+    projection_to_field::ProjectionToField,
 };
 
 use crate::{ConstCoeffBitWidth, EvaluatablePolynomial, EvaluationError, Polynomial};
@@ -119,9 +119,13 @@ impl<T: BinaryPolyCarrier, F: PrimeField> EvaluatablePolynomial<bool, F> for Bin
     }
 }
 
-impl<T: BinaryPolyCarrier, F: PrimeField + 'static> ProjectableToField<F> for BinaryPoly<T> {
+pub struct BinaryPolyProjectionToField<T: BinaryPolyCarrier>(PhantomData<T>);
+
+impl<T: BinaryPolyCarrier, F: PrimeField + 'static> ProjectionToField<BinaryPoly<T>, F>
+    for BinaryPolyProjectionToField<T>
+{
     #[allow(clippy::arithmetic_side_effects)]
-    fn prepare_projection(sampled_value: &F) -> impl Fn(&Self) -> F + 'static {
+    fn prepare_projection(sampled_value: &F) -> impl Fn(&BinaryPoly<T>) -> F + 'static {
         let field_cfg = sampled_value.cfg().clone();
         let r_powers = {
             // It makes sense to preprocess the powers here
@@ -216,11 +220,11 @@ mod test {
     };
     use itertools::Itertools;
     use rand::distr::{Distribution, StandardUniform};
-    use zinc_utils::{inner_product::InnerProduct, projectable_to_field::ProjectableToField};
+    use zinc_utils::{inner_product::InnerProduct, projection_to_field::ProjectionToField};
 
     use crate::{
         EvaluatablePolynomial,
-        univariate::binary::{BinaryPoly, BinaryPolyInnerProduct},
+        univariate::binary::{BinaryPoly, BinaryPolyInnerProduct, BinaryPolyProjectionToField},
     };
 
     const N: usize = 2;
@@ -244,7 +248,7 @@ mod test {
 
     #[test]
     fn test_project_onto_field() {
-        let project = BinaryPoly::<u32>::prepare_projection(&F::from(2));
+        let project = BinaryPolyProjectionToField::prepare_projection(&F::from(2));
         for i in 0..u32::from(u16::MAX) {
             assert_eq!(project(&BinaryPoly::from(i)), F::from(i));
         }
@@ -278,7 +282,7 @@ mod test {
 
         let v = (0..1024).map(BinaryPoly::<u32>::from).collect_vec();
 
-        let project = BinaryPoly::<u32>::prepare_projection(&x);
+        let project = BinaryPolyProjectionToField::prepare_projection(&x);
 
         for (i, el) in v.iter().enumerate() {
             assert_eq!(
@@ -296,7 +300,7 @@ mod test {
             .map(BinaryPoly::<u64>::from)
             .collect_vec();
 
-        let project = BinaryPoly::<u64>::prepare_projection(&x);
+        let project = BinaryPolyProjectionToField::prepare_projection(&x);
 
         for (i, el) in v.iter().enumerate() {
             assert_eq!(

--- a/poly/src/univariate/dense.rs
+++ b/poly/src/univariate/dense.rs
@@ -18,7 +18,7 @@ use zinc_utils::{
     inner_product::{InnerProduct, InnerProductError},
     mul_by_scalar::MulByScalar,
     named::Named,
-    projectable_to_field::ProjectableToField,
+    projection_to_field::ProjectionToField,
 };
 
 use super::binary::BinaryPoly;
@@ -497,18 +497,22 @@ where
     }
 }
 
-impl<R, F, const DEGREE_PLUS_ONE: usize> ProjectableToField<F>
-    for DensePolynomial<R, DEGREE_PLUS_ONE>
+pub struct HornerProjection<R, const DEGREE_PLUS_ONE: usize>(PhantomData<R>);
+
+impl<R, F, const DEGREE_PLUS_ONE: usize> ProjectionToField<DensePolynomial<R, DEGREE_PLUS_ONE>, F>
+    for HornerProjection<R, DEGREE_PLUS_ONE>
 where
     R: Semiring,
     F: PrimeField + for<'a> FromWithConfig<&'a R> + for<'a> MulByScalar<&'a F> + 'static,
 {
     #![allow(clippy::arithmetic_side_effects)] // False alert, field operations are safe
-    fn prepare_projection(sampled_value: &F) -> impl Fn(&Self) -> F + 'static {
+    fn prepare_projection(
+        sampled_value: &F,
+    ) -> impl Fn(&DensePolynomial<R, DEGREE_PLUS_ONE>) -> F + 'static {
         let sampled_value = sampled_value.clone();
         let field_cfg = sampled_value.cfg().clone();
 
-        move |poly: &Self| {
+        move |poly: &DensePolynomial<R, DEGREE_PLUS_ONE>| {
             let coeffs: [F; DEGREE_PLUS_ONE] = poly
                 .coeffs
                 .iter()
@@ -520,6 +524,43 @@ where
             poly2
                 .evaluate_at_point(&sampled_value)
                 .expect("Failed to evaluate polynomial at point")
+        }
+    }
+}
+
+pub struct InnerProductProjection<R, I, const DEGREE_PLUS_ONE: usize>(PhantomData<(R, I)>);
+
+impl<R, F, I, const DEGREE_PLUS_ONE: usize>
+    ProjectionToField<DensePolynomial<R, DEGREE_PLUS_ONE>, F>
+    for InnerProductProjection<R, I, DEGREE_PLUS_ONE>
+where
+    I: InnerProduct<[R], F, F>,
+    R: Semiring,
+    F: PrimeField + 'static,
+{
+    #![allow(clippy::arithmetic_side_effects)] // False alert, field operations are safe
+    fn prepare_projection(
+        sampled_value: &F,
+    ) -> impl Fn(&DensePolynomial<R, DEGREE_PLUS_ONE>) -> F + 'static {
+        let field_cfg = sampled_value.cfg().clone();
+        let r_powers = {
+            // Preprocess powers prior to inner product.
+            let mut r_powers = Vec::with_capacity(DEGREE_PLUS_ONE);
+
+            let mut curr = F::one_with_cfg(&field_cfg);
+            r_powers.push(curr.clone());
+
+            for _ in 1..DEGREE_PLUS_ONE {
+                curr *= sampled_value;
+                r_powers.push(curr.clone());
+            }
+
+            r_powers
+        };
+
+        move |poly: &DensePolynomial<R, DEGREE_PLUS_ONE>| {
+            I::inner_product(&poly.coeffs, &r_powers, F::zero_with_cfg(&field_cfg))
+                .expect("Failed to evaluate polynomial")
         }
     }
 }

--- a/poly/src/univariate/dense.rs
+++ b/poly/src/univariate/dense.rs
@@ -9,6 +9,7 @@ use std::{
     fmt::Display,
     hash::Hash,
     iter::{Product, Sum},
+    marker::PhantomData,
     ops::{Add, AddAssign, Mul, MulAssign, Neg, Sub, SubAssign},
 };
 use zinc_transcript::traits::ConstTranscribable;
@@ -539,14 +540,27 @@ impl<R, const DEGREE_PLUS_ONE: usize> AsRef<[R]> for DensePolynomial<R, DEGREE_P
     }
 }
 
-impl<R, Rhs, Out, const DEGREE_PLUS_ONE: usize> InnerProduct<Rhs, Out>
-    for DensePolynomial<R, DEGREE_PLUS_ONE>
+pub struct DensePolyInnerProduct<
+    R,
+    Rhs,
+    Out,
+    I: InnerProduct<[R], Rhs, Out>,
+    const DEGREE_PLUS_ONE: usize,
+>(PhantomData<(I, R, Rhs, Out)>);
+
+impl<R, Rhs, Out, I, const DEGREE_PLUS_ONE: usize>
+    InnerProduct<DensePolynomial<R, DEGREE_PLUS_ONE>, Rhs, Out>
+    for DensePolyInnerProduct<R, Rhs, Out, I, DEGREE_PLUS_ONE>
 where
-    for<'a> &'a [R]: InnerProduct<Rhs, Out>,
+    I: InnerProduct<[R], Rhs, Out>,
 {
-    #[inline]
-    fn inner_product(&self, rhs: &[Rhs], zero: Out) -> Result<Out, InnerProductError> {
-        self.as_ref().inner_product(rhs, zero)
+    #[inline(always)]
+    fn inner_product(
+        lhs: &DensePolynomial<R, DEGREE_PLUS_ONE>,
+        rhs: &[Rhs],
+        zero: Out,
+    ) -> Result<Out, InnerProductError> {
+        I::inner_product(&lhs.coeffs, rhs, zero)
     }
 }
 

--- a/utils/src/field/boxed_monty.rs
+++ b/utils/src/field/boxed_monty.rs
@@ -1,13 +1,8 @@
 use crypto_bigint::BoxedUint;
-use crypto_primitives::{
-    FromWithConfig, IntoWithConfig, PrimeField, crypto_bigint_boxed_monty::BoxedMontyField,
-    crypto_bigint_uint::Uint,
-};
+use crypto_primitives::{crypto_bigint_boxed_monty::BoxedMontyField, crypto_bigint_uint::Uint};
 use num_traits::CheckedMul;
 
-use crate::{
-    from_ref::FromRef, mul_by_scalar::MulByScalar, projectable_to_field::ProjectableToField,
-};
+use crate::{from_ref::FromRef, mul_by_scalar::MulByScalar};
 
 impl MulByScalar<&Self> for BoxedMontyField {
     fn mul_by_scalar(&self, rhs: &Self) -> Option<Self> {
@@ -25,18 +20,6 @@ impl<const LIMBS: usize> FromRef<Uint<LIMBS>> for BoxedUint {
     #[inline]
     fn from_ref(value: &Uint<LIMBS>) -> Self {
         value.inner().into()
-    }
-}
-
-impl<T> ProjectableToField<BoxedMontyField> for T
-where
-    BoxedMontyField: for<'a> FromWithConfig<&'a T>,
-{
-    fn prepare_projection(
-        sampled_value: &BoxedMontyField,
-    ) -> impl Fn(&Self) -> BoxedMontyField + 'static {
-        let config = sampled_value.cfg().clone();
-        move |value: &T| value.into_with_cfg(&config)
     }
 }
 

--- a/utils/src/field/const_monty.rs
+++ b/utils/src/field/const_monty.rs
@@ -1,12 +1,8 @@
 use crypto_bigint::modular::{ConstMontyForm, ConstMontyParams};
-use crypto_primitives::{
-    crypto_bigint_const_monty::ConstMontyField, crypto_bigint_int::Int, crypto_bigint_uint::Uint,
-};
+use crypto_primitives::{crypto_bigint_const_monty::ConstMontyField, crypto_bigint_uint::Uint};
 use num_traits::CheckedMul;
 
-use crate::{
-    from_ref::FromRef, mul_by_scalar::MulByScalar, projectable_to_field::ProjectableToField,
-};
+use crate::{from_ref::FromRef, mul_by_scalar::MulByScalar};
 
 impl<Mod: ConstMontyParams<LIMBS>, const LIMBS: usize> MulByScalar<&Self>
     for ConstMontyField<Mod, LIMBS>
@@ -46,17 +42,6 @@ impl<Mod: ConstMontyParams<LIMBS>, const LIMBS: usize> FromRef<Self>
     }
 }
 
-impl<Mod: ConstMontyParams<LIMBS>, const LIMBS: usize, const LIMBS2: usize>
-    ProjectableToField<ConstMontyField<Mod, LIMBS>> for Int<LIMBS2>
-{
-    fn prepare_projection(
-        _sampled_value: &ConstMontyField<Mod, LIMBS>,
-    ) -> impl Fn(&Self) -> ConstMontyField<Mod, LIMBS> + 'static {
-        // No need to read anything
-        |value: &Int<LIMBS2>| value.into()
-    }
-}
-
 #[cfg(test)]
 #[allow(
     clippy::arithmetic_side_effects,
@@ -64,6 +49,8 @@ impl<Mod: ConstMontyParams<LIMBS>, const LIMBS: usize, const LIMBS2: usize>
     clippy::cast_possible_wrap
 )]
 mod tests {
+    use crate::projection_to_field::{ProjectionToField, SimpleProjection};
+
     use super::*;
 
     use crypto_bigint::{U128, U256, const_monty_params};
@@ -83,8 +70,7 @@ mod tests {
         // Create a sample field element and an Int value
         let sampled = F::from(5_u64);
 
-        let projection_fn =
-            <Int<{ U128::LIMBS }> as ProjectableToField<F>>::prepare_projection(&sampled);
+        let projection_fn = SimpleProjection::prepare_projection(&sampled);
 
         let int_value = Int::<{ U128::LIMBS }>::from(10_i64);
         let result = projection_fn(&int_value);

--- a/utils/src/field/monty.rs
+++ b/utils/src/field/monty.rs
@@ -1,11 +1,7 @@
-use crypto_primitives::{
-    FromWithConfig, IntoWithConfig, PrimeField, crypto_bigint_monty::MontyField,
-};
+use crypto_primitives::crypto_bigint_monty::MontyField;
 use num_traits::CheckedMul;
 
-use crate::{
-    from_ref::FromRef, mul_by_scalar::MulByScalar, projectable_to_field::ProjectableToField,
-};
+use crate::{from_ref::FromRef, mul_by_scalar::MulByScalar};
 
 impl<const LIMBS: usize> MulByScalar<&Self> for MontyField<LIMBS> {
     fn mul_by_scalar(&self, rhs: &Self) -> Option<Self> {
@@ -16,18 +12,6 @@ impl<const LIMBS: usize> MulByScalar<&Self> for MontyField<LIMBS> {
 impl<const LIMBS: usize> FromRef<Self> for MontyField<LIMBS> {
     fn from_ref(value: &Self) -> Self {
         value.clone()
-    }
-}
-
-impl<T, const LIMBS: usize> ProjectableToField<MontyField<LIMBS>> for T
-where
-    MontyField<LIMBS>: for<'a> FromWithConfig<&'a T>,
-{
-    fn prepare_projection(
-        sampled_value: &MontyField<LIMBS>,
-    ) -> impl Fn(&Self) -> MontyField<LIMBS> + 'static {
-        let config = sampled_value.cfg().clone();
-        move |value: &T| value.into_with_cfg(&config)
     }
 }
 

--- a/utils/src/inner_product.rs
+++ b/utils/src/inner_product.rs
@@ -1,3 +1,5 @@
+use std::ops::Add;
+
 use crypto_primitives::boolean::Boolean;
 use num_traits::CheckedAdd;
 use thiserror::Error;
@@ -76,12 +78,12 @@ where
 /// The inner product for slices containing `Boolean` elements.
 /// Does `checked_add` to sum the elements of the RHS that
 /// correspond to `true` elements of the boolean slice.
-pub struct BooleanInnerProduct;
+pub struct BooleanInnerProductCheckedAdd;
 
 impl<Rhs: Clone, Out: From<Rhs> + CheckedAdd> InnerProduct<[Boolean], Rhs, Out>
-    for BooleanInnerProduct
+    for BooleanInnerProductCheckedAdd
 {
-    /// Boolean inner product.
+    /// Boolean checked inner product.
     fn inner_product(lhs: &[Boolean], rhs: &[Rhs], zero: Out) -> Result<Out, InnerProductError> {
         if lhs.len() != rhs.as_ref().len() {
             return Err(InnerProductError::LengthMismatch {
@@ -99,8 +101,35 @@ impl<Rhs: Clone, Out: From<Rhs> + CheckedAdd> InnerProduct<[Boolean], Rhs, Out>
     }
 }
 
+/// Does the unchecked `add` to sum the elements of the RHS that
+/// correspond to `true` elements of the boolean slice.
+/// Convenient for performing inner product with field elements
+/// whose `add` is safe and does not overflow.
+pub struct BooleanInnerProductUncheckedAdd;
+impl<Rhs: Clone, Out: From<Rhs> + for<'a> Add<&'a Rhs, Output = Out>>
+    InnerProduct<[Boolean], Rhs, Out> for BooleanInnerProductUncheckedAdd
+{
+    #[allow(clippy::arithmetic_side_effects)]
+    fn inner_product(lhs: &[Boolean], rhs: &[Rhs], zero: Out) -> Result<Out, InnerProductError> {
+        if lhs.len() != rhs.as_ref().len() {
+            return Err(InnerProductError::LengthMismatch {
+                lhs: lhs.len(),
+                rhs: rhs.as_ref().len(),
+            });
+        }
+
+        Ok((0..lhs.len())
+            .filter(|&i| lhs[i].into_inner())
+            .fold(zero, |acc, i| acc + &rhs[i]))
+    }
+}
+
 #[cfg(test)]
 mod test {
+    use crypto_bigint::{U64, const_monty_params};
+    use crypto_primitives::crypto_bigint_const_monty::ConstMontyField;
+    use num_traits::ConstZero;
+
     use super::*;
 
     #[test]
@@ -125,7 +154,7 @@ mod test {
     }
 
     #[test]
-    fn boolean_eq_mbs_inner_product() {
+    fn boolean_checked_eq_mbs_inner_product() {
         let lhs = [
             Boolean::from(true),
             Boolean::from(false),
@@ -135,8 +164,31 @@ mod test {
         let rhs = [1i128, 2, 3, 4];
 
         assert_eq!(
-            BooleanInnerProduct::inner_product(&lhs, &rhs, 0),
+            BooleanInnerProductCheckedAdd::inner_product(&lhs, &rhs, 0),
             MBSInnerProduct::inner_product(&rhs, &lhs, 0i128)
+        );
+    }
+
+    const_monty_params!(Params, U64, "0000000000000007");
+
+    #[test]
+    fn boolean_unchecked_eq_boolean_checked() {
+        let lhs = [
+            Boolean::from(true),
+            Boolean::from(false),
+            Boolean::from(true),
+            Boolean::from(true),
+        ];
+        let rhs = [
+            ConstMontyField::<Params, 1>::from(1),
+            ConstMontyField::<Params, 1>::from(2),
+            ConstMontyField::<Params, 1>::from(3),
+            ConstMontyField::<Params, 1>::from(4),
+        ];
+
+        assert_eq!(
+            BooleanInnerProductCheckedAdd::inner_product(&lhs, &rhs, ConstMontyField::ZERO),
+            BooleanInnerProductUncheckedAdd::inner_product(&lhs, &rhs, ConstMontyField::ZERO)
         );
     }
 }

--- a/utils/src/inner_product.rs
+++ b/utils/src/inner_product.rs
@@ -1,4 +1,4 @@
-use std::ops::Add;
+use std::ops::{Add, Mul};
 
 use crypto_primitives::boolean::Boolean;
 use num_traits::CheckedAdd;
@@ -24,11 +24,11 @@ pub enum InnerProductError {
 /// on the `MulByScalar` and `CheckedAdd` traits.
 /// It does `mul_by_scalar` for products of terms
 /// and then combines the results using `checked_add`.
-pub struct MBSInnerProduct;
+pub struct MBSInnerProductChecked;
 
-impl<Lhs, Rhs, Out> InnerProduct<[Lhs], Rhs, Out> for MBSInnerProduct
+impl<Lhs, Rhs, Out> InnerProduct<[Lhs], Rhs, Out> for MBSInnerProductChecked
 where
-    Lhs: CheckedAdd + for<'a> MulByScalar<&'a Rhs>,
+    Lhs: for<'a> MulByScalar<&'a Rhs>,
     Out: From<Lhs> + CheckedAdd,
 {
     /// The mul-by-scalar inner product.
@@ -47,6 +47,35 @@ where
                 acc.checked_add(&product?.into())
                     .ok_or(InnerProductError::Overflow)
             })
+    }
+}
+
+/// An implementation of inner product that piggies back
+/// on the `MulByScalar` and `Add` traits.
+/// It does `mul_by_scalar` for products of terms
+/// and then combines the results using `add`.
+pub struct MBSInnerProductUnchecked;
+
+impl<Lhs, Rhs, Out> InnerProduct<[Lhs], Rhs, Out> for MBSInnerProductUnchecked
+where
+    Lhs: Clone + for<'a> Mul<&'a Rhs, Output = Lhs>,
+    Out: for<'a> Add<&'a Lhs, Output = Out>,
+{
+    /// The mul-by-scalar inner product.
+    #[allow(clippy::arithmetic_side_effects)]
+    fn inner_product(lhs: &[Lhs], rhs: &[Rhs], zero: Out) -> Result<Out, InnerProductError> {
+        if lhs.len() != rhs.len() {
+            return Err(InnerProductError::LengthMismatch {
+                lhs: lhs.len(),
+                rhs: rhs.len(),
+            });
+        }
+
+        Ok(lhs
+            .iter()
+            .zip(rhs)
+            .map(|(lhs, rhs)| lhs.clone() * rhs)
+            .fold(zero, |acc, product| acc + &product))
     }
 }
 
@@ -137,7 +166,7 @@ mod test {
         let lhs = [1, 2, 3];
         let rhs = [4, 5, 6];
         assert_eq!(
-            MBSInnerProduct::inner_product(&lhs, &rhs, 0),
+            MBSInnerProductChecked::inner_product(&lhs, &rhs, 0),
             Ok(4 + 2 * 5 + 3 * 6)
         );
     }
@@ -165,7 +194,7 @@ mod test {
 
         assert_eq!(
             BooleanInnerProductCheckedAdd::inner_product(&lhs, &rhs, 0),
-            MBSInnerProduct::inner_product(&rhs, &lhs, 0i128)
+            MBSInnerProductChecked::inner_product(&rhs, &lhs, 0i128)
         );
     }
 

--- a/utils/src/inner_product.rs
+++ b/utils/src/inner_product.rs
@@ -1,13 +1,13 @@
-use crypto_primitives::{boolean::Boolean, crypto_bigint_int::Int};
-use num_traits::{CheckedAdd, CheckedMul, One, Zero};
+use crypto_primitives::boolean::Boolean;
+use num_traits::CheckedAdd;
 use thiserror::Error;
 
 use crate::{from_ref::FromRef, mul_by_scalar::MulByScalar};
 
-/// A trait for types that can be dot-multiplied.
-pub trait InnerProduct<Rhs, Output> {
+/// A trait for inner product algorithms implementations.
+pub trait InnerProduct<Lhs: ?Sized, Rhs, Output> {
     /// The main entry point for the inner product.
-    fn inner_product(&self, rhs: &[Rhs], zero: Output) -> Result<Output, InnerProductError>;
+    fn inner_product(lhs: &Lhs, rhs: &[Rhs], zero: Output) -> Result<Output, InnerProductError>;
 }
 
 #[derive(Clone, Debug, PartialEq, Error)]
@@ -18,20 +18,27 @@ pub enum InnerProductError {
     Overflow,
 }
 
-impl<Lhs, Rhs, Out> InnerProduct<Rhs, Out> for &[Lhs]
+/// An implementation of inner product that piggies back
+/// on the `MulByScalar` and `CheckedAdd` traits.
+/// It does `mul_by_scalar` for products of terms
+/// and then combines the results using `checked_add`.
+pub struct MBSInnerProduct;
+
+impl<Lhs, Rhs, Out> InnerProduct<[Lhs], Rhs, Out> for MBSInnerProduct
 where
     Lhs: CheckedAdd + for<'a> MulByScalar<&'a Rhs>,
     Out: From<Lhs> + CheckedAdd,
 {
-    fn inner_product(&self, rhs: &[Rhs], zero: Out) -> Result<Out, InnerProductError> {
-        if self.len() != rhs.len() {
+    /// The mul-by-scalar inner product.
+    fn inner_product(lhs: &[Lhs], rhs: &[Rhs], zero: Out) -> Result<Out, InnerProductError> {
+        if lhs.len() != rhs.len() {
             return Err(InnerProductError::LengthMismatch {
-                lhs: self.len(),
+                lhs: lhs.len(),
                 rhs: rhs.len(),
             });
         }
 
-        self.iter()
+        lhs.iter()
             .zip(rhs)
             .map(|(lhs, rhs)| lhs.mul_by_scalar(rhs).ok_or(InnerProductError::Overflow))
             .try_fold(zero, |acc, product| {
@@ -41,101 +48,52 @@ where
     }
 }
 
-impl<Lhs, Rhs, Out> InnerProduct<Rhs, Out> for Vec<Lhs>
+// The inner product for vectors of length 1 (a.k.a. scalars).
+// Uses `mul_by_scalar` to multiply the only components of vectors
+// to get the result.
+pub struct ScalarProduct;
+
+impl<Lhs, Rhs, Out> InnerProduct<Lhs, Rhs, Out> for ScalarProduct
 where
-    for<'a> &'a [Lhs]: InnerProduct<Rhs, Out>,
+    Out: for<'a> MulByScalar<&'a Rhs> + FromRef<Lhs>,
 {
-    #[inline]
-    fn inner_product(&self, rhs: &[Rhs], zero: Out) -> Result<Out, InnerProductError> {
-        self.as_slice().inner_product(rhs, zero)
-    }
-}
-
-impl<Lhs, Rhs, Out, const N: usize> InnerProduct<Rhs, Out> for [Lhs; N]
-where
-    for<'a> &'a [Lhs]: InnerProduct<Rhs, Out>,
-{
-    #[inline]
-    fn inner_product(&self, rhs: &[Rhs], zero: Out) -> Result<Out, InnerProductError> {
-        self.as_slice().inner_product(rhs, zero)
-    }
-}
-
-macro_rules! impl_inner_product_for_primitives {
-    ($($t:ty),*) => {
-       $(
-           impl<T, Out> InnerProduct<T, Out> for $t
-           where
-               T: Zero + One + PartialEq,
-               Out: Zero + One + From<$t> + for<'a> From<&'a T> + CheckedMul,
-           {
-                fn inner_product(&self, point: &[T], _zero: Out) -> Result<Out, InnerProductError> {
-                        if point.len() != 1 {
-                            return Err(InnerProductError::LengthMismatch {
-                                lhs: 1,
-                                rhs: point.len(),
-                            });
-                        }
-
-                        if point[0].is_one() {
-                            return Ok(Out::from(*self))
-                        }
-
-
-                        if point[0].is_zero() {
-                            return Ok(Out::zero());
-                        }
-
-
-                        Out::from(*self).checked_mul(&Out::from(&point[0])).ok_or(InnerProductError::Overflow)
-
-                    }
-           }
-       )*
-    };
-}
-
-impl_inner_product_for_primitives!(i8, i16, i32, i64, i128);
-
-impl<T, Out, const LIMBS: usize> InnerProduct<T, Out> for Int<LIMBS>
-where
-    Int<LIMBS>: for<'a> MulByScalar<&'a T>,
-    Out: FromRef<Self>,
-{
-    fn inner_product(&self, point: &[T], _zero: Out) -> Result<Out, InnerProductError> {
-        if point.len() != 1 {
+    /// A scalar inner product. Assumes `Lhs` is a scalar type
+    /// and always asserts that `point` has only one component.
+    fn inner_product(lhs: &Lhs, point: &[Rhs], _zero: Out) -> Result<Out, InnerProductError> {
+        if point.as_ref().len() != 1 {
             Err(InnerProductError::LengthMismatch {
                 lhs: 1,
-                rhs: point.len(),
+                rhs: point.as_ref().len(),
             })
         } else {
-            Ok(Out::from_ref(
-                &self
-                    .mul_by_scalar(&point[0])
-                    .ok_or(InnerProductError::Overflow)?,
-            ))
+            Ok(Out::from_ref(lhs)
+                .mul_by_scalar(&point[0])
+                .ok_or(InnerProductError::Overflow)?)
         }
     }
 }
 
-impl<Out> InnerProduct<i128, Out> for &[Boolean]
-where
-    Out: CheckedAdd + From<i128>,
+/// The inner product for slices containing `Boolean` elements.
+/// Does `checked_add` to sum the elements of the RHS that
+/// correspond to `true` elements of the boolean slice.
+pub struct BooleanInnerProduct;
+
+impl<Rhs: Clone, Out: From<Rhs> + CheckedAdd> InnerProduct<[Boolean], Rhs, Out>
+    for BooleanInnerProduct
 {
-    /// If we have a slice of booleans we do not need to multiply at all.
-    /// The inner product is just a sum!
-    fn inner_product(&self, rhs: &[i128], zero: Out) -> Result<Out, InnerProductError> {
-        if self.len() != rhs.len() {
+    /// Boolean inner product.
+    fn inner_product(lhs: &[Boolean], rhs: &[Rhs], zero: Out) -> Result<Out, InnerProductError> {
+        if lhs.len() != rhs.as_ref().len() {
             return Err(InnerProductError::LengthMismatch {
-                lhs: self.len(),
-                rhs: rhs.len(),
+                lhs: lhs.len(),
+                rhs: rhs.as_ref().len(),
             });
         }
 
-        (0..self.len())
-            .filter(|&i| self[i].into_inner())
+        (0..lhs.len())
+            .filter(|&i| lhs[i].into_inner())
             .try_fold(zero, |acc, i| {
-                acc.checked_add(&Out::from(rhs[i]))
+                acc.checked_add(&Out::from(rhs[i].clone()))
                     .ok_or(InnerProductError::Overflow)
             })
     }
@@ -149,6 +107,36 @@ mod test {
     fn test_inner_product_basic() {
         let lhs = [1, 2, 3];
         let rhs = [4, 5, 6];
-        assert_eq!(lhs.inner_product(&rhs, 0), Ok(4 + 2 * 5 + 3 * 6));
+        assert_eq!(
+            MBSInnerProduct::inner_product(&lhs, &rhs, 0),
+            Ok(4 + 2 * 5 + 3 * 6)
+        );
+    }
+
+    #[test]
+    fn scalar_product() {
+        let lhs = 42i32;
+        let rhs = 23i128;
+
+        assert_eq!(
+            ScalarProduct::inner_product(&lhs, &[rhs], 0).unwrap(),
+            i128::from(lhs) * rhs
+        )
+    }
+
+    #[test]
+    fn boolean_eq_mbs_inner_product() {
+        let lhs = [
+            Boolean::from(true),
+            Boolean::from(false),
+            Boolean::from(true),
+            Boolean::from(true),
+        ];
+        let rhs = [1i128, 2, 3, 4];
+
+        assert_eq!(
+            BooleanInnerProduct::inner_product(&lhs, &rhs, 0),
+            MBSInnerProduct::inner_product(&rhs, &lhs, 0i128)
+        );
     }
 }

--- a/utils/src/inner_product.rs
+++ b/utils/src/inner_product.rs
@@ -79,9 +79,9 @@ where
     }
 }
 
-// The inner product for vectors of length 1 (a.k.a. scalars).
-// Uses `mul_by_scalar` to multiply the only components of vectors
-// to get the result.
+/// The inner product for vectors of length 1 (a.k.a. scalars).
+/// Uses `mul_by_scalar` to multiply the only components of vectors
+/// to get the result.
 pub struct ScalarProduct;
 
 impl<Lhs, Rhs, Out> InnerProduct<Lhs, Rhs, Out> for ScalarProduct

--- a/utils/src/lib.rs
+++ b/utils/src/lib.rs
@@ -4,4 +4,4 @@ pub mod inner_product;
 pub mod mul_by_scalar;
 pub mod named;
 pub mod ops_macros;
-pub mod projectable_to_field;
+pub mod projection_to_field;

--- a/utils/src/projectable_to_field.rs
+++ b/utils/src/projectable_to_field.rs
@@ -1,9 +1,0 @@
-use crypto_primitives::PrimeField;
-
-/// Trait for preparing a projection function to a field element from a current
-/// type.
-pub trait ProjectableToField<F: PrimeField> {
-    /// Prepare a projection function that will project the current type
-    /// to a prime field using the given sampled value.
-    fn prepare_projection(sampled_value: &F) -> impl Fn(&Self) -> F + 'static;
-}

--- a/utils/src/projection_to_field.rs
+++ b/utils/src/projection_to_field.rs
@@ -1,0 +1,25 @@
+use std::marker::PhantomData;
+
+use crypto_primitives::{FromWithConfig, IntoWithConfig, PrimeField};
+
+/// Trait for preparing a projection function to a field element from a
+/// type.
+pub trait ProjectionToField<T, F: PrimeField> {
+    /// Prepare a projection function that will project the type `T`
+    /// to a prime field using the given sampled value.
+    fn prepare_projection(sampled_value: &F) -> impl Fn(&T) -> F + 'static;
+}
+
+/// If `F` implements `for<'a> FromWithConfig<&'a T>`
+/// we can always project this type onto `T` using this projection.
+pub struct SimpleProjection<F: PrimeField>(PhantomData<F>);
+
+impl<T, F> ProjectionToField<T, F> for SimpleProjection<F>
+where
+    F: for<'a> FromWithConfig<&'a T>,
+{
+    fn prepare_projection(sampled_value: &F) -> impl Fn(&T) -> F + 'static {
+        let config = sampled_value.cfg().clone();
+        move |value: &T| value.into_with_cfg(&config)
+    }
+}

--- a/zip-plus/benches/zip_benches.rs
+++ b/zip-plus/benches/zip_benches.rs
@@ -4,7 +4,7 @@
 mod zip_common;
 
 use zinc_primality::MillerRabin;
-use zinc_utils::inner_product::ScalarProduct;
+use zinc_utils::{inner_product::ScalarProduct, projection_to_field::SimpleProjection};
 use zip_common::*;
 
 use criterion::{Criterion, criterion_group, criterion_main};
@@ -40,7 +40,9 @@ const RAA_CONFIG: RaaConfig = RaaConfig {
 
 fn zip_benchmarks(c: &mut Criterion) {
     let mut group = c.benchmark_group("Zip+");
-    do_bench::<BenchZipTypes, Code>(&mut group, RAA_CONFIG);
+    do_bench::<BenchZipTypes, Code, SimpleProjection<_>, SimpleProjection<_>>(
+        &mut group, RAA_CONFIG,
+    );
     group.finish();
 }
 

--- a/zip-plus/benches/zip_benches.rs
+++ b/zip-plus/benches/zip_benches.rs
@@ -4,6 +4,7 @@
 mod zip_common;
 
 use zinc_primality::MillerRabin;
+use zinc_utils::inner_product::ScalarProduct;
 use zip_common::*;
 
 use criterion::{Criterion, criterion_group, criterion_main};
@@ -27,6 +28,8 @@ impl ZipTypes for BenchZipTypes {
     type Pt = i128;
     type CombR = Int<{ INT_LIMBS * 3 }>;
     type Comb = Self::CombR;
+    type CombDotChal = ScalarProduct;
+    type EvalDotChal = ScalarProduct;
 }
 type Code = RaaCode<BenchZipTypes, 4>;
 

--- a/zip-plus/benches/zip_common.rs
+++ b/zip-plus/benches/zip_common.rs
@@ -18,7 +18,10 @@ use num_traits::One;
 use rand::{distr::StandardUniform, prelude::*};
 use zinc_poly::mle::{DenseMultilinearExtension, MultilinearExtensionRand};
 use zinc_transcript::traits::ConstTranscribable;
-use zinc_utils::{from_ref::FromRef, named::Named, projection_to_field::ProjectionToField};
+use zinc_utils::{
+    from_ref::FromRef, inner_product::MBSInnerProductChecked, named::Named,
+    projection_to_field::ProjectionToField,
+};
 use zip_plus::{
     code::LinearCode,
     merkle::MerkleTree,
@@ -306,8 +309,14 @@ pub fn verify<Zt: ZipTypes, Lc: LinearCode<Zt>, PEval, PCw, const P: usize>(
         ),
         |b| {
             b.iter(|| {
-                ZipPlus::verify::<_, PCw>(&params, &commitment, &point_f, &eval_f, &proof)
-                    .expect("Verification failed");
+                ZipPlus::verify::<_, PCw, MBSInnerProductChecked>(
+                    &params,
+                    &commitment,
+                    &point_f,
+                    &eval_f,
+                    &proof,
+                )
+                .expect("Verification failed");
             })
         },
     );

--- a/zip-plus/benches/zip_common.rs
+++ b/zip-plus/benches/zip_common.rs
@@ -18,7 +18,7 @@ use num_traits::One;
 use rand::{distr::StandardUniform, prelude::*};
 use zinc_poly::mle::{DenseMultilinearExtension, MultilinearExtensionRand};
 use zinc_transcript::traits::ConstTranscribable;
-use zinc_utils::{from_ref::FromRef, named::Named, projectable_to_field::ProjectableToField};
+use zinc_utils::{from_ref::FromRef, named::Named, projection_to_field::ProjectionToField};
 use zip_plus::{
     code::LinearCode,
     merkle::MerkleTree,
@@ -27,15 +27,15 @@ use zip_plus::{
 
 type F = BoxedMontyField;
 
-pub fn do_bench<Zt: ZipTypes, Lc: LinearCode<Zt>>(
+pub fn do_bench<Zt: ZipTypes, Lc: LinearCode<Zt>, PEval, PCw>(
     group: &mut BenchmarkGroup<WallTime>,
     code_config: Lc::Config,
 ) where
     StandardUniform: Distribution<Zt::Eval> + Distribution<Zt::Cw>,
     F: for<'a> FromWithConfig<&'a Zt::Chal> + for<'a> FromWithConfig<&'a Zt::Pt>,
     <F as Field>::Inner: FromRef<Zt::Fmod>,
-    Zt::Eval: ProjectableToField<F>,
-    Zt::Cw: ProjectableToField<F>,
+    PEval: ProjectionToField<Zt::Eval, F>,
+    PCw: ProjectionToField<Zt::Cw, F>,
 {
     encode_rows::<Zt, Lc, 12>(group, code_config);
     encode_rows::<Zt, Lc, 13>(group, code_config);
@@ -66,17 +66,17 @@ pub fn do_bench<Zt: ZipTypes, Lc: LinearCode<Zt>>(
     test::<Zt, Lc, 15>(group, code_config);
     test::<Zt, Lc, 16>(group, code_config);
 
-    evaluate::<Zt, Lc, 12>(group, code_config);
-    evaluate::<Zt, Lc, 13>(group, code_config);
-    evaluate::<Zt, Lc, 14>(group, code_config);
-    evaluate::<Zt, Lc, 15>(group, code_config);
-    evaluate::<Zt, Lc, 16>(group, code_config);
+    evaluate::<Zt, Lc, PEval, 12>(group, code_config);
+    evaluate::<Zt, Lc, PEval, 13>(group, code_config);
+    evaluate::<Zt, Lc, PEval, 14>(group, code_config);
+    evaluate::<Zt, Lc, PEval, 15>(group, code_config);
+    evaluate::<Zt, Lc, PEval, 16>(group, code_config);
 
-    verify::<Zt, Lc, 12>(group, code_config);
-    verify::<Zt, Lc, 13>(group, code_config);
-    verify::<Zt, Lc, 14>(group, code_config);
-    verify::<Zt, Lc, 15>(group, code_config);
-    verify::<Zt, Lc, 16>(group, code_config);
+    verify::<Zt, Lc, PEval, PCw, 12>(group, code_config);
+    verify::<Zt, Lc, PEval, PCw, 13>(group, code_config);
+    verify::<Zt, Lc, PEval, PCw, 14>(group, code_config);
+    verify::<Zt, Lc, PEval, PCw, 15>(group, code_config);
+    verify::<Zt, Lc, PEval, PCw, 16>(group, code_config);
 }
 
 pub fn encode_rows<Zt: ZipTypes, Lc: LinearCode<Zt>, const P: usize>(
@@ -224,14 +224,14 @@ pub fn test<Zt: ZipTypes, Lc: LinearCode<Zt>, const P: usize>(
     );
 }
 
-pub fn evaluate<Zt: ZipTypes, Lc: LinearCode<Zt>, const P: usize>(
+pub fn evaluate<Zt: ZipTypes, Lc: LinearCode<Zt>, PEval, const P: usize>(
     group: &mut BenchmarkGroup<WallTime>,
     code_config: Lc::Config,
 ) where
     StandardUniform: Distribution<Zt::Eval>,
     F: for<'a> FromWithConfig<&'a Zt::Chal> + for<'a> FromWithConfig<&'a Zt::Pt>,
     <F as Field>::Inner: FromRef<Zt::Fmod>,
-    Zt::Eval: ProjectableToField<F>,
+    PEval: ProjectionToField<Zt::Eval, F>,
 {
     let mut rng = ThreadRng::default();
 
@@ -259,8 +259,9 @@ pub fn evaluate<Zt: ZipTypes, Lc: LinearCode<Zt>, const P: usize>(
                 for _ in 0..iters {
                     let proof = test_transcript.clone();
                     let timer = Instant::now();
-                    let (eval_f, proof) = ZipPlus::evaluate::<F>(&params, &poly, &point, proof)
-                        .expect("Evaluation phase failed");
+                    let (eval_f, proof) =
+                        ZipPlus::evaluate::<F, PEval>(&params, &poly, &point, proof)
+                            .expect("Evaluation phase failed");
                     total_duration += timer.elapsed();
                     black_box((eval_f, proof));
                 }
@@ -270,15 +271,15 @@ pub fn evaluate<Zt: ZipTypes, Lc: LinearCode<Zt>, const P: usize>(
     );
 }
 
-pub fn verify<Zt: ZipTypes, Lc: LinearCode<Zt>, const P: usize>(
+pub fn verify<Zt: ZipTypes, Lc: LinearCode<Zt>, PEval, PCw, const P: usize>(
     group: &mut BenchmarkGroup<WallTime>,
     code_config: Lc::Config,
 ) where
     StandardUniform: Distribution<Zt::Eval>,
     F: for<'a> FromWithConfig<&'a Zt::Chal> + for<'a> FromWithConfig<&'a Zt::Pt>,
     <F as Field>::Inner: FromRef<Zt::Fmod>,
-    Zt::Eval: ProjectableToField<F>,
-    Zt::Cw: ProjectableToField<F>,
+    PEval: ProjectionToField<Zt::Eval, F>,
+    PCw: ProjectionToField<Zt::Cw, F>,
 {
     let mut rng = ThreadRng::default();
     let poly_size = 1 << P;
@@ -290,7 +291,7 @@ pub fn verify<Zt: ZipTypes, Lc: LinearCode<Zt>, const P: usize>(
     let point = vec![Zt::Pt::one(); P];
 
     let test_transcript = ZipPlus::test(&params, &poly, &data).expect("Test phase failed");
-    let (eval_f, proof) = ZipPlus::evaluate::<F>(&params, &poly, &point, test_transcript)
+    let (eval_f, proof) = ZipPlus::evaluate::<F, PEval>(&params, &poly, &point, test_transcript)
         .expect("Evaluation phase failed");
     let field_cfg = eval_f.cfg().clone();
     let point_f: Vec<F> = point.iter().map(|v| v.into_with_cfg(&field_cfg)).collect();
@@ -305,7 +306,7 @@ pub fn verify<Zt: ZipTypes, Lc: LinearCode<Zt>, const P: usize>(
         ),
         |b| {
             b.iter(|| {
-                ZipPlus::verify(&params, &commitment, &point_f, &eval_f, &proof)
+                ZipPlus::verify::<_, PCw>(&params, &commitment, &point_f, &eval_f, &proof)
                     .expect("Verification failed");
             })
         },

--- a/zip-plus/benches/zip_plus_benches.rs
+++ b/zip-plus/benches/zip_plus_benches.rs
@@ -35,15 +35,15 @@ impl<const D_PLUS_ONE: usize> ZipTypes for BenchZipPlusTypes<D_PLUS_ONE> {
     type Comb = DensePolynomial<Self::CombR, D_PLUS_ONE>;
     type EvalDotChal = DensePolyInnerProduct<
         Boolean,
-        i128,
-        Int<{ INT_LIMBS * 5 }>,
+        Self::Chal,
+        Self::CombR,
         BooleanInnerProductCheckedAdd,
         D_PLUS_ONE,
     >;
     type CombDotChal = DensePolyInnerProduct<
         Self::CombR,
-        i128,
-        Int<{ INT_LIMBS * 5 }>,
+        Self::Chal,
+        Self::CombR,
         MBSInnerProductChecked,
         D_PLUS_ONE,
     >;

--- a/zip-plus/benches/zip_plus_benches.rs
+++ b/zip-plus/benches/zip_plus_benches.rs
@@ -8,7 +8,7 @@ use zinc_poly::univariate::dense::{
 };
 use zinc_primality::MillerRabin;
 use zinc_utils::inner_product::{
-    BooleanInnerProductCheckedAdd, BooleanInnerProductUncheckedAdd, MBSInnerProduct,
+    BooleanInnerProductCheckedAdd, BooleanInnerProductUncheckedAdd, MBSInnerProductChecked,
 };
 use zip_common::*;
 
@@ -44,7 +44,7 @@ impl<const D_PLUS_ONE: usize> ZipTypes for BenchZipPlusTypes<D_PLUS_ONE> {
         Self::CombR,
         i128,
         Int<{ INT_LIMBS * 5 }>,
-        MBSInnerProduct,
+        MBSInnerProductChecked,
         D_PLUS_ONE,
     >;
 }

--- a/zip-plus/benches/zip_plus_benches.rs
+++ b/zip-plus/benches/zip_plus_benches.rs
@@ -3,9 +3,13 @@
 
 mod zip_common;
 
-use zinc_poly::univariate::dense::{DensePolyInnerProduct, DensePolynomial};
+use zinc_poly::univariate::dense::{
+    DensePolyInnerProduct, DensePolynomial, HornerProjection, InnerProductProjection,
+};
 use zinc_primality::MillerRabin;
-use zinc_utils::inner_product::{BooleanInnerProduct, MBSInnerProduct};
+use zinc_utils::inner_product::{
+    BooleanInnerProductCheckedAdd, BooleanInnerProductUncheckedAdd, MBSInnerProduct,
+};
 use zip_common::*;
 
 use criterion::{Criterion, criterion_group, criterion_main};
@@ -29,6 +33,13 @@ impl<const D_PLUS_ONE: usize> ZipTypes for BenchZipPlusTypes<D_PLUS_ONE> {
     type Pt = i128;
     type CombR = Int<{ INT_LIMBS * 5 }>;
     type Comb = DensePolynomial<Self::CombR, D_PLUS_ONE>;
+    type EvalDotChal = DensePolyInnerProduct<
+        Boolean,
+        i128,
+        Int<{ INT_LIMBS * 5 }>,
+        BooleanInnerProductCheckedAdd,
+        D_PLUS_ONE,
+    >;
     type CombDotChal = DensePolyInnerProduct<
         Self::CombR,
         i128,
@@ -36,14 +47,8 @@ impl<const D_PLUS_ONE: usize> ZipTypes for BenchZipPlusTypes<D_PLUS_ONE> {
         MBSInnerProduct,
         D_PLUS_ONE,
     >;
-    type EvalDotChal = DensePolyInnerProduct<
-        Boolean,
-        i128,
-        Int<{ INT_LIMBS * 5 }>,
-        BooleanInnerProduct,
-        D_PLUS_ONE,
-    >;
 }
+
 type Code<const D_PLUS_ONE: usize> = RaaCode<BenchZipPlusTypes<D_PLUS_ONE>, 4>;
 
 const RAA_CONFIG: RaaConfig = RaaConfig {
@@ -54,8 +59,18 @@ const RAA_CONFIG: RaaConfig = RaaConfig {
 fn zip_plus_benchmarks(c: &mut Criterion) {
     let mut group = c.benchmark_group("Zip+");
 
-    do_bench::<BenchZipPlusTypes<32>, Code<_>>(&mut group, RAA_CONFIG);
-    do_bench::<BenchZipPlusTypes<64>, Code<_>>(&mut group, RAA_CONFIG);
+    do_bench::<
+        BenchZipPlusTypes<32>,
+        Code<_>,
+        InnerProductProjection<Boolean, BooleanInnerProductUncheckedAdd, _>,
+        HornerProjection<_, _>,
+    >(&mut group, RAA_CONFIG);
+    do_bench::<
+        BenchZipPlusTypes<64>,
+        Code<_>,
+        InnerProductProjection<Boolean, BooleanInnerProductUncheckedAdd, _>,
+        HornerProjection<_, _>,
+    >(&mut group, RAA_CONFIG);
 
     group.finish();
 }

--- a/zip-plus/benches/zip_plus_benches.rs
+++ b/zip-plus/benches/zip_plus_benches.rs
@@ -3,8 +3,9 @@
 
 mod zip_common;
 
-use zinc_poly::univariate::dense::DensePolynomial;
+use zinc_poly::univariate::dense::{DensePolyInnerProduct, DensePolynomial};
 use zinc_primality::MillerRabin;
+use zinc_utils::inner_product::{BooleanInnerProduct, MBSInnerProduct};
 use zip_common::*;
 
 use criterion::{Criterion, criterion_group, criterion_main};
@@ -28,6 +29,20 @@ impl<const D_PLUS_ONE: usize> ZipTypes for BenchZipPlusTypes<D_PLUS_ONE> {
     type Pt = i128;
     type CombR = Int<{ INT_LIMBS * 5 }>;
     type Comb = DensePolynomial<Self::CombR, D_PLUS_ONE>;
+    type CombDotChal = DensePolyInnerProduct<
+        Self::CombR,
+        i128,
+        Int<{ INT_LIMBS * 5 }>,
+        MBSInnerProduct,
+        D_PLUS_ONE,
+    >;
+    type EvalDotChal = DensePolyInnerProduct<
+        Boolean,
+        i128,
+        Int<{ INT_LIMBS * 5 }>,
+        BooleanInnerProduct,
+        D_PLUS_ONE,
+    >;
 }
 type Code<const D_PLUS_ONE: usize> = RaaCode<BenchZipPlusTypes<D_PLUS_ONE>, 4>;
 

--- a/zip-plus/src/pcs/phase_commit.rs
+++ b/zip-plus/src/pcs/phase_commit.rs
@@ -208,6 +208,7 @@ mod tests {
     use num_traits::Zero;
     use rand::{Rng, rng};
     use zinc_poly::{mle::DenseMultilinearExtension, univariate::dense::DensePolynomial};
+    use zinc_utils::projection_to_field::SimpleProjection;
 
     const INT_LIMBS: usize = U64::LIMBS;
 
@@ -641,7 +642,9 @@ mod tests {
             expected_test_transcript_size_bytes
         );
 
-        let (_, proof) = TestZip::evaluate::<F>(&param, &mle, &point, test_transcript).unwrap();
+        let (_, proof) =
+            TestZip::evaluate::<F, SimpleProjection<_>>(&param, &mle, &point, test_transcript)
+                .unwrap();
         let actual_proof_size_bytes = proof.0.len();
         let expected_proof_size_bytes = calculate_expected_proof_size_bytes(&param);
         assert_eq!(actual_proof_size_bytes, expected_proof_size_bytes);

--- a/zip-plus/src/pcs/phase_evaluate.rs
+++ b/zip-plus/src/pcs/phase_evaluate.rs
@@ -17,7 +17,7 @@ use zinc_poly::mle::DenseMultilinearExtension;
 use zinc_transcript::traits::{Transcribable, Transcript};
 use zinc_utils::{
     from_ref::FromRef,
-    inner_product::{InnerProduct, MBSInnerProduct},
+    inner_product::{InnerProduct, MBSInnerProductUnchecked},
     mul_by_scalar::MulByScalar,
     projection_to_field::ProjectionToField,
 };
@@ -75,7 +75,7 @@ impl<Zt: ZipTypes, Lc: LinearCode<Zt>> ZipPlus<Zt, Lc> {
         };
 
         transcript.write_field_elements(&q_0_combined_row)?;
-        let eval_f = MBSInnerProduct::inner_product(
+        let eval_f = MBSInnerProductUnchecked::inner_product(
             &q_0_combined_row[..],
             &q_1,
             F::zero_with_cfg(&field_cfg),

--- a/zip-plus/src/pcs/phase_evaluate.rs
+++ b/zip-plus/src/pcs/phase_evaluate.rs
@@ -19,11 +19,11 @@ use zinc_utils::{
     from_ref::FromRef,
     inner_product::{InnerProduct, MBSInnerProduct},
     mul_by_scalar::MulByScalar,
-    projectable_to_field::ProjectableToField,
+    projection_to_field::ProjectionToField,
 };
 
 impl<Zt: ZipTypes, Lc: LinearCode<Zt>> ZipPlus<Zt, Lc> {
-    pub fn evaluate<F>(
+    pub fn evaluate<F, P>(
         pp: &ZipPlusParams<Zt, Lc>,
         poly: &DenseMultilinearExtension<Zt::Eval>,
         point: &[Zt::Pt],
@@ -35,7 +35,7 @@ impl<Zt: ZipTypes, Lc: LinearCode<Zt>> ZipPlus<Zt, Lc> {
             + for<'a> FromWithConfig<&'a Zt::Pt>
             + for<'a> MulByScalar<&'a F>,
         F::Inner: FromRef<Zt::Fmod> + Transcribable,
-        Zt::Eval: ProjectableToField<F>,
+        P: ProjectionToField<Zt::Eval, F>,
     {
         validate_input::<Zt, Lc, _>("evaluate", pp.num_vars, [poly], [point])?;
 
@@ -61,7 +61,7 @@ impl<Zt: ZipTypes, Lc: LinearCode<Zt>> ZipPlus<Zt, Lc> {
             .collect_vec();
         let (q_0, q_1) = point_to_tensor(num_rows, &point, &field_cfg)?;
 
-        let project = Zt::Eval::prepare_projection(&projecting_element);
+        let project = P::prepare_projection(&projecting_element);
         let evaluations: Vec<F> = poly.evaluations.iter().map(project).collect_vec();
 
         let q_0_combined_row = if num_rows > 1 {

--- a/zip-plus/src/pcs/phase_evaluate.rs
+++ b/zip-plus/src/pcs/phase_evaluate.rs
@@ -16,7 +16,9 @@ use itertools::Itertools;
 use zinc_poly::mle::DenseMultilinearExtension;
 use zinc_transcript::traits::{Transcribable, Transcript};
 use zinc_utils::{
-    from_ref::FromRef, inner_product::InnerProduct, mul_by_scalar::MulByScalar,
+    from_ref::FromRef,
+    inner_product::{InnerProduct, MBSInnerProduct},
+    mul_by_scalar::MulByScalar,
     projectable_to_field::ProjectableToField,
 };
 
@@ -73,7 +75,11 @@ impl<Zt: ZipTypes, Lc: LinearCode<Zt>> ZipPlus<Zt, Lc> {
         };
 
         transcript.write_field_elements(&q_0_combined_row)?;
-        let eval_f = (&q_0_combined_row[..]).inner_product(&q_1, F::zero_with_cfg(&field_cfg))?;
+        let eval_f = MBSInnerProduct::inner_product(
+            &q_0_combined_row[..],
+            &q_1,
+            F::zero_with_cfg(&field_cfg),
+        )?;
         Ok((eval_f, transcript.into()))
     }
 }

--- a/zip-plus/src/pcs/phase_test.rs
+++ b/zip-plus/src/pcs/phase_test.rs
@@ -52,7 +52,7 @@ impl<Zt: ZipTypes, Lc: LinearCode<Zt>> ZipPlus<Zt, Lc> {
             let evals: Vec<_> = poly
                 .evaluations
                 .iter()
-                .map(|p| p.inner_product(&alphas, Zt::CombR::ZERO))
+                .map(|p| Zt::EvalDotChal::inner_product(p, &alphas, Zt::CombR::ZERO))
                 .try_collect()?;
 
             // u' in the Zinc paper

--- a/zip-plus/src/pcs/phase_verify.rs
+++ b/zip-plus/src/pcs/phase_verify.rs
@@ -15,7 +15,9 @@ use num_traits::{ConstOne, ConstZero, Zero};
 use zinc_poly::Polynomial;
 use zinc_transcript::traits::{Transcribable, Transcript};
 use zinc_utils::{
-    from_ref::FromRef, inner_product::InnerProduct, mul_by_scalar::MulByScalar,
+    from_ref::FromRef,
+    inner_product::{InnerProduct, MBSInnerProduct},
+    mul_by_scalar::MulByScalar,
     projectable_to_field::ProjectableToField,
 };
 
@@ -143,11 +145,15 @@ impl<Zt: ZipTypes, Lc: LinearCode<Zt>> ZipPlus<Zt, Lc> {
             let column_entries: Vec<_> = column_entries
                 .iter()
                 .map(Zt::Comb::from_ref)
-                .map(|p| p.inner_product(alphas, Zt::CombR::ZERO))
+                .map(|p| Zt::CombDotChal::inner_product(&p, alphas, Zt::CombR::ZERO))
                 .try_collect()?;
-            column_entries.inner_product(coeffs, Zt::CombR::ZERO)?
+            MBSInnerProduct::inner_product(&column_entries, coeffs, Zt::CombR::ZERO)?
         } else {
-            Zt::Comb::from_ref(&column_entries[0]).inner_product(alphas, Zt::CombR::ZERO)?
+            Zt::CombDotChal::inner_product(
+                &Zt::Comb::from_ref(&column_entries[0]),
+                alphas,
+                Zt::CombR::ZERO,
+            )?
         };
 
         if column_entries_comb != encoded_combined_row[column] {
@@ -175,7 +181,9 @@ impl<Zt: ZipTypes, Lc: LinearCode<Zt>> ZipPlus<Zt, Lc> {
 
         let (q_0, q_1) = point_to_tensor(vp.num_rows, point_f, field_cfg)?;
 
-        if q_0_combined_row.inner_product(&q_1, F::zero_with_cfg(field_cfg))? != *eval_f {
+        if MBSInnerProduct::inner_product(&q_0_combined_row, &q_1, F::zero_with_cfg(field_cfg))?
+            != *eval_f
+        {
             return Err(ZipError::InvalidPcsOpen(
                 "Evaluation consistency failure".into(),
             ));
@@ -197,7 +205,7 @@ impl<Zt: ZipTypes, Lc: LinearCode<Zt>> ZipPlus<Zt, Lc> {
     }
 
     fn verify_proximity_q_0<F>(
-        q_0: &Vec<F>,
+        q_0: &[F],
         encoded_q_0_combined_row: &[F],
         column_entries: &[Zt::Cw],
         column: usize,
@@ -211,7 +219,7 @@ impl<Zt: ZipTypes, Lc: LinearCode<Zt>> ZipPlus<Zt, Lc> {
     {
         let column_entries_comb = if num_rows > 1 {
             let column_entries = column_entries.iter().map(project).collect_vec();
-            q_0.inner_product(&column_entries, F::zero_with_cfg(field_cfg))?
+            MBSInnerProduct::inner_product(q_0, &column_entries, F::zero_with_cfg(field_cfg))?
             // TODO: this inner product is taking a long time.
         } else {
             project(column_entries.first().expect("No column entries"))

--- a/zip-plus/src/pcs/phase_verify.rs
+++ b/zip-plus/src/pcs/phase_verify.rs
@@ -250,7 +250,7 @@ mod tests {
     };
     use crypto_bigint::{Random, U64};
     use crypto_primitives::{
-        Field, FromWithConfig, IntoWithConfig, PrimeField,
+        Field, FromWithConfig, IntoWithConfig, PrimeField, boolean::Boolean,
         crypto_bigint_boxed_monty::BoxedMontyField, crypto_bigint_int::Int,
     };
     use itertools::Itertools;
@@ -258,10 +258,12 @@ mod tests {
     use rand::prelude::*;
     use zinc_poly::{
         mle::{DenseMultilinearExtension, MultilinearExtensionRand},
-        univariate::dense::{DensePolynomial, HornerProjection},
+        univariate::dense::{DensePolynomial, HornerProjection, InnerProductProjection},
     };
     use zinc_transcript::traits::Transcribable;
-    use zinc_utils::projection_to_field::SimpleProjection;
+    use zinc_utils::{
+        inner_product::BooleanInnerProductUncheckedAdd, projection_to_field::SimpleProjection,
+    };
 
     const INT_LIMBS: usize = U64::LIMBS;
 
@@ -297,7 +299,7 @@ mod tests {
         {
             let (pp, comm, point_f, eval_f, proof) = setup_full_protocol_poly::<
                 F,
-                HornerProjection<_, _>,
+                InnerProductProjection<Boolean, BooleanInnerProductUncheckedAdd, _>,
                 HornerProjection<_, _>,
                 N,
                 K,
@@ -338,7 +340,7 @@ mod tests {
         {
             let (pp, comm, point_f, eval_f, proof) = setup_full_protocol_poly::<
                 F,
-                HornerProjection<_, _>,
+                InnerProductProjection<Boolean, BooleanInnerProductUncheckedAdd, _>,
                 HornerProjection<_, _>,
                 N,
                 K,
@@ -382,7 +384,7 @@ mod tests {
         {
             let (pp, comm, point_f, eval_f, proof) = setup_full_protocol_poly::<
                 F,
-                HornerProjection<_, _>,
+                InnerProductProjection<Boolean, BooleanInnerProductUncheckedAdd, _>,
                 HornerProjection<_, _>,
                 N,
                 K,
@@ -428,7 +430,7 @@ mod tests {
         {
             let (pp, _comm_poly1, point_f, eval_f, proof_poly1) = setup_full_protocol_poly::<
                 F,
-                HornerProjection<_, _>,
+                InnerProductProjection<Boolean, BooleanInnerProductUncheckedAdd, _>,
                 HornerProjection<_, _>,
                 N,
                 K,
@@ -481,7 +483,7 @@ mod tests {
         {
             let (pp, comm, _point_f, eval_f, proof) = setup_full_protocol_poly::<
                 F,
-                HornerProjection<_, _>,
+                InnerProductProjection<Boolean, BooleanInnerProductUncheckedAdd, _>,
                 HornerProjection<_, _>,
                 N,
                 K,

--- a/zip-plus/src/pcs/phase_verify.rs
+++ b/zip-plus/src/pcs/phase_verify.rs
@@ -258,7 +258,7 @@ mod tests {
     };
     use crypto_bigint::{Random, U64};
     use crypto_primitives::{
-        Field, FromWithConfig, IntoWithConfig, PrimeField, boolean::Boolean,
+        Field, FromWithConfig, IntoWithConfig, PrimeField,
         crypto_bigint_boxed_monty::BoxedMontyField, crypto_bigint_int::Int,
     };
     use itertools::Itertools;
@@ -266,12 +266,11 @@ mod tests {
     use rand::prelude::*;
     use zinc_poly::{
         mle::{DenseMultilinearExtension, MultilinearExtensionRand},
-        univariate::dense::{DensePolynomial, HornerProjection, InnerProductProjection},
+        univariate::dense::{DensePolynomial, HornerProjection},
     };
     use zinc_transcript::traits::Transcribable;
     use zinc_utils::{
-        inner_product::{BooleanInnerProductUncheckedAdd, MBSInnerProductChecked},
-        projection_to_field::SimpleProjection,
+        inner_product::MBSInnerProductChecked, projection_to_field::SimpleProjection,
     };
 
     const INT_LIMBS: usize = U64::LIMBS;
@@ -307,15 +306,8 @@ mod tests {
             assert!(result.is_ok(), "Verification failed: {result:?}")
         };
         {
-            let (pp, comm, point_f, eval_f, proof) = setup_full_protocol_poly::<
-                F,
-                InnerProductProjection<Boolean, BooleanInnerProductUncheckedAdd, _>,
-                HornerProjection<_, _>,
-                N,
-                K,
-                M,
-                DEGREE_PLUS_ONE,
-            >(num_vars);
+            let (pp, comm, point_f, eval_f, proof) =
+                setup_full_protocol_poly::<F, N, K, M, DEGREE_PLUS_ONE>(num_vars);
 
             let result = TestPolyZip::verify::<_, HornerProjection<_, _>, MBSInnerProductChecked>(
                 &pp, &comm, &point_f, &eval_f, &proof,
@@ -348,15 +340,8 @@ mod tests {
         }
 
         {
-            let (pp, comm, point_f, eval_f, proof) = setup_full_protocol_poly::<
-                F,
-                InnerProductProjection<Boolean, BooleanInnerProductUncheckedAdd, _>,
-                HornerProjection<_, _>,
-                N,
-                K,
-                M,
-                DEGREE_PLUS_ONE,
-            >(num_vars);
+            let (pp, comm, point_f, eval_f, proof) =
+                setup_full_protocol_poly::<F, N, K, M, DEGREE_PLUS_ONE>(num_vars);
             let cfg = eval_f.cfg().clone();
 
             let result = TestPolyZip::verify::<_, HornerProjection<_, _>, MBSInnerProductChecked>(
@@ -393,15 +378,8 @@ mod tests {
         }
 
         {
-            let (pp, comm, point_f, eval_f, proof) = setup_full_protocol_poly::<
-                F,
-                InnerProductProjection<Boolean, BooleanInnerProductUncheckedAdd, _>,
-                HornerProjection<_, _>,
-                N,
-                K,
-                M,
-                DEGREE_PLUS_ONE,
-            >(num_vars);
+            let (pp, comm, point_f, eval_f, proof) =
+                setup_full_protocol_poly::<F, N, K, M, DEGREE_PLUS_ONE>(num_vars);
             let tampered = tamper(proof);
             let result = TestPolyZip::verify::<_, HornerProjection<_, _>, MBSInnerProductChecked>(
                 &pp, &comm, &point_f, &eval_f, &tampered,
@@ -439,15 +417,8 @@ mod tests {
         }
 
         {
-            let (pp, _comm_poly1, point_f, eval_f, proof_poly1) = setup_full_protocol_poly::<
-                F,
-                InnerProductProjection<Boolean, BooleanInnerProductUncheckedAdd, _>,
-                HornerProjection<_, _>,
-                N,
-                K,
-                M,
-                DEGREE_PLUS_ONE,
-            >(num_vars);
+            let (pp, _comm_poly1, point_f, eval_f, proof_poly1) =
+                setup_full_protocol_poly::<F, N, K, M, DEGREE_PLUS_ONE>(num_vars);
 
             let different_evals = {
                 let different_eval_coeffs: Vec<_> = (1..=((1 << num_vars)
@@ -492,15 +463,8 @@ mod tests {
         };
 
         {
-            let (pp, comm, _point_f, eval_f, proof) = setup_full_protocol_poly::<
-                F,
-                InnerProductProjection<Boolean, BooleanInnerProductUncheckedAdd, _>,
-                HornerProjection<_, _>,
-                N,
-                K,
-                M,
-                DEGREE_PLUS_ONE,
-            >(num_vars);
+            let (pp, comm, _point_f, eval_f, proof) =
+                setup_full_protocol_poly::<F, N, K, M, DEGREE_PLUS_ONE>(num_vars);
             let invalid_point = make_invalid_point(eval_f.cfg());
 
             let result = TestPolyZip::verify::<_, HornerProjection<_, _>, MBSInnerProductChecked>(

--- a/zip-plus/src/pcs/phase_verify.rs
+++ b/zip-plus/src/pcs/phase_verify.rs
@@ -16,7 +16,7 @@ use zinc_poly::Polynomial;
 use zinc_transcript::traits::{Transcribable, Transcript};
 use zinc_utils::{
     from_ref::FromRef,
-    inner_product::{InnerProduct, MBSInnerProduct},
+    inner_product::{InnerProduct, MBSInnerProductChecked, MBSInnerProductUnchecked},
     mul_by_scalar::MulByScalar,
     projection_to_field::ProjectionToField,
 };
@@ -147,7 +147,7 @@ impl<Zt: ZipTypes, Lc: LinearCode<Zt>> ZipPlus<Zt, Lc> {
                 .map(Zt::Comb::from_ref)
                 .map(|p| Zt::CombDotChal::inner_product(&p, alphas, Zt::CombR::ZERO))
                 .try_collect()?;
-            MBSInnerProduct::inner_product(&column_entries, coeffs, Zt::CombR::ZERO)?
+            MBSInnerProductChecked::inner_product(&column_entries, coeffs, Zt::CombR::ZERO)?
         } else {
             Zt::CombDotChal::inner_product(
                 &Zt::Comb::from_ref(&column_entries[0]),
@@ -181,8 +181,11 @@ impl<Zt: ZipTypes, Lc: LinearCode<Zt>> ZipPlus<Zt, Lc> {
 
         let (q_0, q_1) = point_to_tensor(vp.num_rows, point_f, field_cfg)?;
 
-        if MBSInnerProduct::inner_product(&q_0_combined_row, &q_1, F::zero_with_cfg(field_cfg))?
-            != *eval_f
+        if MBSInnerProductUnchecked::inner_product(
+            &q_0_combined_row,
+            &q_1,
+            F::zero_with_cfg(field_cfg),
+        )? != *eval_f
         {
             return Err(ZipError::InvalidPcsOpen(
                 "Evaluation consistency failure".into(),
@@ -218,7 +221,11 @@ impl<Zt: ZipTypes, Lc: LinearCode<Zt>> ZipPlus<Zt, Lc> {
     {
         let column_entries_comb = if num_rows > 1 {
             let column_entries = column_entries.iter().map(project).collect_vec();
-            MBSInnerProduct::inner_product(q_0, &column_entries, F::zero_with_cfg(field_cfg))?
+            MBSInnerProductUnchecked::inner_product(
+                q_0,
+                &column_entries,
+                F::zero_with_cfg(field_cfg),
+            )?
             // TODO: this inner product is taking a long time.
         } else {
             project(column_entries.first().expect("No column entries"))

--- a/zip-plus/src/pcs/phase_verify.rs
+++ b/zip-plus/src/pcs/phase_verify.rs
@@ -18,11 +18,11 @@ use zinc_utils::{
     from_ref::FromRef,
     inner_product::{InnerProduct, MBSInnerProduct},
     mul_by_scalar::MulByScalar,
-    projectable_to_field::ProjectableToField,
+    projection_to_field::ProjectionToField,
 };
 
 impl<Zt: ZipTypes, Lc: LinearCode<Zt>> ZipPlus<Zt, Lc> {
-    pub fn verify<F>(
+    pub fn verify<F, P>(
         vp: &ZipPlusParams<Zt, Lc>,
         comm: &ZipPlusCommitment,
         point_f: &[F],
@@ -35,7 +35,7 @@ impl<Zt: ZipTypes, Lc: LinearCode<Zt>> ZipPlus<Zt, Lc> {
             + for<'a> FromWithConfig<&'a Zt::Chal>
             + for<'a> MulByScalar<&'a F>,
         F::Inner: FromRef<Zt::Fmod> + Transcribable,
-        Zt::Cw: ProjectableToField<F>,
+        P: ProjectionToField<Zt::Cw, F>,
     {
         validate_input::<Zt, Lc, _>("verify", vp.num_vars, &[], [point_f])?;
 
@@ -52,7 +52,7 @@ impl<Zt: ZipTypes, Lc: LinearCode<Zt>> ZipPlus<Zt, Lc> {
         let projecting_element: Zt::Chal = transcript.fs_transcript.get_challenge();
         let projecting_element: F = (&projecting_element).into_with_cfg(&field_cfg);
 
-        Self::verify_evaluation(
+        Self::verify_evaluation::<_, P>(
             vp,
             point_f,
             eval_f,
@@ -162,7 +162,7 @@ impl<Zt: ZipTypes, Lc: LinearCode<Zt>> ZipPlus<Zt, Lc> {
         Ok(())
     }
 
-    fn verify_evaluation<F>(
+    fn verify_evaluation<F, P>(
         vp: &ZipPlusParams<Zt, Lc>,
         point_f: &[F],
         eval_f: &F,
@@ -174,7 +174,7 @@ impl<Zt: ZipTypes, Lc: LinearCode<Zt>> ZipPlus<Zt, Lc> {
     where
         F: PrimeField + FromRef<F> + for<'a> MulByScalar<&'a F>,
         F::Inner: FromRef<Zt::Fmod> + Transcribable,
-        Zt::Cw: ProjectableToField<F>,
+        P: ProjectionToField<Zt::Cw, F>,
     {
         let q_0_combined_row = transcript.read_field_elements(vp.linear_code.row_len())?;
         let encoded_combined_row = vp.linear_code.encode_f(&q_0_combined_row);
@@ -188,7 +188,7 @@ impl<Zt: ZipTypes, Lc: LinearCode<Zt>> ZipPlus<Zt, Lc> {
                 "Evaluation consistency failure".into(),
             ));
         }
-        let project = Zt::Cw::prepare_projection(&projecting_element);
+        let project = P::prepare_projection(&projecting_element);
         for (column_idx, column_values) in columns_opened.iter() {
             Self::verify_proximity_q_0(
                 &q_0,
@@ -215,7 +215,6 @@ impl<Zt: ZipTypes, Lc: LinearCode<Zt>> ZipPlus<Zt, Lc> {
     ) -> Result<(), ZipError>
     where
         F: PrimeField + for<'a> MulByScalar<&'a F>,
-        Zt::Cw: ProjectableToField<F>,
     {
         let column_entries_comb = if num_rows > 1 {
             let column_entries = column_entries.iter().map(project).collect_vec();
@@ -259,9 +258,10 @@ mod tests {
     use rand::prelude::*;
     use zinc_poly::{
         mle::{DenseMultilinearExtension, MultilinearExtensionRand},
-        univariate::dense::DensePolynomial,
+        univariate::dense::{DensePolynomial, HornerProjection},
     };
     use zinc_transcript::traits::Transcribable;
+    use zinc_utils::projection_to_field::SimpleProjection;
 
     const INT_LIMBS: usize = U64::LIMBS;
 
@@ -285,16 +285,29 @@ mod tests {
     fn successful_verification_of_valid_proof() {
         let num_vars = 4;
         {
-            let (pp, comm, point_f, eval_f, proof) = setup_full_protocol::<F, N, K, M>(num_vars);
+            let (pp, comm, point_f, eval_f, proof) =
+                setup_full_protocol::<F, SimpleProjection<_>, SimpleProjection<_>, N, K, M>(
+                    num_vars,
+                );
 
-            let result = TestZip::verify(&pp, &comm, &point_f, &eval_f, &proof);
+            let result =
+                TestZip::verify::<_, SimpleProjection<_>>(&pp, &comm, &point_f, &eval_f, &proof);
             assert!(result.is_ok(), "Verification failed: {result:?}")
         };
         {
-            let (pp, comm, point_f, eval_f, proof) =
-                setup_full_protocol_poly::<F, N, K, M, DEGREE_PLUS_ONE>(num_vars);
+            let (pp, comm, point_f, eval_f, proof) = setup_full_protocol_poly::<
+                F,
+                HornerProjection<_, _>,
+                HornerProjection<_, _>,
+                N,
+                K,
+                M,
+                DEGREE_PLUS_ONE,
+            >(num_vars);
 
-            let result = TestPolyZip::verify(&pp, &comm, &point_f, &eval_f, &proof);
+            let result = TestPolyZip::verify::<_, HornerProjection<_, _>>(
+                &pp, &comm, &point_f, &eval_f, &proof,
+            );
 
             assert!(result.is_ok(), "Verification failed: {result:?}");
         }
@@ -305,10 +318,13 @@ mod tests {
         let num_vars = 4;
 
         {
-            let (pp, comm, point_f, eval_f, proof) = setup_full_protocol::<F, N, K, M>(num_vars);
+            let (pp, comm, point_f, eval_f, proof) =
+                setup_full_protocol::<F, SimpleProjection<_>, SimpleProjection<_>, N, K, M>(
+                    num_vars,
+                );
             let cfg = eval_f.cfg().clone();
 
-            let result = TestZip::verify(
+            let result = TestZip::verify::<_, SimpleProjection<_>>(
                 &pp,
                 &comm,
                 &point_f,
@@ -320,11 +336,18 @@ mod tests {
         }
 
         {
-            let (pp, comm, point_f, eval_f, proof) =
-                setup_full_protocol_poly::<F, N, K, M, DEGREE_PLUS_ONE>(num_vars);
+            let (pp, comm, point_f, eval_f, proof) = setup_full_protocol_poly::<
+                F,
+                HornerProjection<_, _>,
+                HornerProjection<_, _>,
+                N,
+                K,
+                M,
+                DEGREE_PLUS_ONE,
+            >(num_vars);
             let cfg = eval_f.cfg().clone();
 
-            let result = TestPolyZip::verify(
+            let result = TestPolyZip::verify::<_, HornerProjection<_, _>>(
                 &pp,
                 &comm,
                 &point_f,
@@ -346,17 +369,30 @@ mod tests {
         let num_vars = 4;
 
         {
-            let (pp, comm, point_f, eval, proof) = setup_full_protocol::<F, N, K, M>(num_vars);
+            let (pp, comm, point_f, eval, proof) =
+                setup_full_protocol::<F, SimpleProjection<_>, SimpleProjection<_>, N, K, M>(
+                    num_vars,
+                );
             let tampered = tamper(proof);
-            let result = TestZip::verify(&pp, &comm, &point_f, &eval, &tampered);
+            let result =
+                TestZip::verify::<_, SimpleProjection<_>>(&pp, &comm, &point_f, &eval, &tampered);
             assert!(result.is_err());
         }
 
         {
-            let (pp, comm, point_f, eval_f, proof) =
-                setup_full_protocol_poly::<F, N, K, M, DEGREE_PLUS_ONE>(num_vars);
+            let (pp, comm, point_f, eval_f, proof) = setup_full_protocol_poly::<
+                F,
+                HornerProjection<_, _>,
+                HornerProjection<_, _>,
+                N,
+                K,
+                M,
+                DEGREE_PLUS_ONE,
+            >(num_vars);
             let tampered = tamper(proof);
-            let result = TestPolyZip::verify(&pp, &comm, &point_f, &eval_f, &tampered);
+            let result = TestPolyZip::verify::<_, HornerProjection<_, _>>(
+                &pp, &comm, &point_f, &eval_f, &tampered,
+            );
             assert!(result.is_err());
         }
     }
@@ -366,7 +402,9 @@ mod tests {
         let num_vars = 4;
         {
             let (pp, _comm_poly1, point_f, eval_f, proof_poly1) =
-                setup_full_protocol::<F, N, K, M>(num_vars);
+                setup_full_protocol::<F, SimpleProjection<_>, SimpleProjection<_>, N, K, M>(
+                    num_vars,
+                );
 
             let different_evals: Vec<_> = (20..(20 + (1 << num_vars))).map(Int::from).collect();
             let poly2 = DenseMultilinearExtension::from_evaluations_vec(
@@ -376,14 +414,27 @@ mod tests {
             );
             let (_, comm_poly2) = TestZip::commit(&pp, &poly2).unwrap();
 
-            let result = TestZip::verify(&pp, &comm_poly2, &point_f, &eval_f, &proof_poly1);
+            let result = TestZip::verify::<_, SimpleProjection<_>>(
+                &pp,
+                &comm_poly2,
+                &point_f,
+                &eval_f,
+                &proof_poly1,
+            );
 
             assert!(result.is_err());
         }
 
         {
-            let (pp, _comm_poly1, point_f, eval_f, proof_poly1) =
-                setup_full_protocol_poly::<F, N, K, M, DEGREE_PLUS_ONE>(num_vars);
+            let (pp, _comm_poly1, point_f, eval_f, proof_poly1) = setup_full_protocol_poly::<
+                F,
+                HornerProjection<_, _>,
+                HornerProjection<_, _>,
+                N,
+                K,
+                M,
+                DEGREE_PLUS_ONE,
+            >(num_vars);
 
             let different_evals = {
                 let different_eval_coeffs: Vec<_> = (1..=((1 << num_vars)
@@ -403,7 +454,13 @@ mod tests {
             );
             let (_, comm_poly2) = TestPolyZip::commit(&pp, &poly2).unwrap();
 
-            let result = TestPolyZip::verify(&pp, &comm_poly2, &point_f, &eval_f, &proof_poly1);
+            let result = TestPolyZip::verify::<_, HornerProjection<_, _>>(
+                &pp,
+                &comm_poly2,
+                &point_f,
+                &eval_f,
+                &proof_poly1,
+            );
 
             assert!(result.is_err());
         }
@@ -422,20 +479,42 @@ mod tests {
         };
 
         {
-            let (pp, comm, _point_f, eval_f, proof) =
-                setup_full_protocol_poly::<F, N, K, M, DEGREE_PLUS_ONE>(num_vars);
+            let (pp, comm, _point_f, eval_f, proof) = setup_full_protocol_poly::<
+                F,
+                HornerProjection<_, _>,
+                HornerProjection<_, _>,
+                N,
+                K,
+                M,
+                DEGREE_PLUS_ONE,
+            >(num_vars);
             let invalid_point = make_invalid_point(eval_f.cfg());
 
-            let result = TestPolyZip::verify(&pp, &comm, &invalid_point, &eval_f, &proof);
+            let result = TestPolyZip::verify::<_, HornerProjection<_, _>>(
+                &pp,
+                &comm,
+                &invalid_point,
+                &eval_f,
+                &proof,
+            );
 
             assert!(matches!(result, Err(..)));
         }
 
         {
-            let (pp, comm, _point_f, eval_f, proof) = setup_full_protocol::<F, N, K, M>(num_vars);
+            let (pp, comm, _point_f, eval_f, proof) =
+                setup_full_protocol::<F, SimpleProjection<_>, SimpleProjection<_>, N, K, M>(
+                    num_vars,
+                );
             let invalid_point = make_invalid_point(eval_f.cfg());
 
-            let result = TestZip::verify(&pp, &comm, &invalid_point, &eval_f, &proof);
+            let result = TestZip::verify::<_, SimpleProjection<_>>(
+                &pp,
+                &comm,
+                &invalid_point,
+                &eval_f,
+                &proof,
+            );
 
             assert!(matches!(result, Err(..)));
         }
@@ -459,8 +538,9 @@ mod tests {
             (0..num_vars).map(|i| Int::from(i as i32 + 2)).collect();
 
         let test_mle2_proof = TestZip::test(&pp, &mle2, &data).expect("test phase should succeed");
-        let (eval_f, eval_mle2_proof) = TestZip::evaluate::<F>(&pp, &mle2, &point, test_mle2_proof)
-            .expect("evaluation phase should succeed");
+        let (eval_f, eval_mle2_proof) =
+            TestZip::evaluate::<F, SimpleProjection<_>>(&pp, &mle2, &point, test_mle2_proof)
+                .expect("evaluation phase should succeed");
 
         let eval_mle1 = mle1
             .evaluate(&point, Zero::zero())
@@ -470,8 +550,13 @@ mod tests {
         let point_f: Vec<F> = point.iter().map(|v| v.into_with_cfg(&field_cfg)).collect();
         let eval_mle1_f = eval_mle1.into_with_cfg(&field_cfg);
 
-        let verification_result =
-            TestZip::verify(&pp, &comm, &point_f, &eval_mle1_f, &eval_mle2_proof);
+        let verification_result = TestZip::verify::<_, SimpleProjection<_>>(
+            &pp,
+            &comm,
+            &point_f,
+            &eval_mle1_f,
+            &eval_mle2_proof,
+        );
 
         assert!(verification_result.is_err());
     }
@@ -503,8 +588,9 @@ mod tests {
 
         let test_transcript =
             TestZip::test(&pp, &mle, &corrupted_data).expect("test phase should succeed");
-        let (eval_f, proof) = TestZip::evaluate::<F>(&pp, &mle, &point, test_transcript)
-            .expect("evaluation phase should succeed");
+        let (eval_f, proof) =
+            TestZip::evaluate::<F, SimpleProjection<_>>(&pp, &mle, &point, test_transcript)
+                .expect("evaluation phase should succeed");
         let field_cfg = eval_f.cfg().clone();
 
         let expected_eval = mle
@@ -514,7 +600,8 @@ mod tests {
 
         let point_f: Vec<F> = point.iter().map(|v| v.into_with_cfg(&field_cfg)).collect();
 
-        let verification_result = TestZip::verify(&pp, &comm, &point_f, &eval_f, &proof);
+        let verification_result =
+            TestZip::verify::<_, SimpleProjection<_>>(&pp, &comm, &point_f, &eval_f, &proof);
 
         assert!(verification_result.is_err());
     }
@@ -530,14 +617,15 @@ mod tests {
             (0..num_vars).map(|i| Int::from(i as i32 + 2)).collect();
 
         let test_transcript = TestZip::test(&pp, &mle, &data).expect("test phase should succeed");
-        let (correct_eval_f, proof) = TestZip::evaluate::<F>(&pp, &mle, &point, test_transcript)
-            .expect("evaluation phase should succeed");
+        let (correct_eval_f, proof) =
+            TestZip::evaluate::<F, SimpleProjection<_>>(&pp, &mle, &point, test_transcript)
+                .expect("evaluation phase should succeed");
         let field_cfg = correct_eval_f.cfg().clone();
 
         let incorrect_eval_f = correct_eval_f + F::one_with_cfg(&field_cfg);
         let point_f: Vec<F> = point.iter().map(|v| v.into_with_cfg(&field_cfg)).collect();
 
-        let verification_result = TestZip::verify(
+        let verification_result = TestZip::verify::<_, SimpleProjection<_>>(
             &pp,
             &comm,
             &point_f,
@@ -570,8 +658,9 @@ mod tests {
         let eval = mle.evaluate(&point, Zero::zero()).unwrap();
 
         let test_transcript = TestZip::test(&pp, &mle, &data).expect("test phase should succeed");
-        let (eval_f, mut proof) = TestZip::evaluate::<F>(&pp, &mle, &point, test_transcript)
-            .expect("evaluation phase should succeed");
+        let (eval_f, mut proof) =
+            TestZip::evaluate::<F, SimpleProjection<_>>(&pp, &mle, &point, test_transcript)
+                .expect("evaluation phase should succeed");
         let field_cfg = eval_f.cfg().clone();
 
         assert_eq!(
@@ -593,7 +682,7 @@ mod tests {
         let flip_at = bytes_per_int * (row_len / 2);
         proof.0[flip_at] ^= 0x01;
 
-        let res = TestZip::verify(&pp, &comm, &point_f, &eval_f, &proof);
+        let res = TestZip::verify::<_, SimpleProjection<_>>(&pp, &comm, &point_f, &eval_f, &proof);
 
         match res {
             Err(ZipError::InvalidPcsOpen(msg)) => {
@@ -650,7 +739,9 @@ mod tests {
         data.cw_matrix.to_rows_slices_mut()[0][0] += Int::ONE;
 
         let test_transcript = TestZip::test(&pp, &mle, &data).unwrap();
-        let (eval_f, proof) = TestZip::evaluate::<F>(&pp, &mle, &point, test_transcript).unwrap();
+        let (eval_f, proof) =
+            TestZip::evaluate::<F, SimpleProjection<_>>(&pp, &mle, &point, test_transcript)
+                .unwrap();
         let field_cfg = eval_f.cfg().clone();
 
         let point_f = point
@@ -658,7 +749,8 @@ mod tests {
             .map(|v| v.into_with_cfg(&field_cfg))
             .collect_vec();
         let eval_f = evaluate_in_field(&mle.evaluations, &point_f, &field_cfg);
-        let verification_result = TestZip::verify(&pp, &comm, &point_f, &eval_f, &proof);
+        let verification_result =
+            TestZip::verify::<_, SimpleProjection<_>>(&pp, &comm, &point_f, &eval_f, &proof);
 
         assert!(verification_result.is_err());
     }
@@ -680,7 +772,8 @@ mod tests {
 
         let test_transcript = TestZip::test(&pp, &mle, &data).unwrap();
         let (eval_f, mut proof) =
-            TestZip::evaluate::<F>(&pp, &mle, &point, test_transcript).unwrap();
+            TestZip::evaluate::<F, SimpleProjection<_>>(&pp, &mle, &point, test_transcript)
+                .unwrap();
         let field_cfg = eval_f.cfg().clone();
 
         let point_f: Vec<F> = point.iter().map(|v| v.into_with_cfg(&field_cfg)).collect();
@@ -698,7 +791,7 @@ mod tests {
         let flip_at = tail_start + (bytes_per_field / 4);
         proof.0[flip_at] ^= 0x01;
 
-        let res = TestZip::verify(&pp, &comm, &point_f, &eval_f, &proof);
+        let res = TestZip::verify::<_, SimpleProjection<_>>(&pp, &comm, &point_f, &eval_f, &proof);
 
         match res {
             Err(ZipError::InvalidPcsOpen(msg)) => {
@@ -726,7 +819,8 @@ mod tests {
 
         let test_transcript = TestZip::test(&pp, &mle, &data).unwrap();
         let (real_eval_f, proof) =
-            TestZip::evaluate::<F>(&pp, &mle, &point, test_transcript).unwrap();
+            TestZip::evaluate::<F, SimpleProjection<_>>(&pp, &mle, &point, test_transcript)
+                .unwrap();
         let field_cfg = real_eval_f.cfg().clone();
 
         let eval_f = mle
@@ -735,7 +829,7 @@ mod tests {
             .into_with_cfg(&field_cfg);
         let point_f: Vec<F> = point.iter().map(|v| v.into_with_cfg(&field_cfg)).collect();
 
-        let res = TestZip::verify(&pp, &comm, &point_f, &eval_f, &proof);
+        let res = TestZip::verify::<_, SimpleProjection<_>>(&pp, &comm, &point_f, &eval_f, &proof);
         assert!(res.is_ok());
     }
 
@@ -756,7 +850,8 @@ mod tests {
 
         let test_transcript = TestZip::test(&pp, &mle, &data).unwrap();
         let (real_eval_f, proof) =
-            TestZip::evaluate::<F>(&pp, &mle, &point, test_transcript).unwrap();
+            TestZip::evaluate::<F, SimpleProjection<_>>(&pp, &mle, &point, test_transcript)
+                .unwrap();
         let field_cfg = real_eval_f.cfg().clone();
 
         let eval_f = mle
@@ -765,7 +860,7 @@ mod tests {
             .into_with_cfg(&field_cfg);
         let point_f: Vec<F> = point.iter().map(|v| v.into_with_cfg(&field_cfg)).collect();
 
-        let res = TestZip::verify(&pp, &comm, &point_f, &eval_f, &proof);
+        let res = TestZip::verify::<_, SimpleProjection<_>>(&pp, &comm, &point_f, &eval_f, &proof);
         assert!(res.is_ok());
     }
 
@@ -786,7 +881,9 @@ mod tests {
         point[0] = <Zt as ZipTypes>::Pt::ONE;
 
         let test_transcript = TestZip::test(&pp, &poly, &data).unwrap();
-        let (eval_f, proof) = TestZip::evaluate::<F>(&pp, &poly, &point, test_transcript).unwrap();
+        let (eval_f, proof) =
+            TestZip::evaluate::<F, SimpleProjection<_>>(&pp, &poly, &point, test_transcript)
+                .unwrap();
         let field_cfg = eval_f.cfg().clone();
 
         let expected_eval = poly
@@ -796,7 +893,8 @@ mod tests {
 
         let point_f: Vec<F> = point.iter().map(|v| v.into_with_cfg(&field_cfg)).collect();
 
-        let verification_result = TestZip::verify(&pp, &comm, &point_f, &eval_f, &proof);
+        let verification_result =
+            TestZip::verify::<_, SimpleProjection<_>>(&pp, &comm, &point_f, &eval_f, &proof);
 
         assert!(
             verification_result.is_ok(),
@@ -814,7 +912,9 @@ mod tests {
         let point: Vec<<Zt as ZipTypes>::Pt> = vec![Int::from(1), Int::from(2)];
 
         let test_transcript = TestZip::test(&pp, &poly, &hint).unwrap();
-        let (eval_f, proof) = TestZip::evaluate::<F>(&pp, &poly, &point, test_transcript).unwrap();
+        let (eval_f, proof) =
+            TestZip::evaluate::<F, SimpleProjection<_>>(&pp, &poly, &point, test_transcript)
+                .unwrap();
         let field_cfg = eval_f.cfg().clone();
 
         let expected_eval = poly
@@ -824,7 +924,8 @@ mod tests {
 
         let point_f: Vec<F> = point.iter().map(|v| v.into_with_cfg(&field_cfg)).collect();
 
-        let verification_result = TestZip::verify(&pp, &comm, &point_f, &eval_f, &proof);
+        let verification_result =
+            TestZip::verify::<_, SimpleProjection<_>>(&pp, &comm, &point_f, &eval_f, &proof);
 
         assert!(verification_result.is_ok());
     }
@@ -846,7 +947,8 @@ mod tests {
 
         let test_transcript = TestZip::test(&pp, &mle, &data).unwrap();
         let (real_eval_f, mut proof) =
-            TestZip::evaluate::<F>(&pp, &mle, &point, test_transcript).unwrap();
+            TestZip::evaluate::<F, SimpleProjection<_>>(&pp, &mle, &point, test_transcript)
+                .unwrap();
         let field_cfg = real_eval_f.cfg().clone();
 
         let eval_f = mle
@@ -867,7 +969,7 @@ mod tests {
             *b = 0xFF;
         }
 
-        let res = TestZip::verify(&pp, &comm, &point_f, &eval_f, &proof);
+        let res = TestZip::verify::<_, SimpleProjection<_>>(&pp, &comm, &point_f, &eval_f, &proof);
         assert!(res.is_err());
     }
 
@@ -891,7 +993,8 @@ mod tests {
             // Prover produces a proof once (exactly as in the bench)
             let test_transcript = TestZip::test(&pp, &mle, &data).unwrap();
             let (eval_f, proof) =
-                TestZip::evaluate::<F>(&pp, &mle, &point, test_transcript).unwrap();
+                TestZip::evaluate::<F, SimpleProjection<_>>(&pp, &mle, &point, test_transcript)
+                    .unwrap();
             let field_cfg = eval_f.cfg().clone();
 
             assert_eq!(
@@ -903,7 +1006,8 @@ mod tests {
             let point_f: Vec<F> = point.iter().map(|v| v.into_with_cfg(&field_cfg)).collect();
 
             // Verifier replays verification from the same proof (also like the bench)
-            TestZip::verify(&pp, &commitment, &point_f, &eval_f, &proof).expect("verify");
+            TestZip::verify::<_, SimpleProjection<_>>(&pp, &commitment, &point_f, &eval_f, &proof)
+                .expect("verify");
         }
 
         inner::<12>();
@@ -928,13 +1032,21 @@ mod tests {
             // Prover produces a proof once (exactly as in the bench)
             let test_proof = TestPolyZip::test(&pp, &mle, &data).unwrap();
             let (eval_f, eval_proof) =
-                TestPolyZip::evaluate::<F>(&pp, &mle, &point, test_proof).unwrap();
+                TestPolyZip::evaluate::<F, HornerProjection<_, _>>(&pp, &mle, &point, test_proof)
+                    .unwrap();
             let field_cfg = eval_f.cfg().clone();
 
             let point_f: Vec<F> = point.iter().map(|v| v.into_with_cfg(&field_cfg)).collect();
 
             // Verifier replays verification from the same proof (also like the bench)
-            TestPolyZip::verify(&pp, &commitment, &point_f, &eval_f, &eval_proof).expect("verify");
+            TestPolyZip::verify::<_, HornerProjection<_, _>>(
+                &pp,
+                &commitment,
+                &point_f,
+                &eval_f,
+                &eval_proof,
+            )
+            .expect("verify");
         }
 
         inner::<12>();

--- a/zip-plus/src/pcs/phase_verify.rs
+++ b/zip-plus/src/pcs/phase_verify.rs
@@ -16,13 +16,13 @@ use zinc_poly::Polynomial;
 use zinc_transcript::traits::{Transcribable, Transcript};
 use zinc_utils::{
     from_ref::FromRef,
-    inner_product::{InnerProduct, MBSInnerProductChecked, MBSInnerProductUnchecked},
+    inner_product::{InnerProduct, MBSInnerProductUnchecked},
     mul_by_scalar::MulByScalar,
     projection_to_field::ProjectionToField,
 };
 
 impl<Zt: ZipTypes, Lc: LinearCode<Zt>> ZipPlus<Zt, Lc> {
-    pub fn verify<F, P>(
+    pub fn verify<F, P, I>(
         vp: &ZipPlusParams<Zt, Lc>,
         comm: &ZipPlusCommitment,
         point_f: &[F],
@@ -35,13 +35,14 @@ impl<Zt: ZipTypes, Lc: LinearCode<Zt>> ZipPlus<Zt, Lc> {
             + for<'a> FromWithConfig<&'a Zt::Chal>
             + for<'a> MulByScalar<&'a F>,
         F::Inner: FromRef<Zt::Fmod> + Transcribable,
+        I: InnerProduct<[Zt::CombR], Zt::Chal, Zt::CombR>,
         P: ProjectionToField<Zt::Cw, F>,
     {
         validate_input::<Zt, Lc, _>("verify", vp.num_vars, &[], [point_f])?;
 
         let mut transcript: PcsTranscript = proof.clone().into();
 
-        let columns_opened = Self::verify_testing(vp, &comm.root, &mut transcript)?;
+        let columns_opened = Self::verify_testing::<I>(vp, &comm.root, &mut transcript)?;
 
         let field_modulus = F::Inner::from_ref(
             &transcript
@@ -66,7 +67,7 @@ impl<Zt: ZipTypes, Lc: LinearCode<Zt>> ZipPlus<Zt, Lc> {
     }
 
     #[allow(clippy::arithmetic_side_effects, clippy::type_complexity)]
-    pub(super) fn verify_testing(
+    pub(super) fn verify_testing<I: InnerProduct<[Zt::CombR], Zt::Chal, Zt::CombR>>(
         vp: &ZipPlusParams<Zt, Lc>,
         root: &MtHash,
         transcript: &mut PcsTranscript,
@@ -113,7 +114,7 @@ impl<Zt: ZipTypes, Lc: LinearCode<Zt>> ZipPlus<Zt, Lc> {
 
             if let Some((ref alphas, ref coeffs, ref encoded_combined_row)) = encoded_combined_rows
             {
-                Self::verify_column_testing(
+                Self::verify_column_testing::<I>(
                     alphas,
                     coeffs,
                     encoded_combined_row,
@@ -133,7 +134,7 @@ impl<Zt: ZipTypes, Lc: LinearCode<Zt>> ZipPlus<Zt, Lc> {
         Ok(columns_opened)
     }
 
-    pub(super) fn verify_column_testing(
+    pub(super) fn verify_column_testing<I: InnerProduct<[Zt::CombR], Zt::Chal, Zt::CombR>>(
         alphas: &[Zt::Chal],
         coeffs: &[Zt::Chal],
         encoded_combined_row: &[Zt::CombR],
@@ -147,7 +148,7 @@ impl<Zt: ZipTypes, Lc: LinearCode<Zt>> ZipPlus<Zt, Lc> {
                 .map(Zt::Comb::from_ref)
                 .map(|p| Zt::CombDotChal::inner_product(&p, alphas, Zt::CombR::ZERO))
                 .try_collect()?;
-            MBSInnerProductChecked::inner_product(&column_entries, coeffs, Zt::CombR::ZERO)?
+            I::inner_product(&column_entries, coeffs, Zt::CombR::ZERO)?
         } else {
             Zt::CombDotChal::inner_product(
                 &Zt::Comb::from_ref(&column_entries[0]),
@@ -269,7 +270,8 @@ mod tests {
     };
     use zinc_transcript::traits::Transcribable;
     use zinc_utils::{
-        inner_product::BooleanInnerProductUncheckedAdd, projection_to_field::SimpleProjection,
+        inner_product::{BooleanInnerProductUncheckedAdd, MBSInnerProductChecked},
+        projection_to_field::SimpleProjection,
     };
 
     const INT_LIMBS: usize = U64::LIMBS;
@@ -299,8 +301,9 @@ mod tests {
                     num_vars,
                 );
 
-            let result =
-                TestZip::verify::<_, SimpleProjection<_>>(&pp, &comm, &point_f, &eval_f, &proof);
+            let result = TestZip::verify::<_, SimpleProjection<_>, MBSInnerProductChecked>(
+                &pp, &comm, &point_f, &eval_f, &proof,
+            );
             assert!(result.is_ok(), "Verification failed: {result:?}")
         };
         {
@@ -314,7 +317,7 @@ mod tests {
                 DEGREE_PLUS_ONE,
             >(num_vars);
 
-            let result = TestPolyZip::verify::<_, HornerProjection<_, _>>(
+            let result = TestPolyZip::verify::<_, HornerProjection<_, _>, MBSInnerProductChecked>(
                 &pp, &comm, &point_f, &eval_f, &proof,
             );
 
@@ -333,7 +336,7 @@ mod tests {
                 );
             let cfg = eval_f.cfg().clone();
 
-            let result = TestZip::verify::<_, SimpleProjection<_>>(
+            let result = TestZip::verify::<_, SimpleProjection<_>, MBSInnerProductChecked>(
                 &pp,
                 &comm,
                 &point_f,
@@ -356,7 +359,7 @@ mod tests {
             >(num_vars);
             let cfg = eval_f.cfg().clone();
 
-            let result = TestPolyZip::verify::<_, HornerProjection<_, _>>(
+            let result = TestPolyZip::verify::<_, HornerProjection<_, _>, MBSInnerProductChecked>(
                 &pp,
                 &comm,
                 &point_f,
@@ -383,8 +386,9 @@ mod tests {
                     num_vars,
                 );
             let tampered = tamper(proof);
-            let result =
-                TestZip::verify::<_, SimpleProjection<_>>(&pp, &comm, &point_f, &eval, &tampered);
+            let result = TestZip::verify::<_, SimpleProjection<_>, MBSInnerProductChecked>(
+                &pp, &comm, &point_f, &eval, &tampered,
+            );
             assert!(result.is_err());
         }
 
@@ -399,7 +403,7 @@ mod tests {
                 DEGREE_PLUS_ONE,
             >(num_vars);
             let tampered = tamper(proof);
-            let result = TestPolyZip::verify::<_, HornerProjection<_, _>>(
+            let result = TestPolyZip::verify::<_, HornerProjection<_, _>, MBSInnerProductChecked>(
                 &pp, &comm, &point_f, &eval_f, &tampered,
             );
             assert!(result.is_err());
@@ -423,7 +427,7 @@ mod tests {
             );
             let (_, comm_poly2) = TestZip::commit(&pp, &poly2).unwrap();
 
-            let result = TestZip::verify::<_, SimpleProjection<_>>(
+            let result = TestZip::verify::<_, SimpleProjection<_>, MBSInnerProductChecked>(
                 &pp,
                 &comm_poly2,
                 &point_f,
@@ -463,7 +467,7 @@ mod tests {
             );
             let (_, comm_poly2) = TestPolyZip::commit(&pp, &poly2).unwrap();
 
-            let result = TestPolyZip::verify::<_, HornerProjection<_, _>>(
+            let result = TestPolyZip::verify::<_, HornerProjection<_, _>, MBSInnerProductChecked>(
                 &pp,
                 &comm_poly2,
                 &point_f,
@@ -499,7 +503,7 @@ mod tests {
             >(num_vars);
             let invalid_point = make_invalid_point(eval_f.cfg());
 
-            let result = TestPolyZip::verify::<_, HornerProjection<_, _>>(
+            let result = TestPolyZip::verify::<_, HornerProjection<_, _>, MBSInnerProductChecked>(
                 &pp,
                 &comm,
                 &invalid_point,
@@ -517,7 +521,7 @@ mod tests {
                 );
             let invalid_point = make_invalid_point(eval_f.cfg());
 
-            let result = TestZip::verify::<_, SimpleProjection<_>>(
+            let result = TestZip::verify::<_, SimpleProjection<_>, MBSInnerProductChecked>(
                 &pp,
                 &comm,
                 &invalid_point,
@@ -559,7 +563,7 @@ mod tests {
         let point_f: Vec<F> = point.iter().map(|v| v.into_with_cfg(&field_cfg)).collect();
         let eval_mle1_f = eval_mle1.into_with_cfg(&field_cfg);
 
-        let verification_result = TestZip::verify::<_, SimpleProjection<_>>(
+        let verification_result = TestZip::verify::<_, SimpleProjection<_>, MBSInnerProductChecked>(
             &pp,
             &comm,
             &point_f,
@@ -609,8 +613,9 @@ mod tests {
 
         let point_f: Vec<F> = point.iter().map(|v| v.into_with_cfg(&field_cfg)).collect();
 
-        let verification_result =
-            TestZip::verify::<_, SimpleProjection<_>>(&pp, &comm, &point_f, &eval_f, &proof);
+        let verification_result = TestZip::verify::<_, SimpleProjection<_>, MBSInnerProductChecked>(
+            &pp, &comm, &point_f, &eval_f, &proof,
+        );
 
         assert!(verification_result.is_err());
     }
@@ -634,7 +639,7 @@ mod tests {
         let incorrect_eval_f = correct_eval_f + F::one_with_cfg(&field_cfg);
         let point_f: Vec<F> = point.iter().map(|v| v.into_with_cfg(&field_cfg)).collect();
 
-        let verification_result = TestZip::verify::<_, SimpleProjection<_>>(
+        let verification_result = TestZip::verify::<_, SimpleProjection<_>, MBSInnerProductChecked>(
             &pp,
             &comm,
             &point_f,
@@ -691,7 +696,9 @@ mod tests {
         let flip_at = bytes_per_int * (row_len / 2);
         proof.0[flip_at] ^= 0x01;
 
-        let res = TestZip::verify::<_, SimpleProjection<_>>(&pp, &comm, &point_f, &eval_f, &proof);
+        let res = TestZip::verify::<_, SimpleProjection<_>, MBSInnerProductChecked>(
+            &pp, &comm, &point_f, &eval_f, &proof,
+        );
 
         match res {
             Err(ZipError::InvalidPcsOpen(msg)) => {
@@ -758,8 +765,9 @@ mod tests {
             .map(|v| v.into_with_cfg(&field_cfg))
             .collect_vec();
         let eval_f = evaluate_in_field(&mle.evaluations, &point_f, &field_cfg);
-        let verification_result =
-            TestZip::verify::<_, SimpleProjection<_>>(&pp, &comm, &point_f, &eval_f, &proof);
+        let verification_result = TestZip::verify::<_, SimpleProjection<_>, MBSInnerProductChecked>(
+            &pp, &comm, &point_f, &eval_f, &proof,
+        );
 
         assert!(verification_result.is_err());
     }
@@ -800,7 +808,9 @@ mod tests {
         let flip_at = tail_start + (bytes_per_field / 4);
         proof.0[flip_at] ^= 0x01;
 
-        let res = TestZip::verify::<_, SimpleProjection<_>>(&pp, &comm, &point_f, &eval_f, &proof);
+        let res = TestZip::verify::<_, SimpleProjection<_>, MBSInnerProductChecked>(
+            &pp, &comm, &point_f, &eval_f, &proof,
+        );
 
         match res {
             Err(ZipError::InvalidPcsOpen(msg)) => {
@@ -838,7 +848,9 @@ mod tests {
             .into_with_cfg(&field_cfg);
         let point_f: Vec<F> = point.iter().map(|v| v.into_with_cfg(&field_cfg)).collect();
 
-        let res = TestZip::verify::<_, SimpleProjection<_>>(&pp, &comm, &point_f, &eval_f, &proof);
+        let res = TestZip::verify::<_, SimpleProjection<_>, MBSInnerProductChecked>(
+            &pp, &comm, &point_f, &eval_f, &proof,
+        );
         assert!(res.is_ok());
     }
 
@@ -869,7 +881,9 @@ mod tests {
             .into_with_cfg(&field_cfg);
         let point_f: Vec<F> = point.iter().map(|v| v.into_with_cfg(&field_cfg)).collect();
 
-        let res = TestZip::verify::<_, SimpleProjection<_>>(&pp, &comm, &point_f, &eval_f, &proof);
+        let res = TestZip::verify::<_, SimpleProjection<_>, MBSInnerProductChecked>(
+            &pp, &comm, &point_f, &eval_f, &proof,
+        );
         assert!(res.is_ok());
     }
 
@@ -902,8 +916,9 @@ mod tests {
 
         let point_f: Vec<F> = point.iter().map(|v| v.into_with_cfg(&field_cfg)).collect();
 
-        let verification_result =
-            TestZip::verify::<_, SimpleProjection<_>>(&pp, &comm, &point_f, &eval_f, &proof);
+        let verification_result = TestZip::verify::<_, SimpleProjection<_>, MBSInnerProductChecked>(
+            &pp, &comm, &point_f, &eval_f, &proof,
+        );
 
         assert!(
             verification_result.is_ok(),
@@ -933,8 +948,9 @@ mod tests {
 
         let point_f: Vec<F> = point.iter().map(|v| v.into_with_cfg(&field_cfg)).collect();
 
-        let verification_result =
-            TestZip::verify::<_, SimpleProjection<_>>(&pp, &comm, &point_f, &eval_f, &proof);
+        let verification_result = TestZip::verify::<_, SimpleProjection<_>, MBSInnerProductChecked>(
+            &pp, &comm, &point_f, &eval_f, &proof,
+        );
 
         assert!(verification_result.is_ok());
     }
@@ -978,7 +994,9 @@ mod tests {
             *b = 0xFF;
         }
 
-        let res = TestZip::verify::<_, SimpleProjection<_>>(&pp, &comm, &point_f, &eval_f, &proof);
+        let res = TestZip::verify::<_, SimpleProjection<_>, MBSInnerProductChecked>(
+            &pp, &comm, &point_f, &eval_f, &proof,
+        );
         assert!(res.is_err());
     }
 
@@ -1015,8 +1033,14 @@ mod tests {
             let point_f: Vec<F> = point.iter().map(|v| v.into_with_cfg(&field_cfg)).collect();
 
             // Verifier replays verification from the same proof (also like the bench)
-            TestZip::verify::<_, SimpleProjection<_>>(&pp, &commitment, &point_f, &eval_f, &proof)
-                .expect("verify");
+            TestZip::verify::<_, SimpleProjection<_>, MBSInnerProductChecked>(
+                &pp,
+                &commitment,
+                &point_f,
+                &eval_f,
+                &proof,
+            )
+            .expect("verify");
         }
 
         inner::<12>();
@@ -1048,7 +1072,7 @@ mod tests {
             let point_f: Vec<F> = point.iter().map(|v| v.into_with_cfg(&field_cfg)).collect();
 
             // Verifier replays verification from the same proof (also like the bench)
-            TestPolyZip::verify::<_, HornerProjection<_, _>>(
+            TestPolyZip::verify::<_, HornerProjection<_, _>, MBSInnerProductChecked>(
                 &pp,
                 &commitment,
                 &point_f,

--- a/zip-plus/src/pcs/phase_verify.rs
+++ b/zip-plus/src/pcs/phase_verify.rs
@@ -35,8 +35,8 @@ impl<Zt: ZipTypes, Lc: LinearCode<Zt>> ZipPlus<Zt, Lc> {
             + for<'a> FromWithConfig<&'a Zt::Chal>
             + for<'a> MulByScalar<&'a F>,
         F::Inner: FromRef<Zt::Fmod> + Transcribable,
-        I: InnerProduct<[Zt::CombR], Zt::Chal, Zt::CombR>,
         P: ProjectionToField<Zt::Cw, F>,
+        I: InnerProduct<[Zt::CombR], Zt::Chal, Zt::CombR>,
     {
         validate_input::<Zt, Lc, _>("verify", vp.num_vars, &[], [point_f])?;
 
@@ -295,10 +295,7 @@ mod tests {
     fn successful_verification_of_valid_proof() {
         let num_vars = 4;
         {
-            let (pp, comm, point_f, eval_f, proof) =
-                setup_full_protocol::<F, SimpleProjection<_>, SimpleProjection<_>, N, K, M>(
-                    num_vars,
-                );
+            let (pp, comm, point_f, eval_f, proof) = setup_full_protocol::<F, N, K, M>(num_vars);
 
             let result = TestZip::verify::<_, SimpleProjection<_>, MBSInnerProductChecked>(
                 &pp, &comm, &point_f, &eval_f, &proof,
@@ -322,10 +319,7 @@ mod tests {
         let num_vars = 4;
 
         {
-            let (pp, comm, point_f, eval_f, proof) =
-                setup_full_protocol::<F, SimpleProjection<_>, SimpleProjection<_>, N, K, M>(
-                    num_vars,
-                );
+            let (pp, comm, point_f, eval_f, proof) = setup_full_protocol::<F, N, K, M>(num_vars);
             let cfg = eval_f.cfg().clone();
 
             let result = TestZip::verify::<_, SimpleProjection<_>, MBSInnerProductChecked>(
@@ -366,10 +360,7 @@ mod tests {
         let num_vars = 4;
 
         {
-            let (pp, comm, point_f, eval, proof) =
-                setup_full_protocol::<F, SimpleProjection<_>, SimpleProjection<_>, N, K, M>(
-                    num_vars,
-                );
+            let (pp, comm, point_f, eval, proof) = setup_full_protocol::<F, N, K, M>(num_vars);
             let tampered = tamper(proof);
             let result = TestZip::verify::<_, SimpleProjection<_>, MBSInnerProductChecked>(
                 &pp, &comm, &point_f, &eval, &tampered,
@@ -393,9 +384,7 @@ mod tests {
         let num_vars = 4;
         {
             let (pp, _comm_poly1, point_f, eval_f, proof_poly1) =
-                setup_full_protocol::<F, SimpleProjection<_>, SimpleProjection<_>, N, K, M>(
-                    num_vars,
-                );
+                setup_full_protocol::<F, N, K, M>(num_vars);
 
             let different_evals: Vec<_> = (20..(20 + (1 << num_vars))).map(Int::from).collect();
             let poly2 = DenseMultilinearExtension::from_evaluations_vec(
@@ -479,10 +468,7 @@ mod tests {
         }
 
         {
-            let (pp, comm, _point_f, eval_f, proof) =
-                setup_full_protocol::<F, SimpleProjection<_>, SimpleProjection<_>, N, K, M>(
-                    num_vars,
-                );
+            let (pp, comm, _point_f, eval_f, proof) = setup_full_protocol::<F, N, K, M>(num_vars);
             let invalid_point = make_invalid_point(eval_f.cfg());
 
             let result = TestZip::verify::<_, SimpleProjection<_>, MBSInnerProductChecked>(

--- a/zip-plus/src/pcs/structs.rs
+++ b/zip-plus/src/pcs/structs.rs
@@ -15,12 +15,7 @@ pub trait ZipTypes: Send + Sync {
     const NUM_COLUMN_OPENINGS: usize;
 
     /// Semiring of witness/polynomial evaluations on boolean hypercube
-    type Eval: Clone
-        + Send
-        + Sync
-        + Named
-        + ConstCoeffBitWidth
-        + InnerProduct<Self::Chal, Self::CombR>;
+    type Eval: Clone + Send + Sync + Named + ConstCoeffBitWidth;
 
     /// Semiring of codeword elements, at least as wide as the evaluation ring
     type Cw: FixedSemiring
@@ -51,10 +46,12 @@ pub trait ZipTypes: Send + Sync {
     /// wide as the evaluation, codeword, and challenge rings.
     type Comb: FixedSemiring
         + Polynomial<Self::CombR>
-        + InnerProduct<Self::Chal, Self::CombR>
         + FromRef<Self::Eval>
         + FromRef<Self::Cw>
         + Named;
+
+    type EvalDotChal: InnerProduct<Self::Eval, Self::Chal, Self::CombR>;
+    type CombDotChal: InnerProduct<Self::Comb, Self::Chal, Self::CombR>;
 }
 
 /// Zip is a Polynomial Commitment Scheme (PCS) that supports committing to

--- a/zip-plus/src/pcs/test_utils.rs
+++ b/zip-plus/src/pcs/test_utils.rs
@@ -55,8 +55,8 @@ impl<const N: usize, const K: usize, const M: usize> ZipTypes for TestZipTypes<N
     type Pt = Int<N>;
     type CombR = Int<M>;
     type Comb = Self::CombR;
-    type CombDotChal = ScalarProduct;
     type EvalDotChal = ScalarProduct;
+    type CombDotChal = ScalarProduct;
 }
 
 pub struct TestPolyZipTypes<const K: usize, const M: usize, const DEGREE_PLUS_ONE: usize> {}
@@ -72,8 +72,6 @@ impl<const K: usize, const M: usize, const DEGREE_PLUS_ONE: usize> ZipTypes
     type Pt = i128;
     type CombR = Int<M>;
     type Comb = DensePolynomial<Self::CombR, DEGREE_PLUS_ONE>;
-    type CombDotChal =
-        DensePolyInnerProduct<Self::CombR, i128, Int<M>, MBSInnerProduct, DEGREE_PLUS_ONE>;
     type EvalDotChal = DensePolyInnerProduct<
         Boolean,
         i128,
@@ -81,6 +79,8 @@ impl<const K: usize, const M: usize, const DEGREE_PLUS_ONE: usize> ZipTypes
         BooleanInnerProductCheckedAdd,
         DEGREE_PLUS_ONE,
     >;
+    type CombDotChal =
+        DensePolyInnerProduct<Self::CombR, i128, Int<M>, MBSInnerProduct, DEGREE_PLUS_ONE>;
 }
 
 /// Helper function to set up common parameters for tests.

--- a/zip-plus/src/pcs/test_utils.rs
+++ b/zip-plus/src/pcs/test_utils.rs
@@ -32,7 +32,7 @@ use zinc_primality::MillerRabin;
 use zinc_transcript::traits::{Transcribable, Transcript};
 use zinc_utils::{
     from_ref::FromRef,
-    inner_product::{BooleanInnerProductCheckedAdd, MBSInnerProduct, ScalarProduct},
+    inner_product::{BooleanInnerProductCheckedAdd, MBSInnerProductChecked, ScalarProduct},
     mul_by_scalar::MulByScalar,
     projection_to_field::ProjectionToField,
 };
@@ -80,7 +80,7 @@ impl<const K: usize, const M: usize, const DEGREE_PLUS_ONE: usize> ZipTypes
         DEGREE_PLUS_ONE,
     >;
     type CombDotChal =
-        DensePolyInnerProduct<Self::CombR, i128, Int<M>, MBSInnerProduct, DEGREE_PLUS_ONE>;
+        DensePolyInnerProduct<Self::CombR, i128, Int<M>, MBSInnerProductChecked, DEGREE_PLUS_ONE>;
 }
 
 /// Helper function to set up common parameters for tests.

--- a/zip-plus/src/pcs/test_utils.rs
+++ b/zip-plus/src/pcs/test_utils.rs
@@ -24,11 +24,17 @@ use crypto_primitives::{
 };
 use itertools::Itertools;
 use num_traits::Zero;
-use zinc_poly::{mle::DenseMultilinearExtension, univariate::dense::DensePolynomial};
+use zinc_poly::{
+    mle::DenseMultilinearExtension,
+    univariate::dense::{DensePolyInnerProduct, DensePolynomial},
+};
 use zinc_primality::MillerRabin;
 use zinc_transcript::traits::{Transcribable, Transcript};
 use zinc_utils::{
-    from_ref::FromRef, mul_by_scalar::MulByScalar, projectable_to_field::ProjectableToField,
+    from_ref::FromRef,
+    inner_product::{BooleanInnerProduct, MBSInnerProduct, ScalarProduct},
+    mul_by_scalar::MulByScalar,
+    projectable_to_field::ProjectableToField,
 };
 
 const REPETITION_FACTOR: usize = 4;
@@ -49,6 +55,8 @@ impl<const N: usize, const K: usize, const M: usize> ZipTypes for TestZipTypes<N
     type Pt = Int<N>;
     type CombR = Int<M>;
     type Comb = Self::CombR;
+    type CombDotChal = ScalarProduct;
+    type EvalDotChal = ScalarProduct;
 }
 
 pub struct TestPolyZipTypes<const K: usize, const M: usize, const DEGREE_PLUS_ONE: usize> {}
@@ -64,6 +72,10 @@ impl<const K: usize, const M: usize, const DEGREE_PLUS_ONE: usize> ZipTypes
     type Pt = i128;
     type CombR = Int<M>;
     type Comb = DensePolynomial<Self::CombR, DEGREE_PLUS_ONE>;
+    type CombDotChal =
+        DensePolyInnerProduct<Self::CombR, i128, Int<M>, MBSInnerProduct, DEGREE_PLUS_ONE>;
+    type EvalDotChal =
+        DensePolyInnerProduct<Boolean, i128, Int<M>, BooleanInnerProduct, DEGREE_PLUS_ONE>;
 }
 
 /// Helper function to set up common parameters for tests.

--- a/zip-plus/src/pcs/test_utils.rs
+++ b/zip-plus/src/pcs/test_utils.rs
@@ -74,13 +74,18 @@ impl<const K: usize, const M: usize, const DEGREE_PLUS_ONE: usize> ZipTypes
     type Comb = DensePolynomial<Self::CombR, DEGREE_PLUS_ONE>;
     type EvalDotChal = DensePolyInnerProduct<
         Boolean,
-        i128,
-        Int<M>,
+        Self::Chal,
+        Self::CombR,
         BooleanInnerProductCheckedAdd,
         DEGREE_PLUS_ONE,
     >;
-    type CombDotChal =
-        DensePolyInnerProduct<Self::CombR, i128, Int<M>, MBSInnerProductChecked, DEGREE_PLUS_ONE>;
+    type CombDotChal = DensePolyInnerProduct<
+        Self::CombR,
+        Self::Chal,
+        Self::CombR,
+        MBSInnerProductChecked,
+        DEGREE_PLUS_ONE,
+    >;
 }
 
 /// Helper function to set up common parameters for tests.

--- a/zip-plus/src/pcs/test_utils.rs
+++ b/zip-plus/src/pcs/test_utils.rs
@@ -32,9 +32,9 @@ use zinc_primality::MillerRabin;
 use zinc_transcript::traits::{Transcribable, Transcript};
 use zinc_utils::{
     from_ref::FromRef,
-    inner_product::{BooleanInnerProduct, MBSInnerProduct, ScalarProduct},
+    inner_product::{BooleanInnerProductCheckedAdd, MBSInnerProduct, ScalarProduct},
     mul_by_scalar::MulByScalar,
-    projectable_to_field::ProjectableToField,
+    projection_to_field::ProjectionToField,
 };
 
 const REPETITION_FACTOR: usize = 4;
@@ -74,8 +74,13 @@ impl<const K: usize, const M: usize, const DEGREE_PLUS_ONE: usize> ZipTypes
     type Comb = DensePolynomial<Self::CombR, DEGREE_PLUS_ONE>;
     type CombDotChal =
         DensePolyInnerProduct<Self::CombR, i128, Int<M>, MBSInnerProduct, DEGREE_PLUS_ONE>;
-    type EvalDotChal =
-        DensePolyInnerProduct<Boolean, i128, Int<M>, BooleanInnerProduct, DEGREE_PLUS_ONE>;
+    type EvalDotChal = DensePolyInnerProduct<
+        Boolean,
+        i128,
+        Int<M>,
+        BooleanInnerProductCheckedAdd,
+        DEGREE_PLUS_ONE,
+    >;
 }
 
 /// Helper function to set up common parameters for tests.
@@ -134,7 +139,7 @@ fn setup_test_params_inner<Zt: ZipTypes, Lc: LinearCode<Zt, Config = RaaConfig>>
     (pp, poly)
 }
 
-pub fn setup_full_protocol<F, const N: usize, const K: usize, const M: usize>(
+pub fn setup_full_protocol<F, PEval, PComb, const N: usize, const K: usize, const M: usize>(
     num_vars: usize,
 ) -> (
     ZipPlusParams<
@@ -151,16 +156,18 @@ where
         + for<'a> FromWithConfig<&'a <TestZipTypes<N, K, M> as ZipTypes>::Chal>
         + for<'a> MulByScalar<&'a F>,
     F::Inner: FromRef<<TestZipTypes<N, K, M> as ZipTypes>::Fmod> + Transcribable,
-    <TestZipTypes<N, K, M> as ZipTypes>::Eval: ProjectableToField<F>,
-    <TestZipTypes<N, K, M> as ZipTypes>::Comb: ProjectableToField<F>,
+    PEval: ProjectionToField<<TestZipTypes<N, K, M> as ZipTypes>::Eval, F>,
+    PComb: ProjectionToField<<TestZipTypes<N, K, M> as ZipTypes>::Comb, F>,
 {
-    setup_full_protocol_inner::<_, _, _, N>(num_vars, setup_test_params, || {
+    setup_full_protocol_inner::<_, _, _, PEval, PComb, N>(num_vars, setup_test_params, || {
         (0..num_vars).map(|i| Int::from(i as i32 + 2)).collect()
     })
 }
 
 pub fn setup_full_protocol_poly<
     F,
+    PEval,
+    PComb,
     const N: usize,
     const K: usize,
     const M: usize,
@@ -182,15 +189,15 @@ where
         + for<'a> FromWithConfig<&'a <TestPolyZipTypes<K, M, DEGREE_PLUS_ONE> as ZipTypes>::Chal>
         + for<'a> MulByScalar<&'a F>,
     F::Inner: FromRef<<TestPolyZipTypes<K, M, DEGREE_PLUS_ONE> as ZipTypes>::Fmod> + Transcribable,
-    <TestPolyZipTypes<K, M, DEGREE_PLUS_ONE> as ZipTypes>::Eval: ProjectableToField<F>,
-    <TestPolyZipTypes<K, M, DEGREE_PLUS_ONE> as ZipTypes>::Comb: ProjectableToField<F>,
+    PEval: ProjectionToField<<TestPolyZipTypes<K, M, DEGREE_PLUS_ONE> as ZipTypes>::Eval, F>,
+    PComb: ProjectionToField<<TestPolyZipTypes<K, M, DEGREE_PLUS_ONE> as ZipTypes>::Comb, F>,
 {
-    setup_full_protocol_inner::<_, _, _, N>(num_vars, setup_poly_test_params, || {
+    setup_full_protocol_inner::<_, _, _, PEval, PComb, N>(num_vars, setup_poly_test_params, || {
         (0..num_vars).map(|i| i as i128 + 2).collect()
     })
 }
 
-fn setup_full_protocol_inner<Zt, Lc, F, const N: usize>(
+fn setup_full_protocol_inner<Zt, Lc, F, PEval, PComb, const N: usize>(
     num_vars: usize,
     setup: impl FnOnce(usize) -> (ZipPlusParams<Zt, Lc>, DenseMultilinearExtension<Zt::Eval>),
     prepare_evaluation_point: impl FnOnce() -> Vec<Zt::Pt>,
@@ -209,8 +216,9 @@ where
         + for<'a> FromWithConfig<&'a Zt::Pt>
         + for<'a> MulByScalar<&'a F>,
     F::Inner: FromRef<Zt::Fmod> + Transcribable,
-    Zt::Eval: ProjectableToField<F>,
-    Zt::Comb: ProjectableToField<F> + for<'a> MulByScalar<&'a Zt::Pt>,
+    Zt::Comb: for<'a> MulByScalar<&'a Zt::Pt>,
+    PEval: ProjectionToField<Zt::Eval, F>,
+    PComb: ProjectionToField<Zt::Comb, F>,
 {
     let (pp, poly) = setup(num_vars);
 
@@ -233,7 +241,7 @@ where
         (field_cfg, projecting_element)
     };
 
-    let (eval_f, proof) = ZipPlus::evaluate(&pp, &poly, &point, transcript).unwrap();
+    let (eval_f, proof) = ZipPlus::evaluate::<_, PEval>(&pp, &poly, &point, transcript).unwrap();
 
     // Verify the evaluation is done correctly
     {
@@ -249,7 +257,7 @@ where
         let expected_eval = poly
             .evaluate(&point, Zero::zero())
             .expect("failed to evaluate polynomial");
-        let project = Zt::Comb::prepare_projection(&projecting_element);
+        let project = PComb::prepare_projection(&projecting_element);
         assert_eq!(eval_f, project(&expected_eval));
     }
 

--- a/zip-plus/src/pcs/test_utils.rs
+++ b/zip-plus/src/pcs/test_utils.rs
@@ -39,7 +39,7 @@ use zinc_utils::{
         ScalarProduct,
     },
     mul_by_scalar::MulByScalar,
-    projection_to_field::ProjectionToField,
+    projection_to_field::{ProjectionToField, SimpleProjection},
 };
 
 const REPETITION_FACTOR: usize = 4;
@@ -149,7 +149,7 @@ fn setup_test_params_inner<Zt: ZipTypes, Lc: LinearCode<Zt, Config = RaaConfig>>
     (pp, poly)
 }
 
-pub fn setup_full_protocol<F, PEval, PComb, const N: usize, const K: usize, const M: usize>(
+pub fn setup_full_protocol<F, const N: usize, const K: usize, const M: usize>(
     num_vars: usize,
 ) -> (
     ZipPlusParams<
@@ -164,14 +164,15 @@ pub fn setup_full_protocol<F, PEval, PComb, const N: usize, const K: usize, cons
 where
     F: PrimeField
         + for<'a> FromWithConfig<&'a <TestZipTypes<N, K, M> as ZipTypes>::Chal>
+        + for<'a> FromWithConfig<&'a <TestZipTypes<N, K, M> as ZipTypes>::CombR>
         + for<'a> MulByScalar<&'a F>,
     F::Inner: FromRef<<TestZipTypes<N, K, M> as ZipTypes>::Fmod> + Transcribable,
-    PEval: ProjectionToField<<TestZipTypes<N, K, M> as ZipTypes>::Eval, F>,
-    PComb: ProjectionToField<<TestZipTypes<N, K, M> as ZipTypes>::Comb, F>,
 {
-    setup_full_protocol_inner::<_, _, _, PEval, PComb, N>(num_vars, setup_test_params, || {
-        (0..num_vars).map(|i| Int::from(i as i32 + 2)).collect()
-    })
+    setup_full_protocol_inner::<_, _, _, SimpleProjection<_>, SimpleProjection<_>, N>(
+        num_vars,
+        setup_test_params,
+        || (0..num_vars).map(|i| Int::from(i as i32 + 2)).collect(),
+    )
 }
 
 pub fn setup_full_protocol_poly<
@@ -195,8 +196,8 @@ pub fn setup_full_protocol_poly<
 where
     F: PrimeField
         + for<'a> FromWithConfig<&'a <TestPolyZipTypes<K, M, DEGREE_PLUS_ONE> as ZipTypes>::Chal>
-        + for<'a> MulByScalar<&'a F>
         + for<'a> FromWithConfig<&'a <TestPolyZipTypes<K, M, DEGREE_PLUS_ONE> as ZipTypes>::CombR>
+        + for<'a> MulByScalar<&'a F>
         + 'static,
     F::Inner: FromRef<<TestPolyZipTypes<K, M, DEGREE_PLUS_ONE> as ZipTypes>::Fmod> + Transcribable,
 {

--- a/zip-plus/src/pcs/test_utils.rs
+++ b/zip-plus/src/pcs/test_utils.rs
@@ -26,13 +26,18 @@ use itertools::Itertools;
 use num_traits::Zero;
 use zinc_poly::{
     mle::DenseMultilinearExtension,
-    univariate::dense::{DensePolyInnerProduct, DensePolynomial},
+    univariate::dense::{
+        DensePolyInnerProduct, DensePolynomial, HornerProjection, InnerProductProjection,
+    },
 };
 use zinc_primality::MillerRabin;
 use zinc_transcript::traits::{Transcribable, Transcript};
 use zinc_utils::{
     from_ref::FromRef,
-    inner_product::{BooleanInnerProductCheckedAdd, MBSInnerProductChecked, ScalarProduct},
+    inner_product::{
+        BooleanInnerProductCheckedAdd, BooleanInnerProductUncheckedAdd, MBSInnerProductChecked,
+        ScalarProduct,
+    },
     mul_by_scalar::MulByScalar,
     projection_to_field::ProjectionToField,
 };
@@ -171,8 +176,6 @@ where
 
 pub fn setup_full_protocol_poly<
     F,
-    PEval,
-    PComb,
     const N: usize,
     const K: usize,
     const M: usize,
@@ -192,12 +195,19 @@ pub fn setup_full_protocol_poly<
 where
     F: PrimeField
         + for<'a> FromWithConfig<&'a <TestPolyZipTypes<K, M, DEGREE_PLUS_ONE> as ZipTypes>::Chal>
-        + for<'a> MulByScalar<&'a F>,
+        + for<'a> MulByScalar<&'a F>
+        + for<'a> FromWithConfig<&'a <TestPolyZipTypes<K, M, DEGREE_PLUS_ONE> as ZipTypes>::CombR>
+        + 'static,
     F::Inner: FromRef<<TestPolyZipTypes<K, M, DEGREE_PLUS_ONE> as ZipTypes>::Fmod> + Transcribable,
-    PEval: ProjectionToField<<TestPolyZipTypes<K, M, DEGREE_PLUS_ONE> as ZipTypes>::Eval, F>,
-    PComb: ProjectionToField<<TestPolyZipTypes<K, M, DEGREE_PLUS_ONE> as ZipTypes>::Comb, F>,
 {
-    setup_full_protocol_inner::<_, _, _, PEval, PComb, N>(num_vars, setup_poly_test_params, || {
+    setup_full_protocol_inner::<
+        _,
+        _,
+        _,
+        InnerProductProjection<Boolean, BooleanInnerProductUncheckedAdd, _>,
+        HornerProjection<_, _>,
+        N,
+    >(num_vars, setup_poly_test_params, || {
         (0..num_vars).map(|i| i as i128 + 2).collect()
     })
 }


### PR DESCRIPTION
Currently, implementations of `InnerProduct` and `ProjectableToField` can't be specialised for certain classes of types if a general implentation provided. For instance, `DensePolynomial<Boolean, _>` can't have its own specialised inner product if an implementation is provided for `DensePolynomial<R, _> where R: Semiring`. 

Inner product and projection to field shouldn't be tied to a (generic) type, rather it should be possible to switch between different implementations at will when it's necessary. It does clutter some function calls but I believe it's worth having some freedom.

As a bonus: benchmarks of evaluation phase for zip+ are improved by 90%.