### PR TITLE
Add 1/4-rate IPRS config

### DIFF
--- a/zip-plus/benches/zip_common.rs
+++ b/zip-plus/benches/zip_common.rs
@@ -40,27 +40,27 @@ where
     PEval: ProjectionToField<Zt::Eval, F>,
     PCw: ProjectionToField<Zt::Cw, F>,
 {
-    encode_rows::<Zt, Lc, 12>(group);
-    encode_rows::<Zt, Lc, 13>(group);
-    encode_rows::<Zt, Lc, 14>(group);
-    encode_rows::<Zt, Lc, 15>(group);
-    encode_rows::<Zt, Lc, 16>(group);
+    // encode_rows::<Zt, Lc, 12>(group);
+    // encode_rows::<Zt, Lc, 13>(group);
+    // encode_rows::<Zt, Lc, 14>(group);
+    // encode_rows::<Zt, Lc, 15>(group);
+    // encode_rows::<Zt, Lc, 16>(group);
+ 
+    // encode_single_row::<Zt, Lc, 128>(group);
+    // encode_single_row::<Zt, Lc, 256>(group);
+    // encode_single_row::<Zt, Lc, 512>(group);
+    // encode_single_row::<Zt, Lc, 1024>(group);
 
-    encode_single_row::<Zt, Lc, 128>(group);
-    encode_single_row::<Zt, Lc, 256>(group);
-    encode_single_row::<Zt, Lc, 512>(group);
-    encode_single_row::<Zt, Lc, 1024>(group);
+    // merkle_root::<Zt, 12>(group);
+    // merkle_root::<Zt, 13>(group);
+    // merkle_root::<Zt, 14>(group);
+    // merkle_root::<Zt, 15>(group);
+    // merkle_root::<Zt, 16>(group);
 
-    merkle_root::<Zt, 12>(group);
-    merkle_root::<Zt, 13>(group);
-    merkle_root::<Zt, 14>(group);
-    merkle_root::<Zt, 15>(group);
-    merkle_root::<Zt, 16>(group);
-
-    commit::<Zt, Lc, 12>(group);
-    commit::<Zt, Lc, 13>(group);
+    // commit::<Zt, Lc, 12>(group);
+    // commit::<Zt, Lc, 13>(group);
     commit::<Zt, Lc, 14>(group);
-    commit::<Zt, Lc, 15>(group);
+    // commit::<Zt, Lc, 15>(group);
     commit::<Zt, Lc, 16>(group);
 
     test::<Zt, Lc, 12>(group);

--- a/zip-plus/benches/zip_common.rs
+++ b/zip-plus/benches/zip_common.rs
@@ -44,7 +44,7 @@ where
     // encode_rows::<Zt, Lc, 13>(group);
     // encode_rows::<Zt, Lc, 14>(group);
     // encode_rows::<Zt, Lc, 15>(group);
-    // encode_rows::<Zt, Lc, 16>(group);
+    encode_rows::<Zt, Lc, 16>(group);
  
     // encode_single_row::<Zt, Lc, 128>(group);
     // encode_single_row::<Zt, Lc, 256>(group);
@@ -59,27 +59,27 @@ where
 
     // commit::<Zt, Lc, 12>(group);
     // commit::<Zt, Lc, 13>(group);
-    commit::<Zt, Lc, 14>(group);
+    // commit::<Zt, Lc, 14>(group);
     // commit::<Zt, Lc, 15>(group);
     commit::<Zt, Lc, 16>(group);
 
-    test::<Zt, Lc, 12>(group);
-    test::<Zt, Lc, 13>(group);
-    test::<Zt, Lc, 14>(group);
-    test::<Zt, Lc, 15>(group);
+    // test::<Zt, Lc, 12>(group);
+    // test::<Zt, Lc, 13>(group);
+    // test::<Zt, Lc, 14>(group);
+    // test::<Zt, Lc, 15>(group);
     test::<Zt, Lc, 16>(group);
 
-    evaluate::<Zt, Lc, PEval, 12>(group);
-    evaluate::<Zt, Lc, PEval, 13>(group);
-    evaluate::<Zt, Lc, PEval, 14>(group);
-    evaluate::<Zt, Lc, PEval, 15>(group);
-    evaluate::<Zt, Lc, PEval, 16>(group);
+    // evaluate::<Zt, Lc, PEval, 12>(group);
+    // evaluate::<Zt, Lc, PEval, 13>(group);
+    // evaluate::<Zt, Lc, PEval, 14>(group);
+    // evaluate::<Zt, Lc, PEval, 15>(group);
+    // evaluate::<Zt, Lc, PEval, 16>(group);
 
-    verify::<Zt, Lc, PEval, PCw, 12>(group);
-    verify::<Zt, Lc, PEval, PCw, 13>(group);
-    verify::<Zt, Lc, PEval, PCw, 14>(group);
-    verify::<Zt, Lc, PEval, PCw, 15>(group);
-    verify::<Zt, Lc, PEval, PCw, 16>(group);
+    // verify::<Zt, Lc, PEval, PCw, 12>(group);
+    // verify::<Zt, Lc, PEval, PCw, 13>(group);
+    // verify::<Zt, Lc, PEval, PCw, 14>(group);
+    // verify::<Zt, Lc, PEval, PCw, 15>(group);
+    // verify::<Zt, Lc, PEval, PCw, 16>(group);
 }
 
 pub fn encode_rows<Zt: ZipTypes, Lc: LinearCode<Zt>, const P: usize>(

--- a/zip-plus/benches/zip_plus_benches.rs
+++ b/zip-plus/benches/zip_plus_benches.rs
@@ -28,7 +28,8 @@ use crypto_primitives::{
 };
 use zip_plus::{
     code::{
-        iprs::{IprsCode, PnttConfigF2_16_1},
+        // iprs::{IprsCode, PnttConfigF2_16_1}, // rate 1/2
+        iprs::{IprsCode, PnttConfigF2_16_1_R4}, // rate 1/4
         raa::{RaaCode, RaaConfig},
     },
     pcs::structs::ZipTypes,
@@ -89,7 +90,7 @@ type SomeRaaCode<const D_PLUS_ONE: usize> =
 
 type SomeIprsCode<Twiddle, const DEPTH: usize, const D_PLUS_ONE: usize> = IprsCode<
     BenchZipPlusTypes<Twiddle, D_PLUS_ONE>,
-    PnttConfigF2_16_1<DEPTH>,
+    PnttConfigF2_16_1_R4<DEPTH>,
     BinaryPolyWideningMulByScalar<Twiddle>,
 >;
 

--- a/zip-plus/src/code/iprs.rs
+++ b/zip-plus/src/code/iprs.rs
@@ -13,7 +13,7 @@ use std::{fmt::Debug, iter::Sum, marker::PhantomData, ops::AddAssign};
 use zinc_utils::{from_ref::FromRef, mul_by_scalar::MulByScalar};
 
 use crate::code::iprs::pntt::radix8::{MulByTwiddle, WideningMulByTwiddle};
-pub use pntt::radix8::params::{PnttConfigF2_16_1, PnttInt, Radix8PnttParams};
+pub use pntt::radix8::params::{PnttConfigF2_16_1, PnttConfigF2_16_1_R4, PnttInt, Radix8PnttParams};
 use zinc_utils::mul_by_scalar::WideningMulByScalar;
 
 /// Pseudo Reed-Solomon encoder over the integers. Internally uses a

--- a/zip-plus/src/code/iprs/pntt/radix8/params.rs
+++ b/zip-plus/src/code/iprs/pntt/radix8/params.rs
@@ -162,6 +162,12 @@ impl<C: Config> Radix8PnttParams<C> {
 #[derive(Clone, Copy)]
 pub struct PnttConfigF2_16_1<const DEPTH: usize>;
 
+/// Variant with 4x expansion (output length is 4x input length).
+///
+/// Supports `DEPTH` up to `3`.
+#[derive(Clone, Copy)]
+pub struct PnttConfigF2_16_1_R4<const DEPTH: usize>;
+
 mod fq {
     #![allow(non_local_definitions)]
     use ark_ff::{Fp64, MontBackend, MontConfig};
@@ -182,6 +188,21 @@ impl<const DEPTH: usize> Config for PnttConfigF2_16_1<DEPTH> {
     const FIELD_MODULUS: u32 = fq::MODULUS;
     const BASE_LEN: usize = 32;
     const BASE_DIM: usize = 64;
+    const DEPTH: usize = DEPTH;
+    const BASE_TWIDDLES: [PnttInt; 8] = [1, 4096, -256, 16, -1, -4096, 256, -16];
+
+    fn field_to_int_normalized(x: Self::Field) -> PnttInt {
+        let big_int = fq::FqBackend::into_bigint(x);
+
+        precompute::normalize_field_element(big_int.0[0], Self::FIELD_MODULUS)
+    }
+}
+
+impl<const DEPTH: usize> Config for PnttConfigF2_16_1_R4<DEPTH> {
+    type Field = fq::Fq;
+    const FIELD_MODULUS: u32 = fq::MODULUS;
+    const BASE_LEN: usize = 32;
+    const BASE_DIM: usize = 128;
     const DEPTH: usize = DEPTH;
     const BASE_TWIDDLES: [PnttInt; 8] = [1, 4096, -256, 16, -1, -4096, 256, -16];
 


### PR DESCRIPTION
## Summary
- add 4x-expansion PNTT config for IPRS
- re-export the new config
- switch IPRS benches to the 1/4-rate config

## Testing
- not run (benchmarks previously aborted)