### PR TITLE
IPRS optimisations

### DIFF
--- a/poly/src/univariate/dense.rs
+++ b/poly/src/univariate/dense.rs
@@ -1,7 +1,7 @@
 use crate::{ConstCoeffBitWidth, EvaluatablePolynomial, EvaluationError, Polynomial};
 use core::slice;
 use crypto_primitives::{
-    FixedSemiring, FromWithConfig, IntoWithConfig, PrimeField, Ring, Semiring,
+    FixedSemiring, FromWithConfig, IntoWithConfig, PrimeField, Ring, Semiring, boolean::Boolean,
 };
 use itertools::Itertools;
 use num_traits::{CheckedAdd, CheckedMul, CheckedNeg, CheckedSub, One, Zero};
@@ -18,7 +18,7 @@ use zinc_transcript::traits::ConstTranscribable;
 use zinc_utils::{
     from_ref::FromRef,
     inner_product::{InnerProduct, InnerProductError},
-    mul_by_scalar::MulByScalar,
+    mul_by_scalar::{MulByScalar, WideningMulByScalar},
     named::Named,
     projection_to_field::ProjectionToField,
 };
@@ -625,5 +625,33 @@ where
         zero: Out,
     ) -> Result<Out, InnerProductError> {
         I::inner_product(&lhs.coeffs, rhs, zero)
+    }
+}
+
+#[derive(Clone, Copy, Default)]
+pub struct BinaryPolyWideningMulByScalar<Output>(PhantomData<Output>);
+
+impl<Rhs, Output, const DEGREE_PLUS_ONE: usize>
+    WideningMulByScalar<DensePolynomial<Boolean, DEGREE_PLUS_ONE>, Rhs>
+    for BinaryPolyWideningMulByScalar<Output>
+where
+    Rhs: Copy,
+    Output: From<Rhs> + Send + Sync + Default + Copy + Zero,
+{
+    type Output = DensePolynomial<Output, DEGREE_PLUS_ONE>;
+
+    fn mul_by_scalar_widen(
+        lhs: &DensePolynomial<Boolean, DEGREE_PLUS_ONE>,
+        rhs: &Rhs,
+    ) -> Self::Output {
+        let mut coeffs: [Output; DEGREE_PLUS_ONE] = [Output::zero(); DEGREE_PLUS_ONE];
+
+        coeffs.iter_mut().enumerate().for_each(|(i, out)| {
+            if lhs.coeffs[i].inner() {
+                *out = (*rhs).into();
+            }
+        });
+
+        DensePolynomial { coeffs }
     }
 }

--- a/utils/src/mul_by_scalar.rs
+++ b/utils/src/mul_by_scalar.rs
@@ -65,3 +65,9 @@ impl MulByScalar<&i64> for i128 {
         self.checked_mul(&i128::from(*rhs))
     }
 }
+
+pub trait WideningMulByScalar<Lhs, Rhs>: Clone + Default + Send + Sync {
+    type Output;
+
+    fn mul_by_scalar_widen(lhs: &Lhs, rhs: &Rhs) -> Self::Output;
+}

--- a/zip-plus/benches/zip_plus_benches.rs
+++ b/zip-plus/benches/zip_plus_benches.rs
@@ -8,7 +8,8 @@ use std::marker::PhantomData;
 use zinc_transcript::traits::ConstTranscribable;
 
 use zinc_poly::univariate::dense::{
-    DensePolyInnerProduct, DensePolynomial, HornerProjection, InnerProductProjection,
+    BinaryPolyWideningMulByScalar, DensePolyInnerProduct, DensePolynomial, HornerProjection,
+    InnerProductProjection,
 };
 use zinc_primality::MillerRabin;
 use zinc_utils::{
@@ -86,8 +87,11 @@ impl RaaConfig for BenchRaaConfig {
 type SomeRaaCode<const D_PLUS_ONE: usize> =
     RaaCode<BenchZipPlusTypes<i32, D_PLUS_ONE>, BenchRaaConfig, 4>;
 
-type SomeIprsCode<const DEPTH: usize, const D_PLUS_ONE: usize> =
-    IprsCode<BenchZipPlusTypes<i128, D_PLUS_ONE>, PnttConfigF2_16_1<DEPTH>>;
+type SomeIprsCode<Twiddle, const DEPTH: usize, const D_PLUS_ONE: usize> = IprsCode<
+    BenchZipPlusTypes<Twiddle, D_PLUS_ONE>,
+    PnttConfigF2_16_1<DEPTH>,
+    BinaryPolyWideningMulByScalar<Twiddle>,
+>;
 
 fn zip_plus_benchmarks_raa(c: &mut Criterion) {
     let mut group = c.benchmark_group("Zip+ RAA");
@@ -111,10 +115,9 @@ fn zip_plus_benchmarks_raa(c: &mut Criterion) {
 fn zip_plus_benchmarks_iprs(c: &mut Criterion) {
     let mut group = c.benchmark_group("Zip+ IPRS");
 
-    // TODO: Add proper Zip+ IPRS benchmarks instead!
-    encode_rows::<BenchZipPlusTypes<i128, 32>, SomeIprsCode<1, _>, 16>(&mut group);
-    encode_rows::<BenchZipPlusTypes<i128, 32>, SomeIprsCode<2, _>, 11>(&mut group);
-    encode_rows::<BenchZipPlusTypes<i128, 32>, SomeIprsCode<3, _>, 14>(&mut group);
+    encode_rows::<BenchZipPlusTypes<i64, 32>, SomeIprsCode<i64, 1, _>, 16>(&mut group);
+
+    encode_rows::<BenchZipPlusTypes<i128, 32>, SomeIprsCode<i128, 2, _>, 22>(&mut group);
 }
 
 criterion_group!(benches, zip_plus_benchmarks_raa, zip_plus_benchmarks_iprs);

--- a/zip-plus/src/code/iprs.rs
+++ b/zip-plus/src/code/iprs.rs
@@ -8,39 +8,43 @@ use crate::{
     pcs::structs::ZipTypes,
 };
 use crypto_primitives::{FromPrimitiveWithConfig, FromWithConfig};
-use itertools::Itertools;
 use num_traits::{CheckedAdd, CheckedMul};
 use std::{fmt::Debug, iter::Sum, marker::PhantomData, ops::AddAssign};
 use zinc_utils::{from_ref::FromRef, mul_by_scalar::MulByScalar};
 
+use crate::code::iprs::pntt::radix8::{MulByTwiddle, WideningMulByTwiddle};
 pub use pntt::radix8::params::{PnttConfigF2_16_1, PnttInt, Radix8PnttParams};
+use zinc_utils::mul_by_scalar::WideningMulByScalar;
 
 /// Pseudo Reed-Solomon encoder over the integers. Internally uses a
 /// radix-8 NTT-style recursion with a base Vandermonde matrix sized
 /// `base_len x base_dim` (defaults to 64x32).
 #[derive(Debug, Clone)]
-pub struct IprsCode<Zt: ZipTypes, Config: PnttConfig> {
+pub struct IprsCode<Zt: ZipTypes, Config: PnttConfig, MT> {
     pntt_params: Radix8PnttParams<Config>,
-    _phantom: PhantomData<Zt>,
+    _phantom: PhantomData<(Zt, MT)>,
 }
 
-impl<Zt, Config> IprsCode<Zt, Config>
+impl<Zt, Config, MT> IprsCode<Zt, Config, MT>
 where
     Zt: ZipTypes,
     Config: PnttConfig,
 {
     /// Encode without modular reduction, purely over the integers.
-    fn encode_inner<R>(&self, row: &[R]) -> Vec<R>
+    fn encode_inner<In, Out, M>(&self, row: &[In], mul_in_by_twiddle: &M) -> Vec<Out>
     where
-        R: CheckedAdd
-            + for<'a> AddAssign<&'a R>
+        In: Clone + Send + Sync,
+        Out: CheckedAdd
+            + for<'a> AddAssign<&'a Out>
             + CheckedMul
             + for<'a> MulByScalar<&'a PnttInt>
             + Sum
+            + FromRef<In>
             + Clone
             + Debug
             + Send
             + Sync,
+        M: MulByTwiddle<In, PnttInt, Output = Out>,
     {
         assert_eq!(
             row.len(),
@@ -50,14 +54,14 @@ where
             Config::INPUT_LEN
         );
 
-        pntt::radix8::pntt(row, &self.pntt_params, &MBSMulByTwiddle)
+        pntt::radix8::pntt(row, &self.pntt_params, mul_in_by_twiddle, &MBSMulByTwiddle)
     }
 
     // Do the encoding but make use of the fact
     // that we are dealing with a field.
     fn encode_inner_f<F>(&self, row: &[F]) -> Vec<F>
     where
-        F: FromWithConfig<PnttInt>,
+        F: FromWithConfig<PnttInt> + FromRef<F>,
     {
         assert_eq!(
             row.len(),
@@ -67,20 +71,19 @@ where
             Config::INPUT_LEN
         );
 
-        pntt::radix8::pntt(
-            row,
-            &self.pntt_params,
-            &FieldMulByTwiddle::<_, PnttInt>::new(row[0].cfg().clone()),
-        )
+        let mul_by_twiddle = FieldMulByTwiddle::<_, PnttInt>::new(row[0].cfg().clone());
+
+        pntt::radix8::pntt(row, &self.pntt_params, &mul_by_twiddle, &mul_by_twiddle)
     }
 }
 
-impl<Zt: ZipTypes, Config> LinearCode<Zt> for IprsCode<Zt, Config>
+impl<Zt: ZipTypes, Config, MT> LinearCode<Zt> for IprsCode<Zt, Config, MT>
 where
     Zt: ZipTypes,
     Config: PnttConfig,
     Zt::CombR: for<'a> MulByScalar<&'a PnttInt>,
     Zt::Cw: CheckedAdd + for<'a> MulByScalar<&'a PnttInt>,
+    MT: WideningMulByScalar<Zt::Eval, PnttInt, Output = Zt::Cw>,
 {
     const REPETITION_FACTOR: usize = Config::OUTPUT_LEN / Config::INPUT_LEN;
 
@@ -118,11 +121,7 @@ where
             Config::INPUT_LEN
         );
 
-        self.encode_inner(
-            &row.iter()
-                .map(<Zt::Cw as FromRef<Zt::Eval>>::from_ref)
-                .collect_vec(),
-        )
+        self.encode_inner(row, &WideningMulByTwiddle::<MT>::default())
     }
 
     fn row_len(&self) -> usize {
@@ -134,7 +133,7 @@ where
     }
 
     fn encode_wide(&self, row: &[Zt::CombR]) -> Vec<Zt::CombR> {
-        self.encode_inner(row)
+        self.encode_inner(row, &MBSMulByTwiddle)
     }
 
     fn encode_f<F>(&self, row: &[F]) -> Vec<F>

--- a/zip-plus/src/code/iprs/pntt/radix8.rs
+++ b/zip-plus/src/code/iprs/pntt/radix8.rs
@@ -7,12 +7,12 @@ mod octet_reversal;
 
 pub mod params;
 
-use ark_std::{cfg_chunks_mut, cfg_iter_mut};
+use ark_std::{cfg_chunks_mut, cfg_into_iter};
 use itertools::Itertools;
 use num_traits::{CheckedAdd, CheckedMul};
 #[cfg(feature = "parallel")]
 use rayon::prelude::*;
-use std::{array, fmt::Debug, iter::Sum, mem::MaybeUninit};
+use std::{array, fmt::Debug, iter::Sum};
 use zinc_utils::{add, from_ref::FromRef};
 
 use butterfly::*;
@@ -117,10 +117,8 @@ where
     Out: Clone + CheckedAdd + CheckedMul + Sum + FromRef<In> + Send + Sync,
     M: MulByTwiddle<In, PnttInt, Output = Out>,
 {
-    let mut output = Vec::with_capacity(C::OUTPUT_LEN);
-    cfg_iter_mut!(output.spare_capacity_mut())
-        .enumerate()
-        .for_each(|(i, out)| {
+    cfg_into_iter!(0..C::OUTPUT_LEN)
+        .map(|i| {
             let chunk = i >> C::BASE_DIM_LOG2; // i / C::BASE_DIM
             let row = i & C::BASE_DIM_MASK; // i % C::BASE_DIM
 
@@ -134,7 +132,7 @@ where
 
             // We always know that the first column of the Vandermonde matrix
             // consists of 1's.
-            let result = params.base_matrix[row][1..].iter().enumerate().fold(
+            params.base_matrix[row][1..].iter().enumerate().fold(
                 Out::from_ref(&input[oct_rev_chunk]),
                 |acc, (col, bm_row_col)| {
                     let term = mul_by_twiddle.mul_by_twiddle(
@@ -144,17 +142,9 @@ where
 
                     add!(acc, &term)
                 },
-            );
-
-            *out = MaybeUninit::new(result);
-        });
-
-    // Safety: We initialized all elements in the output.
-    unsafe {
-        output.set_len(C::OUTPUT_LEN);
-    }
-
-    output
+            )
+        })
+        .collect()
 }
 
 // TODO: make unchecked versions of the above.

--- a/zip-plus/src/code/iprs/pntt/radix8.rs
+++ b/zip-plus/src/code/iprs/pntt/radix8.rs
@@ -22,18 +22,18 @@ use params::*;
 pub(crate) use mul_by_twiddle::*;
 
 /// The main entrypoint of the radix-8 pseudo NTT algorithm.
-pub(crate) fn pntt<In, Out, C, MI, MO>(
+pub(crate) fn pntt<In, Out, C, MulInByTwiddle, MulOutByTwiddle>(
     input: &[In],
     params: &Radix8PnttParams<C>,
-    mul_in_by_twiddle: &MI,
-    mul_out_by_twiddle: &MO,
+    mul_in_by_twiddle: &MulInByTwiddle,
+    mul_out_by_twiddle: &MulOutByTwiddle,
 ) -> Vec<Out>
 where
     C: Config,
     In: Clone + Send + Sync,
     Out: CheckedAdd + CheckedMul + Sum + FromRef<In> + Clone + Send + Sync + Debug,
-    MI: MulByTwiddle<In, PnttInt, Output = Out>,
-    MO: MulByTwiddle<Out, PnttInt, Output = Out>,
+    MulInByTwiddle: MulByTwiddle<In, PnttInt, Output = Out>,
+    MulOutByTwiddle: MulByTwiddle<Out, PnttInt, Output = Out>,
 {
     assert_eq!(
         C::INPUT_LEN,

--- a/zip-plus/src/code/iprs/pntt/radix8.rs
+++ b/zip-plus/src/code/iprs/pntt/radix8.rs
@@ -7,13 +7,13 @@ mod octet_reversal;
 
 pub mod params;
 
-use ark_std::{cfg_chunks_mut, cfg_into_iter};
+use ark_std::{cfg_chunks_mut, cfg_iter_mut};
 use itertools::Itertools;
 use num_traits::{CheckedAdd, CheckedMul};
 #[cfg(feature = "parallel")]
 use rayon::prelude::*;
-use std::{array, fmt::Debug, iter::Sum};
-use zinc_utils::add;
+use std::{array, fmt::Debug, iter::Sum, mem::MaybeUninit};
+use zinc_utils::{add, from_ref::FromRef};
 
 use butterfly::*;
 use octet_reversal::*;
@@ -22,11 +22,18 @@ use params::*;
 pub(crate) use mul_by_twiddle::*;
 
 /// The main entrypoint of the radix-8 pseudo NTT algorithm.
-pub(crate) fn pntt<R, C, M>(input: &[R], params: &Radix8PnttParams<C>, mul_by_twiddle: &M) -> Vec<R>
+pub(crate) fn pntt<In, Out, C, MI, MO>(
+    input: &[In],
+    params: &Radix8PnttParams<C>,
+    mul_in_by_twiddle: &MI,
+    mul_out_by_twiddle: &MO,
+) -> Vec<Out>
 where
     C: Config,
-    R: CheckedAdd + CheckedMul + Sum + Clone + Send + Sync + Debug,
-    M: MulByTwiddle<R, PnttInt>,
+    In: Clone + Send + Sync,
+    Out: CheckedAdd + CheckedMul + Sum + FromRef<In> + Clone + Send + Sync + Debug,
+    MI: MulByTwiddle<In, PnttInt, Output = Out>,
+    MO: MulByTwiddle<Out, PnttInt, Output = Out>,
 {
     assert_eq!(
         C::INPUT_LEN,
@@ -36,9 +43,9 @@ where
         input.len()
     );
 
-    let mut output = base_multiply_into_output(input, params, mul_by_twiddle);
+    let mut output = base_multiply_into_output(input, params, mul_in_by_twiddle);
 
-    combine_stages(&mut output, params, mul_by_twiddle);
+    combine_stages(&mut output, params, mul_out_by_twiddle);
 
     output
 }
@@ -51,7 +58,7 @@ fn combine_stages<R, C, M>(out: &mut [R], params: &Radix8PnttParams<C>, mul_by_t
 where
     C: Config,
     R: CheckedAdd + CheckedMul + Clone + Send + Sync + Debug,
-    M: MulByTwiddle<R, PnttInt>,
+    M: MulByTwiddle<R, PnttInt, Output = R>,
 {
     for k in 0..C::DEPTH {
         // The length of chunks in the current layer.
@@ -99,18 +106,21 @@ where
 
 /// Allocates the output vector and performs base layer multiplications.
 #[allow(clippy::arithmetic_side_effects)]
-fn base_multiply_into_output<R, C, M>(
-    input: &[R],
+fn base_multiply_into_output<In, Out, C, M>(
+    input: &[In],
     params: &Radix8PnttParams<C>,
     mul_by_twiddle: &M,
-) -> Vec<R>
+) -> Vec<Out>
 where
     C: Config,
-    R: Clone + CheckedAdd + CheckedMul + Sum + Send + Sync,
-    M: MulByTwiddle<R, PnttInt>,
+    In: Clone + Send + Sync,
+    Out: Clone + CheckedAdd + CheckedMul + Sum + FromRef<In> + Send + Sync,
+    M: MulByTwiddle<In, PnttInt, Output = Out>,
 {
-    cfg_into_iter!(0..C::OUTPUT_LEN)
-        .map(|i| {
+    let mut output = Vec::with_capacity(C::OUTPUT_LEN);
+    cfg_iter_mut!(output.spare_capacity_mut())
+        .enumerate()
+        .for_each(|(i, out)| {
             let chunk = i >> C::BASE_DIM_LOG2; // i / C::BASE_DIM
             let row = i & C::BASE_DIM_MASK; // i % C::BASE_DIM
 
@@ -124,8 +134,8 @@ where
 
             // We always know that the first column of the Vandermonde matrix
             // consists of 1's.
-            params.base_matrix[row][1..].iter().enumerate().fold(
-                input[oct_rev_chunk].clone(),
+            let result = params.base_matrix[row][1..].iter().enumerate().fold(
+                Out::from_ref(&input[oct_rev_chunk]),
                 |acc, (col, bm_row_col)| {
                     let term = mul_by_twiddle.mul_by_twiddle(
                         &input[oct_rev_chunk | ((col + 1) << (3 * C::DEPTH))],
@@ -134,9 +144,17 @@ where
 
                     add!(acc, &term)
                 },
-            )
-        })
-        .collect()
+            );
+
+            *out = MaybeUninit::new(result);
+        });
+
+    // Safety: We initialized all elements in the output.
+    unsafe {
+        output.set_len(C::OUTPUT_LEN);
+    }
+
+    output
 }
 
 // TODO: make unchecked versions of the above.
@@ -225,7 +243,7 @@ mod tests {
 
             let params = Radix8PnttParams::<C>::new();
 
-            let res: Vec<Int<4>> = pntt(&input, &params, &MBSMulByTwiddle);
+            let res: Vec<Int<4>> = pntt(&input, &params, &MBSMulByTwiddle, &MBSMulByTwiddle);
 
             res.into_iter()
                 .map(|x| {

--- a/zip-plus/src/code/iprs/pntt/radix8/butterfly.rs
+++ b/zip-plus/src/code/iprs/pntt/radix8/butterfly.rs
@@ -27,7 +27,7 @@ pub(crate) fn apply_radix_8_butterflies<R, Twiddle, M>(
     mul_by_twiddle: &M,
 ) where
     R: Clone + CheckedAdd,
-    M: MulByTwiddle<R, Twiddle>,
+    M: MulByTwiddle<R, Twiddle, Output = R>,
 {
     ys.into_iter()
         .zip(BUTTERFLY_TABLE.iter())

--- a/zip-plus/src/code/iprs/pntt/radix8/mul_by_twiddle.rs
+++ b/zip-plus/src/code/iprs/pntt/radix8/mul_by_twiddle.rs
@@ -1,14 +1,16 @@
 use crypto_primitives::{FromWithConfig, PrimeField};
 use std::marker::PhantomData;
 
-use zinc_utils::mul_by_scalar::MulByScalar;
+use zinc_utils::mul_by_scalar::{MulByScalar, WideningMulByScalar};
 
 /// A helper trait that allows to provide
 /// the pseudo NTT algorithm a means to
 /// multiply output by twiddles.
 // TODO(alex): Can we get away with using just MulByScalar?
 pub(crate) trait MulByTwiddle<Lhs, Twiddle>: Clone + Send + Sync {
-    fn mul_by_twiddle(&self, lhs: &Lhs, twiddle: &Twiddle) -> Lhs;
+    type Output;
+
+    fn mul_by_twiddle(&self, lhs: &Lhs, twiddle: &Twiddle) -> Self::Output;
 }
 
 /// The twiddle multiplication that
@@ -20,6 +22,8 @@ impl<Lhs, Twiddle> MulByTwiddle<Lhs, Twiddle> for MBSMulByTwiddle
 where
     Lhs: for<'a> MulByScalar<&'a Twiddle>,
 {
+    type Output = Lhs;
+
     #[inline(always)]
     fn mul_by_twiddle(&self, lhs: &Lhs, twiddle: &Twiddle) -> Lhs {
         lhs.mul_by_scalar(twiddle)
@@ -27,10 +31,10 @@ where
     }
 }
 
-#[derive(Debug, Clone)]
 /// If we deal with fields we do not have to
 /// worry about overflows. Multiplication by twiddle
 /// is done by conversions and field operations.
+#[derive(Debug, Clone)]
 pub(crate) struct FieldMulByTwiddle<F: PrimeField, T> {
     config: F::Config,
     _phantom: PhantomData<T>,
@@ -51,7 +55,25 @@ where
     Twiddle: Clone + Into<T>,
     T: Clone + Send + Sync,
 {
+    type Output = F;
+
+    #[inline(always)]
     fn mul_by_twiddle(&self, lhs: &F, twiddle: &Twiddle) -> F {
         F::from_with_cfg(twiddle.clone().into(), &self.config) * lhs
+    }
+}
+
+#[derive(Clone, Default, Copy)]
+pub struct WideningMulByTwiddle<WM>(PhantomData<WM>);
+
+impl<Lhs, Twiddle, WM> MulByTwiddle<Lhs, Twiddle> for WideningMulByTwiddle<WM>
+where
+    WM: WideningMulByScalar<Lhs, Twiddle>,
+{
+    type Output = WM::Output;
+
+    #[inline(always)]
+    fn mul_by_twiddle(&self, lhs: &Lhs, twiddle: &Twiddle) -> Self::Output {
+        WM::mul_by_scalar_widen(lhs, twiddle)
     }
 }

--- a/zip-plus/src/code/iprs/pntt/radix8/mul_by_twiddle.rs
+++ b/zip-plus/src/code/iprs/pntt/radix8/mul_by_twiddle.rs
@@ -66,14 +66,14 @@ where
 #[derive(Clone, Default, Copy)]
 pub struct WideningMulByTwiddle<WM>(PhantomData<WM>);
 
-impl<Lhs, Twiddle, WM> MulByTwiddle<Lhs, Twiddle> for WideningMulByTwiddle<WM>
+impl<Lhs, Twiddle, Inner> MulByTwiddle<Lhs, Twiddle> for WideningMulByTwiddle<Inner>
 where
-    WM: WideningMulByScalar<Lhs, Twiddle>,
+    Inner: WideningMulByScalar<Lhs, Twiddle>,
 {
-    type Output = WM::Output;
+    type Output = Inner::Output;
 
     #[inline(always)]
     fn mul_by_twiddle(&self, lhs: &Lhs, twiddle: &Twiddle) -> Self::Output {
-        WM::mul_by_scalar_widen(lhs, twiddle)
+        Inner::mul_by_scalar_widen(lhs, twiddle)
     }
 }


### PR DESCRIPTION
1. Introduce means to specify a better mul-by-scalar algorithm for binary polynomials (similar to what we did with inner product).
2. Remove unneeded zero argument to all of the pntt subprocedures.
3. Do a bench for i64 coefficients of codewords rather than i128