### PR TITLE
`DenseMultilinearExtension` is a proper collection and coefficients are projected in parallel in eval phase

### DIFF
--- a/piop/src/sumcheck/tests.rs
+++ b/piop/src/sumcheck/tests.rs
@@ -236,7 +236,7 @@ fn different_polynomials_produce_different_proofs() {
 
     let mut poly_mles2 = poly_mles1;
     let one: F = F::ONE;
-    poly_mles2[0].evaluations[0] = F::add_inner(&poly_mles2[0].evaluations[0], one.inner(), &());
+    poly_mles2[0][0] = F::add_inner(&poly_mles2[0].evaluations[0], one.inner(), &());
 
     let comb_fn2 = move |vals: &[F]| -> F { rand_poly_comb_fn(vals, &products1, ()) };
 

--- a/poly/src/mle.rs
+++ b/poly/src/mle.rs
@@ -6,7 +6,7 @@ pub use dense::DenseMultilinearExtension;
 use rand::prelude::*;
 use std::{
     fmt::Debug,
-    ops::{Add, AddAssign, Index, SubAssign},
+    ops::{Add, AddAssign, SubAssign},
 };
 use zinc_utils::mul_by_scalar::MulByScalar;
 
@@ -27,7 +27,6 @@ pub trait MultilinearExtension<T>:
     + for<'a> AddAssign<&'a Self>
     + for<'a> AddAssign<(T, &'a Self)>
     + for<'a> SubAssign<&'a Self>
-    + Index<usize>
 {
     /// Reduce the number of variables of `self` by fixing the
     /// `partial_point.len()` variables at `partial_point`.

--- a/poly/src/mle/dense.rs
+++ b/poly/src/mle/dense.rs
@@ -2,6 +2,10 @@ use core::ops::{Add, AddAssign, Index, IndexMut, Mul, MulAssign, Neg, Sub, SubAs
 use num_traits::Zero;
 #[cfg(feature = "parallel")]
 use rayon::prelude::*;
+use std::{
+    ops::{Deref, DerefMut},
+    slice::SliceIndex,
+};
 
 use crate::{
     EvaluationError,
@@ -87,6 +91,82 @@ impl<R: Clone> DenseMultilinearExtension<R> {
     }
 }
 
+impl<R: Default> FromIterator<R> for DenseMultilinearExtension<R> {
+    fn from_iter<T: IntoIterator<Item = R>>(iter: T) -> Self {
+        let mut evaluations = Vec::from_iter(iter);
+
+        let len = evaluations.len();
+
+        evaluations.resize_with(len.next_power_of_two(), Default::default);
+
+        let num_vars = ark_std::log2(evaluations.len()) as usize;
+
+        Self {
+            evaluations,
+            num_vars,
+        }
+    }
+}
+
+impl<R> Deref for DenseMultilinearExtension<R> {
+    type Target = [R];
+
+    fn deref(&self) -> &Self::Target {
+        &self.evaluations
+    }
+}
+
+impl<R> DerefMut for DenseMultilinearExtension<R> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.evaluations
+    }
+}
+
+impl<R> IntoIterator for DenseMultilinearExtension<R> {
+    type Item = R;
+
+    type IntoIter = std::vec::IntoIter<R>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.evaluations.into_iter()
+    }
+}
+
+#[cfg(feature = "parallel")]
+impl<R: Send + Sync> IntoParallelIterator for DenseMultilinearExtension<R> {
+    type Iter = rayon::vec::IntoIter<R>;
+
+    type Item = R;
+
+    fn into_par_iter(self) -> Self::Iter {
+        self.evaluations.into_par_iter()
+    }
+}
+
+#[cfg(feature = "parallel")]
+impl<'data, R: Send + Sync> IntoParallelRefIterator<'data> for &'data DenseMultilinearExtension<R> {
+    type Iter = rayon::slice::Iter<'data, R>;
+
+    type Item = &'data R;
+
+    fn par_iter(&'data self) -> Self::Iter {
+        self.evaluations.par_iter()
+    }
+}
+
+#[cfg(feature = "parallel")]
+impl<'data, R: Send + Sync> IntoParallelRefMutIterator<'data>
+    for &'data mut DenseMultilinearExtension<R>
+{
+    type Iter = rayon::slice::IterMut<'data, R>;
+
+    type Item = &'data mut R;
+
+    fn par_iter_mut(&'data mut self) -> Self::Iter {
+        self.evaluations.par_iter_mut()
+    }
+}
+
 impl<R: Semiring> DenseMultilinearExtension<R> {
     pub fn evaluate<S>(&self, point: &[S], zero: R) -> Result<R, EvaluationError>
     where
@@ -95,7 +175,6 @@ impl<R: Semiring> DenseMultilinearExtension<R> {
         if point.len() == self.num_vars {
             Ok(self
                 .fixed_variables(point, zero)
-                .evaluations
                 .into_iter()
                 .next()
                 .expect("Evaluations should not be empty"))
@@ -111,17 +190,14 @@ impl<R: Semiring> DenseMultilinearExtension<R> {
     where
         G: FnMut(&mut R),
     {
-        self.evaluations.iter_mut().for_each(f);
+        self.iter_mut().for_each(f);
     }
 
     fn binary<G>(&mut self, other: &Self, mut f: G)
     where
         G: FnMut(&mut R, &R),
     {
-        self.evaluations
-            .iter_mut()
-            .zip(other.evaluations.iter())
-            .for_each(|(a, b)| f(a, b));
+        self.iter_mut().zip(other.iter()).for_each(|(a, b)| f(a, b));
     }
 }
 
@@ -144,7 +220,6 @@ where
             return;
         }
 
-        let poly = &mut self.evaluations;
         let nv = self.num_vars;
         let dim = partial_point.len();
 
@@ -152,15 +227,15 @@ where
         for i in 1..dim + 1 {
             for b in 0..1 << (nv - i) {
                 *r.inner_mut() = partial_point[i - 1].inner().clone();
-                if poly[2 * b + 1] != poly[2 * b] {
+                if self[2 * b + 1] != self[2 * b] {
                     // a = f(1) - f(0)
-                    let a = F::sub_inner(&poly[2 * b + 1], &poly[2 * b], config);
+                    let a = F::sub_inner(&self[2 * b + 1], &self[2 * b], config);
 
-                    // poly[b] = f(0) + r * a
+                    // self[b] = f(0) + r * a
                     r.mul_assign_by_inner(&a);
-                    poly[b] = F::add_inner(&poly[2 * b], r.inner(), config);
+                    self[b] = F::add_inner(&self[2 * b], r.inner(), config);
                 } else {
-                    poly[b] = poly[2 * b].clone();
+                    self[b] = self[2 * b].clone();
                 };
             }
         }
@@ -183,7 +258,6 @@ where
         if point.len() == self.num_vars {
             Some(F::new_unchecked_with_cfg(
                 self.fixed_variables_with_config(point, config)
-                    .evaluations
                     .into_iter()
                     .next()
                     .expect("Evaluations should not be empty"),
@@ -209,23 +283,22 @@ where
             "too many partial points"
         );
 
-        let poly = &mut self.evaluations;
         let nv = self.num_vars;
         let dim = partial_point.len();
 
         for i in 1..dim + 1 {
             let r = &partial_point[i - 1];
             for b in 0..1 << (nv - i) {
-                let left = &poly[2 * b];
-                let right = &poly[2 * b + 1];
+                let left = &self[2 * b];
+                let right = &self[2 * b + 1];
                 // a = f(1) - f(0)
                 let a = sub!(right, &left);
                 if a != zero {
-                    // poly[b] = f(0) + r * a
+                    // self[b] = f(0) + r * a
                     let ar = a.mul_by_scalar(r).expect("Multiplication overflow");
-                    poly[b] = add!(left, &ar);
+                    self[b] = add!(left, &ar);
                 } else {
-                    poly[b] = left.clone();
+                    self[b] = left.clone();
                 };
             }
         }
@@ -246,27 +319,24 @@ where
 
 impl<R> MultilinearExtensionRand<R> for DenseMultilinearExtension<R>
 where
-    R: Clone,
+    R: Clone + Default,
     StandardUniform: Distribution<R>,
 {
     fn rand<Rng: RngCore + ?Sized>(num_vars: usize, rng: &mut Rng) -> Self {
-        Self {
-            num_vars,
-            evaluations: (0..1 << num_vars).map(|_| rng.random::<R>()).collect(),
-        }
+        (0..1 << num_vars).map(|_| rng.random::<R>()).collect()
     }
 }
 
-impl<T> Index<usize> for DenseMultilinearExtension<T> {
-    type Output = T;
+impl<T, I: SliceIndex<[T]>> Index<I> for DenseMultilinearExtension<T> {
+    type Output = I::Output;
 
-    fn index(&self, index: usize) -> &Self::Output {
+    fn index(&self, index: I) -> &Self::Output {
         &self.evaluations[index]
     }
 }
 
-impl<T> IndexMut<usize> for DenseMultilinearExtension<T> {
-    fn index_mut(&mut self, index: usize) -> &mut Self::Output {
+impl<T, I: SliceIndex<[T]>> IndexMut<I> for DenseMultilinearExtension<T> {
+    fn index_mut(&mut self, index: I) -> &mut Self::Output {
         &mut self.evaluations[index]
     }
 }
@@ -533,10 +603,9 @@ mod tests {
         ]);
         let dense = DenseMultilinearExtension::from_matrix(&m, F::zero_with_cfg(&cfg));
         assert_eq!(dense.num_vars, 3);
-        let evals = dense.evaluations;
-        assert_eq!(evals[0], 5u64.into_with_cfg(&cfg));
-        assert_eq!(evals[5], 7u64.into_with_cfg(&cfg));
-        assert!(evals.iter().enumerate().all(|(i, v)| if i == 0 || i == 5 {
+        assert_eq!(dense[0], 5u64.into_with_cfg(&cfg));
+        assert_eq!(dense[5], 7u64.into_with_cfg(&cfg));
+        assert!(dense.iter().enumerate().all(|(i, v)| if i == 0 || i == 5 {
             true
         } else {
             v.is_zero_with_cfg(&cfg)

--- a/poly/src/mle/dense.rs
+++ b/poly/src/mle/dense.rs
@@ -91,10 +91,8 @@ impl<R: Clone> DenseMultilinearExtension<R> {
     }
 }
 
-impl<R: Default> FromIterator<R> for DenseMultilinearExtension<R> {
-    fn from_iter<T: IntoIterator<Item = R>>(iter: T) -> Self {
-        let mut evaluations = Vec::from_iter(iter);
-
+impl<R: Default> DenseMultilinearExtension<R> {
+    pub fn from_evaluations_vec_pad(mut evaluations: Vec<R>) -> Self {
         let len = evaluations.len();
 
         evaluations.resize_with(len.next_power_of_two(), Default::default);
@@ -105,6 +103,12 @@ impl<R: Default> FromIterator<R> for DenseMultilinearExtension<R> {
             evaluations,
             num_vars,
         }
+    }
+}
+
+impl<R: Default> FromIterator<R> for DenseMultilinearExtension<R> {
+    fn from_iter<T: IntoIterator<Item = R>>(iter: T) -> Self {
+        Self::from_evaluations_vec_pad(iter.into_iter().collect())
     }
 }
 
@@ -129,6 +133,16 @@ impl<R> IntoIterator for DenseMultilinearExtension<R> {
 
     fn into_iter(self) -> Self::IntoIter {
         self.evaluations.into_iter()
+    }
+}
+
+#[cfg(feature = "parallel")]
+impl<R: Send + Default> FromParallelIterator<R> for DenseMultilinearExtension<R> {
+    fn from_par_iter<I>(par_iter: I) -> Self
+    where
+        I: IntoParallelIterator<Item = R>,
+    {
+        Self::from_evaluations_vec_pad(par_iter.into_par_iter().collect())
     }
 }
 

--- a/poly/src/mle/dense.rs
+++ b/poly/src/mle/dense.rs
@@ -97,7 +97,7 @@ impl<R: Default> DenseMultilinearExtension<R> {
 
         evaluations.resize_with(len.next_power_of_two(), Default::default);
 
-        let num_vars = ark_std::log2(evaluations.len()) as usize;
+        let num_vars = crate::utils::log2(evaluations.len()) as usize;
 
         Self {
             evaluations,

--- a/poly/src/univariate/binary.rs
+++ b/poly/src/univariate/binary.rs
@@ -336,7 +336,7 @@ where
     F: PrimeField + FromRef<F> + 'static,
 {
     #![allow(clippy::arithmetic_side_effects)] // False alert, field operations are safe
-    fn prepare_projection(sampled_value: &F) -> impl Fn(&Self) -> F + 'static {
+    fn prepare_projection(sampled_value: &F) -> impl Fn(&Self) -> F + Send + Sync + 'static {
         let field_cfg = sampled_value.cfg().clone();
         let r_powers = {
             // Preprocess powers prior to inner product.

--- a/poly/src/univariate/dense.rs
+++ b/poly/src/univariate/dense.rs
@@ -540,7 +540,7 @@ where
     #![allow(clippy::arithmetic_side_effects)] // False alert, field operations are safe
     fn prepare_projection(
         sampled_value: &F,
-    ) -> impl Fn(&DensePolynomial<R, DEGREE_PLUS_ONE>) -> F + 'static {
+    ) -> impl Fn(&DensePolynomial<R, DEGREE_PLUS_ONE>) -> F + Send + Sync + 'static {
         let sampled_value = sampled_value.clone();
         let field_cfg = sampled_value.cfg().clone();
 

--- a/utils/src/field/boxed_monty.rs
+++ b/utils/src/field/boxed_monty.rs
@@ -34,7 +34,7 @@ where
 {
     fn prepare_projection(
         sampled_value: &BoxedMontyField,
-    ) -> impl Fn(&Self) -> BoxedMontyField + 'static {
+    ) -> impl Fn(&Self) -> BoxedMontyField + Send + Sync + 'static {
         let config = sampled_value.cfg().clone();
         move |value: &T| value.into_with_cfg(&config)
     }

--- a/utils/src/field/const_monty.rs
+++ b/utils/src/field/const_monty.rs
@@ -53,7 +53,7 @@ impl<Mod: ConstMontyParams<LIMBS>, const LIMBS: usize, const LIMBS2: usize>
 {
     fn prepare_projection(
         _sampled_value: &ConstMontyField<Mod, LIMBS>,
-    ) -> impl Fn(&Self) -> ConstMontyField<Mod, LIMBS> + 'static {
+    ) -> impl Fn(&Self) -> ConstMontyField<Mod, LIMBS> + Send + Sync + 'static {
         // No need to read anything
         |value: &Int<LIMBS2>| value.into()
     }

--- a/utils/src/field/monty.rs
+++ b/utils/src/field/monty.rs
@@ -28,7 +28,7 @@ where
 {
     fn prepare_projection(
         sampled_value: &MontyField<LIMBS>,
-    ) -> impl Fn(&Self) -> MontyField<LIMBS> + 'static {
+    ) -> impl Fn(&Self) -> MontyField<LIMBS> + Send + Sync + 'static {
         let config = sampled_value.cfg().clone();
         move |value: &T| value.into_with_cfg(&config)
     }

--- a/zip-plus/benches/zip_common.rs
+++ b/zip-plus/benches/zip_common.rs
@@ -98,7 +98,7 @@ pub fn encode_rows<Zt: ZipTypes, Lc: LinearCode<Zt>, const P: usize>(
             let row_len = params.linear_code.row_len();
             let poly = DenseMultilinearExtension::<<Zt as ZipTypes>::Eval>::rand(P, &mut rng);
             b.iter(|| {
-                let cw = ZipPlus::encode_rows(&params, row_len, &poly.evaluations);
+                let cw = ZipPlus::encode_rows(&params, row_len, &poly);
                 black_box(cw)
             })
         },

--- a/zip-plus/src/pcs/phase_commit.rs
+++ b/zip-plus/src/pcs/phase_commit.rs
@@ -71,16 +71,16 @@ impl<Zt: ZipTypes, Lc: LinearCode<Zt>> ZipPlus<Zt, Lc> {
 
         let expected_num_evals = pp.num_rows * pp.linear_code.row_len();
         assert_eq!(
-            poly.evaluations.len(),
+            poly.len(),
             expected_num_evals,
             "Polynomial has an incorrect number of evaluations ({}) for the expected matrix size ({})",
-            poly.evaluations.len(),
+            poly.len(),
             expected_num_evals
         );
 
         let row_len = pp.linear_code.row_len();
 
-        let cw_matrix = Self::encode_rows(pp, row_len, &poly.evaluations);
+        let cw_matrix = Self::encode_rows(pp, row_len, poly);
 
         let merkle_tree = MerkleTree::new(&cw_matrix.to_rows_slices());
         let root = merkle_tree.root();
@@ -115,7 +115,7 @@ impl<Zt: ZipTypes, Lc: LinearCode<Zt>> ZipPlus<Zt, Lc> {
 
         let row_len = pp.linear_code.row_len();
 
-        let rows = Self::encode_rows(pp, row_len, &poly.evaluations);
+        let rows = Self::encode_rows(pp, row_len, poly);
         Ok(rows)
     }
 
@@ -230,8 +230,7 @@ mod tests {
         let (pp, _) = setup_test_params(3); // Setup for 3 variables
 
         // Create polynomial with 4 variables (which is > 3)
-        let evaluations = (1..=16).map(Int::from).collect();
-        let poly = DenseMultilinearExtension::from_evaluations_vec(4, evaluations, Zero::zero());
+        let poly: DenseMultilinearExtension<_> = (1..=16).map(Int::from).collect();
 
         let result = TestZip::commit(&pp, &poly);
         assert!(result.is_err());
@@ -291,16 +290,8 @@ mod tests {
         let (pp, _) = setup_test_params(3);
 
         let polys = vec![
-            DenseMultilinearExtension::from_evaluations_vec(
-                3,
-                (1..=8).map(Int::from).collect(),
-                Zero::zero(),
-            ),
-            DenseMultilinearExtension::from_evaluations_vec(
-                3,
-                (9..=16).map(Int::from).collect(),
-                Zero::zero(),
-            ),
+            (1..=8).map(Int::from).collect(),
+            (9..=16).map(Int::from).collect(),
         ];
 
         let results = TestZip::batch_commit(&pp, &polys);
@@ -314,7 +305,7 @@ mod tests {
     #[test]
     fn encode_rows_produces_correct_size() {
         let (pp, poly) = setup_test_params(3);
-        let encoded = TestZip::encode_rows(&pp, pp.linear_code.row_len(), &poly.evaluations);
+        let encoded = TestZip::encode_rows(&pp, pp.linear_code.row_len(), &poly);
 
         assert_eq!(encoded.num_rows, pp.num_rows);
         assert_eq!(encoded.num_cols, pp.linear_code.codeword_len());
@@ -325,12 +316,12 @@ mod tests {
     #[test]
     fn encoded_rows_match_linear_code_definition() {
         let (pp, poly) = setup_test_params(3);
-        let encoded = TestZip::encode_rows(&pp, pp.linear_code.row_len(), &poly.evaluations);
+        let encoded = TestZip::encode_rows(&pp, pp.linear_code.row_len(), &poly);
 
         for (i, row_chunk) in encoded.as_rows().enumerate() {
             let start = i * pp.linear_code.row_len();
             let end = start + pp.linear_code.row_len();
-            let row_evals = &poly.evaluations[start..end];
+            let row_evals = &poly[start..end];
             let expected_encoding = pp.linear_code.encode(row_evals);
             assert_eq!(
                 row_chunk,

--- a/zip-plus/src/pcs/phase_evaluate.rs
+++ b/zip-plus/src/pcs/phase_evaluate.rs
@@ -58,7 +58,7 @@ impl<Zt: ZipTypes, Lc: LinearCode<Zt>> ZipPlus<Zt, Lc> {
         let (q_0, q_1) = point_to_tensor(num_rows, &point, &field_cfg)?;
 
         let project = Zt::Eval::prepare_projection(&projecting_element);
-        let evaluations: Vec<F> = poly.evaluations.iter().map(project).collect_vec();
+        let evaluations: Vec<F> = poly.iter().map(project).collect_vec();
 
         let q_0_combined_row = if num_rows > 1 {
             // Return the evaluation row combination

--- a/zip-plus/src/pcs/phase_evaluate.rs
+++ b/zip-plus/src/pcs/phase_evaluate.rs
@@ -9,8 +9,11 @@ use crate::{
     pcs_transcript::PcsTranscript,
     utils::combine_rows,
 };
+use ark_std::cfg_iter;
 use crypto_primitives::{FromWithConfig, IntoWithConfig, PrimeField};
 use itertools::Itertools;
+#[cfg(feature = "parallel")]
+use rayon::prelude::*;
 use zinc_poly::mle::DenseMultilinearExtension;
 use zinc_transcript::traits::{Transcribable, Transcript};
 use zinc_utils::{
@@ -58,7 +61,7 @@ impl<Zt: ZipTypes, Lc: LinearCode<Zt>> ZipPlus<Zt, Lc> {
         let (q_0, q_1) = point_to_tensor(num_rows, &point, &field_cfg)?;
 
         let project = Zt::Eval::prepare_projection(&projecting_element);
-        let evaluations: Vec<F> = poly.iter().map(project).collect_vec();
+        let evaluations: Vec<F> = cfg_iter!(poly).map(project).collect();
 
         let q_0_combined_row = if num_rows > 1 {
             // Return the evaluation row combination

--- a/zip-plus/src/pcs/phase_evaluate.rs
+++ b/zip-plus/src/pcs/phase_evaluate.rs
@@ -9,7 +9,6 @@ use crate::{
     pcs_transcript::PcsTranscript,
     utils::combine_rows,
 };
-use ark_std::cfg_iter;
 use crypto_primitives::{FromWithConfig, IntoWithConfig, PrimeField};
 use itertools::Itertools;
 #[cfg(feature = "parallel")]
@@ -17,6 +16,7 @@ use rayon::prelude::*;
 use zinc_poly::mle::DenseMultilinearExtension;
 use zinc_transcript::traits::{Transcribable, Transcript};
 use zinc_utils::{
+    cfg_iter,
     from_ref::FromRef,
     inner_product::{InnerProduct, MBSInnerProductUnchecked},
     mul_by_scalar::MulByScalar,

--- a/zip-plus/src/pcs/phase_test.rs
+++ b/zip-plus/src/pcs/phase_test.rs
@@ -50,7 +50,6 @@ impl<Zt: ZipTypes, Lc: LinearCode<Zt>> ZipPlus<Zt, Lc> {
                 .get_challenges::<Zt::Chal>(pp.num_rows);
 
             let evals: Vec<_> = poly
-                .evaluations
                 .iter()
                 .map(|p| Zt::EvalDotChal::inner_product(p, &alphas, Zt::CombR::ZERO))
                 .try_collect()?;
@@ -105,7 +104,7 @@ mod tests {
     };
     use crypto_bigint::U64;
     use crypto_primitives::crypto_bigint_int::Int;
-    use num_traits::{ConstOne, Zero};
+    use num_traits::ConstOne;
     use zinc_poly::mle::DenseMultilinearExtension;
 
     const INT_LIMBS: usize = U64::LIMBS;
@@ -167,12 +166,8 @@ mod tests {
         let (pp, _) = setup_test_params(num_vars);
 
         let oversized_num_vars = 5;
-        let oversized_evals: Vec<_> = (0..1 << oversized_num_vars).map(Int::from).collect();
-        let oversized_poly = DenseMultilinearExtension::from_evaluations_vec(
-            oversized_num_vars,
-            oversized_evals,
-            Zero::zero(),
-        );
+        let oversized_poly: DenseMultilinearExtension<_> =
+            (0..1 << oversized_num_vars).map(Int::from).collect();
 
         // This hint is for a 4-variable poly, but we need it as a placeholder.
         let (hint, _) = TestZip::commit(&pp, &setup_test_params::<N, K, M>(num_vars).1).unwrap();

--- a/zip-plus/src/pcs/phase_verify.rs
+++ b/zip-plus/src/pcs/phase_verify.rs
@@ -373,12 +373,9 @@ mod tests {
             let (pp, _comm_poly1, point_f, eval_f, proof_poly1) =
                 setup_full_protocol::<F, N, K, M>(num_vars);
 
-            let different_evals: Vec<_> = (20..(20 + (1 << num_vars))).map(Int::from).collect();
-            let poly2 = DenseMultilinearExtension::from_evaluations_vec(
-                num_vars,
-                different_evals,
-                Zero::zero(),
-            );
+            let poly2: DenseMultilinearExtension<_> =
+                (20..(20 + (1 << num_vars))).map(Int::from).collect();
+
             let (_, comm_poly2) = TestZip::commit(&pp, &poly2).unwrap();
 
             let result = TestZip::verify(&pp, &comm_poly2, &point_f, &eval_f, &proof_poly1);
@@ -453,12 +450,7 @@ mod tests {
 
         let (data, comm) = TestZip::commit(&pp, &mle1).unwrap();
 
-        let different_evals: Vec<_> = (20..=35).map(Int::from).collect();
-        let mle2 = DenseMultilinearExtension::from_evaluations_vec(
-            num_vars,
-            different_evals,
-            Zero::zero(),
-        );
+        let mle2: DenseMultilinearExtension<_> = (20..=35).map(Int::from).collect();
 
         let point: Vec<<Zt as ZipTypes>::Pt> =
             (0..num_vars).map(|i| Int::from(i as i32 + 2)).collect();
@@ -556,15 +548,13 @@ mod tests {
     #[test]
     fn verification_fails_if_proximity_check_is_invalid() {
         let poly_size = 8; // row_len=4, num_rows=2 -> proximity checks are active
-        let n = 3;
 
         let linear_code = C::new(poly_size);
         let pp = TestZip::setup(poly_size, linear_code);
 
-        let evaluations: Vec<_> = (0..poly_size as i32)
+        let mle: DenseMultilinearExtension<_> = (0..poly_size as i32)
             .map(<Zt as ZipTypes>::Eval::from)
             .collect();
-        let mle = DenseMultilinearExtension::from_evaluations_slice(n, &evaluations, Zero::zero());
 
         let (data, comm) = TestZip::commit(&pp, &mle).expect("commit should succeed");
 
@@ -643,10 +633,9 @@ mod tests {
         let poly_size = 1 << n;
         let linear_code: C = C::new(poly_size);
         let pp = TestZip::setup(poly_size, linear_code);
-        let evaluations: Vec<_> = (0..poly_size)
+        let mle: DenseMultilinearExtension<_> = (0..poly_size)
             .map(|_| <Zt as ZipTypes>::Eval::from(rng.random::<i8>()))
             .collect();
-        let mle = DenseMultilinearExtension::from_evaluations_slice(n, &evaluations, Zero::zero());
         let point: Vec<_> = (0..n)
             .map(|_| <Zt as ZipTypes>::Pt::random(&mut rng))
             .collect();
@@ -662,7 +651,7 @@ mod tests {
             .iter()
             .map(|v| v.into_with_cfg(&field_cfg))
             .collect_vec();
-        let eval_f = evaluate_in_field(&mle.evaluations, &point_f, &field_cfg);
+        let eval_f = evaluate_in_field(&mle, &point_f, &field_cfg);
         let verification_result = TestZip::verify(&pp, &comm, &point_f, &eval_f, &proof);
 
         assert!(verification_result.is_err());
@@ -674,9 +663,8 @@ mod tests {
         let linear_code = C::new(poly_size);
         let pp = TestZip::setup(poly_size, linear_code);
 
-        let evaluations: Vec<_> = (0..poly_size as i32).map(Int::<INT_LIMBS>::from).collect();
-        let n = 3;
-        let mle = DenseMultilinearExtension::from_evaluations_slice(n, &evaluations, Zero::zero());
+        let mle: DenseMultilinearExtension<_> =
+            (0..poly_size as i32).map(Int::<INT_LIMBS>::from).collect();
 
         let (data, comm) = TestZip::commit(&pp, &mle).expect("commit should succeed");
 
@@ -720,9 +708,7 @@ mod tests {
         let linear_code = C::new(poly_size);
         let pp = TestZip::setup(poly_size, linear_code);
 
-        let evaluations: Vec<_> = vec![Int::<INT_LIMBS>::ZERO; poly_size];
-        let n = 3;
-        let mle = DenseMultilinearExtension::from_evaluations_slice(n, &evaluations, Zero::zero());
+        let mle: DenseMultilinearExtension<_> = (0..poly_size).map(|_| Int::ZERO).collect();
 
         let (data, comm) = TestZip::commit(&pp, &mle).expect("commit should succeed");
 
@@ -751,9 +737,8 @@ mod tests {
         let linear_code = C::new(poly_size);
         let pp = TestZip::setup(poly_size, linear_code);
 
-        let evaluations: Vec<_> = (1..=poly_size as i32).map(Int::<INT_LIMBS>::from).collect();
-        let mle =
-            DenseMultilinearExtension::from_evaluations_slice(num_vars, &evaluations, Zero::zero());
+        let mle: DenseMultilinearExtension<_> =
+            (1..=poly_size as i32).map(Int::<INT_LIMBS>::from).collect();
 
         let (data, comm) = TestZip::commit(&pp, &mle).expect("commit should succeed");
 
@@ -840,9 +825,8 @@ mod tests {
         let linear_code = C::new(poly_size);
         let pp = TestZip::setup(poly_size, linear_code);
 
-        let evaluations: Vec<_> = (1..=poly_size as i32).map(Int::<INT_LIMBS>::from).collect();
-        let n = 3;
-        let mle = DenseMultilinearExtension::from_evaluations_slice(n, &evaluations, Zero::zero());
+        let mle: DenseMultilinearExtension<_> =
+            (1..=poly_size as i32).map(Int::<INT_LIMBS>::from).collect();
 
         let (data, comm) = TestZip::commit(&pp, &mle).expect("commit should succeed");
 
@@ -891,7 +875,7 @@ mod tests {
 
             // Same point choice as the bench
             let point = vec![1i64; P].iter().map(|v| v.into()).collect_vec();
-            let eval = *mle.evaluations.last().expect("nonempty evals");
+            let eval = *mle.last().expect("nonempty evals");
 
             // Prover produces a proof once (exactly as in the bench)
             let test_transcript = TestZip::test(&pp, &mle, &data).unwrap();

--- a/zip-plus/src/pcs/structs.rs
+++ b/zip-plus/src/pcs/structs.rs
@@ -16,7 +16,7 @@ pub trait ZipTypes: Send + Sync {
     const NUM_COLUMN_OPENINGS: usize;
 
     /// Semiring of witness/polynomial evaluations on boolean hypercube
-    type Eval: Named + ConstCoeffBitWidth + Clone + Send + Sync;
+    type Eval: Named + ConstCoeffBitWidth + Default + Clone + Send + Sync;
 
     /// Semiring of codeword elements, at least as wide as the evaluation ring
     type Cw: FixedSemiring

--- a/zip-plus/src/pcs/test_utils.rs
+++ b/zip-plus/src/pcs/test_utils.rs
@@ -253,14 +253,8 @@ where
     // Verify the evaluation is done correctly
     {
         // Widen up polynomial for evaluation
-        let poly = DenseMultilinearExtension {
-            evaluations: poly
-                .evaluations
-                .iter()
-                .map(Zt::Comb::from_ref)
-                .collect_vec(),
-            num_vars,
-        };
+        let poly: DenseMultilinearExtension<_> = poly.iter().map(Zt::Comb::from_ref).collect();
+
         let expected_eval = poly
             .evaluate(&point, Zero::zero())
             .expect("failed to evaluate polynomial");


### PR DESCRIPTION
* `DenseMultilinearExtension` now implements all the traits that a normal collection should implement greatly improving the ergonomics.
* In the evaluation phase we always project coefficients of an MLE sequentially no matter if `features="parallel"` is enabled. The PR fixes that. This greatly improves parallel performance of the evaluation phase.