### PR TITLE
`Semiring` implemenetation for univariate polynomials only require the coefficients to be `FixedSemiring`

### DIFF
--- a/piop/src/sumcheck/tests/utils.rs
+++ b/piop/src/sumcheck/tests/utils.rs
@@ -51,7 +51,14 @@ pub fn rand_poly_comb_fn<F: PrimeField>(
 ) -> F {
     let mut result = F::zero_with_cfg(&config);
     for (coef, indices) in products {
-        let term = coef.clone() * indices.iter().map(|&i| &vals[i]).product::<F>();
+        let term = coef.clone()
+            * indices
+                .iter()
+                .map(|&i| &vals[i])
+                .fold(F::one_with_cfg(&config), |mut acc, next| {
+                    acc *= next;
+                    acc
+                });
         result += &term;
     }
 

--- a/poly/src/univariate/dense.rs
+++ b/poly/src/univariate/dense.rs
@@ -361,10 +361,7 @@ impl<'a, R: FixedSemiring, const DEGREE_PLUS_ONE: usize> Product<&'a Self>
     }
 }
 
-impl<R: FixedSemiring, const DEGREE_PLUS_ONE: usize> Semiring
-    for DensePolynomial<R, DEGREE_PLUS_ONE>
-{
-}
+impl<R: Semiring, const DEGREE_PLUS_ONE: usize> Semiring for DensePolynomial<R, DEGREE_PLUS_ONE> {}
 
 impl<R: Ring + FixedSemiring, const DEGREE_PLUS_ONE: usize> Ring
     for DensePolynomial<R, DEGREE_PLUS_ONE>

--- a/poly/src/univariate/nat_evaluation.rs
+++ b/poly/src/univariate/nat_evaluation.rs
@@ -1,4 +1,3 @@
-use num_traits::Zero;
 use std::convert::identity;
 
 use crypto_primitives::{FromPrimitiveWithConfig, Semiring};
@@ -173,17 +172,13 @@ where
     R: Semiring,
     F: Fn(u64) -> R + Send + Sync,
 {
-    if a.is_zero() {
-        return from_u64(1);
-    }
-
     (1..=(a as u64))
-        .map(from_u64)
+        .map(&from_u64)
         .reduce(|mut acc, next| {
             acc *= next;
             acc
         })
-        .expect("The iterator cannot be empty as we have checked if a is zero")
+        .unwrap_or(from_u64(1))
 }
 
 #[cfg(test)]

--- a/poly/src/univariate/nat_evaluation.rs
+++ b/poly/src/univariate/nat_evaluation.rs
@@ -167,6 +167,7 @@ impl<F: FromPrimitiveWithConfig> EvaluatablePolynomial<F, F> for NatEvaluatedPol
 }
 
 /// Compute the factorial(a) = 1 * 2 * ... * a.
+#[allow(clippy::arithmetic_side_effects)]
 fn factorial<R, F>(a: usize, from_u64: F) -> R
 where
     R: Semiring,
@@ -176,7 +177,13 @@ where
         return from_u64(1);
     }
 
-    (1..=(a as u64)).map(from_u64).product()
+    (1..=(a as u64))
+        .map(from_u64)
+        .reduce(|mut acc, next| {
+            acc *= next;
+            acc
+        })
+        .expect("The iterator cannot be empty as we have checked if a is zero")
 }
 
 #[cfg(test)]

--- a/zip-plus/benches/zip_plus_benches.rs
+++ b/zip-plus/benches/zip_plus_benches.rs
@@ -3,7 +3,6 @@
 
 mod zip_common;
 
-use num_traits::{One, Zero};
 use std::marker::PhantomData;
 
 use zinc_poly::univariate::{
@@ -22,7 +21,7 @@ use zip_common::*;
 use criterion::{Criterion, criterion_group, criterion_main};
 use crypto_bigint::U64;
 use crypto_primitives::{
-    Semiring, boolean::Boolean, crypto_bigint_int::Int, crypto_bigint_uint::Uint,
+    FixedSemiring, boolean::Boolean, crypto_bigint_int::Int, crypto_bigint_uint::Uint,
 };
 use zip_plus::{
     code::{
@@ -43,11 +42,9 @@ where
         + Default
         + FromRef<Boolean>
         + Named
-        + Semiring
+        + FixedSemiring
         + Send
-        + Sync
-        + Zero
-        + One,
+        + Sync,
     Int<5>: FromRef<CwCoeff>,
 {
     const NUM_COLUMN_OPENINGS: usize = 650;

--- a/zip-plus/src/code/iprs/pntt/radix8.rs
+++ b/zip-plus/src/code/iprs/pntt/radix8.rs
@@ -12,7 +12,7 @@ use itertools::Itertools;
 use num_traits::{CheckedAdd, CheckedMul};
 #[cfg(feature = "parallel")]
 use rayon::prelude::*;
-use std::{array, fmt::Debug, iter::Sum};
+use std::{array, fmt::Debug};
 use zinc_utils::{add, from_ref::FromRef};
 
 use butterfly::*;
@@ -29,7 +29,7 @@ pub(crate) fn pntt<In, Out, C, MulInByTwiddle, MulOutByTwiddle>(
 where
     C: Config,
     In: Clone + Send + Sync,
-    Out: CheckedAdd + CheckedMul + Sum + FromRef<In> + Clone + Send + Sync + Debug,
+    Out: CheckedAdd + CheckedMul + FromRef<In> + Clone + Send + Sync + Debug,
     MulInByTwiddle: MulByTwiddle<In, PnttInt, Output = Out>,
     MulOutByTwiddle: MulByTwiddle<Out, PnttInt, Output = Out>,
 {
@@ -108,7 +108,7 @@ fn base_multiply_into_output<In, Out, C, M>(input: &[In], params: &Radix8PnttPar
 where
     C: Config,
     In: Clone + Send + Sync,
-    Out: Clone + CheckedAdd + CheckedMul + Sum + FromRef<In> + Send + Sync,
+    Out: Clone + CheckedAdd + CheckedMul + FromRef<In> + Send + Sync,
     M: MulByTwiddle<In, PnttInt, Output = Out>,
 {
     cfg_into_iter!(0..C::OUTPUT_LEN)

--- a/zip-plus/src/pcs/phase_evaluate.rs
+++ b/zip-plus/src/pcs/phase_evaluate.rs
@@ -65,7 +65,7 @@ impl<Zt: ZipTypes, Lc: LinearCode<Zt>> ZipPlus<Zt, Lc> {
 
         let q_0_combined_row = if num_rows > 1 {
             // Return the evaluation row combination
-            combine_rows(&q_0, &evaluations, row_len)
+            combine_rows(&q_0, &evaluations, row_len, &F::zero_with_cfg(&field_cfg))
         } else {
             // If there is only one row, we have no need to take linear combinations
             // We just return the evaluation row combination

--- a/zip-plus/src/pcs/phase_test.rs
+++ b/zip-plus/src/pcs/phase_test.rs
@@ -56,7 +56,8 @@ impl<Zt: ZipTypes, Lc: LinearCode<Zt>> ZipPlus<Zt, Lc> {
                 .try_collect()?;
 
             // u' in the Zinc paper
-            let combined_row = combine_rows(&coeffs, &evals, pp.linear_code.row_len());
+            let combined_row =
+                combine_rows(&coeffs, &evals, pp.linear_code.row_len(), &Zt::CombR::ZERO);
 
             transcript.write_const_many(&combined_row)?;
         }

--- a/zip-plus/src/utils.rs
+++ b/zip-plus/src/utils.rs
@@ -1,10 +1,8 @@
 use ark_std::cfg_iter_mut;
+use num_traits::CheckedAdd;
 use rand::{rngs::StdRng, seq::SliceRandom};
 use rand_core::SeedableRng;
-use std::{
-    iter::{Iterator, Sum},
-    mem::MaybeUninit,
-};
+use std::{iter::Iterator, mem::MaybeUninit};
 use zinc_utils::mul_by_scalar::MulByScalar;
 
 #[cfg(feature = "parallel")]
@@ -28,6 +26,7 @@ use rayon::prelude::*;
 /// - `coeffs`: Coefficients applied to each row.
 /// - `evaluations`: Flattened evaluations arranged row-wise.
 /// - `row_len`: Number of columns per evaluation row.
+/// - `zero`: Additive neutral element of `El`.
 ///
 /// # Returns
 ///
@@ -36,10 +35,11 @@ pub(super) fn combine_rows<Coeff, El>(
     coeffs: &[Coeff],
     evaluations: &[El],
     row_len: usize,
+    zero: &El,
 ) -> Vec<El>
 where
     Coeff: Send + Sync,
-    El: Clone + Sum + for<'z> MulByScalar<&'z Coeff> + Send + Sync,
+    El: Clone + CheckedAdd + for<'z> MulByScalar<&'z Coeff> + Send + Sync,
 {
     let mut combined_row = Vec::with_capacity(row_len);
 
@@ -54,7 +54,11 @@ where
                         eval.mul_by_scalar(coeff)
                             .expect("Cannot multiply evaluation by coefficient")
                     })
-                    .sum(),
+                    .reduce(|mut acc, next| {
+                        acc = acc.checked_add(&next).expect("addition overflow");
+                        acc
+                    })
+                    .unwrap_or(zero.clone()),
             );
         });
 
@@ -82,7 +86,7 @@ mod test {
         let evaluations = vec![3, 4, 5, 6];
         let row_len = 2;
 
-        let result = combine_rows(&coeffs, &evaluations, row_len);
+        let result = combine_rows(&coeffs, &evaluations, row_len, &0);
 
         assert_eq!(result, vec![(3 + 2 * 5), (4 + 2 * 6)]);
     }
@@ -93,7 +97,7 @@ mod test {
         let evaluations = vec![2, 4, 6, 8];
         let row_len = 2;
 
-        let result = combine_rows(&coeffs, &evaluations, row_len);
+        let result = combine_rows(&coeffs, &evaluations, row_len, &0);
 
         assert_eq!(result, vec![(3 * 2 + 4 * 6), (3 * 4 + 4 * 8)]);
     }
@@ -103,7 +107,7 @@ mod test {
         let evaluations = vec![2000, -3000, 4000, -5000];
         let row_len = 2;
 
-        let result = combine_rows(&coeffs, &evaluations, row_len);
+        let result = combine_rows(&coeffs, &evaluations, row_len, &0);
 
         assert_eq!(
             result,


### PR DESCRIPTION
Some changes were applied as `Semiring` does not contains `Sum` and `Product` anymore. The changes are mostly `.fold` and `.reduce` instead of `.sum` and `.product`.