### PR TITLE
Add IPRS matrix-shape benches and base-length PNTT configs

### DIFF
--- a/zip-plus/Cargo.toml
+++ b/zip-plus/Cargo.toml
@@ -40,6 +40,7 @@ workspace = true
 parallel = ["dep:rayon", "zinc-utils/parallel", "zinc-poly/parallel", "ark-ff/parallel", "ark-poly/parallel"]
 asm = ["zinc-transcript/asm"]
 simd = ["zinc-poly/simd"]
+bench-64 = []
 
 [[bench]]
 name = "zip_benches"

--- a/zip-plus/benches/zip_benches.rs
+++ b/zip-plus/benches/zip_benches.rs
@@ -13,7 +13,7 @@ use crypto_primitives::{crypto_bigint_int::Int, crypto_bigint_uint::Uint};
 use zinc_utils::UNCHECKED;
 use zip_plus::{
     code::{
-        iprs::{IprsCode, PnttConfigF2_16_1_Depth2_Rate1_2},
+        iprs::{IprsCode, PnttConfigF2_16_1_Depth2_Rate1_2, PnttConfigF2_16_1_Depth2_Rate1_4},
         raa::{RaaCode, RaaConfig},
     },
     pcs::structs::ZipTypes,
@@ -60,6 +60,8 @@ impl WideningMulByScalar<i32, i64> for I32WideningMulByScalar {
 }
 
 type IprsCodeDepth2 = IprsCode<BenchZipTypes, PnttConfigF2_16_1_Depth2_Rate1_2, I32WideningMulByScalar>;
+type IprsCodeDepth2Rate1_4 =
+    IprsCode<BenchZipTypes, PnttConfigF2_16_1_Depth2_Rate1_4, I32WideningMulByScalar>;
 
 fn zip_benchmarks(c: &mut Criterion) {
     let mut group = c.benchmark_group("Zip+");
@@ -73,5 +75,11 @@ fn zip_benchmarks_iprs(c: &mut Criterion) {
     group.finish();
 }
 
-criterion_group!(benches, zip_benchmarks, zip_benchmarks_iprs);
+fn zip_benchmarks_iprs_rate1_4(c: &mut Criterion) {
+    let mut group = c.benchmark_group("Zip IPRS rate1_4");
+    do_bench_iprs_matrices::<BenchZipTypes, IprsCodeDepth2Rate1_4, UNCHECKED>(&mut group);
+    group.finish();
+}
+
+criterion_group!(benches, zip_benchmarks, zip_benchmarks_iprs, zip_benchmarks_iprs_rate1_4);
 criterion_main!(benches);

--- a/zip-plus/benches/zip_benches.rs
+++ b/zip-plus/benches/zip_benches.rs
@@ -12,9 +12,13 @@ use crypto_bigint::U64;
 use crypto_primitives::{crypto_bigint_int::Int, crypto_bigint_uint::Uint};
 use zinc_utils::UNCHECKED;
 use zip_plus::{
-    code::raa::{RaaCode, RaaConfig},
+    code::{
+        iprs::{IprsCode, PnttConfigF2_16_1_Depth2_Rate1_2},
+        raa::{RaaCode, RaaConfig},
+    },
     pcs::structs::ZipTypes,
 };
+use zinc_utils::mul_by_scalar::WideningMulByScalar;
 
 const INT_LIMBS: usize = U64::LIMBS;
 
@@ -43,11 +47,31 @@ impl RaaConfig for BenchRaaConfig {
 
 type Code = RaaCode<BenchZipTypes, BenchRaaConfig, 4>;
 
+#[derive(Clone, Default)]
+struct I32WideningMulByScalar;
+
+impl WideningMulByScalar<i32, i64> for I32WideningMulByScalar {
+    type Output = i64;
+
+    #[allow(clippy::arithmetic_side_effects)]
+    fn mul_by_scalar_widen(lhs: &i32, rhs: &i64) -> Self::Output {
+        i64::from(*lhs) * *rhs
+    }
+}
+
+type IprsCodeDepth2 = IprsCode<BenchZipTypes, PnttConfigF2_16_1_Depth2_Rate1_2, I32WideningMulByScalar>;
+
 fn zip_benchmarks(c: &mut Criterion) {
     let mut group = c.benchmark_group("Zip+");
     do_bench::<BenchZipTypes, Code, UNCHECKED>(&mut group);
     group.finish();
 }
 
-criterion_group!(benches, zip_benchmarks);
+fn zip_benchmarks_iprs(c: &mut Criterion) {
+    let mut group = c.benchmark_group("Zip IPRS");
+    do_bench_iprs_matrices::<BenchZipTypes, IprsCodeDepth2, UNCHECKED>(&mut group);
+    group.finish();
+}
+
+criterion_group!(benches, zip_benchmarks, zip_benchmarks_iprs);
 criterion_main!(benches);

--- a/zip-plus/benches/zip_benches.rs
+++ b/zip-plus/benches/zip_benches.rs
@@ -13,7 +13,17 @@ use crypto_primitives::{crypto_bigint_int::Int, crypto_bigint_uint::Uint};
 use zinc_utils::UNCHECKED;
 use zip_plus::{
     code::{
-        iprs::{IprsCode, PnttConfigF2_16_1_Depth2_Rate1_2, PnttConfigF2_16_1_Depth2_Rate1_4},
+        iprs::{
+            IprsCode,
+            PnttConfigF2_16_1_Base16_Depth1_Rate1_2,
+            PnttConfigF2_16_1_Base16_Depth1_Rate1_4,
+            PnttConfigF2_16_1_Base32_Depth1_Rate1_2,
+            PnttConfigF2_16_1_Base32_Depth1_Rate1_4,
+            PnttConfigF2_16_1_Base64_Depth1_Rate1_2,
+            PnttConfigF2_16_1_Base64_Depth1_Rate1_4,
+            PnttConfigF2_16_1_Depth2_Rate1_2,
+            PnttConfigF2_16_1_Depth2_Rate1_4,
+        },
         raa::{RaaCode, RaaConfig},
     },
     pcs::structs::ZipTypes,
@@ -63,6 +73,20 @@ type IprsCodeDepth2 = IprsCode<BenchZipTypes, PnttConfigF2_16_1_Depth2_Rate1_2, 
 type IprsCodeDepth2Rate1_4 =
     IprsCode<BenchZipTypes, PnttConfigF2_16_1_Depth2_Rate1_4, I32WideningMulByScalar>;
 
+type IprsCodeDepth1Base16 =
+    IprsCode<BenchZipTypes, PnttConfigF2_16_1_Base16_Depth1_Rate1_2, I32WideningMulByScalar>;
+type IprsCodeDepth1Base32 =
+    IprsCode<BenchZipTypes, PnttConfigF2_16_1_Base32_Depth1_Rate1_2, I32WideningMulByScalar>;
+type IprsCodeDepth1Base64 =
+    IprsCode<BenchZipTypes, PnttConfigF2_16_1_Base64_Depth1_Rate1_2, I32WideningMulByScalar>;
+
+type IprsCodeDepth1Base16Rate1_4 =
+    IprsCode<BenchZipTypes, PnttConfigF2_16_1_Base16_Depth1_Rate1_4, I32WideningMulByScalar>;
+type IprsCodeDepth1Base32Rate1_4 =
+    IprsCode<BenchZipTypes, PnttConfigF2_16_1_Base32_Depth1_Rate1_4, I32WideningMulByScalar>;
+type IprsCodeDepth1Base64Rate1_4 =
+    IprsCode<BenchZipTypes, PnttConfigF2_16_1_Base64_Depth1_Rate1_4, I32WideningMulByScalar>;
+
 fn zip_benchmarks(c: &mut Criterion) {
     let mut group = c.benchmark_group("Zip+");
     do_bench::<BenchZipTypes, Code, UNCHECKED>(&mut group);
@@ -75,11 +99,40 @@ fn zip_benchmarks_iprs(c: &mut Criterion) {
     group.finish();
 }
 
+fn zip_benchmarks_iprs_matrix_shapes(c: &mut Criterion) {
+    let mut group = c.benchmark_group("Zip IPRS Matrix Shapes");
+    do_bench_iprs_matrix_shapes::<BenchZipTypes, IprsCodeDepth1Base16, UNCHECKED>(&mut group);
+    do_bench_iprs_matrix_shapes::<BenchZipTypes, IprsCodeDepth1Base32, UNCHECKED>(&mut group);
+    do_bench_iprs_matrix_shapes::<BenchZipTypes, IprsCodeDepth1Base64, UNCHECKED>(&mut group);
+    group.finish();
+}
+
 fn zip_benchmarks_iprs_rate1_4(c: &mut Criterion) {
     let mut group = c.benchmark_group("Zip IPRS rate1_4");
     do_bench_iprs_matrices::<BenchZipTypes, IprsCodeDepth2Rate1_4, UNCHECKED>(&mut group);
     group.finish();
 }
 
-criterion_group!(benches, zip_benchmarks, zip_benchmarks_iprs, zip_benchmarks_iprs_rate1_4);
+fn zip_benchmarks_iprs_rate1_4_matrix_shapes(c: &mut Criterion) {
+    let mut group = c.benchmark_group("Zip IPRS rate1_4 Matrix Shapes");
+    do_bench_iprs_matrix_shapes::<BenchZipTypes, IprsCodeDepth1Base16Rate1_4, UNCHECKED>(
+        &mut group,
+    );
+    do_bench_iprs_matrix_shapes::<BenchZipTypes, IprsCodeDepth1Base32Rate1_4, UNCHECKED>(
+        &mut group,
+    );
+    do_bench_iprs_matrix_shapes::<BenchZipTypes, IprsCodeDepth1Base64Rate1_4, UNCHECKED>(
+        &mut group,
+    );
+    group.finish();
+}
+
+criterion_group!(
+    benches,
+    zip_benchmarks,
+    zip_benchmarks_iprs,
+    zip_benchmarks_iprs_matrix_shapes,
+    zip_benchmarks_iprs_rate1_4,
+    zip_benchmarks_iprs_rate1_4_matrix_shapes
+);
 criterion_main!(benches);

--- a/zip-plus/benches/zip_common.rs
+++ b/zip-plus/benches/zip_common.rs
@@ -80,6 +80,52 @@ pub fn do_bench<Zt: ZipTypes, Lc: LinearCode<Zt>, const CHECK_FOR_OVERFLOWS: boo
     verify::<Zt, Lc, CHECK_FOR_OVERFLOWS, 16>(group);
 }
 
+pub fn do_bench_iprs_matrices<Zt: ZipTypes, Lc: LinearCode<Zt>, const CHECK_FOR_OVERFLOWS: bool>(
+    group: &mut BenchmarkGroup<WallTime>,
+) where
+    StandardUniform: Distribution<Zt::Eval> + Distribution<Zt::Cw>,
+    F: for<'a> FromWithConfig<&'a Zt::Chal> + for<'a> FromWithConfig<&'a Zt::Pt>,
+    <F as Field>::Inner: FromRef<Zt::Fmod>,
+    Zt::Eval: ProjectableToField<F>,
+    Zt::Cw: ProjectableToField<F>,
+{
+    encode_rows::<Zt, Lc, 13>(group);
+    encode_rows::<Zt, Lc, 14>(group);
+    encode_rows::<Zt, Lc, 15>(group);
+    encode_rows::<Zt, Lc, 16>(group);
+    encode_rows::<Zt, Lc, 17>(group);
+
+    merkle_root::<Zt, 13>(group);
+    merkle_root::<Zt, 14>(group);
+    merkle_root::<Zt, 15>(group);
+    merkle_root::<Zt, 16>(group);
+    merkle_root::<Zt, 17>(group);
+
+    commit::<Zt, Lc, 13>(group);
+    commit::<Zt, Lc, 14>(group);
+    commit::<Zt, Lc, 15>(group);
+    commit::<Zt, Lc, 16>(group);
+    commit::<Zt, Lc, 17>(group);
+
+    test::<Zt, Lc, CHECK_FOR_OVERFLOWS, 13>(group);
+    test::<Zt, Lc, CHECK_FOR_OVERFLOWS, 14>(group);
+    test::<Zt, Lc, CHECK_FOR_OVERFLOWS, 15>(group);
+    test::<Zt, Lc, CHECK_FOR_OVERFLOWS, 16>(group);
+    test::<Zt, Lc, CHECK_FOR_OVERFLOWS, 17>(group);
+
+    evaluate::<Zt, Lc, CHECK_FOR_OVERFLOWS, 13>(group);
+    evaluate::<Zt, Lc, CHECK_FOR_OVERFLOWS, 14>(group);
+    evaluate::<Zt, Lc, CHECK_FOR_OVERFLOWS, 15>(group);
+    evaluate::<Zt, Lc, CHECK_FOR_OVERFLOWS, 16>(group);
+    evaluate::<Zt, Lc, CHECK_FOR_OVERFLOWS, 17>(group);
+
+    verify::<Zt, Lc, CHECK_FOR_OVERFLOWS, 13>(group);
+    verify::<Zt, Lc, CHECK_FOR_OVERFLOWS, 14>(group);
+    verify::<Zt, Lc, CHECK_FOR_OVERFLOWS, 15>(group);
+    verify::<Zt, Lc, CHECK_FOR_OVERFLOWS, 16>(group);
+    verify::<Zt, Lc, CHECK_FOR_OVERFLOWS, 17>(group);
+}
+
 pub fn encode_rows<Zt: ZipTypes, Lc: LinearCode<Zt>, const P: usize>(
     group: &mut BenchmarkGroup<WallTime>,
 ) where

--- a/zip-plus/benches/zip_common.rs
+++ b/zip-plus/benches/zip_common.rs
@@ -85,14 +85,15 @@ pub fn do_bench_iprs_matrices<Zt: ZipTypes, Lc: LinearCode<Zt>, const CHECK_FOR_
     Zt::Eval: ProjectableToField<F>,
     Zt::Cw: ProjectableToField<F>,
 {
-    
-    commit::<Zt, Lc, 14>(group);
-    commit::<Zt, Lc, 15>(group);
-    commit::<Zt, Lc, 16>(group);
-    commit::<Zt, Lc, 17>(group);
-    test::<Zt, Lc, CHECK_FOR_OVERFLOWS, 16>(group);
-    evaluate::<Zt, Lc, CHECK_FOR_OVERFLOWS, 16>(group);
-    verify::<Zt, Lc, CHECK_FOR_OVERFLOWS, 16>(group);
+    commit::<Zt, Lc, 13>(group);
+    // commit::<Zt, Lc, 14>(group);
+    // commit::<Zt, Lc, 14>(group);
+    // commit::<Zt, Lc, 15>(group);
+    // commit::<Zt, Lc, 16>(group);
+    // commit::<Zt, Lc, 17>(group);
+    // test::<Zt, Lc, CHECK_FOR_OVERFLOWS, 16>(group);
+    // evaluate::<Zt, Lc, CHECK_FOR_OVERFLOWS, 16>(group);
+    // verify::<Zt, Lc, CHECK_FOR_OVERFLOWS, 16>(group);
 
 }
 

--- a/zip-plus/benches/zip_common.rs
+++ b/zip-plus/benches/zip_common.rs
@@ -122,7 +122,7 @@ pub fn encode_rows<Zt: ZipTypes, Lc: LinearCode<Zt>, const P: usize>(
 
     group.bench_function(
         format!(
-            "EncodeRows: {} -> {}, matrix = {rows}x{row_len}, poly_size = 2^{P}",
+            "EncodeRows: matrix={rows}x{row_len}, {} -> {}, poly_size=2^{P}",
             Zt::Eval::type_name(),
             Zt::Cw::type_name(),
             rows = rows,
@@ -214,7 +214,7 @@ pub fn commit<Zt: ZipTypes, Lc: LinearCode<Zt>, const P: usize>(
 
     group.bench_function(
         format!(
-            "Commit: Eval={}, Cw={}, Comb={}, matrix={rows}x{row_len}, poly_size=2^{P}",
+            "Commit: matrix={rows}x{row_len}, Eval={}, Cw={}, Comb={}, poly_size=2^{P}",
             Zt::Eval::type_name(),
             Zt::Cw::type_name(),
             Zt::Comb::type_name(),
@@ -256,7 +256,7 @@ pub fn test<Zt: ZipTypes, Lc: LinearCode<Zt>, const CHECK_FOR_OVERFLOWS: bool, c
 
     group.bench_function(
         format!(
-            "Test: Eval={}, Cw={}, Comb={}, matrix={rows}x{row_len}, poly_size=2^{P}",
+            "Test: matrix={rows}x{row_len}, Eval={}, Cw={}, Comb={}, poly_size=2^{P}",
             Zt::Eval::type_name(),
             Zt::Cw::type_name(),
             Zt::Comb::type_name(),
@@ -298,7 +298,7 @@ pub fn evaluate<Zt: ZipTypes, Lc: LinearCode<Zt>, const CHECK_FOR_OVERFLOWS: boo
 
     group.bench_function(
         format!(
-            "Evaluate: Eval={}, Cw={}, Comb={}, matrix={rows}x{row_len}, poly_size=2^{P}, modulus=({} bits)",
+            "Evaluate: matrix={rows}x{row_len}, Eval={}, Cw={}, Comb={}, poly_size=2^{P}, modulus=({} bits)",
             Zt::Eval::type_name(),
             Zt::Cw::type_name(),
             Zt::Comb::type_name(),
@@ -354,7 +354,7 @@ pub fn verify<Zt: ZipTypes, Lc: LinearCode<Zt>, const CHECK_FOR_OVERFLOWS: bool,
 
     group.bench_function(
         format!(
-            "Verify: Eval={}, Cw={}, Comb={}, matrix={rows}x{row_len}, poly_size=2^{P}, modulus=({} bits)",
+            "Verify: matrix={rows}x{row_len}, Eval={}, Cw={}, Comb={}, poly_size=2^{P}, modulus=({} bits)",
             Zt::Eval::type_name(),
             Zt::Cw::type_name(),
             Zt::Comb::type_name(),

--- a/zip-plus/benches/zip_common.rs
+++ b/zip-plus/benches/zip_common.rs
@@ -85,12 +85,14 @@ pub fn do_bench_iprs_matrices<Zt: ZipTypes, Lc: LinearCode<Zt>, const CHECK_FOR_
     Zt::Eval: ProjectableToField<F>,
     Zt::Cw: ProjectableToField<F>,
 {
-    //merkle_root::<Zt, 17>(group);
-
-    commit::<Zt, Lc, 13>(group);
-    test::<Zt, Lc, CHECK_FOR_OVERFLOWS, 13>(group);
-    evaluate::<Zt, Lc, CHECK_FOR_OVERFLOWS, 13>(group);
-    verify::<Zt, Lc, CHECK_FOR_OVERFLOWS, 13>(group);
+    
+    commit::<Zt, Lc, 14>(group);
+    commit::<Zt, Lc, 15>(group);
+    commit::<Zt, Lc, 16>(group);
+    commit::<Zt, Lc, 17>(group);
+    test::<Zt, Lc, CHECK_FOR_OVERFLOWS, 16>(group);
+    evaluate::<Zt, Lc, CHECK_FOR_OVERFLOWS, 16>(group);
+    verify::<Zt, Lc, CHECK_FOR_OVERFLOWS, 16>(group);
 
 }
 

--- a/zip-plus/benches/zip_common.rs
+++ b/zip-plus/benches/zip_common.rs
@@ -86,11 +86,11 @@ pub fn do_bench_iprs_matrices<Zt: ZipTypes, Lc: LinearCode<Zt>, const CHECK_FOR_
     Zt::Cw: ProjectableToField<F>,
 {
     commit::<Zt, Lc, 13>(group);
-    // commit::<Zt, Lc, 14>(group);
-    // commit::<Zt, Lc, 14>(group);
-    // commit::<Zt, Lc, 15>(group);
-    // commit::<Zt, Lc, 16>(group);
-    // commit::<Zt, Lc, 17>(group);
+    commit::<Zt, Lc, 14>(group);
+    commit::<Zt, Lc, 14>(group);
+    commit::<Zt, Lc, 15>(group);
+    commit::<Zt, Lc, 16>(group);
+    commit::<Zt, Lc, 17>(group);
     // test::<Zt, Lc, CHECK_FOR_OVERFLOWS, 16>(group);
     // evaluate::<Zt, Lc, CHECK_FOR_OVERFLOWS, 16>(group);
     // verify::<Zt, Lc, CHECK_FOR_OVERFLOWS, 16>(group);

--- a/zip-plus/benches/zip_common.rs
+++ b/zip-plus/benches/zip_common.rs
@@ -38,46 +38,42 @@ pub fn do_bench<Zt: ZipTypes, Lc: LinearCode<Zt>, const CHECK_FOR_OVERFLOWS: boo
     Zt::Eval: ProjectableToField<F>,
     Zt::Cw: ProjectableToField<F>,
 {
-    encode_rows::<Zt, Lc, 12>(group);
-    encode_rows::<Zt, Lc, 13>(group);
-    encode_rows::<Zt, Lc, 14>(group);
-    encode_rows::<Zt, Lc, 15>(group);
-    encode_rows::<Zt, Lc, 16>(group);
+    // encode_rows::<Zt, Lc, 12>(group);
+    // encode_rows::<Zt, Lc, 13>(group);
+    // encode_rows::<Zt, Lc, 14>(group);
+    // encode_rows::<Zt, Lc, 15>(group);
+    // encode_rows::<Zt, Lc, 16>(group);
 
-    encode_single_row::<Zt, Lc, 128>(group);
-    encode_single_row::<Zt, Lc, 256>(group);
-    encode_single_row::<Zt, Lc, 512>(group);
-    encode_single_row::<Zt, Lc, 1024>(group);
+    // encode_single_row::<Zt, Lc, 128>(group);
+    // encode_single_row::<Zt, Lc, 256>(group);
+    // encode_single_row::<Zt, Lc, 512>(group);
+    // encode_single_row::<Zt, Lc, 1024>(group);
 
-    merkle_root::<Zt, 12>(group);
-    merkle_root::<Zt, 13>(group);
-    merkle_root::<Zt, 14>(group);
-    merkle_root::<Zt, 15>(group);
-    merkle_root::<Zt, 16>(group);
-
-    commit::<Zt, Lc, 12>(group);
+    // merkle_root::<Zt, 12>(group);
+    // merkle_root::<Zt, 13>(group);
+    // merkle_root::<Zt, 14>(group);
+    // merkle_root::<Zt, 15>(group);
+    // merkle_root::<Zt, 16>(group);
+    // commit::<Zt, Lc, 12>(group);
     commit::<Zt, Lc, 13>(group);
-    commit::<Zt, Lc, 14>(group);
-    commit::<Zt, Lc, 15>(group);
-    commit::<Zt, Lc, 16>(group);
-
-    test::<Zt, Lc, CHECK_FOR_OVERFLOWS, 12>(group);
-    test::<Zt, Lc, CHECK_FOR_OVERFLOWS, 13>(group);
-    test::<Zt, Lc, CHECK_FOR_OVERFLOWS, 14>(group);
-    test::<Zt, Lc, CHECK_FOR_OVERFLOWS, 15>(group);
-    test::<Zt, Lc, CHECK_FOR_OVERFLOWS, 16>(group);
-
-    evaluate::<Zt, Lc, CHECK_FOR_OVERFLOWS, 12>(group);
-    evaluate::<Zt, Lc, CHECK_FOR_OVERFLOWS, 13>(group);
-    evaluate::<Zt, Lc, CHECK_FOR_OVERFLOWS, 14>(group);
-    evaluate::<Zt, Lc, CHECK_FOR_OVERFLOWS, 15>(group);
-    evaluate::<Zt, Lc, CHECK_FOR_OVERFLOWS, 16>(group);
-
-    verify::<Zt, Lc, CHECK_FOR_OVERFLOWS, 12>(group);
-    verify::<Zt, Lc, CHECK_FOR_OVERFLOWS, 13>(group);
-    verify::<Zt, Lc, CHECK_FOR_OVERFLOWS, 14>(group);
-    verify::<Zt, Lc, CHECK_FOR_OVERFLOWS, 15>(group);
-    verify::<Zt, Lc, CHECK_FOR_OVERFLOWS, 16>(group);
+    // commit::<Zt, Lc, 14>(group);
+    // commit::<Zt, Lc, 15>(group);
+    // commit::<Zt, Lc, 16>(group);
+    // test::<Zt, Lc, CHECK_FOR_OVERFLOWS, 12>(group);
+    // test::<Zt, Lc, CHECK_FOR_OVERFLOWS, 13>(group);
+    // test::<Zt, Lc, CHECK_FOR_OVERFLOWS, 14>(group);
+    // test::<Zt, Lc, CHECK_FOR_OVERFLOWS, 15>(group);
+    // test::<Zt, Lc, CHECK_FOR_OVERFLOWS, 16>(group);
+    // evaluate::<Zt, Lc, CHECK_FOR_OVERFLOWS, 12>(group);
+    // evaluate::<Zt, Lc, CHECK_FOR_OVERFLOWS, 13>(group);
+    // evaluate::<Zt, Lc, CHECK_FOR_OVERFLOWS, 14>(group);
+    // evaluate::<Zt, Lc, CHECK_FOR_OVERFLOWS, 15>(group);
+    // evaluate::<Zt, Lc, CHECK_FOR_OVERFLOWS, 16>(group);
+    // verify::<Zt, Lc, CHECK_FOR_OVERFLOWS, 12>(group);
+    // verify::<Zt, Lc, CHECK_FOR_OVERFLOWS, 13>(group);
+    // verify::<Zt, Lc, CHECK_FOR_OVERFLOWS, 14>(group);
+    // verify::<Zt, Lc, CHECK_FOR_OVERFLOWS, 15>(group);
+    // verify::<Zt, Lc, CHECK_FOR_OVERFLOWS, 16>(group);
 }
 
 pub fn do_bench_iprs_matrices<Zt: ZipTypes, Lc: LinearCode<Zt>, const CHECK_FOR_OVERFLOWS: bool>(
@@ -89,41 +85,13 @@ pub fn do_bench_iprs_matrices<Zt: ZipTypes, Lc: LinearCode<Zt>, const CHECK_FOR_
     Zt::Eval: ProjectableToField<F>,
     Zt::Cw: ProjectableToField<F>,
 {
-    encode_rows::<Zt, Lc, 13>(group);
-    encode_rows::<Zt, Lc, 14>(group);
-    encode_rows::<Zt, Lc, 15>(group);
-    encode_rows::<Zt, Lc, 16>(group);
-    encode_rows::<Zt, Lc, 17>(group);
-
-    merkle_root::<Zt, 13>(group);
-    merkle_root::<Zt, 14>(group);
-    merkle_root::<Zt, 15>(group);
-    merkle_root::<Zt, 16>(group);
-    merkle_root::<Zt, 17>(group);
+    //merkle_root::<Zt, 17>(group);
 
     commit::<Zt, Lc, 13>(group);
-    commit::<Zt, Lc, 14>(group);
-    commit::<Zt, Lc, 15>(group);
-    commit::<Zt, Lc, 16>(group);
-    commit::<Zt, Lc, 17>(group);
-
     test::<Zt, Lc, CHECK_FOR_OVERFLOWS, 13>(group);
-    test::<Zt, Lc, CHECK_FOR_OVERFLOWS, 14>(group);
-    test::<Zt, Lc, CHECK_FOR_OVERFLOWS, 15>(group);
-    test::<Zt, Lc, CHECK_FOR_OVERFLOWS, 16>(group);
-    test::<Zt, Lc, CHECK_FOR_OVERFLOWS, 17>(group);
-
     evaluate::<Zt, Lc, CHECK_FOR_OVERFLOWS, 13>(group);
-    evaluate::<Zt, Lc, CHECK_FOR_OVERFLOWS, 14>(group);
-    evaluate::<Zt, Lc, CHECK_FOR_OVERFLOWS, 15>(group);
-    evaluate::<Zt, Lc, CHECK_FOR_OVERFLOWS, 16>(group);
-    evaluate::<Zt, Lc, CHECK_FOR_OVERFLOWS, 17>(group);
-
     verify::<Zt, Lc, CHECK_FOR_OVERFLOWS, 13>(group);
-    verify::<Zt, Lc, CHECK_FOR_OVERFLOWS, 14>(group);
-    verify::<Zt, Lc, CHECK_FOR_OVERFLOWS, 15>(group);
-    verify::<Zt, Lc, CHECK_FOR_OVERFLOWS, 16>(group);
-    verify::<Zt, Lc, CHECK_FOR_OVERFLOWS, 17>(group);
+
 }
 
 pub fn encode_rows<Zt: ZipTypes, Lc: LinearCode<Zt>, const P: usize>(
@@ -131,18 +99,22 @@ pub fn encode_rows<Zt: ZipTypes, Lc: LinearCode<Zt>, const P: usize>(
 ) where
     StandardUniform: Distribution<Zt::Eval>,
 {
+    let poly_size = 1 << P;
+    let linear_code = Lc::new(poly_size);
+    let params = ZipPlus::setup(poly_size, linear_code);
+    let row_len = params.linear_code.row_len();
+    let rows = poly_size / row_len;
+
     group.bench_function(
         format!(
-            "EncodeRows: {} -> {}, poly_size = 2^{P}",
+            "EncodeRows: {} -> {}, matrix = {rows}x{row_len}, poly_size = 2^{P}",
             Zt::Eval::type_name(),
-            Zt::Cw::type_name()
+            Zt::Cw::type_name(),
+            rows = rows,
+            row_len = row_len
         ),
         |b| {
             let mut rng = ThreadRng::default();
-            let poly_size = 1 << P;
-            let linear_code = Lc::new(poly_size);
-            let params = ZipPlus::setup(poly_size, linear_code);
-            let row_len = params.linear_code.row_len();
             let poly = DenseMultilinearExtension::<<Zt as ZipTypes>::Eval>::rand(P, &mut rng);
             b.iter(|| {
                 let cw = ZipPlus::encode_rows(&params, row_len, &poly);
@@ -222,13 +194,17 @@ pub fn commit<Zt: ZipTypes, Lc: LinearCode<Zt>, const P: usize>(
     let poly_size = 1 << P;
     let linear_code = Lc::new(poly_size);
     let params = ZipPlus::setup(poly_size, linear_code);
+    let row_len = params.linear_code.row_len();
+    let rows = poly_size / row_len;
 
     group.bench_function(
         format!(
-            "Commit: Eval={}, Cw={}, Comb={}, poly_size=2^{P}",
+            "Commit: Eval={}, Cw={}, Comb={}, matrix={rows}x{row_len}, poly_size=2^{P}",
             Zt::Eval::type_name(),
             Zt::Cw::type_name(),
-            Zt::Comb::type_name()
+            Zt::Comb::type_name(),
+            rows = rows,
+            row_len = row_len
         ),
         |b| {
             b.iter_custom(|iters| {
@@ -257,16 +233,20 @@ pub fn test<Zt: ZipTypes, Lc: LinearCode<Zt>, const CHECK_FOR_OVERFLOWS: bool, c
     let poly_size = 1 << P;
     let linear_code = Lc::new(poly_size);
     let params = ZipPlus::setup(poly_size, linear_code);
+    let row_len = params.linear_code.row_len();
+    let rows = poly_size / row_len;
 
     let poly = DenseMultilinearExtension::rand(P, &mut rng);
     let (data, _) = ZipPlus::commit(&params, &poly).unwrap();
 
     group.bench_function(
         format!(
-            "Test: Eval={}, Cw={}, Comb={}, poly_size=2^{P}",
+            "Test: Eval={}, Cw={}, Comb={}, matrix={rows}x{row_len}, poly_size=2^{P}",
             Zt::Eval::type_name(),
             Zt::Cw::type_name(),
             Zt::Comb::type_name(),
+            rows = rows,
+            row_len = row_len,
         ),
         |b| {
             b.iter(|| {
@@ -291,6 +271,8 @@ pub fn evaluate<Zt: ZipTypes, Lc: LinearCode<Zt>, const CHECK_FOR_OVERFLOWS: boo
     let poly_size = 1 << P;
     let linear_code = Lc::new(poly_size);
     let params = ZipPlus::setup(poly_size, linear_code);
+    let row_len = params.linear_code.row_len();
+    let rows = poly_size / row_len;
 
     let poly = DenseMultilinearExtension::rand(P, &mut rng);
     let (data, _) = ZipPlus::commit(&params, &poly).unwrap();
@@ -301,11 +283,13 @@ pub fn evaluate<Zt: ZipTypes, Lc: LinearCode<Zt>, const CHECK_FOR_OVERFLOWS: boo
 
     group.bench_function(
         format!(
-            "Evaluate: Eval={}, Cw={}, Comb={}, poly_size=2^{P}, modulus=({} bits)",
+            "Evaluate: Eval={}, Cw={}, Comb={}, matrix={rows}x{row_len}, poly_size=2^{P}, modulus=({} bits)",
             Zt::Eval::type_name(),
             Zt::Cw::type_name(),
             Zt::Comb::type_name(),
-            Zt::Fmod::NUM_BYTES * 8
+            Zt::Fmod::NUM_BYTES * 8,
+            rows = rows,
+            row_len = row_len
         ),
         |b| {
             b.iter_custom(|iters| {
@@ -338,6 +322,8 @@ pub fn verify<Zt: ZipTypes, Lc: LinearCode<Zt>, const CHECK_FOR_OVERFLOWS: bool,
     let poly_size = 1 << P;
     let linear_code = Lc::new(poly_size);
     let params = ZipPlus::setup(poly_size, linear_code);
+    let row_len = params.linear_code.row_len();
+    let rows = poly_size / row_len;
 
     let poly = DenseMultilinearExtension::rand(P, &mut rng);
     let (data, commitment) = ZipPlus::commit(&params, &poly).unwrap();
@@ -353,11 +339,13 @@ pub fn verify<Zt: ZipTypes, Lc: LinearCode<Zt>, const CHECK_FOR_OVERFLOWS: bool,
 
     group.bench_function(
         format!(
-            "Verify: Eval={}, Cw={}, Comb={}, poly_size=2^{P}, modulus=({} bits)",
+            "Verify: Eval={}, Cw={}, Comb={}, matrix={rows}x{row_len}, poly_size=2^{P}, modulus=({} bits)",
             Zt::Eval::type_name(),
             Zt::Cw::type_name(),
             Zt::Comb::type_name(),
-            Zt::Fmod::NUM_BYTES * 8
+            Zt::Fmod::NUM_BYTES * 8,
+            rows = rows,
+            row_len = row_len
         ),
         |b| {
             b.iter(|| {

--- a/zip-plus/benches/zip_common.rs
+++ b/zip-plus/benches/zip_common.rs
@@ -97,6 +97,18 @@ pub fn do_bench_iprs_matrices<Zt: ZipTypes, Lc: LinearCode<Zt>, const CHECK_FOR_
 
 }
 
+pub fn do_bench_iprs_matrix_shapes<Zt: ZipTypes, Lc: LinearCode<Zt>, const CHECK_FOR_OVERFLOWS: bool>(
+    group: &mut BenchmarkGroup<WallTime>,
+) where
+    StandardUniform: Distribution<Zt::Eval> + Distribution<Zt::Cw>,
+    F: for<'a> FromWithConfig<&'a Zt::Chal> + for<'a> FromWithConfig<&'a Zt::Pt>,
+    <F as Field>::Inner: FromRef<Zt::Fmod>,
+    Zt::Eval: ProjectableToField<F>,
+    Zt::Cw: ProjectableToField<F>,
+{
+    commit::<Zt, Lc, 11>(group);
+}
+
 pub fn encode_rows<Zt: ZipTypes, Lc: LinearCode<Zt>, const P: usize>(
     group: &mut BenchmarkGroup<WallTime>,
 ) where

--- a/zip-plus/benches/zip_plus_benches.rs
+++ b/zip-plus/benches/zip_plus_benches.rs
@@ -21,7 +21,17 @@ use crypto_primitives::{
 };
 use zip_plus::{
     code::{
-        iprs::{IprsCode, PnttConfigF2_16_1_Depth2_Rate1_2, PnttConfigF2_16_1_Depth2_Rate1_4},
+        iprs::{
+            IprsCode,
+            PnttConfigF2_16_1_Base16_Depth1_Rate1_2,
+            PnttConfigF2_16_1_Base16_Depth1_Rate1_4,
+            PnttConfigF2_16_1_Base32_Depth1_Rate1_2,
+            PnttConfigF2_16_1_Base32_Depth1_Rate1_4,
+            PnttConfigF2_16_1_Base64_Depth1_Rate1_2,
+            PnttConfigF2_16_1_Base64_Depth1_Rate1_4,
+            PnttConfigF2_16_1_Depth2_Rate1_2,
+            PnttConfigF2_16_1_Depth2_Rate1_4,
+        },
         raa::{RaaCode, RaaConfig},
     },
     pcs::structs::ZipTypes,
@@ -74,9 +84,45 @@ type SomeIprsCodeDepth2<Twiddle, const D_PLUS_ONE: usize> = IprsCode<
     BinaryPolyWideningMulByScalar<Twiddle>,
 >;
 
+type SomeIprsCodeDepth1Base16<Twiddle, const D_PLUS_ONE: usize> = IprsCode<
+    BenchZipPlusTypes<Twiddle, D_PLUS_ONE>,
+    PnttConfigF2_16_1_Base16_Depth1_Rate1_2,
+    BinaryPolyWideningMulByScalar<Twiddle>,
+>;
+
+type SomeIprsCodeDepth1Base32<Twiddle, const D_PLUS_ONE: usize> = IprsCode<
+    BenchZipPlusTypes<Twiddle, D_PLUS_ONE>,
+    PnttConfigF2_16_1_Base32_Depth1_Rate1_2,
+    BinaryPolyWideningMulByScalar<Twiddle>,
+>;
+
+type SomeIprsCodeDepth1Base64<Twiddle, const D_PLUS_ONE: usize> = IprsCode<
+    BenchZipPlusTypes<Twiddle, D_PLUS_ONE>,
+    PnttConfigF2_16_1_Base64_Depth1_Rate1_2,
+    BinaryPolyWideningMulByScalar<Twiddle>,
+>;
+
 type SomeIprsCodeDepth2Rate1_4<Twiddle, const D_PLUS_ONE: usize> = IprsCode<
     BenchZipPlusTypes<Twiddle, D_PLUS_ONE>,
     PnttConfigF2_16_1_Depth2_Rate1_4,
+    BinaryPolyWideningMulByScalar<Twiddle>,
+>;
+
+type SomeIprsCodeDepth1Base16Rate1_4<Twiddle, const D_PLUS_ONE: usize> = IprsCode<
+    BenchZipPlusTypes<Twiddle, D_PLUS_ONE>,
+    PnttConfigF2_16_1_Base16_Depth1_Rate1_4,
+    BinaryPolyWideningMulByScalar<Twiddle>,
+>;
+
+type SomeIprsCodeDepth1Base32Rate1_4<Twiddle, const D_PLUS_ONE: usize> = IprsCode<
+    BenchZipPlusTypes<Twiddle, D_PLUS_ONE>,
+    PnttConfigF2_16_1_Base32_Depth1_Rate1_4,
+    BinaryPolyWideningMulByScalar<Twiddle>,
+>;
+
+type SomeIprsCodeDepth1Base64Rate1_4<Twiddle, const D_PLUS_ONE: usize> = IprsCode<
+    BenchZipPlusTypes<Twiddle, D_PLUS_ONE>,
+    PnttConfigF2_16_1_Base64_Depth1_Rate1_4,
     BinaryPolyWideningMulByScalar<Twiddle>,
 >;
 
@@ -103,6 +149,28 @@ fn zip_plus_benchmarks_iprs(c: &mut Criterion) {
     group.finish();
 }
 
+fn zip_plus_benchmarks_iprs_matrix_shapes(c: &mut Criterion) {
+    let mut group = c.benchmark_group("Zip+ IPRS Matrix Shapes");
+
+    do_bench_iprs_matrix_shapes::<
+        BenchZipPlusTypes<i64, 32>,
+        SomeIprsCodeDepth1Base16<i64, 32>,
+        UNCHECKED,
+    >(&mut group);
+    do_bench_iprs_matrix_shapes::<
+        BenchZipPlusTypes<i64, 32>,
+        SomeIprsCodeDepth1Base32<i64, 32>,
+        UNCHECKED,
+    >(&mut group);
+    do_bench_iprs_matrix_shapes::<
+        BenchZipPlusTypes<i64, 32>,
+        SomeIprsCodeDepth1Base64<i64, 32>,
+        UNCHECKED,
+    >(&mut group);
+
+    group.finish();
+}
+
 fn zip_plus_benchmarks_iprs_rate1_4(c: &mut Criterion) {
     let mut group = c.benchmark_group("Zip+ IPRS rate1_4");
 
@@ -122,10 +190,34 @@ fn zip_plus_benchmarks_iprs_rate1_4(c: &mut Criterion) {
     group.finish();
 }
 
+fn zip_plus_benchmarks_iprs_rate1_4_matrix_shapes(c: &mut Criterion) {
+    let mut group = c.benchmark_group("Zip+ IPRS rate1_4 Matrix Shapes");
+
+    do_bench_iprs_matrix_shapes::<
+        BenchZipPlusTypes<i64, 32>,
+        SomeIprsCodeDepth1Base16Rate1_4<i64, 32>,
+        UNCHECKED,
+    >(&mut group);
+    do_bench_iprs_matrix_shapes::<
+        BenchZipPlusTypes<i64, 32>,
+        SomeIprsCodeDepth1Base32Rate1_4<i64, 32>,
+        UNCHECKED,
+    >(&mut group);
+    do_bench_iprs_matrix_shapes::<
+        BenchZipPlusTypes<i64, 32>,
+        SomeIprsCodeDepth1Base64Rate1_4<i64, 32>,
+        UNCHECKED,
+    >(&mut group);
+
+    group.finish();
+}
+
 criterion_group!(
     benches,
     zip_plus_benchmarks_raa,
     zip_plus_benchmarks_iprs,
-    zip_plus_benchmarks_iprs_rate1_4
+    zip_plus_benchmarks_iprs_matrix_shapes,
+    zip_plus_benchmarks_iprs_rate1_4,
+    zip_plus_benchmarks_iprs_rate1_4_matrix_shapes
 );
 criterion_main!(benches);

--- a/zip-plus/benches/zip_plus_benches.rs
+++ b/zip-plus/benches/zip_plus_benches.rs
@@ -21,7 +21,7 @@ use crypto_primitives::{
 };
 use zip_plus::{
     code::{
-        iprs::{IprsCode, PnttConfigF2_16_1},
+        iprs::{IprsCode, PnttConfigF2_16_1_Depth2_Rate1_2},
         raa::{RaaCode, RaaConfig},
     },
     pcs::structs::ZipTypes,
@@ -68,9 +68,9 @@ impl RaaConfig for BenchRaaConfig {
 type SomeRaaCode<const D_PLUS_ONE: usize> =
     RaaCode<BenchZipPlusTypes<i32, D_PLUS_ONE>, BenchRaaConfig, 4>;
 
-type SomeIprsCode<Twiddle, const DEPTH: usize, const D_PLUS_ONE: usize> = IprsCode<
+type SomeIprsCodeDepth2<Twiddle, const D_PLUS_ONE: usize> = IprsCode<
     BenchZipPlusTypes<Twiddle, D_PLUS_ONE>,
-    PnttConfigF2_16_1<DEPTH>,
+    PnttConfigF2_16_1_Depth2_Rate1_2,
     BinaryPolyWideningMulByScalar<Twiddle>,
 >;
 
@@ -86,8 +86,12 @@ fn zip_plus_benchmarks_raa(c: &mut Criterion) {
 fn zip_plus_benchmarks_iprs(c: &mut Criterion) {
     let mut group = c.benchmark_group("Zip+ IPRS");
 
-    do_bench::<BenchZipPlusTypes<i64, 32>, SomeIprsCode<i64, 1, 32>, UNCHECKED>(&mut group);
-    do_bench::<BenchZipPlusTypes<i64, 64>, SomeIprsCode<i64, 1, 64>, UNCHECKED>(&mut group);
+    do_bench_iprs_matrices::<BenchZipPlusTypes<i64, 32>, SomeIprsCodeDepth2<i64, 32>, UNCHECKED>(
+        &mut group,
+    );
+    do_bench_iprs_matrices::<BenchZipPlusTypes<i64, 64>, SomeIprsCodeDepth2<i64, 64>, UNCHECKED>(
+        &mut group,
+    );
 
     group.finish();
 }

--- a/zip-plus/benches/zip_plus_benches.rs
+++ b/zip-plus/benches/zip_plus_benches.rs
@@ -76,7 +76,6 @@ type SomeIprsCodeDepth2<Twiddle, const D_PLUS_ONE: usize> = IprsCode<
 
 fn zip_plus_benchmarks_raa(c: &mut Criterion) {
     let mut group = c.benchmark_group("Zip+ RAA");
-
     do_bench::<BenchZipPlusTypes<i32, 32>, SomeRaaCode<_>, UNCHECKED>(&mut group);
     do_bench::<BenchZipPlusTypes<i32, 64>, SomeRaaCode<_>, UNCHECKED>(&mut group);
 
@@ -96,5 +95,9 @@ fn zip_plus_benchmarks_iprs(c: &mut Criterion) {
     group.finish();
 }
 
-criterion_group!(benches, zip_plus_benchmarks_raa, zip_plus_benchmarks_iprs);
+criterion_group!(
+    benches,
+    zip_plus_benchmarks_raa,
+    zip_plus_benchmarks_iprs
+);
 criterion_main!(benches);

--- a/zip-plus/benches/zip_plus_benches.rs
+++ b/zip-plus/benches/zip_plus_benches.rs
@@ -31,6 +31,7 @@ use zip_plus::{
             PnttConfigF2_16_1_Base64_Depth1_Rate1_4,
             PnttConfigF2_16_1_Depth2_Rate1_2,
             PnttConfigF2_16_1_Depth2_Rate1_4,
+            PnttConfigF12289_Depth3_Rate1_2,
         },
         raa::{RaaCode, RaaConfig},
     },
@@ -126,6 +127,14 @@ type SomeIprsCodeDepth1Base64Rate1_4<Twiddle, const D_PLUS_ONE: usize> = IprsCod
     BinaryPolyWideningMulByScalar<Twiddle>,
 >;
 
+/// IPRS code using the smallest possible field (F_12289) for depth-3 rate-1/2.
+/// Encodes messages of size 2^11 with BASE_LEN=4, BASE_DIM=8.
+type SomeIprsCodeF12289Depth3<Twiddle, const D_PLUS_ONE: usize> = IprsCode<
+    BenchZipPlusTypes<Twiddle, D_PLUS_ONE>,
+    PnttConfigF12289_Depth3_Rate1_2,
+    BinaryPolyWideningMulByScalar<Twiddle>,
+>;
+
 fn zip_plus_benchmarks_raa(c: &mut Criterion) {
     let mut group = c.benchmark_group("Zip+ RAA");
     do_bench::<BenchZipPlusTypes<i32, 32>, SomeRaaCode<_>, UNCHECKED>(&mut group);
@@ -212,12 +221,32 @@ fn zip_plus_benchmarks_iprs_rate1_4_matrix_shapes(c: &mut Criterion) {
     group.finish();
 }
 
+/// Benchmarks for IPRS with F_12289 (smallest field for depth-3).
+/// This configuration uses:
+/// - Field: F_12289 (p = 3 * 2^12 + 1)
+/// - BASE_LEN = 4, BASE_DIM = 8
+/// - DEPTH = 3
+/// - Rate = 1/2
+/// - Message size = 2^11
+fn zip_plus_benchmarks_iprs_f12289(c: &mut Criterion) {
+    let mut group = c.benchmark_group("Zip+ IPRS F12289 Depth3");
+
+    do_bench_iprs_matrices::<
+        BenchZipPlusTypes<i64, 32>,
+        SomeIprsCodeF12289Depth3<i64, 32>,
+        UNCHECKED,
+    >(&mut group);
+
+    group.finish();
+}
+
 criterion_group!(
     benches,
     zip_plus_benchmarks_raa,
     zip_plus_benchmarks_iprs,
     zip_plus_benchmarks_iprs_matrix_shapes,
     zip_plus_benchmarks_iprs_rate1_4,
-    zip_plus_benchmarks_iprs_rate1_4_matrix_shapes
+    zip_plus_benchmarks_iprs_rate1_4_matrix_shapes,
+    zip_plus_benchmarks_iprs_f12289
 );
 criterion_main!(benches);

--- a/zip-plus/benches/zip_plus_benches.rs
+++ b/zip-plus/benches/zip_plus_benches.rs
@@ -21,7 +21,7 @@ use crypto_primitives::{
 };
 use zip_plus::{
     code::{
-        iprs::{IprsCode, PnttConfigF2_16_1_Depth2_Rate1_2},
+        iprs::{IprsCode, PnttConfigF2_16_1_Depth2_Rate1_2, PnttConfigF2_16_1_Depth2_Rate1_4},
         raa::{RaaCode, RaaConfig},
     },
     pcs::structs::ZipTypes,
@@ -74,10 +74,17 @@ type SomeIprsCodeDepth2<Twiddle, const D_PLUS_ONE: usize> = IprsCode<
     BinaryPolyWideningMulByScalar<Twiddle>,
 >;
 
+type SomeIprsCodeDepth2Rate1_4<Twiddle, const D_PLUS_ONE: usize> = IprsCode<
+    BenchZipPlusTypes<Twiddle, D_PLUS_ONE>,
+    PnttConfigF2_16_1_Depth2_Rate1_4,
+    BinaryPolyWideningMulByScalar<Twiddle>,
+>;
+
 fn zip_plus_benchmarks_raa(c: &mut Criterion) {
     let mut group = c.benchmark_group("Zip+ RAA");
     do_bench::<BenchZipPlusTypes<i32, 32>, SomeRaaCode<_>, UNCHECKED>(&mut group);
-    do_bench::<BenchZipPlusTypes<i32, 64>, SomeRaaCode<_>, UNCHECKED>(&mut group);
+    // Skipped 64-bit benchmarks.
+    // do_bench::<BenchZipPlusTypes<i32, 64>, SomeRaaCode<_>, UNCHECKED>(&mut group);
 
     group.finish();
 }
@@ -88,9 +95,29 @@ fn zip_plus_benchmarks_iprs(c: &mut Criterion) {
     do_bench_iprs_matrices::<BenchZipPlusTypes<i64, 32>, SomeIprsCodeDepth2<i64, 32>, UNCHECKED>(
         &mut group,
     );
-    do_bench_iprs_matrices::<BenchZipPlusTypes<i64, 64>, SomeIprsCodeDepth2<i64, 64>, UNCHECKED>(
-        &mut group,
-    );
+    // Skipped 64-bit benchmarks.
+    // do_bench_iprs_matrices::<BenchZipPlusTypes<i64, 64>, SomeIprsCodeDepth2<i64, 64>, UNCHECKED>(
+    //     &mut group,
+    // );
+
+    group.finish();
+}
+
+fn zip_plus_benchmarks_iprs_rate1_4(c: &mut Criterion) {
+    let mut group = c.benchmark_group("Zip+ IPRS rate1_4");
+
+    do_bench_iprs_matrices::<
+        BenchZipPlusTypes<i64, 32>,
+        SomeIprsCodeDepth2Rate1_4<i64, 32>,
+        UNCHECKED,
+    >(&mut group);
+
+    // Skipped 64-bit benchmarks.
+    // do_bench_iprs_matrices::<
+    //     BenchZipPlusTypes<i64, 64>,
+    //     SomeIprsCodeDepth2Rate1_4<i64, 64>,
+    //     UNCHECKED,
+    // >(&mut group);
 
     group.finish();
 }
@@ -98,6 +125,7 @@ fn zip_plus_benchmarks_iprs(c: &mut Criterion) {
 criterion_group!(
     benches,
     zip_plus_benchmarks_raa,
-    zip_plus_benchmarks_iprs
+    zip_plus_benchmarks_iprs,
+    zip_plus_benchmarks_iprs_rate1_4
 );
 criterion_main!(benches);

--- a/zip-plus/src/code/iprs.rs
+++ b/zip-plus/src/code/iprs.rs
@@ -12,7 +12,14 @@ use crate::{
 };
 use crypto_primitives::{FromPrimitiveWithConfig, FromWithConfig};
 use num_traits::{CheckedAdd, CheckedMul};
-pub use pntt::radix8::params::{PnttConfigF2_16_1, PnttInt, Radix8PnttParams};
+pub use pntt::radix8::params::{
+    PnttConfigF2_16_1,
+    PnttConfigF2_16_1_Depth2_Rate1_2,
+    PnttConfigF2_16_1_Depth2_Rate1_4,
+    PnttConfigF2_16_1_Rate1_4,
+    PnttInt,
+    Radix8PnttParams,
+};
 use std::{fmt::Debug, iter::Sum, marker::PhantomData, ops::AddAssign};
 use zinc_utils::{
     CHECKED,

--- a/zip-plus/src/code/iprs.rs
+++ b/zip-plus/src/code/iprs.rs
@@ -23,6 +23,8 @@ pub use pntt::radix8::params::{
     PnttConfigF2_16_1_Depth2_Rate1_2,
     PnttConfigF2_16_1_Depth2_Rate1_4,
     PnttConfigF2_16_1_Rate1_4,
+    PnttConfigF12289_Rate1_2,
+    PnttConfigF12289_Depth3_Rate1_2,
     PnttInt,
     Radix8PnttParams,
 };

--- a/zip-plus/src/code/iprs.rs
+++ b/zip-plus/src/code/iprs.rs
@@ -13,6 +13,12 @@ use crate::{
 use crypto_primitives::{FromPrimitiveWithConfig, FromWithConfig};
 use num_traits::{CheckedAdd, CheckedMul};
 pub use pntt::radix8::params::{
+    PnttConfigF2_16_1_Base16_Depth1_Rate1_2,
+    PnttConfigF2_16_1_Base16_Depth1_Rate1_4,
+    PnttConfigF2_16_1_Base32_Depth1_Rate1_2,
+    PnttConfigF2_16_1_Base32_Depth1_Rate1_4,
+    PnttConfigF2_16_1_Base64_Depth1_Rate1_2,
+    PnttConfigF2_16_1_Base64_Depth1_Rate1_4,
     PnttConfigF2_16_1,
     PnttConfigF2_16_1_Depth2_Rate1_2,
     PnttConfigF2_16_1_Depth2_Rate1_4,

--- a/zip-plus/src/code/iprs/pntt/radix8/params.rs
+++ b/zip-plus/src/code/iprs/pntt/radix8/params.rs
@@ -159,8 +159,21 @@ impl<C: Config> Radix8PnttParams<C> {
 /// the field `Fp` for `p = 2^16 + 1`.
 ///
 /// Supports `DEPTH` up to `3`.
+///
+/// With `BASE_LEN = 32` and `BASE_DIM = 64`,
+/// this yields rate $\frac{1}{2}$ codes.
 #[derive(Clone, Copy)]
 pub struct PnttConfigF2_16_1<const DEPTH: usize>;
+
+/// Pseudo NTT configuration derived from
+/// the field `Fp` for `p = 2^16 + 1`.
+///
+/// Supports `DEPTH` up to `3`.
+///
+/// With `BASE_LEN = 32` and `BASE_DIM = 128`,
+/// this yields rate $\frac{1}{4}$ codes.
+#[derive(Clone, Copy)]
+pub struct PnttConfigF2_16_1_Rate1_4<const DEPTH: usize>;
 
 mod fq {
     #![allow(non_local_definitions)]
@@ -191,6 +204,27 @@ impl<const DEPTH: usize> Config for PnttConfigF2_16_1<DEPTH> {
         precompute::normalize_field_element(big_int.0[0], Self::FIELD_MODULUS)
     }
 }
+
+impl<const DEPTH: usize> Config for PnttConfigF2_16_1_Rate1_4<DEPTH> {
+    type Field = fq::Fq;
+    const FIELD_MODULUS: u32 = fq::MODULUS;
+    const BASE_LEN: usize = 32;
+    const BASE_DIM: usize = 128;
+    const DEPTH: usize = DEPTH;
+    const BASE_TWIDDLES: [PnttInt; 8] = [1, 4096, -256, 16, -1, -4096, 256, -16];
+
+    fn field_to_int_normalized(x: Self::Field) -> PnttInt {
+        let big_int = fq::FqBackend::into_bigint(x);
+
+        precompute::normalize_field_element(big_int.0[0], Self::FIELD_MODULUS)
+    }
+}
+
+/// Depth-2 configuration for message size $2^{11}$ with rate $\frac{1}{2}$.
+pub type PnttConfigF2_16_1_Depth2_Rate1_2 = PnttConfigF2_16_1<2>;
+
+/// Depth-2 configuration for message size $2^{11}$ with rate $\frac{1}{4}$.
+pub type PnttConfigF2_16_1_Depth2_Rate1_4 = PnttConfigF2_16_1_Rate1_4<2>;
 
 #[cfg(test)]
 mod tests {

--- a/zip-plus/src/code/iprs/pntt/radix8/params.rs
+++ b/zip-plus/src/code/iprs/pntt/radix8/params.rs
@@ -175,6 +175,22 @@ pub struct PnttConfigF2_16_1<const DEPTH: usize>;
 #[derive(Clone, Copy)]
 pub struct PnttConfigF2_16_1_Rate1_4<const DEPTH: usize>;
 
+/// Pseudo NTT configuration derived from
+/// the field `Fp` for `p = 2^16 + 1`.
+///
+/// With `BASE_LEN` and `BASE_DIM = 2 * BASE_LEN`,
+/// this yields rate $\frac{1}{2}$ codes.
+#[derive(Clone, Copy)]
+pub struct PnttConfigF2_16_1_Rate1_2_Base<const BASE_LEN: usize, const DEPTH: usize>;
+
+/// Pseudo NTT configuration derived from
+/// the field `Fp` for `p = 2^16 + 1`.
+///
+/// With `BASE_LEN` and `BASE_DIM = 4 * BASE_LEN`,
+/// this yields rate $\frac{1}{4}$ codes.
+#[derive(Clone, Copy)]
+pub struct PnttConfigF2_16_1_Rate1_4_Base<const BASE_LEN: usize, const DEPTH: usize>;
+
 mod fq {
     #![allow(non_local_definitions)]
     use ark_ff::{Fp64, MontBackend, MontConfig};
@@ -220,11 +236,69 @@ impl<const DEPTH: usize> Config for PnttConfigF2_16_1_Rate1_4<DEPTH> {
     }
 }
 
+impl<const BASE_LEN: usize, const DEPTH: usize> Config
+    for PnttConfigF2_16_1_Rate1_2_Base<BASE_LEN, DEPTH>
+{
+    type Field = fq::Fq;
+    const FIELD_MODULUS: u32 = fq::MODULUS;
+    const BASE_LEN: usize = BASE_LEN;
+    const BASE_DIM: usize = BASE_LEN * 2;
+    const DEPTH: usize = DEPTH;
+    const BASE_TWIDDLES: [PnttInt; 8] = [1, 4096, -256, 16, -1, -4096, 256, -16];
+
+    fn field_to_int_normalized(x: Self::Field) -> PnttInt {
+        let big_int = fq::FqBackend::into_bigint(x);
+
+        precompute::normalize_field_element(big_int.0[0], Self::FIELD_MODULUS)
+    }
+}
+
+impl<const BASE_LEN: usize, const DEPTH: usize> Config
+    for PnttConfigF2_16_1_Rate1_4_Base<BASE_LEN, DEPTH>
+{
+    type Field = fq::Fq;
+    const FIELD_MODULUS: u32 = fq::MODULUS;
+    const BASE_LEN: usize = BASE_LEN;
+    const BASE_DIM: usize = BASE_LEN * 4;
+    const DEPTH: usize = DEPTH;
+    const BASE_TWIDDLES: [PnttInt; 8] = [1, 4096, -256, 16, -1, -4096, 256, -16];
+
+    fn field_to_int_normalized(x: Self::Field) -> PnttInt {
+        let big_int = fq::FqBackend::into_bigint(x);
+
+        precompute::normalize_field_element(big_int.0[0], Self::FIELD_MODULUS)
+    }
+}
+
 /// Depth-2 configuration for message size $2^{11}$ with rate $\frac{1}{2}$.
 pub type PnttConfigF2_16_1_Depth2_Rate1_2 = PnttConfigF2_16_1<2>;
 
 /// Depth-2 configuration for message size $2^{11}$ with rate $\frac{1}{4}$.
 pub type PnttConfigF2_16_1_Depth2_Rate1_4 = PnttConfigF2_16_1_Rate1_4<2>;
+
+/// Depth-1 configuration for message size $2^{7}$ with rate $\frac{1}{2}$.
+pub type PnttConfigF2_16_1_Base16_Depth1_Rate1_2 =
+    PnttConfigF2_16_1_Rate1_2_Base<16, 1>;
+
+/// Depth-1 configuration for message size $2^{8}$ with rate $\frac{1}{2}$.
+pub type PnttConfigF2_16_1_Base32_Depth1_Rate1_2 =
+    PnttConfigF2_16_1_Rate1_2_Base<32, 1>;
+
+/// Depth-1 configuration for message size $2^{9}$ with rate $\frac{1}{2}$.
+pub type PnttConfigF2_16_1_Base64_Depth1_Rate1_2 =
+    PnttConfigF2_16_1_Rate1_2_Base<64, 1>;
+
+/// Depth-1 configuration for message size $2^{7}$ with rate $\frac{1}{4}$.
+pub type PnttConfigF2_16_1_Base16_Depth1_Rate1_4 =
+    PnttConfigF2_16_1_Rate1_4_Base<16, 1>;
+
+/// Depth-1 configuration for message size $2^{8}$ with rate $\frac{1}{4}$.
+pub type PnttConfigF2_16_1_Base32_Depth1_Rate1_4 =
+    PnttConfigF2_16_1_Rate1_4_Base<32, 1>;
+
+/// Depth-1 configuration for message size $2^{9}$ with rate $\frac{1}{4}$.
+pub type PnttConfigF2_16_1_Base64_Depth1_Rate1_4 =
+    PnttConfigF2_16_1_Rate1_4_Base<64, 1>;
 
 #[cfg(test)]
 mod tests {

--- a/zip-plus/src/code/iprs/pntt/radix8/params.rs
+++ b/zip-plus/src/code/iprs/pntt/radix8/params.rs
@@ -206,6 +206,24 @@ mod fq {
     pub const MODULUS: u32 = FqConfig::MODULUS.0[0] as u32;
 }
 
+/// Field Fp for p = 12289 = 3 * 2^12 + 1.
+/// This is the smallest prime supporting 4096th roots of unity,
+/// enabling depth-3 configurations with BASE_DIM up to 8.
+mod fq_12289 {
+    #![allow(non_local_definitions)]
+    use ark_ff::{Fp64, MontBackend, MontConfig};
+    #[derive(MontConfig)]
+    #[modulus = "12289"]
+    #[generator = "11"]
+    pub struct FqConfig;
+
+    pub type FqBackend = MontBackend<FqConfig, 1>;
+    pub type Fq = Fp64<FqBackend>;
+
+    #[allow(clippy::cast_possible_truncation)]
+    pub const MODULUS: u32 = FqConfig::MODULUS.0[0] as u32;
+}
+
 impl<const DEPTH: usize> Config for PnttConfigF2_16_1<DEPTH> {
     type Field = fq::Fq;
     const FIELD_MODULUS: u32 = fq::MODULUS;
@@ -300,6 +318,36 @@ pub type PnttConfigF2_16_1_Base32_Depth1_Rate1_4 =
 pub type PnttConfigF2_16_1_Base64_Depth1_Rate1_4 =
     PnttConfigF2_16_1_Rate1_4_Base<64, 1>;
 
+/// Pseudo NTT configuration derived from the field Fp for p = 12289.
+/// This is the smallest prime supporting 4096th roots of unity.
+///
+/// With `BASE_LEN = 4` and `BASE_DIM = 8`, this yields rate 1/2 codes.
+/// At `DEPTH = 3`, this encodes messages of size 2^11.
+#[derive(Clone, Copy)]
+pub struct PnttConfigF12289_Rate1_2<const BASE_LEN: usize, const DEPTH: usize>;
+
+impl<const BASE_LEN: usize, const DEPTH: usize> Config
+    for PnttConfigF12289_Rate1_2<BASE_LEN, DEPTH>
+{
+    type Field = fq_12289::Fq;
+    const FIELD_MODULUS: u32 = fq_12289::MODULUS;
+    const BASE_LEN: usize = BASE_LEN;
+    const BASE_DIM: usize = BASE_LEN * 2;
+    const DEPTH: usize = DEPTH;
+    // 8th roots of unity in F_12289 (normalized to [-p/2, p/2])
+    const BASE_TWIDDLES: [PnttInt; 8] = [1, -4043, 1479, 5146, -1, 4043, -1479, -5146];
+
+    fn field_to_int_normalized(x: Self::Field) -> PnttInt {
+        let big_int = fq_12289::FqBackend::into_bigint(x);
+
+        precompute::normalize_field_element(big_int.0[0], Self::FIELD_MODULUS)
+    }
+}
+
+/// Depth-3 configuration for message size $2^{11}$ with rate $\frac{1}{2}$.
+/// Uses the smallest possible base field: $\mathbb{F}_{12289}$ where $12289 = 3 \cdot 2^{12} + 1$.
+pub type PnttConfigF12289_Depth3_Rate1_2 = PnttConfigF12289_Rate1_2<4, 3>;
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -316,5 +364,23 @@ mod tests {
     #[test]
     fn check_twiddles() {
         check_twiddles_generic::<PnttConfigF2_16_1<1>>();
+    }
+
+    #[test]
+    fn check_twiddles_f12289() {
+        check_twiddles_generic::<PnttConfigF12289_Depth3_Rate1_2>();
+    }
+
+    #[test]
+    fn check_f12289_depth3_config() {
+        // Verify the configuration parameters
+        type C = PnttConfigF12289_Depth3_Rate1_2;
+        assert_eq!(C::BASE_LEN, 4);
+        assert_eq!(C::BASE_DIM, 8);
+        assert_eq!(C::DEPTH, 3);
+        assert_eq!(C::INPUT_LEN, 2048); // 4 * 8^3 = 2^11
+        assert_eq!(C::OUTPUT_LEN, 4096); // 8 * 8^3 = 2^12
+        assert_eq!(C::FIELD_MODULUS, 12289);
+        // Rate = INPUT_LEN / OUTPUT_LEN = 1/2
     }
 }


### PR DESCRIPTION
- Added benches and configs for matrix dimensions: [4, 8, …, 64] x ^{11}$ and ^{4}$ x ^{7}$, ^{3}$ x ^{8}$, ^{2}$ x ^{9}$
- Added rate /4$ IPRS config
- Minor changes: show matrix dimensions in benchmark labels; skip degree-64 benches