### PR TITLE
Store projected coefficients

### DIFF
--- a/piop/src/ideal_check.rs
+++ b/piop/src/ideal_check.rs
@@ -80,16 +80,20 @@ impl<IcTypes: IdealCheckTypes<DEGREE_PLUS_ONE>, const DEGREE_PLUS_ONE: usize>
         // TODO(Ilia): if there's a lot of scalars
         //             we should do this in parallel probably.
         let projected_scalars: HashMap<IcTypes::Witness, DynamicPolynomialF<IcTypes::F>> =
-            HashMap::from_iter(uair_scalars.into_iter().map(|scalar| {
-                (scalar.clone(), {
-                    let mut dynamic_poly =
-                        DynamicPolynomialF::from(scalar.project_coefficients(&projecting_element));
+            uair_scalars
+                .into_iter()
+                .map(|scalar| {
+                    (scalar.clone(), {
+                        let mut dynamic_poly = DynamicPolynomialF::from(
+                            scalar.project_coefficients(&projecting_element),
+                        );
 
-                    dynamic_poly.trim();
+                        dynamic_poly.trim();
 
-                    dynamic_poly
+                        dynamic_poly
+                    })
                 })
-            }));
+                .collect();
 
         let combined_mles = combined_poly_builder::compute_combined_polynomials::<IcTypes, U, _>(
             trace,

--- a/piop/src/ideal_check.rs
+++ b/piop/src/ideal_check.rs
@@ -9,17 +9,18 @@ use derive_more::From;
 use itertools::Itertools;
 #[cfg(feature = "parallel")]
 use rayon::prelude::*;
-use std::marker::PhantomData;
+use std::{collections::HashMap, marker::PhantomData};
 use structs::*;
 use thiserror::Error;
 use zinc_poly::{
-    EvaluationError,
+    CoefficientProjectable, EvaluationError,
     mle::{DenseMultilinearExtension, MultilinearExtensionWithConfig},
     univariate::dynamic::over_field::DynamicPolynomialF,
 };
 use zinc_transcript::traits::{ConstTranscribable, Transcript};
 use zinc_uair::{
     Uair,
+    collect_scalars::collect_scalars,
     ideal::{Ideal, IdealCheck},
     ideal_collector::{IdealOrZero, collect_ideals},
 };
@@ -73,11 +74,30 @@ impl<IcTypes: IdealCheckTypes<DEGREE_PLUS_ONE>, const DEGREE_PLUS_ONE: usize>
     {
         let projecting_element = transcript.get_field_challenge(field_cfg);
 
+        // Project UAIR scalars prior to doing anything.
+        let uair_scalars = collect_scalars::<IcTypes::Witness, U>();
+
+        // TODO(Ilia): if there's a lot of scalars
+        //             we should do this in parallel probably.
+        let projected_scalars: HashMap<IcTypes::Witness, DynamicPolynomialF<IcTypes::F>> =
+            HashMap::from_iter(uair_scalars.into_iter().map(|scalar| {
+                (scalar.clone(), {
+                    let mut dynamic_poly =
+                        DynamicPolynomialF::from(scalar.project_coefficients(&projecting_element));
+
+                    dynamic_poly.trim();
+
+                    dynamic_poly
+                })
+            }));
+
         let combined_mles = combined_poly_builder::compute_combined_polynomials::<IcTypes, U, _>(
             trace,
             &projecting_element,
+            &projected_scalars,
             num_constraints,
         );
+
         let mut transcription_buf: Vec<u8> = vec![0; <IcTypes::F as Field>::Inner::NUM_BYTES];
 
         let evaluation_point = transcript.get_field_challenges(num_vars, field_cfg);
@@ -106,6 +126,7 @@ impl<IcTypes: IdealCheckTypes<DEGREE_PLUS_ONE>, const DEGREE_PLUS_ONE: usize>
             ProverState {
                 evaluation_point,
                 combined_mles,
+                projected_scalars,
             },
         ))
     }

--- a/piop/src/ideal_check.rs
+++ b/piop/src/ideal_check.rs
@@ -176,7 +176,8 @@ impl<IcTypes: IdealCheckTypes<DEGREE_PLUS_ONE>, const DEGREE_PLUS_ONE: usize>
     {
         // Sample a field element to maintain FS symmetry with
         // the prover.
-        let _: IcTypes::F = transcript.get_field_challenge(field_cfg);
+        // We also will need it in a later stage of the protocol.
+        let coefficient_projecting_element: IcTypes::F = transcript.get_field_challenge(field_cfg);
 
         let mut transcription_buf: Vec<u8> = vec![0; <IcTypes::F as Field>::Inner::NUM_BYTES];
 
@@ -202,6 +203,7 @@ impl<IcTypes: IdealCheckTypes<DEGREE_PLUS_ONE>, const DEGREE_PLUS_ONE: usize>
         Ok(VerifierSubClaim {
             evaluation_point,
             values: combined_mle_values,
+            coefficient_projecting_element,
         })
     }
 }

--- a/piop/src/ideal_check/combined_poly_builder.rs
+++ b/piop/src/ideal_check/combined_poly_builder.rs
@@ -1,4 +1,4 @@
-use std::mem::MaybeUninit;
+use std::{collections::HashMap, mem::MaybeUninit};
 
 use crypto_primitives::{DenseRowMatrix, Field, Matrix, PrimeField};
 use itertools::Itertools;
@@ -23,6 +23,7 @@ pub fn compute_combined_polynomials<
 >(
     trace: &[DenseMultilinearExtension<IcTypes::Witness>],
     projecting_element: &IcTypes::F,
+    projected_scalars: &HashMap<IcTypes::Witness, DynamicPolynomialF<IcTypes::F>>,
     num_constraints: usize,
 ) -> Vec<Vec<DenseMultilinearExtension<<IcTypes::F as Field>::Inner>>>
 where
@@ -45,7 +46,7 @@ where
                     up,
                     down,
                     num_constraints,
-                    projecting_element,
+                    projected_scalars,
                 )
             })
             .collect();
@@ -109,7 +110,7 @@ fn combine_rows_and_get_max_degree<IcTypes, U, const DEGREE_PLUS_ONE: usize>(
     up: &[DynamicPolynomialF<IcTypes::F>],
     down: &[DynamicPolynomialF<IcTypes::F>],
     num_constraints: usize,
-    projecting_element: &IcTypes::F,
+    projected_scalars: &HashMap<IcTypes::Witness, DynamicPolynomialF<IcTypes::F>>,
 ) -> (usize, Vec<DynamicPolynomialF<IcTypes::F>>)
 where
     IcTypes: IdealCheckTypes<DEGREE_PLUS_ONE>,
@@ -117,12 +118,19 @@ where
 {
     let mut constraint_builder = CombinedPolyRowBuilder::new(num_constraints);
 
+    let project = |x: &IcTypes::Witness| {
+        projected_scalars
+            .get(x)
+            .cloned()
+            .expect("all scalars should have been projected at this point")
+    };
+
     U::constrain_general(
         &mut constraint_builder,
         up,
         down,
-        |x| x.project_coefficients(projecting_element).into(),
-        |x, y| Some(DynamicPolynomialF::from(y.project_coefficients(projecting_element)) * x),
+        &project,
+        |x, y| Some(project(y) * x),
         ImpossibleIdeal::from_ref,
     );
 

--- a/piop/src/ideal_check/structs.rs
+++ b/piop/src/ideal_check/structs.rs
@@ -1,3 +1,5 @@
+use std::collections::HashMap;
+
 use crypto_primitives::{Field, FromWithConfig, Semiring};
 use zinc_poly::{
     CoefficientProjectable, mle::DenseMultilinearExtension,
@@ -30,6 +32,7 @@ pub struct Proof<IcTypes: IdealCheckTypes<DEGREE_PLUS_ONE>, const DEGREE_PLUS_ON
 pub struct ProverState<IcTypes: IdealCheckTypes<DEGREE_PLUS_ONE>, const DEGREE_PLUS_ONE: usize> {
     pub evaluation_point: Vec<IcTypes::F>,
     pub combined_mles: Vec<Vec<DenseMultilinearExtension<<IcTypes::F as Field>::Inner>>>,
+    pub projected_scalars: HashMap<IcTypes::Witness, DynamicPolynomialF<IcTypes::F>>,
 }
 
 pub struct VerifierSubClaim<IcTypes: IdealCheckTypes<DEGREE_PLUS_ONE>, const DEGREE_PLUS_ONE: usize>

--- a/piop/src/ideal_check/structs.rs
+++ b/piop/src/ideal_check/structs.rs
@@ -39,4 +39,5 @@ pub struct VerifierSubClaim<IcTypes: IdealCheckTypes<DEGREE_PLUS_ONE>, const DEG
 {
     pub evaluation_point: Vec<IcTypes::F>,
     pub values: Vec<DynamicPolynomialF<IcTypes::F>>,
+    pub coefficient_projecting_element: IcTypes::F,
 }

--- a/test-uair/src/lib.rs
+++ b/test-uair/src/lib.rs
@@ -169,3 +169,87 @@ impl<const LIMBS: usize> GenerateWitness<DensePolynomial<Int<LIMBS>, 32>>
         vec![a, b, c]
     }
 }
+
+pub struct TestAirScalarMultiplications;
+
+impl<const LIMBS: usize> Uair<DensePolynomial<Int<LIMBS>, 32>> for TestAirScalarMultiplications {
+    type Ideal = DegreeOneIdeal<Int<LIMBS>>;
+
+    fn num_cols() -> usize {
+        3
+    }
+
+    fn constrain_general<B, FromR, MulByScalar, IFromR>(
+        b: &mut B,
+        up: &[B::Expr],
+        _down: &[B::Expr],
+        from_ref: FromR,
+        mbs: MulByScalar,
+        ideal_from_ref: IFromR,
+    ) where
+        B: ConstraintBuilder,
+        IFromR: Fn(&Self::Ideal) -> B::Ideal,
+        FromR: Fn(&DensePolynomial<Int<LIMBS>, 32>) -> B::Expr,
+        MulByScalar: Fn(&B::Expr, &DensePolynomial<Int<LIMBS>, 32>) -> Option<B::Expr>,
+    {
+        b.assert_in_ideal(
+            mbs(
+                &up[0],
+                &DensePolynomial::new([Int::from_i8(-1), Int::from_i8(0), Int::from_i8(1)]),
+            )
+            .expect("arithmetic overflow")
+                + &up[1]
+                - &up[2]
+                + from_ref(&DensePolynomial::new([
+                    Int::from_i8(1),
+                    Int::from_i8(2),
+                    Int::from_i8(3),
+                    Int::from_i8(4),
+                ])),
+            &ideal_from_ref(&DegreeOneIdeal::new(Int::from(2))),
+        );
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashSet;
+
+    use zinc_uair::{collect_scalars::collect_scalars, constraint_counter::count_constraints};
+
+    use super::*;
+
+    const LIMBS: usize = 4;
+
+    #[test]
+    fn test_uair_simple_multiplication_correct_constraints_number() {
+        assert_eq!(
+            count_constraints::<DensePolynomial<Int<LIMBS>, 32>, TestUairSimpleMultiplication>(),
+            3
+        );
+    }
+
+    #[test]
+    fn test_air_no_multiplication_correct_constraints_number() {
+        assert_eq!(
+            count_constraints::<DensePolynomial<Int<LIMBS>, 32>, TestAirNoMultiplication>(),
+            1
+        );
+    }
+
+    #[test]
+    fn test_air_scalar_multiplications_correct_collect_scalars() {
+        assert_eq!(
+            collect_scalars::<DensePolynomial<Int<LIMBS>, 32>, TestAirScalarMultiplications>(),
+            HashSet::from_iter(vec![
+                DensePolynomial::new([Int::from_i8(-1), Int::from_i8(0), Int::from_i8(1)]),
+                DensePolynomial::new([
+                    Int::from_i8(1),
+                    Int::from_i8(2),
+                    Int::from_i8(3),
+                    Int::from_i8(4),
+                ])
+            ])
+        );
+    }
+}

--- a/test-uair/src/lib.rs
+++ b/test-uair/src/lib.rs
@@ -213,8 +213,6 @@ impl<const LIMBS: usize> Uair<DensePolynomial<Int<LIMBS>, 32>> for TestAirScalar
 
 #[cfg(test)]
 mod tests {
-    use std::collections::HashSet;
-
     use zinc_uair::{collect_scalars::collect_scalars, constraint_counter::count_constraints};
 
     use super::*;
@@ -241,7 +239,7 @@ mod tests {
     fn test_air_scalar_multiplications_correct_collect_scalars() {
         assert_eq!(
             collect_scalars::<DensePolynomial<Int<LIMBS>, 32>, TestAirScalarMultiplications>(),
-            HashSet::from_iter(vec![
+            (vec![
                 DensePolynomial::new([Int::from_i8(-1), Int::from_i8(0), Int::from_i8(1)]),
                 DensePolynomial::new([
                     Int::from_i8(1),
@@ -249,7 +247,9 @@ mod tests {
                     Int::from_i8(3),
                     Int::from_i8(4),
                 ])
-            ])
+            ]
+            .into_iter()
+            .collect())
         );
     }
 }

--- a/uair/src/collect_scalars.rs
+++ b/uair/src/collect_scalars.rs
@@ -1,0 +1,34 @@
+use std::{cell::RefCell, collections::HashSet};
+
+use crypto_primitives::Semiring;
+
+use crate::{
+    Uair, do_nothing_builder::DoNothingBuilder, dummy_semiring::DummySemiring,
+    ideal::ImpossibleIdeal,
+};
+
+/// Collect all the scalars appearing in a UAIR.
+/// Useful to store results of intermediate operations on scalars
+/// between protocol stages, e.g. field projections.
+pub fn collect_scalars<R: Semiring + 'static, U: Uair<R>>() -> HashSet<R> {
+    let scalars = RefCell::new(HashSet::new());
+
+    let dummy_up_and_down = vec![DummySemiring; U::num_cols()];
+
+    U::constrain_general(
+        &mut DoNothingBuilder,
+        &dummy_up_and_down,
+        &dummy_up_and_down,
+        |x| {
+            scalars.borrow_mut().insert(x.clone());
+            DummySemiring
+        },
+        |_x, y| {
+            scalars.borrow_mut().insert(y.clone());
+            Some(DummySemiring)
+        },
+        |_| ImpossibleIdeal,
+    );
+
+    scalars.into_inner()
+}

--- a/uair/src/do_nothing_builder.rs
+++ b/uair/src/do_nothing_builder.rs
@@ -1,0 +1,19 @@
+use crate::{ConstraintBuilder, dummy_semiring::DummySemiring, ideal::ImpossibleIdeal};
+
+#[derive(Clone, Copy, Debug, Default)]
+pub struct DoNothingBuilder;
+
+impl ConstraintBuilder for DoNothingBuilder {
+    type Expr = DummySemiring;
+    type Ideal = ImpossibleIdeal;
+
+    #[inline(always)]
+    fn assert_in_ideal(&mut self, _expr: Self::Expr, _ideal: &Self::Ideal) {
+        // do nothing
+    }
+
+    #[inline(always)]
+    fn assert_zero(&mut self, _expr: Self::Expr) {
+        // do nothing
+    }
+}

--- a/uair/src/lib.rs
+++ b/uair/src/lib.rs
@@ -1,6 +1,8 @@
 //! UAIR description tools.
 
+pub mod collect_scalars;
 pub mod constraint_counter;
+pub mod do_nothing_builder;
 pub mod dummy_semiring;
 pub mod ideal;
 pub mod ideal_collector;


### PR DESCRIPTION
To avoid double projecting scalar coefficients of a UAIR we keep a `HashMap` of scalar projections.