### PR TITLE
Add unchecked addition optimization to IPRS encoding

### DIFF
--- a/zip-plus/benches/zip_plus_benches.rs
+++ b/zip-plus/benches/zip_plus_benches.rs
@@ -68,11 +68,13 @@ impl RaaConfig for BenchRaaConfig {
 type SomeRaaCode<const D_PLUS_ONE: usize> =
     RaaCode<BenchZipPlusTypes<i32, D_PLUS_ONE>, BenchRaaConfig, 4>;
 
-type SomeIprsCode<Twiddle, const DEPTH: usize, const D_PLUS_ONE: usize> = IprsCode<
-    BenchZipPlusTypes<Twiddle, D_PLUS_ONE>,
-    PnttConfigF2_16_1<DEPTH>,
-    BinaryPolyWideningMulByScalar<Twiddle>,
->;
+type SomeIprsCode<Twiddle, const DEPTH: usize, const D_PLUS_ONE: usize, const CHECK: bool> =
+    IprsCode<
+        BenchZipPlusTypes<Twiddle, D_PLUS_ONE>,
+        PnttConfigF2_16_1<DEPTH>,
+        BinaryPolyWideningMulByScalar<Twiddle>,
+        CHECK,
+    >;
 
 fn zip_plus_benchmarks_raa(c: &mut Criterion) {
     let mut group = c.benchmark_group("Zip+ RAA");
@@ -86,8 +88,12 @@ fn zip_plus_benchmarks_raa(c: &mut Criterion) {
 fn zip_plus_benchmarks_iprs(c: &mut Criterion) {
     let mut group = c.benchmark_group("Zip+ IPRS");
 
-    do_bench::<BenchZipPlusTypes<i64, 32>, SomeIprsCode<i64, 1, 32>, UNCHECKED>(&mut group);
-    do_bench::<BenchZipPlusTypes<i64, 64>, SomeIprsCode<i64, 1, 64>, UNCHECKED>(&mut group);
+    do_bench::<BenchZipPlusTypes<i64, 32>, SomeIprsCode<i64, 1, 32, UNCHECKED>, UNCHECKED>(
+        &mut group,
+    );
+    do_bench::<BenchZipPlusTypes<i64, 64>, SomeIprsCode<i64, 1, 64, UNCHECKED>, UNCHECKED>(
+        &mut group,
+    );
 
     group.finish();
 }

--- a/zip-plus/src/code/iprs.rs
+++ b/zip-plus/src/code/iprs.rs
@@ -13,7 +13,12 @@ use crate::{
 use crypto_primitives::{FromPrimitiveWithConfig, FromWithConfig};
 use num_traits::{CheckedAdd, CheckedMul};
 pub use pntt::radix8::params::{PnttConfigF2_16_1, PnttInt, Radix8PnttParams};
-use std::{fmt::Debug, iter::Sum, marker::PhantomData, ops::AddAssign};
+use std::{
+    fmt::Debug,
+    iter::Sum,
+    marker::PhantomData,
+    ops::{Add, AddAssign},
+};
 use zinc_utils::{
     CHECKED,
     from_ref::FromRef,
@@ -24,12 +29,12 @@ use zinc_utils::{
 /// radix-8 NTT-style recursion with a base Vandermonde matrix sized
 /// `base_len x base_dim` (defaults to 64x32).
 #[derive(Debug, Clone)]
-pub struct IprsCode<Zt: ZipTypes, Config: PnttConfig, MT> {
+pub struct IprsCode<Zt: ZipTypes, Config: PnttConfig, MT, const CHECK: bool> {
     pntt_params: Radix8PnttParams<Config>,
     _phantom: PhantomData<(Zt, MT)>,
 }
 
-impl<Zt, Config, MT> IprsCode<Zt, Config, MT>
+impl<Zt, Config, MT, const CHECK: bool> IprsCode<Zt, Config, MT, CHECK>
 where
     Zt: ZipTypes,
     Config: PnttConfig,
@@ -40,6 +45,7 @@ where
         In: Clone + Send + Sync,
         Out: CheckedAdd
             + for<'a> AddAssign<&'a Out>
+            + for<'a> Add<&'a Out, Output = Out>
             + CheckedMul
             + for<'a> MulByScalar<&'a PnttInt>
             + Sum
@@ -58,7 +64,7 @@ where
             Config::INPUT_LEN
         );
 
-        pntt::radix8::pntt::<_, _, _, M, MBSMulByTwiddle<CHECKED>>(row, &self.pntt_params)
+        pntt::radix8::pntt::<_, _, _, M, MBSMulByTwiddle<CHECKED>, CHECK>(row, &self.pntt_params)
     }
 
     // Do the encoding but make use of the fact
@@ -75,14 +81,18 @@ where
             Config::INPUT_LEN
         );
 
-        pntt::radix8::pntt::<_, _, _, FieldMulByTwiddle<_, PnttInt>, FieldMulByTwiddle<_, PnttInt>>(
-            row,
-            &self.pntt_params,
-        )
+        pntt::radix8::pntt::<
+            _,
+            _,
+            _,
+            FieldMulByTwiddle<_, PnttInt>,
+            FieldMulByTwiddle<_, PnttInt>,
+            CHECK,
+        >(row, &self.pntt_params)
     }
 }
 
-impl<Zt: ZipTypes, Config, MT> LinearCode<Zt> for IprsCode<Zt, Config, MT>
+impl<Zt: ZipTypes, Config, MT, const CHECK: bool> LinearCode<Zt> for IprsCode<Zt, Config, MT, CHECK>
 where
     Zt: ZipTypes,
     Config: PnttConfig,

--- a/zip-plus/src/code/iprs.rs
+++ b/zip-plus/src/code/iprs.rs
@@ -29,12 +29,12 @@ use zinc_utils::{
 /// radix-8 NTT-style recursion with a base Vandermonde matrix sized
 /// `base_len x base_dim` (defaults to 64x32).
 #[derive(Debug, Clone)]
-pub struct IprsCode<Zt: ZipTypes, Config: PnttConfig, MT, const CHECK: bool> {
+pub struct IprsCode<Zt: ZipTypes, Config: PnttConfig, MT, const CHECK_ADDITION: bool> {
     pntt_params: Radix8PnttParams<Config>,
     _phantom: PhantomData<(Zt, MT)>,
 }
 
-impl<Zt, Config, MT, const CHECK: bool> IprsCode<Zt, Config, MT, CHECK>
+impl<Zt, Config, MT, const CHECK_ADDITION: bool> IprsCode<Zt, Config, MT, CHECK_ADDITION>
 where
     Zt: ZipTypes,
     Config: PnttConfig,
@@ -64,7 +64,10 @@ where
             Config::INPUT_LEN
         );
 
-        pntt::radix8::pntt::<_, _, _, M, MBSMulByTwiddle<CHECKED>, CHECK>(row, &self.pntt_params)
+        pntt::radix8::pntt::<_, _, _, M, MBSMulByTwiddle<CHECKED>, CHECK_ADDITION>(
+            row,
+            &self.pntt_params,
+        )
     }
 
     // Do the encoding but make use of the fact
@@ -87,12 +90,13 @@ where
             _,
             FieldMulByTwiddle<_, PnttInt>,
             FieldMulByTwiddle<_, PnttInt>,
-            CHECK,
+            CHECK_ADDITION,
         >(row, &self.pntt_params)
     }
 }
 
-impl<Zt: ZipTypes, Config, MT, const CHECK: bool> LinearCode<Zt> for IprsCode<Zt, Config, MT, CHECK>
+impl<Zt: ZipTypes, Config, MT, const CHECK_ADDITION: bool> LinearCode<Zt>
+    for IprsCode<Zt, Config, MT, CHECK_ADDITION>
 where
     Zt: ZipTypes,
     Config: PnttConfig,

--- a/zip-plus/src/code/iprs/pntt/radix8.rs
+++ b/zip-plus/src/code/iprs/pntt/radix8.rs
@@ -21,7 +21,7 @@ use params::*;
 pub(crate) use mul_by_twiddle::*;
 
 /// The main entrypoint of the radix-8 pseudo NTT algorithm.
-pub(crate) fn pntt<In, Out, C, MulInByTwiddle, MulOutByTwiddle, const CHECK: bool>(
+pub(crate) fn pntt<In, Out, C, MulInByTwiddle, MulOutByTwiddle, const CHECK_ADDITION: bool>(
     input: &[In],
     params: &Radix8PnttParams<C>,
 ) -> Vec<Out>
@@ -47,9 +47,10 @@ where
         input.len()
     );
 
-    let mut output = base_multiply_into_output::<_, _, _, MulInByTwiddle, CHECK>(input, params);
+    let mut output =
+        base_multiply_into_output::<_, _, _, MulInByTwiddle, CHECK_ADDITION>(input, params);
 
-    combine_stages::<_, _, MulOutByTwiddle, CHECK>(&mut output, params);
+    combine_stages::<_, _, MulOutByTwiddle, CHECK_ADDITION>(&mut output, params);
 
     output
 }
@@ -58,7 +59,7 @@ where
 /// Assumes `out` contains the result of multiplications of the base chunks
 /// with the `base_matrix`.
 #[allow(clippy::arithmetic_side_effects)]
-fn combine_stages<R, C, M, const CHECK: bool>(out: &mut [R], params: &Radix8PnttParams<C>)
+fn combine_stages<R, C, M, const CHECK_ADDITION: bool>(out: &mut [R], params: &Radix8PnttParams<C>)
 where
     C: Config,
     R: CheckedAdd + CheckedMul + Clone + Send + Sync + Debug + for<'a> Add<&'a R, Output = R>,
@@ -102,7 +103,11 @@ where
                     .expect("We are guaranteed to have the right length here");
 
                 // Perform butterflies.
-                apply_radix_8_butterflies::<_, _, M, CHECK>(ys, &subresults, &layer_twiddles[i]);
+                apply_radix_8_butterflies::<_, _, M, CHECK_ADDITION>(
+                    ys,
+                    &subresults,
+                    &layer_twiddles[i],
+                );
             }
         });
     }
@@ -110,7 +115,7 @@ where
 
 /// Allocates the output vector and performs base layer multiplications.
 #[allow(clippy::arithmetic_side_effects)]
-fn base_multiply_into_output<In, Out, C, M, const CHECK: bool>(
+fn base_multiply_into_output<In, Out, C, M, const CHECK_ADDITION: bool>(
     input: &[In],
     params: &Radix8PnttParams<C>,
 ) -> Vec<Out>
@@ -149,7 +154,11 @@ where
                         bm_row_col,
                     );
 
-                    if CHECK { add!(acc, &term) } else { acc + &term }
+                    if CHECK_ADDITION {
+                        add!(acc, &term)
+                    } else {
+                        acc + &term
+                    }
                 },
             )
         })

--- a/zip-plus/src/code/iprs/pntt/radix8.rs
+++ b/zip-plus/src/code/iprs/pntt/radix8.rs
@@ -11,7 +11,7 @@ use itertools::Itertools;
 use num_traits::{CheckedAdd, CheckedMul};
 #[cfg(feature = "parallel")]
 use rayon::prelude::*;
-use std::{array, fmt::Debug};
+use std::{array, fmt::Debug, ops::Add};
 use zinc_utils::{add, cfg_chunks_mut, cfg_into_iter, from_ref::FromRef};
 
 use butterfly::*;
@@ -21,14 +21,32 @@ use params::*;
 pub(crate) use mul_by_twiddle::*;
 
 /// The main entrypoint of the radix-8 pseudo NTT algorithm.
-pub(crate) fn pntt<In, Out, C, MulInByTwiddle, MulOutByTwiddle>(
+///
+/// The `CHECK` const generic controls overflow checking:
+/// - When `CHECK` is `true`, performs overflow-checked addition (safer).
+/// - When `CHECK` is `false`, uses unchecked addition (faster, ~12-15%
+///   speedup).
+///
+/// The unchecked version is safe for IPRS encoding because:
+/// - Input: i32 (31 bits), Twiddle: i64 (16 bits)
+/// - After widening multiply: 47 bits
+/// - After 8 additions in butterfly: 50 bits, after 32 in base layer: 52 bits
+/// - i64 capacity: 63 bits, so overflow is impossible.
+pub(crate) fn pntt<In, Out, C, MulInByTwiddle, MulOutByTwiddle, const CHECK: bool>(
     input: &[In],
     params: &Radix8PnttParams<C>,
 ) -> Vec<Out>
 where
     C: Config,
     In: Clone + Send + Sync,
-    Out: CheckedAdd + CheckedMul + FromRef<In> + Clone + Send + Sync + Debug,
+    Out: CheckedAdd
+        + CheckedMul
+        + FromRef<In>
+        + Clone
+        + Send
+        + Sync
+        + Debug
+        + for<'a> Add<&'a Out, Output = Out>,
     MulInByTwiddle: MulByTwiddle<In, PnttInt, Output = Out>,
     MulOutByTwiddle: MulByTwiddle<Out, PnttInt, Output = Out>,
 {
@@ -40,9 +58,9 @@ where
         input.len()
     );
 
-    let mut output = base_multiply_into_output::<_, _, _, MulInByTwiddle>(input, params);
+    let mut output = base_multiply_into_output::<_, _, _, MulInByTwiddle, CHECK>(input, params);
 
-    combine_stages::<_, _, MulOutByTwiddle>(&mut output, params);
+    combine_stages::<_, _, MulOutByTwiddle, CHECK>(&mut output, params);
 
     output
 }
@@ -51,10 +69,10 @@ where
 /// Assumes `out` contains the result of multiplications of the base chunks
 /// with the `base_matrix`.
 #[allow(clippy::arithmetic_side_effects)]
-fn combine_stages<R, C, M>(out: &mut [R], params: &Radix8PnttParams<C>)
+fn combine_stages<R, C, M, const CHECK: bool>(out: &mut [R], params: &Radix8PnttParams<C>)
 where
     C: Config,
-    R: CheckedAdd + CheckedMul + Clone + Send + Sync + Debug,
+    R: CheckedAdd + CheckedMul + Clone + Send + Sync + Debug + for<'a> Add<&'a R, Output = R>,
     M: MulByTwiddle<R, PnttInt, Output = R>,
 {
     for k in 0..C::DEPTH {
@@ -95,19 +113,31 @@ where
                     .expect("We are guaranteed to have the right length here");
 
                 // Perform butterflies.
-                apply_radix_8_butterflies::<_, _, M>(ys, &subresults, &layer_twiddles[i]);
+                apply_radix_8_butterflies::<_, _, M, CHECK>(ys, &subresults, &layer_twiddles[i]);
             }
         });
     }
 }
 
 /// Allocates the output vector and performs base layer multiplications.
+///
+/// When `CHECK` is `true`, performs overflow-checked addition.
+/// When `CHECK` is `false`, uses unchecked addition for better performance.
 #[allow(clippy::arithmetic_side_effects)]
-fn base_multiply_into_output<In, Out, C, M>(input: &[In], params: &Radix8PnttParams<C>) -> Vec<Out>
+fn base_multiply_into_output<In, Out, C, M, const CHECK: bool>(
+    input: &[In],
+    params: &Radix8PnttParams<C>,
+) -> Vec<Out>
 where
     C: Config,
     In: Clone + Send + Sync,
-    Out: Clone + CheckedAdd + CheckedMul + FromRef<In> + Send + Sync,
+    Out: Clone
+        + CheckedAdd
+        + CheckedMul
+        + FromRef<In>
+        + Send
+        + Sync
+        + for<'a> Add<&'a Out, Output = Out>,
     M: MulByTwiddle<In, PnttInt, Output = Out>,
 {
     cfg_into_iter!(0..C::OUTPUT_LEN)
@@ -133,14 +163,12 @@ where
                         bm_row_col,
                     );
 
-                    add!(acc, &term)
+                    if CHECK { add!(acc, &term) } else { acc + &term }
                 },
             )
         })
         .collect()
 }
-
-// TODO: make unchecked versions of the above.
 
 #[cfg(test)]
 mod tests {
@@ -185,8 +213,9 @@ mod tests {
         let our_res = {
             let params = Radix8PnttParams::<C>::new();
 
-            let output =
-                base_multiply_into_output::<_, _, _, MBSMulByTwiddle<CHECKED>>(&input, &params);
+            let output = base_multiply_into_output::<_, _, _, MBSMulByTwiddle<CHECKED>, CHECKED>(
+                &input, &params,
+            );
 
             output.into_iter().map(C::Field::from).collect_vec()
         };
@@ -228,7 +257,7 @@ mod tests {
             let params = Radix8PnttParams::<C>::new();
 
             let res: Vec<Int<4>> =
-                pntt::<_, _, _, MBSMulByTwiddle<CHECKED>, MBSMulByTwiddle<CHECKED>>(
+                pntt::<_, _, _, MBSMulByTwiddle<CHECKED>, MBSMulByTwiddle<CHECKED>, CHECKED>(
                     &input, &params,
                 );
 

--- a/zip-plus/src/code/iprs/pntt/radix8.rs
+++ b/zip-plus/src/code/iprs/pntt/radix8.rs
@@ -21,17 +21,6 @@ use params::*;
 pub(crate) use mul_by_twiddle::*;
 
 /// The main entrypoint of the radix-8 pseudo NTT algorithm.
-///
-/// The `CHECK` const generic controls overflow checking:
-/// - When `CHECK` is `true`, performs overflow-checked addition (safer).
-/// - When `CHECK` is `false`, uses unchecked addition (faster, ~12-15%
-///   speedup).
-///
-/// The unchecked version is safe for IPRS encoding because:
-/// - Input: i32 (31 bits), Twiddle: i64 (16 bits)
-/// - After widening multiply: 47 bits
-/// - After 8 additions in butterfly: 50 bits, after 32 in base layer: 52 bits
-/// - i64 capacity: 63 bits, so overflow is impossible.
 pub(crate) fn pntt<In, Out, C, MulInByTwiddle, MulOutByTwiddle, const CHECK: bool>(
     input: &[In],
     params: &Radix8PnttParams<C>,
@@ -120,9 +109,6 @@ where
 }
 
 /// Allocates the output vector and performs base layer multiplications.
-///
-/// When `CHECK` is `true`, performs overflow-checked addition.
-/// When `CHECK` is `false`, uses unchecked addition for better performance.
 #[allow(clippy::arithmetic_side_effects)]
 fn base_multiply_into_output<In, Out, C, M, const CHECK: bool>(
     input: &[In],

--- a/zip-plus/src/code/iprs/pntt/radix8/butterfly.rs
+++ b/zip-plus/src/code/iprs/pntt/radix8/butterfly.rs
@@ -1,3 +1,5 @@
+use std::ops::Add;
+
 use num_traits::CheckedAdd;
 use zinc_utils::add;
 
@@ -20,12 +22,14 @@ const BUTTERFLY_TABLE: [[usize; 7]; 8] = [
 /// of subresults in `x`. `twiddles[j][i]` is the factor to multiply
 /// `x[j + 1]` by when the butterfly table requests the `i`-th twiddle.
 /// Use `mul_by_twiddle` as a means to multiply `Out` by `Twiddle`.
-pub(crate) fn apply_radix_8_butterflies<R, Twiddle, M>(
+///
+#[allow(clippy::arithmetic_side_effects)]
+pub(crate) fn apply_radix_8_butterflies<R, Twiddle, M, const CHECK: bool>(
     ys: [&mut R; 8],
     xs: &[R],
     twiddles: &[[Twiddle; 8]; 7],
 ) where
-    R: Clone + CheckedAdd,
+    R: Clone + CheckedAdd + for<'a> Add<&'a R, Output = R>,
     M: MulByTwiddle<R, Twiddle, Output = R>,
 {
     ys.into_iter()
@@ -34,7 +38,8 @@ pub(crate) fn apply_radix_8_butterflies<R, Twiddle, M>(
             *y = xs[1..].iter().zip(&butterfly_row[..]).enumerate().fold(
                 xs[0].clone(),
                 |a, (j_minus_1, (x, &twiddle_idx))| {
-                    add!(a, &M::mul_by_twiddle(x, &twiddles[j_minus_1][twiddle_idx]))
+                    let term = M::mul_by_twiddle(x, &twiddles[j_minus_1][twiddle_idx]);
+                    if CHECK { add!(a, &term) } else { a + &term }
                 },
             )
         });

--- a/zip-plus/src/code/iprs/pntt/radix8/butterfly.rs
+++ b/zip-plus/src/code/iprs/pntt/radix8/butterfly.rs
@@ -23,7 +23,7 @@ const BUTTERFLY_TABLE: [[usize; 7]; 8] = [
 /// `x[j + 1]` by when the butterfly table requests the `i`-th twiddle.
 /// Use `mul_by_twiddle` as a means to multiply `Out` by `Twiddle`.
 #[allow(clippy::arithmetic_side_effects)]
-pub(crate) fn apply_radix_8_butterflies<R, Twiddle, M, const CHECK: bool>(
+pub(crate) fn apply_radix_8_butterflies<R, Twiddle, M, const CHECK_ADDITION: bool>(
     ys: [&mut R; 8],
     xs: &[R],
     twiddles: &[[Twiddle; 8]; 7],
@@ -38,7 +38,11 @@ pub(crate) fn apply_radix_8_butterflies<R, Twiddle, M, const CHECK: bool>(
                 xs[0].clone(),
                 |a, (j_minus_1, (x, &twiddle_idx))| {
                     let term = M::mul_by_twiddle(x, &twiddles[j_minus_1][twiddle_idx]);
-                    if CHECK { add!(a, &term) } else { a + &term }
+                    if CHECK_ADDITION {
+                        add!(a, &term)
+                    } else {
+                        a + &term
+                    }
                 },
             )
         });

--- a/zip-plus/src/code/iprs/pntt/radix8/butterfly.rs
+++ b/zip-plus/src/code/iprs/pntt/radix8/butterfly.rs
@@ -22,7 +22,6 @@ const BUTTERFLY_TABLE: [[usize; 7]; 8] = [
 /// of subresults in `x`. `twiddles[j][i]` is the factor to multiply
 /// `x[j + 1]` by when the butterfly table requests the `i`-th twiddle.
 /// Use `mul_by_twiddle` as a means to multiply `Out` by `Twiddle`.
-///
 #[allow(clippy::arithmetic_side_effects)]
 pub(crate) fn apply_radix_8_butterflies<R, Twiddle, M, const CHECK: bool>(
     ys: [&mut R; 8],


### PR DESCRIPTION
Adds `const CHECK: bool` generic parameter to `IprsCode` and the underlying `PNTT` functions to allow toggling overflow checking at compile time. 
When CHECK = false (UNCHECKED), uses direct addition instead of checked_add, avoiding clone + overflow check overhead. 

```
Zip+ IPRS/EncodeRows: BPoly<31> -> Poly<i64, 31>, poly_size = 2^13
                        time:   [6.0335 ms 6.2425 ms 6.5143 ms]
                        change: [−32.360% −31.928% −29.210%] (p = 0.00 < 0.05)
                        Performance has improved.
````