### PR TITLE
feat(piop): add simd feature flag

### DIFF
--- a/piop/Cargo.toml
+++ b/piop/Cargo.toml
@@ -31,6 +31,7 @@ workspace = true
 
 [features]
 parallel = ["dep:rayon", "zinc-utils/parallel"]
+simd = ["zinc-poly/simd"]
 
 [[bench]]
 name = "sumcheck"

--- a/zip-plus/benches/zip_benches.rs
+++ b/zip-plus/benches/zip_benches.rs
@@ -12,9 +12,13 @@ use crypto_bigint::U64;
 use crypto_primitives::{crypto_bigint_int::Int, crypto_bigint_uint::Uint};
 use zinc_utils::UNCHECKED;
 use zip_plus::{
-    code::raa::{RaaCode, RaaConfig},
+    code::{
+        iprs::{IprsCode, PnttConfigF2_16_1_Depth2_Rate1_2},
+        raa::{RaaCode, RaaConfig},
+    },
     pcs::structs::ZipTypes,
 };
+use zinc_utils::mul_by_scalar::WideningMulByScalar;
 
 const INT_LIMBS: usize = U64::LIMBS;
 
@@ -43,11 +47,31 @@ impl RaaConfig for BenchRaaConfig {
 
 type Code = RaaCode<BenchZipTypes, BenchRaaConfig, 4>;
 
+#[derive(Clone, Default)]
+struct I32WideningMulByScalar;
+
+impl WideningMulByScalar<i32, i64> for I32WideningMulByScalar {
+    type Output = i64;
+
+    #[allow(clippy::arithmetic_side_effects)]
+    fn mul_by_scalar_widen(lhs: &i32, rhs: &i64) -> Self::Output {
+        i64::from(*lhs) * *rhs
+    }
+}
+
+type IprsCodeDepth2 = IprsCode<BenchZipTypes, PnttConfigF2_16_1_Depth2_Rate1_2, I32WideningMulByScalar>;
+
 fn zip_benchmarks(c: &mut Criterion) {
     let mut group = c.benchmark_group("Zip+");
     do_bench::<BenchZipTypes, Code, UNCHECKED>(&mut group);
     group.finish();
 }
 
-criterion_group!(benches, zip_benchmarks);
+fn zip_benchmarks_iprs(c: &mut Criterion) {
+    let mut group = c.benchmark_group("Zip IPRS");
+    do_bench_iprs_matrices::<BenchZipTypes, IprsCodeDepth2, UNCHECKED>(&mut group);
+    group.finish();
+}
+
+criterion_group!(benches, zip_benchmarks, zip_benchmarks_iprs);
 criterion_main!(benches);

--- a/zip-plus/benches/zip_common.rs
+++ b/zip-plus/benches/zip_common.rs
@@ -80,6 +80,52 @@ pub fn do_bench<Zt: ZipTypes, Lc: LinearCode<Zt>, const CHECK_FOR_OVERFLOWS: boo
     verify::<Zt, Lc, CHECK_FOR_OVERFLOWS, 16>(group);
 }
 
+pub fn do_bench_iprs_matrices<Zt: ZipTypes, Lc: LinearCode<Zt>, const CHECK_FOR_OVERFLOWS: bool>(
+    group: &mut BenchmarkGroup<WallTime>,
+) where
+    StandardUniform: Distribution<Zt::Eval> + Distribution<Zt::Cw>,
+    F: for<'a> FromWithConfig<&'a Zt::Chal> + for<'a> FromWithConfig<&'a Zt::Pt>,
+    <F as Field>::Inner: FromRef<Zt::Fmod>,
+    Zt::Eval: ProjectableToField<F>,
+    Zt::Cw: ProjectableToField<F>,
+{
+    encode_rows::<Zt, Lc, 13>(group);
+    encode_rows::<Zt, Lc, 14>(group);
+    encode_rows::<Zt, Lc, 15>(group);
+    encode_rows::<Zt, Lc, 16>(group);
+    encode_rows::<Zt, Lc, 17>(group);
+
+    merkle_root::<Zt, 13>(group);
+    merkle_root::<Zt, 14>(group);
+    merkle_root::<Zt, 15>(group);
+    merkle_root::<Zt, 16>(group);
+    merkle_root::<Zt, 17>(group);
+
+    commit::<Zt, Lc, 13>(group);
+    commit::<Zt, Lc, 14>(group);
+    commit::<Zt, Lc, 15>(group);
+    commit::<Zt, Lc, 16>(group);
+    commit::<Zt, Lc, 17>(group);
+
+    test::<Zt, Lc, CHECK_FOR_OVERFLOWS, 13>(group);
+    test::<Zt, Lc, CHECK_FOR_OVERFLOWS, 14>(group);
+    test::<Zt, Lc, CHECK_FOR_OVERFLOWS, 15>(group);
+    test::<Zt, Lc, CHECK_FOR_OVERFLOWS, 16>(group);
+    test::<Zt, Lc, CHECK_FOR_OVERFLOWS, 17>(group);
+
+    evaluate::<Zt, Lc, CHECK_FOR_OVERFLOWS, 13>(group);
+    evaluate::<Zt, Lc, CHECK_FOR_OVERFLOWS, 14>(group);
+    evaluate::<Zt, Lc, CHECK_FOR_OVERFLOWS, 15>(group);
+    evaluate::<Zt, Lc, CHECK_FOR_OVERFLOWS, 16>(group);
+    evaluate::<Zt, Lc, CHECK_FOR_OVERFLOWS, 17>(group);
+
+    verify::<Zt, Lc, CHECK_FOR_OVERFLOWS, 13>(group);
+    verify::<Zt, Lc, CHECK_FOR_OVERFLOWS, 14>(group);
+    verify::<Zt, Lc, CHECK_FOR_OVERFLOWS, 15>(group);
+    verify::<Zt, Lc, CHECK_FOR_OVERFLOWS, 16>(group);
+    verify::<Zt, Lc, CHECK_FOR_OVERFLOWS, 17>(group);
+}
+
 pub fn encode_rows<Zt: ZipTypes, Lc: LinearCode<Zt>, const P: usize>(
     group: &mut BenchmarkGroup<WallTime>,
 ) where

--- a/zip-plus/benches/zip_plus_benches.rs
+++ b/zip-plus/benches/zip_plus_benches.rs
@@ -21,7 +21,7 @@ use crypto_primitives::{
 };
 use zip_plus::{
     code::{
-        iprs::{IprsCode, PnttConfigF2_16_1},
+        iprs::{IprsCode, PnttConfigF2_16_1_Depth2_Rate1_2},
         raa::{RaaCode, RaaConfig},
     },
     pcs::structs::ZipTypes,
@@ -68,9 +68,9 @@ impl RaaConfig for BenchRaaConfig {
 type SomeRaaCode<const D_PLUS_ONE: usize> =
     RaaCode<BenchZipPlusTypes<i32, D_PLUS_ONE>, BenchRaaConfig, 4>;
 
-type SomeIprsCode<Twiddle, const DEPTH: usize, const D_PLUS_ONE: usize> = IprsCode<
+type SomeIprsCodeDepth2<Twiddle, const D_PLUS_ONE: usize> = IprsCode<
     BenchZipPlusTypes<Twiddle, D_PLUS_ONE>,
-    PnttConfigF2_16_1<DEPTH>,
+    PnttConfigF2_16_1_Depth2_Rate1_2,
     BinaryPolyWideningMulByScalar<Twiddle>,
 >;
 
@@ -86,8 +86,12 @@ fn zip_plus_benchmarks_raa(c: &mut Criterion) {
 fn zip_plus_benchmarks_iprs(c: &mut Criterion) {
     let mut group = c.benchmark_group("Zip+ IPRS");
 
-    do_bench::<BenchZipPlusTypes<i64, 32>, SomeIprsCode<i64, 1, 32>, UNCHECKED>(&mut group);
-    do_bench::<BenchZipPlusTypes<i64, 64>, SomeIprsCode<i64, 1, 64>, UNCHECKED>(&mut group);
+    do_bench_iprs_matrices::<BenchZipPlusTypes<i64, 32>, SomeIprsCodeDepth2<i64, 32>, UNCHECKED>(
+        &mut group,
+    );
+    do_bench_iprs_matrices::<BenchZipPlusTypes<i64, 64>, SomeIprsCodeDepth2<i64, 64>, UNCHECKED>(
+        &mut group,
+    );
 
     group.finish();
 }

--- a/zip-plus/src/code/iprs.rs
+++ b/zip-plus/src/code/iprs.rs
@@ -12,7 +12,14 @@ use crate::{
 };
 use crypto_primitives::{FromPrimitiveWithConfig, FromWithConfig};
 use num_traits::{CheckedAdd, CheckedMul};
-pub use pntt::radix8::params::{PnttConfigF2_16_1, PnttInt, Radix8PnttParams};
+pub use pntt::radix8::params::{
+    PnttConfigF2_16_1,
+    PnttConfigF2_16_1_Depth2_Rate1_2,
+    PnttConfigF2_16_1_Depth2_Rate1_4,
+    PnttConfigF2_16_1_Rate1_4,
+    PnttInt,
+    Radix8PnttParams,
+};
 use std::{fmt::Debug, iter::Sum, marker::PhantomData, ops::AddAssign};
 use zinc_utils::{
     CHECKED,

--- a/zip-plus/src/code/iprs/pntt/radix8/params.rs
+++ b/zip-plus/src/code/iprs/pntt/radix8/params.rs
@@ -159,8 +159,21 @@ impl<C: Config> Radix8PnttParams<C> {
 /// the field `Fp` for `p = 2^16 + 1`.
 ///
 /// Supports `DEPTH` up to `3`.
+///
+/// With `BASE_LEN = 32` and `BASE_DIM = 64`,
+/// this yields rate $\frac{1}{2}$ codes.
 #[derive(Clone, Copy)]
 pub struct PnttConfigF2_16_1<const DEPTH: usize>;
+
+/// Pseudo NTT configuration derived from
+/// the field `Fp` for `p = 2^16 + 1`.
+///
+/// Supports `DEPTH` up to `3`.
+///
+/// With `BASE_LEN = 32` and `BASE_DIM = 128`,
+/// this yields rate $\frac{1}{4}$ codes.
+#[derive(Clone, Copy)]
+pub struct PnttConfigF2_16_1_Rate1_4<const DEPTH: usize>;
 
 mod fq {
     #![allow(non_local_definitions)]
@@ -191,6 +204,27 @@ impl<const DEPTH: usize> Config for PnttConfigF2_16_1<DEPTH> {
         precompute::normalize_field_element(big_int.0[0], Self::FIELD_MODULUS)
     }
 }
+
+impl<const DEPTH: usize> Config for PnttConfigF2_16_1_Rate1_4<DEPTH> {
+    type Field = fq::Fq;
+    const FIELD_MODULUS: u32 = fq::MODULUS;
+    const BASE_LEN: usize = 32;
+    const BASE_DIM: usize = 128;
+    const DEPTH: usize = DEPTH;
+    const BASE_TWIDDLES: [PnttInt; 8] = [1, 4096, -256, 16, -1, -4096, 256, -16];
+
+    fn field_to_int_normalized(x: Self::Field) -> PnttInt {
+        let big_int = fq::FqBackend::into_bigint(x);
+
+        precompute::normalize_field_element(big_int.0[0], Self::FIELD_MODULUS)
+    }
+}
+
+/// Depth-2 configuration for message size $2^{11}$ with rate $\frac{1}{2}$.
+pub type PnttConfigF2_16_1_Depth2_Rate1_2 = PnttConfigF2_16_1<2>;
+
+/// Depth-2 configuration for message size $2^{11}$ with rate $\frac{1}{4}$.
+pub type PnttConfigF2_16_1_Depth2_Rate1_4 = PnttConfigF2_16_1_Rate1_4<2>;
 
 #[cfg(test)]
 mod tests {


### PR DESCRIPTION
## Summary

Add a `simd` feature flag to the `zinc-piop` crate, forwarding it to `zinc-poly/simd`.

## What it does

When `zinc-piop` is built with `--features simd`, this enables SIMD-optimized binary polynomial operations in `zinc-poly` (NEON on ARM, AVX512 on x86_64). This matches the existing pattern in `zip-plus`, which already forwards the `simd` feature to `zinc-poly`.

## Changes

- **piop/Cargo.toml**: Added `simd = ["zinc-poly/simd"]` to `[features]`