### PR TITLE
Preallocate transcript capacity in Zip+ test phase

### DIFF
--- a/zip-plus/src/merkle.rs
+++ b/zip-plus/src/merkle.rs
@@ -329,6 +329,7 @@ impl MerkleProof {
 
     /// Estimate the number of bytes that would be written to [[PcsTranscript]]
     /// when an instance of this type is transcribed.
+    #[allow(clippy::arithmetic_side_effects)] // Overflow isn't possible
     pub fn estimate_transcribed_size(merkle_tree_height: usize) -> usize {
         // Note the proof does not include leaf layer, so we subtract 1.
         3 * u64::NUM_BYTES + (merkle_tree_height - 1) * MtHash::NUM_BYTES

--- a/zip-plus/src/merkle.rs
+++ b/zip-plus/src/merkle.rs
@@ -77,6 +77,10 @@ impl MerkleTree {
         build_merkle_tree_from_leaves(leaves)
     }
 
+    pub fn height(&self) -> usize {
+        self.layers.len()
+    }
+
     pub fn root(&self) -> MtHash {
         self.layers
             .last()
@@ -321,6 +325,13 @@ impl MerkleProof {
             return Err(MerkleError::InvalidRootHash);
         }
         Ok(())
+    }
+
+    /// Estimate the number of bytes that would be written to [[PcsTranscript]]
+    /// when an instance of this type is transcribed.
+    pub fn estimate_transcribed_size(merkle_tree_height: usize) -> usize {
+        // Note the proof does not include leaf layer, so we subtract 1.
+        3 * u64::NUM_BYTES + (merkle_tree_height - 1) * MtHash::NUM_BYTES
     }
 }
 

--- a/zip-plus/src/pcs/phase_test.rs
+++ b/zip-plus/src/pcs/phase_test.rs
@@ -27,17 +27,17 @@ impl<Zt: ZipTypes, Lc: LinearCode<Zt>> ZipPlus<Zt, Lc> {
     ) -> Result<ZipPlusTestTranscript, ZipError> {
         validate_input::<Zt, Lc, bool>("test", pp.num_vars, &[poly], &[])?;
 
-        let mut transcript = PcsTranscript::new_with_capacity(
+        let estimated_transcript_size =
             // Combined rows
             pp.linear_code.row_len() * Zt::CombR::NUM_BYTES
             // Column openings
             + Zt::NUM_COLUMN_OPENINGS * (
-                // Column itself
-                commit_hint.cw_matrix.num_rows * Zt::Cw::NUM_BYTES
+            // Column itself
+            commit_hint.cw_matrix.num_rows * Zt::Cw::NUM_BYTES
                 // Merkle proof
                 + MerkleProof::estimate_transcribed_size(commit_hint.merkle_tree.height())
-            ),
-        );
+            );
+        let mut transcript = PcsTranscript::new_with_capacity(estimated_transcript_size);
 
         // If we can take linear combinations, perform the proximity test
         if pp.num_rows > 1 {
@@ -85,10 +85,9 @@ impl<Zt: ZipTypes, Lc: LinearCode<Zt>> ZipPlus<Zt, Lc> {
             Self::open_merkle_trees_for_column(commit_hint, column, &mut transcript)?;
         }
 
-        let transcript_storage = transcript.stream.get_ref();
         assert_eq!(
-            transcript_storage.len(),
-            transcript_storage.capacity(),
+            transcript.stream.get_ref().len(),
+            estimated_transcript_size,
             "PCS transcript capacity was precalculated incorrectly"
         );
 

--- a/zip-plus/src/pcs/phase_test.rs
+++ b/zip-plus/src/pcs/phase_test.rs
@@ -32,8 +32,8 @@ impl<Zt: ZipTypes, Lc: LinearCode<Zt>> ZipPlus<Zt, Lc> {
             pp.linear_code.row_len() * Zt::CombR::NUM_BYTES
             // Column openings
             + Zt::NUM_COLUMN_OPENINGS * (
-            // Column itself
-            commit_hint.cw_matrix.num_rows * Zt::Cw::NUM_BYTES
+                // Column itself
+                commit_hint.cw_matrix.num_rows * Zt::Cw::NUM_BYTES
                 // Merkle proof
                 + MerkleProof::estimate_transcribed_size(commit_hint.merkle_tree.height())
             );

--- a/zip-plus/src/pcs/phase_test.rs
+++ b/zip-plus/src/pcs/phase_test.rs
@@ -2,6 +2,7 @@ use crate::{
     ZipError,
     code::LinearCode,
     combine_rows,
+    merkle::MerkleProof,
     pcs::{
         ZipPlusTestTranscript,
         structs::{ZipPlus, ZipPlusHint, ZipPlusParams, ZipTypes},
@@ -11,7 +12,7 @@ use crate::{
 };
 use num_traits::{ConstOne, ConstZero, Zero};
 use zinc_poly::{Polynomial, mle::DenseMultilinearExtension};
-use zinc_transcript::traits::Transcript;
+use zinc_transcript::traits::{ConstTranscribable, Transcript};
 use zinc_utils::{cfg_iter_mut, inner_product::InnerProduct, mul_by_scalar::MulByScalar};
 
 #[cfg(feature = "parallel")]
@@ -26,7 +27,17 @@ impl<Zt: ZipTypes, Lc: LinearCode<Zt>> ZipPlus<Zt, Lc> {
     ) -> Result<ZipPlusTestTranscript, ZipError> {
         validate_input::<Zt, Lc, bool>("test", pp.num_vars, &[poly], &[])?;
 
-        let mut transcript = PcsTranscript::new();
+        let mut transcript = PcsTranscript::new_with_capacity(
+            // Combined rows
+            pp.linear_code.row_len() * Zt::CombR::NUM_BYTES
+            // Column openings
+            + Zt::NUM_COLUMN_OPENINGS * (
+                // Column itself
+                commit_hint.cw_matrix.num_rows * Zt::Cw::NUM_BYTES
+                // Merkle proof
+                + MerkleProof::estimate_transcribed_size(commit_hint.merkle_tree.height())
+            ),
+        );
 
         // If we can take linear combinations, perform the proximity test
         if pp.num_rows > 1 {
@@ -73,6 +84,13 @@ impl<Zt: ZipTypes, Lc: LinearCode<Zt>> ZipPlus<Zt, Lc> {
             let column = transcript.squeeze_challenge_idx(pp.linear_code.codeword_len());
             Self::open_merkle_trees_for_column(commit_hint, column, &mut transcript)?;
         }
+
+        let transcript_storage = transcript.stream.get_ref();
+        assert_eq!(
+            transcript_storage.len(),
+            transcript_storage.capacity(),
+            "PCS transcript capacity was precalculated incorrectly"
+        );
 
         Ok(transcript.into())
     }

--- a/zip-plus/src/pcs_transcript.rs
+++ b/zip-plus/src/pcs_transcript.rs
@@ -8,6 +8,20 @@ use zinc_transcript::{
 };
 use zinc_utils::{add, mul, rem};
 
+macro_rules! safe_cast {
+    ($value:expr, $from:ident, $to:ident) => {
+        $to::try_from($value).map_err(|_err| {
+            ZipError::Transcript(
+                ErrorKind::Unsupported,
+                format!(
+                    "Failed to convert {} to {}",
+                    stringify!($from),
+                    stringify!($to)
+                ),
+            )
+        })
+    };
+}
 /// A transcript for Polynomial Commitment Scheme (PCS) operations.
 /// Manages both Fiat-Shamir transformations and serialization/deserialization
 /// of proof data.
@@ -29,9 +43,11 @@ impl PcsTranscript {
     }
 
     pub fn new_with_capacity(capacity: usize) -> Self {
+        // We zero-initialize the stream vector in advance to avoid dealing with
+        // MaybeUninit
         Self {
             fs_transcript: Default::default(),
-            stream: Cursor::new(Vec::with_capacity(capacity)),
+            stream: Cursor::new(vec![0; capacity]),
         }
     }
 
@@ -117,12 +133,18 @@ impl PcsTranscript {
     }
 
     pub fn write_const<T: ConstTranscribable>(&mut self, v: &T) -> Result<(), ZipError> {
+        let prev_pos = safe_cast!(self.stream.position(), u64, usize)?;
+        let data_len = T::NUM_BYTES;
+        let next_pos = add!(prev_pos, data_len);
+
         let inner = self.stream.get_mut();
-        let old_len = inner.len();
-        let new_len = add!(old_len, T::NUM_BYTES);
-        inner.resize(new_len, 0_u8);
-        v.write_transcription_bytes(&mut inner[old_len..]);
-        self.stream.set_position(new_len as u64);
+        // Enlarge the inner buffer if needed
+        if inner.len() < next_pos {
+            inner.resize(next_pos, 0_u8);
+        }
+
+        v.write_transcription_bytes(&mut inner[prev_pos..next_pos]);
+        self.stream.set_position(safe_cast!(next_pos, usize, u64)?);
         Ok(())
     }
 
@@ -141,17 +163,22 @@ impl PcsTranscript {
         T: ConstTranscribable + 'a,
         I: IntoIterator<Item = &'a T>,
     {
-        let inner = self.stream.get_mut();
-        let old_len = inner.len();
-        let new_len = add!(old_len, mul!(vs_len, T::NUM_BYTES));
-        inner.resize(new_len, 0_u8);
+        let prev_pos = safe_cast!(self.stream.position(), u64, usize)?;
+        let data_len = mul!(vs_len, T::NUM_BYTES);
+        let next_pos = add!(prev_pos, data_len);
 
-        inner[old_len..]
+        let inner = self.stream.get_mut();
+        // Enlarge the inner buffer if needed
+        if inner.len() < next_pos {
+            inner.resize(next_pos, 0_u8);
+        }
+
+        inner[prev_pos..next_pos]
             .chunks_mut(T::NUM_BYTES)
             .zip(vs)
             .for_each(|(chunk, v)| v.write_transcription_bytes(chunk));
 
-        self.stream.set_position(new_len as u64);
+        self.stream.set_position(next_pos as u64);
         Ok(())
     }
 
@@ -169,22 +196,12 @@ impl PcsTranscript {
     }
 
     fn write_usize(&mut self, value: usize) -> Result<(), ZipError> {
-        let value_u64: u64 = value.try_into().map_err(|_err| {
-            ZipError::Transcript(
-                ErrorKind::Unsupported,
-                "Failed to convert usize to u64".to_string(),
-            )
-        })?;
+        let value_u64 = safe_cast!(value, usize, u64)?;
         self.write_const(&value_u64)
     }
 
     fn read_usize(&mut self) -> Result<usize, ZipError> {
-        self.read_const::<u64>()?.try_into().map_err(|_| {
-            ZipError::Transcript(
-                ErrorKind::Unsupported,
-                "Failed to convert u64 to usize".to_string(),
-            )
-        })
+        safe_cast!(self.read_const::<u64>()?, u64, usize)
     }
 
     /// Generates a pseudorandom index based on the current transcript state.

--- a/zip-plus/src/pcs_transcript.rs
+++ b/zip-plus/src/pcs_transcript.rs
@@ -28,6 +28,13 @@ impl PcsTranscript {
         Self::default()
     }
 
+    pub fn new_with_capacity(capacity: usize) -> Self {
+        Self {
+            fs_transcript: Default::default(),
+            stream: Cursor::new(Vec::with_capacity(capacity)),
+        }
+    }
+
     // TODO if we change this to an iterator we may be able to save some memory
     pub fn write_field_elements<F>(&mut self, elems: &[F]) -> Result<(), ZipError>
     where


### PR DESCRIPTION
Since we know the future size of the transcript cursor, we can allocate it in advance. So we do.
This does not give a visible performance advantage though 😞 

Resolves #76