### PR TITLE
Compile time configuration for linear codes

### DIFF
--- a/zip-plus/benches/zip_benches.rs
+++ b/zip-plus/benches/zip_benches.rs
@@ -11,7 +11,7 @@ use criterion::{Criterion, criterion_group, criterion_main};
 use crypto_bigint::U64;
 use crypto_primitives::{crypto_bigint_int::Int, crypto_bigint_uint::Uint};
 use zip_plus::{
-    code::raa::{RaaCode, RaaConfigGeneric},
+    code::raa::{RaaCode, RaaConfig},
     pcs::structs::ZipTypes,
 };
 
@@ -31,7 +31,15 @@ impl ZipTypes for BenchZipTypes {
     type CombDotChal = ScalarProduct;
     type EvalDotChal = ScalarProduct;
 }
-type Code = RaaCode<BenchZipTypes, RaaConfigGeneric<false, false>, 4>;
+
+#[derive(Clone, Copy)]
+struct BenchRaaConfig;
+impl RaaConfig for BenchRaaConfig {
+    const PERMUTE_IN_PLACE: bool = false;
+    const CHECK_FOR_OVERFLOWS: bool = false;
+}
+
+type Code = RaaCode<BenchZipTypes, BenchRaaConfig, 4>;
 
 fn zip_benchmarks(c: &mut Criterion) {
     let mut group = c.benchmark_group("Zip+");

--- a/zip-plus/benches/zip_benches.rs
+++ b/zip-plus/benches/zip_benches.rs
@@ -11,7 +11,7 @@ use criterion::{Criterion, criterion_group, criterion_main};
 use crypto_bigint::U64;
 use crypto_primitives::{crypto_bigint_int::Int, crypto_bigint_uint::Uint};
 use zip_plus::{
-    code::raa::{RaaCode, RaaConfig},
+    code::raa::{RaaCode, RaaConfigGeneric},
     pcs::structs::ZipTypes,
 };
 
@@ -31,18 +31,11 @@ impl ZipTypes for BenchZipTypes {
     type CombDotChal = ScalarProduct;
     type EvalDotChal = ScalarProduct;
 }
-type Code = RaaCode<BenchZipTypes, 4>;
-
-const RAA_CONFIG: RaaConfig = RaaConfig {
-    check_for_overflows: false,
-    permute_in_place: false,
-};
+type Code = RaaCode<BenchZipTypes, RaaConfigGeneric<false, false>, 4>;
 
 fn zip_benchmarks(c: &mut Criterion) {
     let mut group = c.benchmark_group("Zip+");
-    do_bench::<BenchZipTypes, Code, SimpleProjection<_>, SimpleProjection<_>>(
-        &mut group, RAA_CONFIG,
-    );
+    do_bench::<BenchZipTypes, Code, SimpleProjection<_>, SimpleProjection<_>>(&mut group);
     group.finish();
 }
 

--- a/zip-plus/benches/zip_common.rs
+++ b/zip-plus/benches/zip_common.rs
@@ -32,26 +32,24 @@ use zip_plus::{
 const INT_LIMBS: usize = U64::LIMBS;
 type F = MontyField<{ INT_LIMBS * 4 }>;
 
-pub fn do_bench<Zt: ZipTypes, Lc: LinearCode<Zt>, PEval, PCw>(
-    group: &mut BenchmarkGroup<WallTime>,
-    code_config: Lc::Config,
-) where
+pub fn do_bench<Zt: ZipTypes, Lc: LinearCode<Zt>, PEval, PCw>(group: &mut BenchmarkGroup<WallTime>)
+where
     StandardUniform: Distribution<Zt::Eval> + Distribution<Zt::Cw>,
     F: for<'a> FromWithConfig<&'a Zt::Chal> + for<'a> FromWithConfig<&'a Zt::Pt>,
     <F as Field>::Inner: FromRef<Zt::Fmod>,
     PEval: ProjectionToField<Zt::Eval, F>,
     PCw: ProjectionToField<Zt::Cw, F>,
 {
-    encode_rows::<Zt, Lc, 12>(group, code_config);
-    encode_rows::<Zt, Lc, 13>(group, code_config);
-    encode_rows::<Zt, Lc, 14>(group, code_config);
-    encode_rows::<Zt, Lc, 15>(group, code_config);
-    encode_rows::<Zt, Lc, 16>(group, code_config);
+    encode_rows::<Zt, Lc, 12>(group);
+    encode_rows::<Zt, Lc, 13>(group);
+    encode_rows::<Zt, Lc, 14>(group);
+    encode_rows::<Zt, Lc, 15>(group);
+    encode_rows::<Zt, Lc, 16>(group);
 
-    encode_single_row::<Zt, Lc, 128>(group, code_config);
-    encode_single_row::<Zt, Lc, 256>(group, code_config);
-    encode_single_row::<Zt, Lc, 512>(group, code_config);
-    encode_single_row::<Zt, Lc, 1024>(group, code_config);
+    encode_single_row::<Zt, Lc, 128>(group);
+    encode_single_row::<Zt, Lc, 256>(group);
+    encode_single_row::<Zt, Lc, 512>(group);
+    encode_single_row::<Zt, Lc, 1024>(group);
 
     merkle_root::<Zt, 12>(group);
     merkle_root::<Zt, 13>(group);
@@ -59,34 +57,33 @@ pub fn do_bench<Zt: ZipTypes, Lc: LinearCode<Zt>, PEval, PCw>(
     merkle_root::<Zt, 15>(group);
     merkle_root::<Zt, 16>(group);
 
-    commit::<Zt, Lc, 12>(group, code_config);
-    commit::<Zt, Lc, 13>(group, code_config);
-    commit::<Zt, Lc, 14>(group, code_config);
-    commit::<Zt, Lc, 15>(group, code_config);
-    commit::<Zt, Lc, 16>(group, code_config);
+    commit::<Zt, Lc, 12>(group);
+    commit::<Zt, Lc, 13>(group);
+    commit::<Zt, Lc, 14>(group);
+    commit::<Zt, Lc, 15>(group);
+    commit::<Zt, Lc, 16>(group);
 
-    test::<Zt, Lc, 12>(group, code_config);
-    test::<Zt, Lc, 13>(group, code_config);
-    test::<Zt, Lc, 14>(group, code_config);
-    test::<Zt, Lc, 15>(group, code_config);
-    test::<Zt, Lc, 16>(group, code_config);
+    test::<Zt, Lc, 12>(group);
+    test::<Zt, Lc, 13>(group);
+    test::<Zt, Lc, 14>(group);
+    test::<Zt, Lc, 15>(group);
+    test::<Zt, Lc, 16>(group);
 
-    evaluate::<Zt, Lc, PEval, 12>(group, code_config);
-    evaluate::<Zt, Lc, PEval, 13>(group, code_config);
-    evaluate::<Zt, Lc, PEval, 14>(group, code_config);
-    evaluate::<Zt, Lc, PEval, 15>(group, code_config);
-    evaluate::<Zt, Lc, PEval, 16>(group, code_config);
+    evaluate::<Zt, Lc, PEval, 12>(group);
+    evaluate::<Zt, Lc, PEval, 13>(group);
+    evaluate::<Zt, Lc, PEval, 14>(group);
+    evaluate::<Zt, Lc, PEval, 15>(group);
+    evaluate::<Zt, Lc, PEval, 16>(group);
 
-    verify::<Zt, Lc, PEval, PCw, 12>(group, code_config);
-    verify::<Zt, Lc, PEval, PCw, 13>(group, code_config);
-    verify::<Zt, Lc, PEval, PCw, 14>(group, code_config);
-    verify::<Zt, Lc, PEval, PCw, 15>(group, code_config);
-    verify::<Zt, Lc, PEval, PCw, 16>(group, code_config);
+    verify::<Zt, Lc, PEval, PCw, 12>(group);
+    verify::<Zt, Lc, PEval, PCw, 13>(group);
+    verify::<Zt, Lc, PEval, PCw, 14>(group);
+    verify::<Zt, Lc, PEval, PCw, 15>(group);
+    verify::<Zt, Lc, PEval, PCw, 16>(group);
 }
 
 pub fn encode_rows<Zt: ZipTypes, Lc: LinearCode<Zt>, const P: usize>(
     group: &mut BenchmarkGroup<WallTime>,
-    code_config: Lc::Config,
 ) where
     StandardUniform: Distribution<Zt::Eval>,
 {
@@ -99,7 +96,7 @@ pub fn encode_rows<Zt: ZipTypes, Lc: LinearCode<Zt>, const P: usize>(
         |b| {
             let mut rng = ThreadRng::default();
             let poly_size = 1 << P;
-            let linear_code = Lc::new(poly_size, code_config);
+            let linear_code = Lc::new(poly_size);
             let params = ZipPlus::setup(poly_size, linear_code);
             let row_len = params.linear_code.row_len();
             let poly = DenseMultilinearExtension::<<Zt as ZipTypes>::Eval>::rand(P, &mut rng);
@@ -113,7 +110,6 @@ pub fn encode_rows<Zt: ZipTypes, Lc: LinearCode<Zt>, const P: usize>(
 
 pub fn encode_single_row<Zt: ZipTypes, Lc: LinearCode<Zt>, const ROW_LEN: usize>(
     group: &mut BenchmarkGroup<WallTime>,
-    code_config: Lc::Config,
 ) where
     StandardUniform: Distribution<Zt::Eval>,
 {
@@ -126,7 +122,7 @@ pub fn encode_single_row<Zt: ZipTypes, Lc: LinearCode<Zt>, const ROW_LEN: usize>
         |b| {
             let mut rng = ThreadRng::default();
             let poly_size = ROW_LEN * ROW_LEN;
-            let linear_code = Lc::new(poly_size, code_config);
+            let linear_code = Lc::new(poly_size);
             assert_eq!(linear_code.row_len(), ROW_LEN, "Unexpected row_len");
             let message: Vec<<Zt as ZipTypes>::Eval> =
                 (0..ROW_LEN).map(|_i| rng.random()).collect();
@@ -164,13 +160,12 @@ where
 
 pub fn commit<Zt: ZipTypes, Lc: LinearCode<Zt>, const P: usize>(
     group: &mut BenchmarkGroup<WallTime>,
-    code_config: Lc::Config,
 ) where
     StandardUniform: Distribution<Zt::Eval>,
 {
     let mut rng = ThreadRng::default();
     let poly_size = 1 << P;
-    let linear_code = Lc::new(poly_size, code_config);
+    let linear_code = Lc::new(poly_size);
     let params = ZipPlus::setup(poly_size, linear_code);
 
     group.bench_function(
@@ -197,16 +192,14 @@ pub fn commit<Zt: ZipTypes, Lc: LinearCode<Zt>, const P: usize>(
     );
 }
 
-pub fn test<Zt: ZipTypes, Lc: LinearCode<Zt>, const P: usize>(
-    group: &mut BenchmarkGroup<WallTime>,
-    code_config: Lc::Config,
-) where
+pub fn test<Zt: ZipTypes, Lc: LinearCode<Zt>, const P: usize>(group: &mut BenchmarkGroup<WallTime>)
+where
     StandardUniform: Distribution<Zt::Eval>,
 {
     let mut rng = ThreadRng::default();
 
     let poly_size = 1 << P;
-    let linear_code = Lc::new(poly_size, code_config);
+    let linear_code = Lc::new(poly_size);
     let params = ZipPlus::setup(poly_size, linear_code);
 
     let poly = DenseMultilinearExtension::rand(P, &mut rng);
@@ -231,7 +224,6 @@ pub fn test<Zt: ZipTypes, Lc: LinearCode<Zt>, const P: usize>(
 
 pub fn evaluate<Zt: ZipTypes, Lc: LinearCode<Zt>, PEval, const P: usize>(
     group: &mut BenchmarkGroup<WallTime>,
-    code_config: Lc::Config,
 ) where
     StandardUniform: Distribution<Zt::Eval>,
     F: for<'a> FromWithConfig<&'a Zt::Chal> + for<'a> FromWithConfig<&'a Zt::Pt>,
@@ -241,7 +233,7 @@ pub fn evaluate<Zt: ZipTypes, Lc: LinearCode<Zt>, PEval, const P: usize>(
     let mut rng = ThreadRng::default();
 
     let poly_size = 1 << P;
-    let linear_code = Lc::new(poly_size, code_config);
+    let linear_code = Lc::new(poly_size);
     let params = ZipPlus::setup(poly_size, linear_code);
 
     let poly = DenseMultilinearExtension::rand(P, &mut rng);
@@ -278,7 +270,6 @@ pub fn evaluate<Zt: ZipTypes, Lc: LinearCode<Zt>, PEval, const P: usize>(
 
 pub fn verify<Zt: ZipTypes, Lc: LinearCode<Zt>, PEval, PCw, const P: usize>(
     group: &mut BenchmarkGroup<WallTime>,
-    code_config: Lc::Config,
 ) where
     StandardUniform: Distribution<Zt::Eval>,
     F: for<'a> FromWithConfig<&'a Zt::Chal> + for<'a> FromWithConfig<&'a Zt::Pt>,
@@ -288,7 +279,7 @@ pub fn verify<Zt: ZipTypes, Lc: LinearCode<Zt>, PEval, PCw, const P: usize>(
 {
     let mut rng = ThreadRng::default();
     let poly_size = 1 << P;
-    let linear_code = Lc::new(poly_size, code_config);
+    let linear_code = Lc::new(poly_size);
     let params = ZipPlus::setup(poly_size, linear_code);
 
     let poly = DenseMultilinearExtension::rand(P, &mut rng);

--- a/zip-plus/benches/zip_plus_benches.rs
+++ b/zip-plus/benches/zip_plus_benches.rs
@@ -52,8 +52,8 @@ impl<const D_PLUS_ONE: usize> ZipTypes for BenchZipPlusTypes<D_PLUS_ONE> {
 #[derive(Clone, Copy)]
 struct BenchRaaConfig;
 impl RaaConfig for BenchRaaConfig {
-    const PERMUTE_IN_PLACE: bool = false;
-    const CHECK_FOR_OVERFLOWS: bool = true;
+    const PERMUTE_IN_PLACE: bool = true;
+    const CHECK_FOR_OVERFLOWS: bool = false;
 }
 
 type Code<const D_PLUS_ONE: usize> = RaaCode<BenchZipPlusTypes<D_PLUS_ONE>, BenchRaaConfig, 4>;

--- a/zip-plus/benches/zip_plus_benches.rs
+++ b/zip-plus/benches/zip_plus_benches.rs
@@ -16,7 +16,7 @@ use criterion::{Criterion, criterion_group, criterion_main};
 use crypto_bigint::U64;
 use crypto_primitives::{boolean::Boolean, crypto_bigint_int::Int, crypto_bigint_uint::Uint};
 use zip_plus::{
-    code::raa::{RaaCode, RaaConfigGeneric},
+    code::raa::{RaaCode, RaaConfig},
     pcs::structs::ZipTypes,
 };
 
@@ -49,8 +49,14 @@ impl<const D_PLUS_ONE: usize> ZipTypes for BenchZipPlusTypes<D_PLUS_ONE> {
     >;
 }
 
-type Code<const D_PLUS_ONE: usize> =
-    RaaCode<BenchZipPlusTypes<D_PLUS_ONE>, RaaConfigGeneric<true, false>, 4>;
+#[derive(Clone, Copy)]
+struct BenchRaaConfig;
+impl RaaConfig for BenchRaaConfig {
+    const PERMUTE_IN_PLACE: bool = false;
+    const CHECK_FOR_OVERFLOWS: bool = true;
+}
+
+type Code<const D_PLUS_ONE: usize> = RaaCode<BenchZipPlusTypes<D_PLUS_ONE>, BenchRaaConfig, 4>;
 
 fn zip_plus_benchmarks(c: &mut Criterion) {
     let mut group = c.benchmark_group("Zip+");

--- a/zip-plus/benches/zip_plus_benches.rs
+++ b/zip-plus/benches/zip_plus_benches.rs
@@ -16,7 +16,7 @@ use criterion::{Criterion, criterion_group, criterion_main};
 use crypto_bigint::U64;
 use crypto_primitives::{boolean::Boolean, crypto_bigint_int::Int, crypto_bigint_uint::Uint};
 use zip_plus::{
-    code::raa::{RaaCode, RaaConfig},
+    code::raa::{RaaCode, RaaConfigGeneric},
     pcs::structs::ZipTypes,
 };
 
@@ -49,12 +49,8 @@ impl<const D_PLUS_ONE: usize> ZipTypes for BenchZipPlusTypes<D_PLUS_ONE> {
     >;
 }
 
-type Code<const D_PLUS_ONE: usize> = RaaCode<BenchZipPlusTypes<D_PLUS_ONE>, 4>;
-
-const RAA_CONFIG: RaaConfig = RaaConfig {
-    check_for_overflows: false,
-    permute_in_place: true,
-};
+type Code<const D_PLUS_ONE: usize> =
+    RaaCode<BenchZipPlusTypes<D_PLUS_ONE>, RaaConfigGeneric<true, false>, 4>;
 
 fn zip_plus_benchmarks(c: &mut Criterion) {
     let mut group = c.benchmark_group("Zip+");
@@ -64,13 +60,13 @@ fn zip_plus_benchmarks(c: &mut Criterion) {
         Code<_>,
         InnerProductProjection<Boolean, BooleanInnerProductUncheckedAdd, _>,
         HornerProjection<_, _>,
-    >(&mut group, RAA_CONFIG);
+    >(&mut group);
     do_bench::<
         BenchZipPlusTypes<64>,
         Code<_>,
         InnerProductProjection<Boolean, BooleanInnerProductUncheckedAdd, _>,
         HornerProjection<_, _>,
-    >(&mut group, RAA_CONFIG);
+    >(&mut group);
 
     group.finish();
 }

--- a/zip-plus/src/code.rs
+++ b/zip-plus/src/code.rs
@@ -6,8 +6,6 @@ use crypto_primitives::PrimeField;
 use zinc_utils::from_ref::FromRef;
 
 pub trait LinearCode<Zt: ZipTypes>: Sync + Send {
-    type Config: Copy;
-
     /// Repetition factor, a.k.a. inverse rate, the ratio of codeword length to
     /// input row length. Has to be at a power of 2.
     ///
@@ -16,7 +14,7 @@ pub trait LinearCode<Zt: ZipTypes>: Sync + Send {
     /// makes using it too much of a hassle.
     const REPETITION_FACTOR: usize;
 
-    fn new(poly_size: usize, cfg: Self::Config) -> Self;
+    fn new(poly_size: usize) -> Self;
 
     /// Length of each input row before encoding
     fn row_len(&self) -> usize;

--- a/zip-plus/src/code/raa.rs
+++ b/zip-plus/src/code/raa.rs
@@ -5,12 +5,25 @@ use std::{marker::PhantomData, ops::AddAssign};
 use zinc_poly::ConstCoeffBitWidth;
 use zinc_utils::{add, from_ref::FromRef, mul};
 
+pub trait RaaConfig: Copy + Send + Sync {
+    const PERMUTE_IN_PLACE: bool;
+    const CHECK_FOR_OVERFLOWS: bool;
+}
+
+#[derive(Clone, Copy)]
+pub struct RaaConfigGeneric<const PERMUTE_IN_PLACE: bool, const CHECK_FOR_OVERFLOWS: bool>;
+
+impl<const PERMUTE_IN_PLACE: bool, const CHECK_FOR_OVERFLOWS: bool> RaaConfig
+    for RaaConfigGeneric<PERMUTE_IN_PLACE, CHECK_FOR_OVERFLOWS>
+{
+    const PERMUTE_IN_PLACE: bool = PERMUTE_IN_PLACE;
+    const CHECK_FOR_OVERFLOWS: bool = CHECK_FOR_OVERFLOWS;
+}
+
 /// Implementation of a repeat-accumulate-accumulate (RAA) codes over the binary
 /// field, as defined by the Blaze paper (https://eprint.iacr.org/2024/1609)
 #[derive(Debug, Clone)]
-pub struct RaaCode<Zt: ZipTypes, const REP: usize> {
-    pub(crate) cfg: RaaConfig,
-
+pub struct RaaCode<Zt: ZipTypes, Config: RaaConfig, const REP: usize> {
     pub(crate) row_len: usize,
     /// Randomness seed for the first permutation
     pub(crate) perm_1_seed: u64,
@@ -24,20 +37,10 @@ pub struct RaaCode<Zt: ZipTypes, const REP: usize> {
     /// Second permutation
     pub(crate) perm_2: Vec<usize>,
 
-    phantom: PhantomData<Zt>,
+    phantom: PhantomData<(Zt, Config)>,
 }
 
-#[derive(Debug, Clone, Copy)]
-pub struct RaaConfig {
-    /// Whether to check for overflows during encoding
-    pub check_for_overflows: bool,
-
-    /// Whether to permute the codeword in place, instead of copying it using a
-    /// precomputed permutation.
-    pub permute_in_place: bool,
-}
-
-impl<Zt: ZipTypes, const REP: usize> RaaCode<Zt, REP> {
+impl<Zt: ZipTypes, Config: RaaConfig, const REP: usize> RaaCode<Zt, Config, REP> {
     /// Do the actual encoding, as per RAA spec
     fn encode_inner<In, Out>(&self, row: &[In]) -> Vec<Out>
     where
@@ -50,22 +53,22 @@ impl<Zt: ZipTypes, const REP: usize> RaaCode<Zt, REP> {
         );
 
         let mut result: Vec<Out> = repeat(row, REP);
-        if self.cfg.permute_in_place {
+        if Config::PERMUTE_IN_PLACE {
             shuffle_seeded(&mut result, self.perm_1_seed);
         } else {
             result = clone_shuffled(&result, &self.perm_1);
         }
-        if self.cfg.check_for_overflows {
+        if Config::CHECK_FOR_OVERFLOWS {
             accumulate(&mut result);
         } else {
             accumulate_unchecked(&mut result);
         }
-        if self.cfg.permute_in_place {
+        if Config::PERMUTE_IN_PLACE {
             shuffle_seeded(&mut result, self.perm_2_seed);
         } else {
             result = clone_shuffled(&result, &self.perm_2);
         }
-        if self.cfg.check_for_overflows {
+        if Config::CHECK_FOR_OVERFLOWS {
             accumulate(&mut result);
         } else {
             accumulate_unchecked(&mut result);
@@ -75,12 +78,12 @@ impl<Zt: ZipTypes, const REP: usize> RaaCode<Zt, REP> {
     }
 }
 
-impl<Zt: ZipTypes, const REP: usize> LinearCode<Zt> for RaaCode<Zt, REP> {
-    type Config = RaaConfig;
-
+impl<Zt: ZipTypes, Config: RaaConfig, const REP: usize> LinearCode<Zt>
+    for RaaCode<Zt, Config, REP>
+{
     const REPETITION_FACTOR: usize = REP;
 
-    fn new(poly_size: usize, cfg: RaaConfig) -> Self {
+    fn new(poly_size: usize) -> Self {
         assert!(
             REP.is_power_of_two(),
             "Repetition factor must be a power of two"
@@ -130,7 +133,6 @@ impl<Zt: ZipTypes, const REP: usize> LinearCode<Zt> for RaaCode<Zt, REP> {
         shuffle_seeded(&mut perm_2, PERM_2_SEED);
 
         Self {
-            cfg,
             row_len,
             perm_1_seed: PERM_1_SEED,
             perm_2_seed: PERM_2_SEED,
@@ -246,23 +248,20 @@ mod tests {
     const K: usize = INT_LIMBS * 4;
     const M: usize = INT_LIMBS * 8;
 
-    fn test_raa<Zt, F>(poly_size: usize, f: F)
-    where
-        Zt: ZipTypes,
-        F: Fn(&RaaCode<Zt, REPETITION_FACTOR>),
-    {
-        for check_for_overflows in [true, false] {
-            for permute_in_place in [true, false] {
-                let code = RaaCode::<Zt, REPETITION_FACTOR>::new(
-                    poly_size,
-                    RaaConfig {
-                        check_for_overflows,
-                        permute_in_place,
-                    },
-                );
-                f(&code)
+    macro_rules! test_raa {
+        ($zt:ty, $poly_size:expr, $f:expr) => {
+            test_raa!($zt, $poly_size, $f, RaaConfigGeneric<false, false>);
+            test_raa!($zt, $poly_size, $f, RaaConfigGeneric<false, true>);
+            test_raa!($zt, $poly_size, $f, RaaConfigGeneric<true, false>);
+            test_raa!($zt, $poly_size, $f, RaaConfigGeneric<true, true>);
+        };
+
+        ($zt:ty, $poly_size:expr, $f:expr, $config:ty) => {
+            {
+                let code = RaaCode::<$zt, $config, REPETITION_FACTOR>::new($poly_size);
+                $f(&code)
             }
-        }
+        };
     }
 
     #[test]
@@ -350,8 +349,9 @@ mod tests {
     }
 
     #[test]
+    #[allow(clippy::arithmetic_side_effects)] // False alert
     fn encoding_preserves_linearity() {
-        test_raa::<TestZipTypes<N, K, M>, _>(16, |code| {
+        test_raa!(TestZipTypes<N, K, M>, 16, |code: &RaaCode<_, _, _>| {
             let a: Vec<Int<N>> = (1..=4).map(Int::<N>::from).collect();
             let b: Vec<Int<N>> = (5..=8).map(Int::<N>::from).collect();
             let sum_ab: Vec<Int<N>> = a.iter().zip(b.iter()).map(|(x, y)| *x + y).collect();
@@ -367,7 +367,7 @@ mod tests {
                 .collect();
 
             assert_eq!(encode_sum_ab, sum_encode_ab);
-        })
+        });
     }
 
     /// Since our shuffle seeds are fixed, we can test the encoding
@@ -376,32 +376,22 @@ mod tests {
     fn encoding_produces_predictable_results() {
         let a: Vec<Int<N>> = (1..=4).map(Int::<N>::from).collect();
 
-        for check_for_overflows in [true, false] {
-            for permute_in_place in [true, false] {
-                let code = RaaCode::<TestZipTypes<N, K, M>, REPETITION_FACTOR>::new(
-                    16,
-                    RaaConfig {
-                        check_for_overflows,
-                        permute_in_place,
-                    },
-                );
-
-                let encode_a: Vec<Int<K>> = code.encode(&a);
-                assert_eq!(
-                    encode_a,
-                    [
-                        0x1E, 0x36, 0x39, 0x5A, 0x70, 0x7E, 0xA5, 0xC1, 0xCB, 0xDC, 0xF9, 0x11E,
-                        0x124, 0x14C, 0x14D, 0x160
-                    ]
-                    .map(Int::<K>::from)
-                );
-            }
-        }
+        test_raa!(TestZipTypes<N, K, M>, 16, |code: &RaaCode<_, _, _>| {
+            let encode_a: Vec<Int<K>> = code.encode(&a);
+            assert_eq!(
+                encode_a,
+                [
+                    0x1E, 0x36, 0x39, 0x5A, 0x70, 0x7E, 0xA5, 0xC1, 0xCB, 0xDC, 0xF9, 0x11E, 0x124,
+                    0x14C, 0x14D, 0x160
+                ]
+                .map(Int::<K>::from)
+            );
+        });
     }
 
     #[test]
     fn encoding_zero_vector_results_in_zero_codeword() {
-        test_raa::<TestZipTypes<N, K, M>, _>(16, |code| {
+        test_raa!(TestZipTypes<N, K, M>, 16, |code: &RaaCode<_, _, _>| {
             let zero_vector: Vec<_> = vec![Int::<N>::zero(); code.row_len()];
             let encoded_vector: Vec<Int<K>> = code.encode(&zero_vector);
 
@@ -411,7 +401,7 @@ mod tests {
                 encoded_vector, expected_codeword,
                 "Encoding a zero vector should result in a zero codeword"
             );
-        })
+        });
     }
 
     #[test]
@@ -419,24 +409,20 @@ mod tests {
         let data: Vec<Int<N>> = (1..=1024).map(Int::<N>::from).collect();
         let poly_size = data.len() * data.len();
         let codeword_1: Vec<Int<K>> = {
-            let code_in_place = RaaCode::<TestZipTypes<N, K, M>, REPETITION_FACTOR>::new(
-                poly_size,
-                RaaConfig {
-                    check_for_overflows: true,
-                    permute_in_place: true,
-                },
-            );
+            let code_in_place = RaaCode::<
+                TestZipTypes<N, K, M>,
+                RaaConfigGeneric<true, true>,
+                REPETITION_FACTOR,
+            >::new(poly_size);
             code_in_place.encode(&data)
         };
 
         let codeword_2: Vec<Int<K>> = {
-            let code_cloning = RaaCode::<TestZipTypes<N, K, M>, REPETITION_FACTOR>::new(
-                poly_size,
-                RaaConfig {
-                    check_for_overflows: true,
-                    permute_in_place: false,
-                },
-            );
+            let code_cloning = RaaCode::<
+                TestZipTypes<N, K, M>,
+                RaaConfigGeneric<false, true>,
+                REPETITION_FACTOR,
+            >::new(poly_size);
             code_cloning.encode(&data)
         };
         assert_eq!(
@@ -451,22 +437,20 @@ mod tests {
         const N: usize = 1;
         const K: usize = 1;
 
-        let _code = RaaCode::<TestZipTypes<N, K, N>, REPETITION_FACTOR>::new(
-            1 << 30,
-            RaaConfig {
-                check_for_overflows: true,
-                permute_in_place: false,
-            },
-        );
+        let _code = RaaCode::<
+            TestZipTypes<N, K, N>,
+            RaaConfigGeneric<false, true>,
+            REPETITION_FACTOR,
+        >::new(1 << 30);
     }
 
     #[test]
     #[should_panic(expected = "Row length must match the code's row length")]
     #[cfg(debug_assertions)]
     fn encode_panics_on_mismatched_row_length() {
-        test_raa::<TestZipTypes<N, K, M>, _>(16, |code| {
+        test_raa!(TestZipTypes<N, K, M>, 16, |code: &RaaCode<_, _, _>| {
             let incorrect_row = vec![Int::<N>::from(1), Int::<N>::from(2), Int::<N>::from(3)];
             let _: Vec<Int<K>> = code.encode(&incorrect_row);
-        })
+        });
     }
 }

--- a/zip-plus/src/code/raa.rs
+++ b/zip-plus/src/code/raa.rs
@@ -10,16 +10,6 @@ pub trait RaaConfig: Copy + Send + Sync {
     const CHECK_FOR_OVERFLOWS: bool;
 }
 
-#[derive(Clone, Copy)]
-pub struct RaaConfigGeneric<const PERMUTE_IN_PLACE: bool, const CHECK_FOR_OVERFLOWS: bool>;
-
-impl<const PERMUTE_IN_PLACE: bool, const CHECK_FOR_OVERFLOWS: bool> RaaConfig
-    for RaaConfigGeneric<PERMUTE_IN_PLACE, CHECK_FOR_OVERFLOWS>
-{
-    const PERMUTE_IN_PLACE: bool = PERMUTE_IN_PLACE;
-    const CHECK_FOR_OVERFLOWS: bool = CHECK_FOR_OVERFLOWS;
-}
-
 /// Implementation of a repeat-accumulate-accumulate (RAA) codes over the binary
 /// field, as defined by the Blaze paper (https://eprint.iacr.org/2024/1609)
 #[derive(Debug, Clone)]
@@ -247,6 +237,16 @@ mod tests {
     const N: usize = INT_LIMBS;
     const K: usize = INT_LIMBS * 4;
     const M: usize = INT_LIMBS * 8;
+
+    #[derive(Clone, Copy)]
+    struct RaaConfigGeneric<const PERMUTE_IN_PLACE: bool, const CHECK_FOR_OVERFLOWS: bool>;
+
+    impl<const PERMUTE_IN_PLACE: bool, const CHECK_FOR_OVERFLOWS: bool> RaaConfig
+        for RaaConfigGeneric<PERMUTE_IN_PLACE, CHECK_FOR_OVERFLOWS>
+    {
+        const PERMUTE_IN_PLACE: bool = PERMUTE_IN_PLACE;
+        const CHECK_FOR_OVERFLOWS: bool = CHECK_FOR_OVERFLOWS;
+    }
 
     macro_rules! test_raa {
         ($zt:ty, $poly_size:expr, $f:expr) => {

--- a/zip-plus/src/code/raa.rs
+++ b/zip-plus/src/code/raa.rs
@@ -6,7 +6,10 @@ use zinc_poly::ConstCoeffBitWidth;
 use zinc_utils::{add, from_ref::FromRef, mul};
 
 pub trait RaaConfig: Copy + Send + Sync {
+    /// Whether to permute the codeword in place, instead of copying it using a
+    /// precomputed permutation.
     const PERMUTE_IN_PLACE: bool;
+    /// Whether to check for overflows during encoding
     const CHECK_FOR_OVERFLOWS: bool;
 }
 

--- a/zip-plus/src/code/raa_sign_flip.rs
+++ b/zip-plus/src/code/raa_sign_flip.rs
@@ -9,14 +9,14 @@ use zinc_utils::{from_ref::FromRef, neg};
 /// Flips signs of every second entry in the codeword, starting from the second
 /// one.
 #[derive(Debug, Clone)]
-pub struct RaaSignFlippingCode<Zt: ZipTypes, const REP: usize>
+pub struct RaaSignFlippingCode<Zt: ZipTypes, Config: RaaConfig, const REP: usize>
 where
     Zt::Cw: Ring,
 {
-    raa: RaaCode<Zt, REP>,
+    raa: RaaCode<Zt, Config, REP>,
 }
 
-impl<Zt: ZipTypes, const REP: usize> RaaSignFlippingCode<Zt, REP>
+impl<Zt: ZipTypes, Config: RaaConfig, const REP: usize> RaaSignFlippingCode<Zt, Config, REP>
 where
     Zt::Cw: Ring,
 {
@@ -37,24 +37,24 @@ where
         );
 
         let mut result: Vec<Out> = repeat(row, REP);
-        flip_even_signs(&mut result, self.raa.cfg.check_for_overflows);
-        if self.raa.cfg.permute_in_place {
+        flip_even_signs(&mut result, Config::CHECK_FOR_OVERFLOWS);
+        if Config::PERMUTE_IN_PLACE {
             shuffle_seeded(&mut result, self.raa.perm_1_seed);
         } else {
             result = clone_shuffled(&result, &self.raa.perm_1);
         }
-        if self.raa.cfg.check_for_overflows {
+        if Config::CHECK_FOR_OVERFLOWS {
             accumulate(&mut result);
         } else {
             accumulate_unchecked(&mut result);
         }
-        flip_even_signs(&mut result, self.raa.cfg.check_for_overflows);
-        if self.raa.cfg.permute_in_place {
+        flip_even_signs(&mut result, Config::CHECK_FOR_OVERFLOWS);
+        if Config::PERMUTE_IN_PLACE {
             shuffle_seeded(&mut result, self.raa.perm_2_seed);
         } else {
             result = clone_shuffled(&result, &self.raa.perm_2);
         }
-        if self.raa.cfg.check_for_overflows {
+        if Config::CHECK_FOR_OVERFLOWS {
             accumulate(&mut result);
         } else {
             accumulate_unchecked(&mut result);
@@ -64,17 +64,16 @@ where
     }
 }
 
-impl<Zt: ZipTypes, const REP: usize> LinearCode<Zt> for RaaSignFlippingCode<Zt, REP>
+impl<Zt: ZipTypes, Config: RaaConfig, const REP: usize> LinearCode<Zt>
+    for RaaSignFlippingCode<Zt, Config, REP>
 where
     Zt::Cw: Ring,
 {
-    type Config = <RaaCode<Zt, REP> as LinearCode<Zt>>::Config;
-
     const REPETITION_FACTOR: usize = REP;
 
-    fn new(poly_size: usize, cfg: Self::Config) -> Self {
+    fn new(poly_size: usize) -> Self {
         Self {
-            raa: RaaCode::new(poly_size, cfg),
+            raa: RaaCode::new(poly_size),
         }
     }
 

--- a/zip-plus/src/pcs/phase_commit.rs
+++ b/zip-plus/src/pcs/phase_commit.rs
@@ -218,10 +218,10 @@ mod tests {
     const DEGREE_PLUS_ONE: usize = 3;
 
     type Zt = TestZipTypes<N, K, M>;
-    type C = RaaSignFlippingCode<Zt, 4>;
+    type C = RaaSignFlippingCode<Zt, TestRaaConfig, 4>;
 
     type PolyZt = TestPolyZipTypes<K, M, DEGREE_PLUS_ONE>;
-    type PolyC = RaaCode<PolyZt, 4>;
+    type PolyC = RaaCode<PolyZt, TestRaaConfig, 4>;
 
     type TestZip = ZipPlus<Zt, C>;
     type TestPolyZip = ZipPlus<PolyZt, PolyC>;
@@ -265,7 +265,7 @@ mod tests {
 
     #[test]
     fn commit_succeeds_for_small_polynomial() {
-        let code = C::new(16, RAA_CFG);
+        let code = C::new(16);
         let pp = ZipPlusParams::new(4, 4, code);
 
         let evaluations = vec![Int::from(42); 16];
@@ -277,7 +277,7 @@ mod tests {
 
     #[test]
     fn commit_succeeds_for_two_variables() {
-        let code = C::new(4, RAA_CFG);
+        let code = C::new(4);
         let pp = ZipPlusParams::new(2, 2, code);
 
         let evaluations = vec![Int::from(1), Int::from(2), Int::from(3), Int::from(4)];
@@ -414,7 +414,7 @@ mod tests {
         let results: Vec<Vec<Vec<Int<4>>>> = (0..10)
             .into_par_iter()
             .map(|_| {
-                let code = C::new(poly_size, RAA_CFG);
+                let code = C::new(poly_size);
                 let pp = ZipPlusParams::new(num_vars, 8, code);
 
                 let rows = TestZip::encode_rows(&pp, pp.linear_code.row_len(), &poly.evaluations);
@@ -464,7 +464,7 @@ mod tests {
 
     #[test]
     fn encode_rows_succeeds_for_single_row() {
-        let code = C::new(4, RAA_CFG);
+        let code = C::new(4);
         let pp = ZipPlusParams::new(2, 1, code);
 
         // Create a polynomial with 2 variables and 4 evaluations
@@ -477,7 +477,7 @@ mod tests {
 
     #[test]
     fn encode_rows_succeeds_for_single_poly_row() {
-        let code = PolyC::new(4, RAA_CFG);
+        let code = PolyC::new(4);
         let pp = ZipPlusParams::new(2, 1, code);
 
         // Create a polynomial with 2 variables and 4 evaluations
@@ -620,7 +620,7 @@ mod tests {
         let mut rng = rng();
         let num_vars = 4;
         let poly_size = 1 << num_vars;
-        let linear_code = C::new(poly_size, RAA_CFG);
+        let linear_code = C::new(poly_size);
         let param = TestZip::setup(poly_size, linear_code);
         let evaluations: Vec<_> = (0..poly_size)
             .map(|_| <Zt as ZipTypes>::Eval::from(rng.random::<i8>()))

--- a/zip-plus/src/pcs/phase_test.rs
+++ b/zip-plus/src/pcs/phase_test.rs
@@ -115,10 +115,10 @@ mod tests {
     const DEGREE_PLUS_ONE: usize = 3;
 
     type Zt = TestZipTypes<N, K, M>;
-    type C = RaaSignFlippingCode<Zt, 4>;
+    type C = RaaSignFlippingCode<Zt, TestRaaConfig, 4>;
 
     type PolyZt = TestPolyZipTypes<K, M, DEGREE_PLUS_ONE>;
-    type PolyC = RaaCode<PolyZt, 4>;
+    type PolyC = RaaCode<PolyZt, TestRaaConfig, 4>;
 
     type TestZip = ZipPlus<Zt, C>;
     type TestPolyZip = ZipPlus<PolyZt, PolyC>;

--- a/zip-plus/src/pcs/phase_verify.rs
+++ b/zip-plus/src/pcs/phase_verify.rs
@@ -283,10 +283,10 @@ mod tests {
     type F = BoxedMontyField;
 
     type Zt = TestZipTypes<N, K, M>;
-    type C = RaaSignFlippingCode<Zt, 4>;
+    type C = RaaSignFlippingCode<Zt, TestRaaConfig, 4>;
 
     type PolyZt = TestPolyZipTypes<K, M, DEGREE_PLUS_ONE>;
-    type PolyC = RaaCode<PolyZt, 4>;
+    type PolyC = RaaCode<PolyZt, TestRaaConfig, 4>;
 
     type TestZip = ZipPlus<Zt, C>;
     type TestPolyZip = ZipPlus<PolyZt, PolyC>;
@@ -605,7 +605,7 @@ mod tests {
         let poly_size = 8; // row_len=4, num_rows=2 -> proximity checks are active
         let n = 3;
 
-        let linear_code = C::new(poly_size, RAA_CFG);
+        let linear_code = C::new(poly_size);
         let pp = TestZip::setup(poly_size, linear_code);
 
         let evaluations: Vec<_> = (0..poly_size as i32)
@@ -691,7 +691,7 @@ mod tests {
 
         let n = 3;
         let poly_size = 1 << n;
-        let linear_code: C = C::new(poly_size, RAA_CFG);
+        let linear_code: C = C::new(poly_size);
         let pp = TestZip::setup(poly_size, linear_code);
         let evaluations: Vec<_> = (0..poly_size)
             .map(|_| <Zt as ZipTypes>::Eval::from(rng.random::<i8>()))
@@ -725,7 +725,7 @@ mod tests {
     #[test]
     fn verification_fails_if_evaluation_consistency_check_is_invalid() {
         let poly_size = 8;
-        let linear_code = C::new(poly_size, RAA_CFG);
+        let linear_code = C::new(poly_size);
         let pp = TestZip::setup(poly_size, linear_code);
 
         let evaluations: Vec<_> = (0..poly_size as i32).map(Int::<INT_LIMBS>::from).collect();
@@ -774,7 +774,7 @@ mod tests {
     #[test]
     fn verification_succeeds_for_zero_polynomial() {
         let poly_size = 8;
-        let linear_code = C::new(poly_size, RAA_CFG);
+        let linear_code = C::new(poly_size);
         let pp = TestZip::setup(poly_size, linear_code);
 
         let evaluations: Vec<_> = vec![Int::<INT_LIMBS>::ZERO; poly_size];
@@ -808,7 +808,7 @@ mod tests {
     fn verification_succeeds_at_zero_point() {
         let num_vars = 3;
         let poly_size = 1 << num_vars;
-        let linear_code = C::new(poly_size, RAA_CFG);
+        let linear_code = C::new(poly_size);
         let pp = TestZip::setup(poly_size, linear_code);
 
         let evaluations: Vec<_> = (1..=poly_size as i32).map(Int::<INT_LIMBS>::from).collect();
@@ -908,7 +908,7 @@ mod tests {
     #[test]
     fn verification_fails_if_proximity_values_are_too_large() {
         let poly_size = 8;
-        let linear_code = C::new(poly_size, RAA_CFG);
+        let linear_code = C::new(poly_size);
         let pp = TestZip::setup(poly_size, linear_code);
 
         let evaluations: Vec<_> = (1..=poly_size as i32).map(Int::<INT_LIMBS>::from).collect();
@@ -957,7 +957,7 @@ mod tests {
             let mut rng = ThreadRng::default();
             // Match the benchmark’s transcript usage for linear code construction
             let poly_size = 1 << P;
-            let linear_code = C::new(poly_size, RAA_CFG);
+            let linear_code = C::new(poly_size);
             let pp = TestZip::setup(poly_size, linear_code);
 
             let mle = DenseMultilinearExtension::rand(P, &mut rng);
@@ -1003,7 +1003,7 @@ mod tests {
             let mut rng = ThreadRng::default();
             // Match the benchmark’s transcript usage for linear code construction
             let poly_size = 1 << P;
-            let linear_code = PolyC::new(poly_size, RAA_CFG);
+            let linear_code = PolyC::new(poly_size);
             let pp = TestPolyZip::setup(poly_size, linear_code);
 
             let mle = DenseMultilinearExtension::rand(P, &mut rng);

--- a/zip-plus/src/pcs/test_utils.rs
+++ b/zip-plus/src/pcs/test_utils.rs
@@ -9,7 +9,7 @@
 use crate::{
     code::{
         LinearCode,
-        raa::{RaaCode, RaaConfig},
+        raa::{RaaCode, RaaConfigGeneric},
         raa_sign_flip::RaaSignFlippingCode,
     },
     pcs::{
@@ -44,10 +44,7 @@ use zinc_utils::{
 
 const REPETITION_FACTOR: usize = 4;
 
-pub const RAA_CFG: RaaConfig = RaaConfig {
-    check_for_overflows: true,
-    permute_in_place: false,
-};
+pub type TestRaaConfig = RaaConfigGeneric<false, true>;
 
 pub struct TestZipTypes<const N: usize, const K: usize, const M: usize> {}
 impl<const N: usize, const K: usize, const M: usize> ZipTypes for TestZipTypes<N, K, M> {
@@ -99,7 +96,7 @@ pub fn setup_test_params<const N: usize, const K: usize, const M: usize>(
 ) -> (
     ZipPlusParams<
         TestZipTypes<N, K, M>,
-        RaaSignFlippingCode<TestZipTypes<N, K, M>, REPETITION_FACTOR>,
+        RaaSignFlippingCode<TestZipTypes<N, K, M>, TestRaaConfig, REPETITION_FACTOR>,
     >,
     DenseMultilinearExtension<<TestZipTypes<N, K, M> as ZipTypes>::Eval>,
 ) {
@@ -114,7 +111,7 @@ pub fn setup_poly_test_params<const K: usize, const M: usize, const DEGREE_PLUS_
 ) -> (
     ZipPlusParams<
         TestPolyZipTypes<K, M, DEGREE_PLUS_ONE>,
-        RaaCode<TestPolyZipTypes<K, M, DEGREE_PLUS_ONE>, REPETITION_FACTOR>,
+        RaaCode<TestPolyZipTypes<K, M, DEGREE_PLUS_ONE>, TestRaaConfig, REPETITION_FACTOR>,
     >,
     DenseMultilinearExtension<<TestPolyZipTypes<K, M, DEGREE_PLUS_ONE> as ZipTypes>::Eval>,
 ) {
@@ -129,14 +126,14 @@ pub fn setup_poly_test_params<const K: usize, const M: usize, const DEGREE_PLUS_
     })
 }
 
-fn setup_test_params_inner<Zt: ZipTypes, Lc: LinearCode<Zt, Config = RaaConfig>>(
+fn setup_test_params_inner<Zt: ZipTypes, Lc: LinearCode<Zt>>(
     num_vars: usize,
     prepare_evaluations: impl FnOnce(usize) -> Vec<Zt::Eval>,
 ) -> (ZipPlusParams<Zt, Lc>, DenseMultilinearExtension<Zt::Eval>) {
     let poly_size = 1 << num_vars;
     let num_rows = 1 << num_vars.div_ceil(2);
 
-    let code = Lc::new(poly_size, RAA_CFG);
+    let code = Lc::new(poly_size);
     let pp = ZipPlusParams::new(num_vars, num_rows, code);
 
     let evaluations = prepare_evaluations(poly_size);
@@ -154,7 +151,7 @@ pub fn setup_full_protocol<F, const N: usize, const K: usize, const M: usize>(
 ) -> (
     ZipPlusParams<
         TestZipTypes<N, K, M>,
-        RaaSignFlippingCode<TestZipTypes<N, K, M>, REPETITION_FACTOR>,
+        RaaSignFlippingCode<TestZipTypes<N, K, M>, TestRaaConfig, REPETITION_FACTOR>,
     >,
     ZipPlusCommitment,
     Vec<F>,
@@ -186,7 +183,7 @@ pub fn setup_full_protocol_poly<
 ) -> (
     ZipPlusParams<
         TestPolyZipTypes<K, M, DEGREE_PLUS_ONE>,
-        RaaCode<TestPolyZipTypes<K, M, DEGREE_PLUS_ONE>, REPETITION_FACTOR>,
+        RaaCode<TestPolyZipTypes<K, M, DEGREE_PLUS_ONE>, TestRaaConfig, REPETITION_FACTOR>,
     >,
     ZipPlusCommitment,
     Vec<F>,

--- a/zip-plus/src/pcs/test_utils.rs
+++ b/zip-plus/src/pcs/test_utils.rs
@@ -9,7 +9,7 @@
 use crate::{
     code::{
         LinearCode,
-        raa::{RaaCode, RaaConfigGeneric},
+        raa::{RaaCode, RaaConfig},
         raa_sign_flip::RaaSignFlippingCode,
     },
     pcs::{
@@ -44,7 +44,13 @@ use zinc_utils::{
 
 const REPETITION_FACTOR: usize = 4;
 
-pub type TestRaaConfig = RaaConfigGeneric<false, true>;
+#[derive(Clone, Copy)]
+pub struct TestRaaConfig;
+
+impl RaaConfig for TestRaaConfig {
+    const PERMUTE_IN_PLACE: bool = false;
+    const CHECK_FOR_OVERFLOWS: bool = true;
+}
 
 pub struct TestZipTypes<const N: usize, const K: usize, const M: usize> {}
 impl<const N: usize, const K: usize, const M: usize> ZipTypes for TestZipTypes<N, K, M> {


### PR DESCRIPTION
Since we always should know the configuration of the codes at compile time there is no need to drag them along in runtime.

It does bring some nuisance in tests but that's addressed via macros.