### PR TITLE
Add ideal check benchmarks and parallelize combined poly builder

### DIFF
--- a/piop/Cargo.toml
+++ b/piop/Cargo.toml
@@ -40,3 +40,8 @@ simd = ["zinc-poly/simd"]
 [[bench]]
 name = "sumcheck"
 harness = false
+
+[[bench]]
+name = "ideal_check"
+harness = false
+

--- a/piop/benches/ideal_check.rs
+++ b/piop/benches/ideal_check.rs
@@ -1,0 +1,269 @@
+use std::hint::black_box;
+
+use criterion::{
+    AxisScale, BatchSize, BenchmarkGroup, BenchmarkId, Criterion, PlotConfiguration,
+    criterion_group, criterion_main, measurement::WallTime,
+};
+use crypto_primitives::{
+    ConstIntSemiring, Field, Semiring, crypto_bigint_int::Int, crypto_bigint_monty::MontyField,
+};
+use rand::rng;
+use zinc_piop::ideal_check::{IdealCheckProtocol, IdealCheckTypes, Proof};
+use zinc_poly::univariate::{
+    dense::DensePolynomial, dynamic::over_field::DynamicPolynomialF, ideal::DegreeOneIdeal,
+};
+use zinc_primality::{MillerRabin, PrimalityTest};
+use zinc_test_uair::{GenerateWitness, TestAirNoMultiplication, TestUairSimpleMultiplication};
+use zinc_transcript::{
+    KeccakTranscript,
+    traits::{ConstTranscribable, Transcript},
+};
+use zinc_uair::{
+    Uair, constraint_counter::count_constraints, ideal::IdealCheck, ideal_collector::IdealOrZero,
+};
+use zinc_utils::from_ref::FromRef;
+
+const DEGREE_PLUS_ONE: usize = 32;
+
+#[derive(Clone)]
+struct BenchIcTypes<const FIELD_LIMBS: usize, const INT_LIMBS: usize>;
+
+impl<const FIELD_LIMBS: usize, const INT_LIMBS: usize> IdealCheckTypes<DEGREE_PLUS_ONE>
+    for BenchIcTypes<FIELD_LIMBS, INT_LIMBS>
+{
+    type WitnessCoeff = Int<INT_LIMBS>;
+    type Witness = DensePolynomial<Int<INT_LIMBS>, DEGREE_PLUS_ONE>;
+    type F = MontyField<FIELD_LIMBS>;
+}
+
+trait BenchIcTrait {
+    const FIELD_LIMBS: usize;
+}
+
+impl<const FIELD_LIMBS: usize, const INT_LIMBS: usize> BenchIcTrait
+    for BenchIcTypes<FIELD_LIMBS, INT_LIMBS>
+{
+    const FIELD_LIMBS: usize = FIELD_LIMBS;
+}
+
+#[allow(clippy::arithmetic_side_effects)]
+fn bench_no_mult<IcTypes>(group: &mut BenchmarkGroup<WallTime>, witness_size: usize)
+where
+    IcTypes: IdealCheckTypes<DEGREE_PLUS_ONE> + BenchIcTrait + Clone,
+    IcTypes::WitnessCoeff: Semiring + 'static,
+    IcTypes::F: Field,
+    <IcTypes::F as Field>::Inner:
+        ConstIntSemiring + FromRef<<IcTypes::F as Field>::Inner> + ConstTranscribable,
+    TestAirNoMultiplication: Uair<IcTypes::Witness, Ideal = DegreeOneIdeal<IcTypes::WitnessCoeff>>
+        + GenerateWitness<IcTypes::Witness>,
+    MillerRabin: PrimalityTest<<IcTypes::F as Field>::Inner>,
+{
+    let mut rng = rng();
+    let num_vars = zinc_utils::log2(witness_size) as usize;
+    let trace = TestAirNoMultiplication::generate_witness(num_vars, &mut rng);
+
+    let params = format!("NoMult/LIMBS={}/nvars={}", IcTypes::FIELD_LIMBS, num_vars);
+
+    let transcript = KeccakTranscript::new();
+
+    let num_constraints = count_constraints::<IcTypes::Witness, TestAirNoMultiplication>();
+
+    let prove =
+        |(trace, mut transcript): (Vec<_>, KeccakTranscript)| -> Proof<IcTypes, DEGREE_PLUS_ONE> {
+            let field_cfg = transcript
+                .get_random_field_cfg::<IcTypes::F, <IcTypes::F as Field>::Inner, MillerRabin>();
+            IdealCheckProtocol::prove_as_subprotocol::<TestAirNoMultiplication>(
+                &mut transcript,
+                &trace,
+                num_constraints,
+                num_vars,
+                &field_cfg,
+            )
+            .expect("Prover failed")
+            .0
+        };
+
+    group.bench_with_input(
+        BenchmarkId::new("Ideal Check Prover", &params),
+        &(trace.clone(), transcript.clone()),
+        |bench, (trace, transcript)| {
+            bench.iter_batched(
+                || (trace.clone(), transcript.clone()),
+                |(trace, transcript)| {
+                    let _ = black_box(&prove((trace, transcript)));
+                },
+                BatchSize::SmallInput,
+            );
+        },
+    );
+
+    let proof = prove((trace, transcript.clone()));
+
+    group.bench_with_input(
+        BenchmarkId::new("Ideal Check Verifier", &params),
+        &(proof, transcript),
+        |bench, (proof, transcript)| {
+            bench.iter_batched(
+                || (proof.clone(), transcript.clone()),
+                |(proof, mut transcript)| {
+                    let field_cfg = transcript.get_random_field_cfg::<
+                        IcTypes::F,
+                        <IcTypes::F as Field>::Inner,
+                        MillerRabin,
+                    >();
+                    let _ = black_box(IdealCheckProtocol::verify_as_subprotocol::<
+                        TestAirNoMultiplication,
+                        _,
+                        _,
+                    >(
+                        &mut transcript,
+                        proof,
+                        num_constraints,
+                        num_vars,
+                        |ideal_over_ring| {
+                            ideal_over_ring.map(|i| DegreeOneIdeal::from_with_cfg(i, &field_cfg))
+                        },
+                        &field_cfg,
+                    ))
+                    .expect("Failed to verify");
+                },
+                BatchSize::SmallInput,
+            );
+        },
+    );
+}
+
+pub fn bench_no_mult_3(group: &mut BenchmarkGroup<WallTime>, witness_size: usize) {
+    bench_no_mult::<BenchIcTypes<3, 4>>(group, witness_size)
+}
+
+pub fn bench_no_mult_4(group: &mut BenchmarkGroup<WallTime>, witness_size: usize) {
+    bench_no_mult::<BenchIcTypes<4, 5>>(group, witness_size)
+}
+
+#[allow(clippy::arithmetic_side_effects)]
+fn bench_simple_mult<IcTypes>(group: &mut BenchmarkGroup<WallTime>, witness_size: usize)
+where
+    IcTypes: IdealCheckTypes<DEGREE_PLUS_ONE> + BenchIcTrait + Clone,
+    IcTypes::F: Field,
+    <IcTypes::F as Field>::Inner:
+        ConstIntSemiring + FromRef<<IcTypes::F as Field>::Inner> + ConstTranscribable,
+    TestUairSimpleMultiplication: Uair<IcTypes::Witness> + GenerateWitness<IcTypes::Witness>,
+    MillerRabin: PrimalityTest<<IcTypes::F as Field>::Inner>,
+    IdealOrZero<DegreeOneIdeal<IcTypes::F>>: IdealCheck<DynamicPolynomialF<IcTypes::F>>,
+{
+    let mut rng = rng();
+    let num_vars = zinc_utils::log2(witness_size) as usize;
+    let trace = TestUairSimpleMultiplication::generate_witness(num_vars, &mut rng);
+
+    let params = format!(
+        "SimpleMult/LIMBS={}/nvars={}",
+        IcTypes::FIELD_LIMBS,
+        num_vars
+    );
+
+    let transcript = KeccakTranscript::new();
+
+    let num_constraints = count_constraints::<IcTypes::Witness, TestUairSimpleMultiplication>();
+
+    let prove =
+        |(trace, mut transcript): (Vec<_>, KeccakTranscript)| -> Proof<IcTypes, DEGREE_PLUS_ONE> {
+            let field_cfg = transcript
+                .get_random_field_cfg::<IcTypes::F, <IcTypes::F as Field>::Inner, MillerRabin>();
+            IdealCheckProtocol::prove_as_subprotocol::<TestUairSimpleMultiplication>(
+                &mut transcript,
+                &trace,
+                num_constraints,
+                num_vars,
+                &field_cfg,
+            )
+            .expect("Prover failed")
+            .0
+        };
+
+    group.bench_with_input(
+        BenchmarkId::new("Ideal Check Prover", &params),
+        &(trace.clone(), transcript.clone()),
+        |bench, (trace, transcript)| {
+            bench.iter_batched(
+                || (trace.clone(), transcript.clone()),
+                |(trace, transcript)| {
+                    let _ = black_box(&prove((trace, transcript)));
+                },
+                BatchSize::SmallInput,
+            );
+        },
+    );
+
+    let proof = prove((trace, transcript.clone()));
+
+    group.bench_with_input(
+        BenchmarkId::new("Ideal Check Verifier", &params),
+        &(proof, transcript),
+        |bench, (proof, transcript)| {
+            bench.iter_batched(
+                || (proof.clone(), transcript.clone()),
+                |(proof, mut transcript)| {
+                    let field_cfg = transcript.get_random_field_cfg::<
+                        IcTypes::F,
+                        <IcTypes::F as Field>::Inner,
+                        MillerRabin,
+                    >();
+                    let _ = black_box(IdealCheckProtocol::verify_as_subprotocol::<
+                        TestUairSimpleMultiplication,
+                        _,
+                        _,
+                    >(
+                        &mut transcript,
+                        proof,
+                        num_constraints,
+                        num_vars,
+                        |_ideal_over_ring| IdealOrZero::zero(),
+                        &field_cfg,
+                    ))
+                    .expect("Failed to verify");
+                },
+                BatchSize::SmallInput,
+            );
+        },
+    );
+}
+
+pub fn bench_simple_mult_3(group: &mut BenchmarkGroup<WallTime>, witness_size: usize) {
+    bench_simple_mult::<BenchIcTypes<3, 4>>(group, witness_size)
+}
+
+pub fn bench_simple_mult_4(group: &mut BenchmarkGroup<WallTime>, witness_size: usize) {
+    bench_simple_mult::<BenchIcTypes<4, 5>>(group, witness_size)
+}
+
+/// Before/after diff for combined_poly_builder (parallel vs sequential):
+///   1. cargo bench -p zinc-piop --bench ideal_check -- "Ideal Check Prover"
+///      --save-baseline sequential
+///   2. cargo bench -p zinc-piop --bench ideal_check --features parallel --
+///      "Ideal Check Prover" --baseline sequential
+pub fn ideal_check_benches(c: &mut Criterion) {
+    let plot_config = PlotConfiguration::default().summary_scale(AxisScale::Logarithmic);
+
+    let mut group = c.benchmark_group("Ideal check benchmarks");
+    group.plot_config(plot_config);
+
+    bench_no_mult_3(&mut group, 1 << 13);
+    bench_no_mult_4(&mut group, 1 << 13);
+    bench_no_mult_3(&mut group, 1 << 14);
+    bench_no_mult_4(&mut group, 1 << 14);
+    bench_no_mult_3(&mut group, 1 << 15);
+    bench_no_mult_4(&mut group, 1 << 15);
+    bench_no_mult_3(&mut group, 1 << 16);
+    bench_no_mult_4(&mut group, 1 << 16);
+    bench_no_mult_3(&mut group, 1 << 17);
+    bench_no_mult_4(&mut group, 1 << 17);
+
+    bench_simple_mult_3(&mut group, 1 << 2);
+    bench_simple_mult_4(&mut group, 1 << 2);
+
+    group.finish();
+}
+
+criterion_group!(benches, ideal_check_benches);
+criterion_main!(benches);

--- a/piop/src/ideal_check.rs
+++ b/piop/src/ideal_check.rs
@@ -10,7 +10,7 @@ use itertools::Itertools;
 #[cfg(feature = "parallel")]
 use rayon::prelude::*;
 use std::{collections::HashMap, marker::PhantomData};
-use structs::*;
+pub use structs::*;
 use thiserror::Error;
 use zinc_poly::{
     CoefficientProjectable, EvaluationError,

--- a/piop/src/ideal_check/combined_poly_builder.rs
+++ b/piop/src/ideal_check/combined_poly_builder.rs
@@ -1,6 +1,6 @@
 use std::{collections::HashMap, mem::MaybeUninit};
 
-use crypto_primitives::{DenseRowMatrix, Field, Matrix, PrimeField};
+use crypto_primitives::{DenseRowMatrix, Field, PrimeField};
 use itertools::Itertools;
 use zinc_poly::{
     CoefficientProjectable,
@@ -8,7 +8,10 @@ use zinc_poly::{
     univariate::dynamic::over_field::DynamicPolynomialF,
 };
 use zinc_uair::{ConstraintBuilder, Uair, ideal::ImpossibleIdeal};
-use zinc_utils::from_ref::FromRef;
+use zinc_utils::{cfg_chunks_mut, cfg_into_iter, cfg_iter, from_ref::FromRef};
+
+#[cfg(feature = "parallel")]
+use rayon::prelude::*;
 
 use crate::ideal_check::structs::IdealCheckTypes;
 
@@ -16,6 +19,7 @@ use crate::ideal_check::structs::IdealCheckTypes;
 /// obtains the combined polynomials' MLE coefficients.
 /// Since each coefficient is also a univariate polynomial
 /// we split the resulting MLE into coefficient MLEs.
+#[allow(clippy::arithmetic_side_effects)]
 pub fn compute_combined_polynomials<
     IcTypes: IdealCheckTypes<DEGREE_PLUS_ONE>,
     U,
@@ -37,14 +41,14 @@ where
 
     let field_zero = IcTypes::F::zero_with_cfg(projecting_element.cfg());
 
+    let rows: Vec<_> = trace_matrix.as_rows().collect();
+    let indices: Vec<usize> = (0..num_rows - 1).collect();
     let mut max_degrees_and_combined_poly_rows: Vec<(usize, Vec<DynamicPolynomialF<IcTypes::F>>)> =
-        trace_matrix
-            .as_rows()
-            .zip(trace_matrix.as_rows().skip(1))
-            .map(|(up, down)| {
+        cfg_iter!(indices)
+            .map(|&i| {
                 combine_rows_and_get_max_degree::<IcTypes, U, _>(
-                    up,
-                    down,
+                    rows[i],
+                    rows[i + 1],
                     num_constraints,
                     projected_scalars,
                 )
@@ -89,15 +93,17 @@ fn project_trace_matrix<IcTypes: IdealCheckTypes<DEGREE_PLUS_ONE>, const DEGREE_
 ) -> DenseRowMatrix<DynamicPolynomialF<<IcTypes as IdealCheckTypes<DEGREE_PLUS_ONE>>::F>> {
     let mut matr = DenseRowMatrix::uninit(num_rows, num_cols);
 
-    matr.cells_mut().enumerate().for_each(|(row_idx, row)| {
-        row.for_each(|(col_idx, cell)| {
-            *cell = MaybeUninit::new(
-                trace[col_idx][row_idx]
-                    .project_coefficients(projecting_element)
-                    .into(),
-            );
+    cfg_chunks_mut!(matr.data, num_cols)
+        .enumerate()
+        .for_each(|(row_idx, row)| {
+            for (col_idx, cell) in row.iter_mut().enumerate() {
+                *cell = MaybeUninit::new(
+                    trace[col_idx][row_idx]
+                        .project_coefficients(projecting_element)
+                        .into(),
+                );
+            }
         });
-    });
 
     unsafe { matr.init() }
 }
@@ -158,7 +164,7 @@ fn prepare_coefficient_mles<
     max_degrees_and_combined_poly_rows: &[(usize, Vec<DynamicPolynomialF<IcTypes::F>>)],
     field_zero: &IcTypes::F,
 ) -> Vec<Vec<DenseMultilinearExtension<<IcTypes::F as Field>::Inner>>> {
-    (0..num_constraints)
+    cfg_into_iter!(0..num_constraints)
         .map(|constraint| {
             (0..=max_degree)
                 .map(|coeff| {
@@ -175,7 +181,7 @@ fn prepare_coefficient_mles<
                 })
                 .collect_vec()
         })
-        .collect_vec()
+        .collect()
 }
 
 pub struct CombinedPolyRowBuilder<F: PrimeField> {


### PR DESCRIPTION
## Summary
- Introduce Criterion benchmarks for the ideal check prover and verifier across multiple field sizes (3/4 limbs) and witness sizes (2^13–2^17)
- Parallelize trace matrix projection, row combination, and coefficient MLE preparation in `combined_poly_builder` using rayon feature-gated macros
- Make ideal check structs public for bench access

## Test plan
- [x] Run `cargo bench -p zinc-piop --bench ideal_check` to verify benchmarks work
- [x] Run `cargo bench -p zinc-piop --bench ideal_check --features parallel` to verify parallel path
- [x] Confirm CI (linter, clippy, tests) passes

## Benchmark Results: 
### TestAirNoMultiplication 

| Config | Sequential | Parallel | Speedup |
|--------|-----------|----------|---------|
| LIMBS=3, nvars=13 | ~88 ms* | 19.9 ms | ~4.4x |
| LIMBS=4, nvars=13 | ~113 ms* | 24.9 ms | ~4.5x |
| LIMBS=3, nvars=14 | 170.7 ms | 38.3 ms | ~4.5x |
| LIMBS=4, nvars=14 | 221.4 ms | 47.4 ms | ~4.7x |
| LIMBS=3, nvars=15 | 341.0 ms | 74.5 ms | ~4.6x |
| LIMBS=4, nvars=15 | 442.9 ms | 94.4 ms | ~4.7x |
| LIMBS=3, nvars=16 | 683.0 ms | 151.6 ms | ~4.5x |
| LIMBS=4, nvars=16 | 886.1 ms | 189.1 ms | ~4.7x |
| LIMBS=3, nvars=17 | 1.366 s | 311.8 ms | ~4.4x |
| LIMBS=4, nvars=17 | 1.782 s | 397.7 ms | ~4.5x |

Consistent ~78-79% reduction across all sizes (~4.5x speedup). Only prover benchmarks were run.

### TestUairSimpleMultiplication 
| Config | Sequential | Parallel | Speedup |
|--------|-----------|----------|---------|
| LIMBS=3, nvars=2 | ~370.6 µs | 521.8 µs | 0.71x (slower) |
| LIMBS=4, nvars=2 | ~715.8 µs | 691.8 µs | ~1.03x |

At small witness sizes (nvars=2), parallelism overhead dominates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)