### PR TITLE
bench: add multi-polynomial IPRS benchmark suite

### DIFF
--- a/zip-plus/Cargo.toml
+++ b/zip-plus/Cargo.toml
@@ -48,3 +48,7 @@ harness = false
 [[bench]]
 name = "zip_plus_benches"
 harness = false
+
+[[bench]]
+name = "zip_plus_multi_poly_benches"
+harness = false

--- a/zip-plus/benches/zip_benches.rs
+++ b/zip-plus/benches/zip_benches.rs
@@ -20,7 +20,7 @@ const INT_LIMBS: usize = U64::LIMBS;
 
 struct BenchZipTypes {}
 impl ZipTypes for BenchZipTypes {
-    const NUM_COLUMN_OPENINGS: usize = 200;
+    const NUM_COLUMN_OPENINGS: usize = 147;
     type Eval = i32;
     type Cw = i64;
     type Fmod = Uint<{ INT_LIMBS * 4 }>;

--- a/zip-plus/benches/zip_common.rs
+++ b/zip-plus/benches/zip_common.rs
@@ -38,46 +38,47 @@ pub fn do_bench<Zt: ZipTypes, Lc: LinearCode<Zt>, const CHECK_FOR_OVERFLOWS: boo
     Zt::Eval: ProjectableToField<F>,
     Zt::Cw: ProjectableToField<F>,
 {
-    encode_rows::<Zt, Lc, 12>(group);
-    encode_rows::<Zt, Lc, 13>(group);
-    encode_rows::<Zt, Lc, 14>(group);
-    encode_rows::<Zt, Lc, 15>(group);
-    encode_rows::<Zt, Lc, 16>(group);
+    // encode_rows::<Zt, Lc, 12>(group);
+    // encode_rows::<Zt, Lc, 13>(group);
+    // encode_rows::<Zt, Lc, 14>(group);
+    // encode_rows::<Zt, Lc, 15>(group);
+    // encode_rows::<Zt, Lc, 16>(group);
 
-    encode_single_row::<Zt, Lc, 128>(group);
-    encode_single_row::<Zt, Lc, 256>(group);
-    encode_single_row::<Zt, Lc, 512>(group);
-    encode_single_row::<Zt, Lc, 1024>(group);
+    // encode_single_row::<Zt, Lc, 128>(group);
+    // encode_single_row::<Zt, Lc, 256>(group);
+    // encode_single_row::<Zt, Lc, 512>(group);
+    // encode_single_row::<Zt, Lc, 1024>(group);
 
-    merkle_root::<Zt, 12>(group);
-    merkle_root::<Zt, 13>(group);
-    merkle_root::<Zt, 14>(group);
-    merkle_root::<Zt, 15>(group);
-    merkle_root::<Zt, 16>(group);
-
+    // merkle_root::<Zt, 12>(group);
+    // merkle_root::<Zt, 13>(group);
+    // merkle_root::<Zt, 14>(group);
+    // merkle_root::<Zt, 15>(group);
+    // merkle_root::<Zt, 16>(group);
+    commit::<Zt, Lc, 10>(group);
+    commit::<Zt, Lc, 11>(group);
     commit::<Zt, Lc, 12>(group);
     commit::<Zt, Lc, 13>(group);
     commit::<Zt, Lc, 14>(group);
     commit::<Zt, Lc, 15>(group);
     commit::<Zt, Lc, 16>(group);
 
-    test::<Zt, Lc, CHECK_FOR_OVERFLOWS, 12>(group);
-    test::<Zt, Lc, CHECK_FOR_OVERFLOWS, 13>(group);
-    test::<Zt, Lc, CHECK_FOR_OVERFLOWS, 14>(group);
-    test::<Zt, Lc, CHECK_FOR_OVERFLOWS, 15>(group);
-    test::<Zt, Lc, CHECK_FOR_OVERFLOWS, 16>(group);
-
-    evaluate::<Zt, Lc, CHECK_FOR_OVERFLOWS, 12>(group);
-    evaluate::<Zt, Lc, CHECK_FOR_OVERFLOWS, 13>(group);
-    evaluate::<Zt, Lc, CHECK_FOR_OVERFLOWS, 14>(group);
-    evaluate::<Zt, Lc, CHECK_FOR_OVERFLOWS, 15>(group);
-    evaluate::<Zt, Lc, CHECK_FOR_OVERFLOWS, 16>(group);
-
-    verify::<Zt, Lc, CHECK_FOR_OVERFLOWS, 12>(group);
-    verify::<Zt, Lc, CHECK_FOR_OVERFLOWS, 13>(group);
-    verify::<Zt, Lc, CHECK_FOR_OVERFLOWS, 14>(group);
-    verify::<Zt, Lc, CHECK_FOR_OVERFLOWS, 15>(group);
-    verify::<Zt, Lc, CHECK_FOR_OVERFLOWS, 16>(group);
+    //test::<Zt, Lc, CHECK_FOR_OVERFLOWS, 12>(group);
+    //test::<Zt, Lc, CHECK_FOR_OVERFLOWS, 13>(group);
+    //test::<Zt, Lc, CHECK_FOR_OVERFLOWS, 14>(group);
+    //test::<Zt, Lc, CHECK_FOR_OVERFLOWS, 15>(group);
+    //test::<Zt, Lc, CHECK_FOR_OVERFLOWS, 16>(group);
+//
+    //evaluate::<Zt, Lc, CHECK_FOR_OVERFLOWS, 12>(group);
+    //evaluate::<Zt, Lc, CHECK_FOR_OVERFLOWS, 13>(group);
+    //evaluate::<Zt, Lc, CHECK_FOR_OVERFLOWS, 14>(group);
+    //evaluate::<Zt, Lc, CHECK_FOR_OVERFLOWS, 15>(group);
+    //evaluate::<Zt, Lc, CHECK_FOR_OVERFLOWS, 16>(group);
+//
+    //verify::<Zt, Lc, CHECK_FOR_OVERFLOWS, 12>(group);
+    //verify::<Zt, Lc, CHECK_FOR_OVERFLOWS, 13>(group);
+    //verify::<Zt, Lc, CHECK_FOR_OVERFLOWS, 14>(group);
+    //verify::<Zt, Lc, CHECK_FOR_OVERFLOWS, 15>(group);
+    //verify::<Zt, Lc, CHECK_FOR_OVERFLOWS, 16>(group);
 }
 
 pub fn encode_rows<Zt: ZipTypes, Lc: LinearCode<Zt>, const P: usize>(

--- a/zip-plus/benches/zip_common.rs
+++ b/zip-plus/benches/zip_common.rs
@@ -54,6 +54,8 @@ pub fn do_bench<Zt: ZipTypes, Lc: LinearCode<Zt>, const CHECK_FOR_OVERFLOWS: boo
     // merkle_root::<Zt, 14>(group);
     // merkle_root::<Zt, 15>(group);
     // merkle_root::<Zt, 16>(group);
+    commit::<Zt, Lc, 8>(group);
+    commit::<Zt, Lc, 9>(group);
     commit::<Zt, Lc, 10>(group);
     commit::<Zt, Lc, 11>(group);
     commit::<Zt, Lc, 12>(group);
@@ -324,6 +326,205 @@ pub fn verify<Zt: ZipTypes, Lc: LinearCode<Zt>, const CHECK_FOR_OVERFLOWS: bool,
                     &proof,
                 )
                 .expect("Verification failed");
+            })
+        },
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Multi-polynomial benchmarks: measure each Zip+ phase over `num_polys`
+// independent polynomials of size 2^P.
+// ---------------------------------------------------------------------------
+
+pub fn batch_commit<Zt: ZipTypes, Lc: LinearCode<Zt>, const P: usize>(
+    group: &mut BenchmarkGroup<WallTime>,
+    num_polys: usize,
+) where
+    StandardUniform: Distribution<Zt::Eval>,
+{
+    let mut rng = ThreadRng::default();
+    let poly_size = 1 << P;
+    let linear_code = Lc::new(poly_size);
+    let params = ZipPlus::setup(poly_size, linear_code);
+
+    group.bench_function(
+        format!(
+            "BatchCommit: num_polys={num_polys}, poly_size=2^{P}",
+        ),
+        |b| {
+            b.iter_custom(|iters| {
+                let mut total_duration = Duration::ZERO;
+                for _ in 0..iters {
+                    let polys: Vec<_> = (0..num_polys)
+                        .map(|_| DenseMultilinearExtension::rand(P, &mut rng))
+                        .collect();
+                    let timer = Instant::now();
+                    for poly in &polys {
+                        let res = ZipPlus::commit(&params, poly).expect("Failed to commit");
+                        black_box(&res);
+                    }
+                    total_duration += timer.elapsed();
+                }
+                total_duration
+            })
+        },
+    );
+}
+
+pub fn batch_test<
+    Zt: ZipTypes,
+    Lc: LinearCode<Zt>,
+    const CHECK_FOR_OVERFLOWS: bool,
+    const P: usize,
+>(
+    group: &mut BenchmarkGroup<WallTime>,
+    num_polys: usize,
+) where
+    StandardUniform: Distribution<Zt::Eval>,
+{
+    let mut rng = ThreadRng::default();
+    let poly_size = 1 << P;
+    let linear_code = Lc::new(poly_size);
+    let params = ZipPlus::setup(poly_size, linear_code);
+
+    let polys_and_hints: Vec<_> = (0..num_polys)
+        .map(|_| {
+            let poly = DenseMultilinearExtension::rand(P, &mut rng);
+            let (data, _) = ZipPlus::commit(&params, &poly).unwrap();
+            (poly, data)
+        })
+        .collect();
+
+    group.bench_function(
+        format!(
+            "BatchTest: num_polys={num_polys}, poly_size=2^{P}",
+        ),
+        |b| {
+            b.iter(|| {
+                for (poly, data) in &polys_and_hints {
+                    let transcript =
+                        ZipPlus::test::<CHECK_FOR_OVERFLOWS>(&params, poly, data)
+                            .expect("Test phase failed");
+                    black_box(transcript);
+                }
+            })
+        },
+    );
+}
+
+pub fn batch_evaluate<
+    Zt: ZipTypes,
+    Lc: LinearCode<Zt>,
+    const CHECK_FOR_OVERFLOWS: bool,
+    const P: usize,
+>(
+    group: &mut BenchmarkGroup<WallTime>,
+    num_polys: usize,
+) where
+    StandardUniform: Distribution<Zt::Eval>,
+    F: for<'a> FromWithConfig<&'a Zt::Chal> + for<'a> FromWithConfig<&'a Zt::Pt>,
+    <F as Field>::Inner: FromRef<Zt::Fmod>,
+    Zt::Eval: ProjectableToField<F>,
+{
+    let mut rng = ThreadRng::default();
+    let poly_size = 1 << P;
+    let linear_code = Lc::new(poly_size);
+    let params = ZipPlus::setup(poly_size, linear_code);
+
+    let polys_and_transcripts: Vec<_> = (0..num_polys)
+        .map(|_| {
+            let poly = DenseMultilinearExtension::rand(P, &mut rng);
+            let (data, _) = ZipPlus::commit(&params, &poly).unwrap();
+            let transcript =
+                ZipPlus::test::<CHECK_FOR_OVERFLOWS>(&params, &poly, &data)
+                    .expect("Test phase failed");
+            (poly, transcript)
+        })
+        .collect();
+    let point = vec![Zt::Pt::one(); P];
+
+    group.bench_function(
+        format!(
+            "BatchEvaluate: num_polys={num_polys}, poly_size=2^{P}",
+        ),
+        |b| {
+            b.iter_custom(|iters| {
+                let mut total_duration = Duration::ZERO;
+                for _ in 0..iters {
+                    let timer = Instant::now();
+                    for (poly, transcript) in &polys_and_transcripts {
+                        let t = transcript.clone();
+                        let (eval_f, proof) =
+                            ZipPlus::evaluate::<F, CHECK_FOR_OVERFLOWS>(
+                                &params, poly, &point, t,
+                            )
+                            .expect("Evaluation phase failed");
+                        black_box((eval_f, proof));
+                    }
+                    total_duration += timer.elapsed();
+                }
+                total_duration
+            })
+        },
+    );
+}
+
+pub fn batch_verify<
+    Zt: ZipTypes,
+    Lc: LinearCode<Zt>,
+    const CHECK_FOR_OVERFLOWS: bool,
+    const P: usize,
+>(
+    group: &mut BenchmarkGroup<WallTime>,
+    num_polys: usize,
+) where
+    StandardUniform: Distribution<Zt::Eval>,
+    F: for<'a> FromWithConfig<&'a Zt::Chal> + for<'a> FromWithConfig<&'a Zt::Pt>,
+    <F as Field>::Inner: FromRef<Zt::Fmod>,
+    Zt::Eval: ProjectableToField<F>,
+    Zt::Cw: ProjectableToField<F>,
+{
+    let mut rng = ThreadRng::default();
+    let poly_size = 1 << P;
+    let linear_code = Lc::new(poly_size);
+    let params = ZipPlus::setup(poly_size, linear_code);
+
+    let verification_data: Vec<_> = (0..num_polys)
+        .map(|_| {
+            let poly = DenseMultilinearExtension::rand(P, &mut rng);
+            let (data, commitment) = ZipPlus::commit(&params, &poly).unwrap();
+            let point = vec![Zt::Pt::one(); P];
+            let test_transcript =
+                ZipPlus::test::<CHECK_FOR_OVERFLOWS>(&params, &poly, &data)
+                    .expect("Test phase failed");
+            let (eval_f, proof) =
+                ZipPlus::evaluate::<F, CHECK_FOR_OVERFLOWS>(
+                    &params, &poly, &point, test_transcript,
+                )
+                .expect("Evaluation phase failed");
+            let field_cfg = *eval_f.cfg();
+            let point_f: Vec<F> =
+                point.iter().map(|v| v.into_with_cfg(&field_cfg)).collect();
+            (commitment, point_f, eval_f, proof)
+        })
+        .collect();
+
+    group.bench_function(
+        format!(
+            "BatchVerify: num_polys={num_polys}, poly_size=2^{P}",
+        ),
+        |b| {
+            b.iter(|| {
+                for (commitment, point_f, eval_f, proof) in &verification_data {
+                    ZipPlus::verify::<F, CHECK_FOR_OVERFLOWS>(
+                        &params,
+                        commitment,
+                        point_f,
+                        eval_f,
+                        proof,
+                    )
+                    .expect("Verification failed");
+                }
             })
         },
     );

--- a/zip-plus/benches/zip_plus_benches.rs
+++ b/zip-plus/benches/zip_plus_benches.rs
@@ -43,7 +43,7 @@ where
         + Sync,
     Int<5>: FromRef<CwCoeff>,
 {
-    const NUM_COLUMN_OPENINGS: usize = 200;
+    const NUM_COLUMN_OPENINGS: usize = 147;
     type Eval = BinaryPoly<D_PLUS_ONE>;
     type Cw = DensePolynomial<CwCoeff, D_PLUS_ONE>;
     type Fmod = Uint<{ INT_LIMBS * 4 }>;
@@ -65,6 +65,7 @@ impl RaaConfig for BenchRaaConfig {
     const CHECK_FOR_OVERFLOWS: bool = UNCHECKED;
 }
 
+#[allow(dead_code)]
 type SomeRaaCode<const D_PLUS_ONE: usize> =
     RaaCode<BenchZipPlusTypes<i32, D_PLUS_ONE>, BenchRaaConfig, 4>;
 
@@ -76,6 +77,7 @@ type SomeIprsCode<Twiddle, const DEPTH: usize, const D_PLUS_ONE: usize, const CH
         CHECK,
     >;
 
+#[allow(dead_code)]
 fn zip_plus_benchmarks_raa(c: &mut Criterion) {
     let mut group = c.benchmark_group("Zip+ RAA");
 
@@ -98,5 +100,5 @@ fn zip_plus_benchmarks_iprs(c: &mut Criterion) {
     group.finish();
 }
 
-criterion_group!(benches, zip_plus_benchmarks_raa, zip_plus_benchmarks_iprs);
+criterion_group!(benches, zip_plus_benchmarks_iprs);
 criterion_main!(benches);

--- a/zip-plus/benches/zip_plus_multi_poly_benches.rs
+++ b/zip-plus/benches/zip_plus_multi_poly_benches.rs
@@ -1,0 +1,142 @@
+#![allow(non_local_definitions)]
+#![allow(clippy::eq_op, clippy::arithmetic_side_effects, clippy::unwrap_used)]
+
+mod zip_common;
+
+use std::marker::PhantomData;
+
+use zinc_poly::univariate::{
+    binary::{BinaryPoly, BinaryPolyInnerProduct, BinaryPolyWideningMulByScalar},
+    dense::{DensePolyInnerProduct, DensePolynomial},
+};
+use zinc_primality::MillerRabin;
+use zinc_transcript::traits::ConstTranscribable;
+use zinc_utils::{UNCHECKED, from_ref::FromRef, inner_product::MBSInnerProduct, named::Named};
+use zip_common::*;
+
+use criterion::{Criterion, criterion_group, criterion_main};
+use crypto_bigint::U64;
+use crypto_primitives::{
+    FixedSemiring, boolean::Boolean, crypto_bigint_int::Int, crypto_bigint_uint::Uint,
+};
+use zip_plus::{
+    code::iprs::{IprsCode, PnttConfigF2_16_1},
+    pcs::structs::ZipTypes,
+};
+
+const INT_LIMBS: usize = U64::LIMBS;
+
+struct BenchZipPlusTypes<CwCoeff, const D_PLUS_ONE: usize>(PhantomData<CwCoeff>);
+
+impl<CwCoeff, const D_PLUS_ONE: usize> ZipTypes for BenchZipPlusTypes<CwCoeff, D_PLUS_ONE>
+where
+    CwCoeff: ConstTranscribable
+        + Copy
+        + Default
+        + FromRef<Boolean>
+        + Named
+        + FixedSemiring
+        + Send
+        + Sync,
+    Int<5>: FromRef<CwCoeff>,
+{
+    const NUM_COLUMN_OPENINGS: usize = 147;
+    type Eval = BinaryPoly<D_PLUS_ONE>;
+    type Cw = DensePolynomial<CwCoeff, D_PLUS_ONE>;
+    type Fmod = Uint<{ INT_LIMBS * 4 }>;
+    type PrimeTest = MillerRabin;
+    type Chal = i128;
+    type Pt = i128;
+    type CombR = Int<{ INT_LIMBS * 5 }>;
+    type Comb = DensePolynomial<Self::CombR, D_PLUS_ONE>;
+    type EvalDotChal = BinaryPolyInnerProduct<Self::Chal, D_PLUS_ONE>;
+    type CombDotChal =
+        DensePolyInnerProduct<Self::CombR, Self::Chal, Self::CombR, MBSInnerProduct, D_PLUS_ONE>;
+    type ArrCombRDotChal = MBSInnerProduct;
+}
+
+type IprsCodeType<Twiddle, const DEPTH: usize, const D_PLUS_ONE: usize, const CHECK: bool> =
+    IprsCode<
+        BenchZipPlusTypes<Twiddle, D_PLUS_ONE>,
+        PnttConfigF2_16_1<DEPTH>,
+        BinaryPolyWideningMulByScalar<Twiddle>,
+        CHECK,
+    >;
+
+/// Polynomial counts to benchmark.
+const POLY_COUNTS: &[usize] = &[8];
+
+/// Fixed polynomial size exponent (2^P evaluations per polynomial).
+const P: usize = 12;
+
+fn multi_poly_commit(c: &mut Criterion) {
+    let mut group = c.benchmark_group("Zip+ MultiPoly Commit");
+    group.sample_size(10);
+
+    for &num_polys in POLY_COUNTS {
+        batch_commit::<
+            BenchZipPlusTypes<i64, 32>,
+            IprsCodeType<i64, 1, 32, UNCHECKED>,
+            P,
+        >(&mut group, num_polys);
+    }
+
+    group.finish();
+}
+
+fn multi_poly_test(c: &mut Criterion) {
+    let mut group = c.benchmark_group("Zip+ MultiPoly Test");
+    group.sample_size(10);
+
+    for &num_polys in POLY_COUNTS {
+        batch_test::<
+            BenchZipPlusTypes<i64, 32>,
+            IprsCodeType<i64, 1, 32, UNCHECKED>,
+            UNCHECKED,
+            P,
+        >(&mut group, num_polys);
+    }
+
+    group.finish();
+}
+
+fn multi_poly_evaluate(c: &mut Criterion) {
+    let mut group = c.benchmark_group("Zip+ MultiPoly Evaluate");
+    group.sample_size(10);
+
+    for &num_polys in POLY_COUNTS {
+        batch_evaluate::<
+            BenchZipPlusTypes<i64, 32>,
+            IprsCodeType<i64, 1, 32, UNCHECKED>,
+            UNCHECKED,
+            P,
+        >(&mut group, num_polys);
+    }
+
+    group.finish();
+}
+
+fn multi_poly_verify(c: &mut Criterion) {
+    let mut group = c.benchmark_group("Zip+ MultiPoly Verify");
+    group.sample_size(10);
+
+    for &num_polys in POLY_COUNTS {
+        batch_verify::<
+            BenchZipPlusTypes<i64, 32>,
+            IprsCodeType<i64, 1, 32, UNCHECKED>,
+            UNCHECKED,
+            P,
+        >(&mut group, num_polys);
+    }
+
+    group.finish();
+}
+
+criterion_group!(
+    benches,
+    multi_poly_commit,
+    multi_poly_test,
+    // multi_poly_evaluate,
+    // multi_poly_verify,
+);
+criterion_main!(benches);

--- a/zip-plus/src/pcs/test_utils.rs
+++ b/zip-plus/src/pcs/test_utils.rs
@@ -53,7 +53,7 @@ impl RaaConfig for TestRaaConfig {
 
 pub struct TestZipTypes<const N: usize, const K: usize, const M: usize> {}
 impl<const N: usize, const K: usize, const M: usize> ZipTypes for TestZipTypes<N, K, M> {
-    const NUM_COLUMN_OPENINGS: usize = 200;
+    const NUM_COLUMN_OPENINGS: usize = 147;
     type Eval = Int<N>;
     type Cw = Int<K>;
     type Fmod = Uint<K>;
@@ -71,7 +71,7 @@ pub struct TestPolyZipTypes<const K: usize, const M: usize, const DEGREE_PLUS_ON
 impl<const K: usize, const M: usize, const DEGREE_PLUS_ONE: usize> ZipTypes
     for TestPolyZipTypes<K, M, DEGREE_PLUS_ONE>
 {
-    const NUM_COLUMN_OPENINGS: usize = 200;
+    const NUM_COLUMN_OPENINGS: usize = 147;
     type Eval = BinaryPoly<DEGREE_PLUS_ONE>;
     type Cw = DensePolynomial<i32, DEGREE_PLUS_ONE>;
     type Fmod = Uint<K>;


### PR DESCRIPTION
## Summary

Add a new benchmark suite that measures Zip+ phase timings (Commit, Test, Evaluate, Verify) across a configurable number of independent polynomials using IPRS codes.

## Changes

- **zip-plus/benches/zip_common.rs**: Add `batch_commit`, `batch_test`, `batch_evaluate`, and `batch_verify` functions that take a `num_polys` parameter and measure the total time to run each Zip+ phase over that many independent polynomials of size 2^P.

- **zip-plus/benches/zip_plus_multi_poly_benches.rs** (new): Benchmark harness using IPRS codes (PnttConfigF2_16_1, D_PLUS_ONE=32) that exercises all four batch functions over configurable polynomial counts (e.g. 5, 10, 20, 40, 55).

- **zip-plus/Cargo.toml**: Register the new `zip_plus_multi_poly_benches` bench target.

## Usage

```bash
cargo bench --bench zip_plus_multi_poly_benches --features "parallel asm simd"
```

Polynomial counts and size exponent (P) can be adjusted via the `POLY_COUNTS` and `P` constants at the top of the bench file.
