### PR TITLE
Some collection traits for univariate polynomials

### DIFF
--- a/poly/src/univariate/binary_ref.rs
+++ b/poly/src/univariate/binary_ref.rs
@@ -13,7 +13,7 @@ use std::{
     hash::Hash,
     iter::{Product, Sum},
     marker::PhantomData,
-    ops::{Add, AddAssign, Mul, MulAssign, Sub, SubAssign},
+    ops::{Add, AddAssign, Deref, DerefMut, Mul, MulAssign, Sub, SubAssign},
 };
 use zinc_transcript::traits::ConstTranscribable;
 use zinc_utils::{
@@ -313,6 +313,34 @@ impl<const DEGREE_PLUS_ONE: usize> From<&BinaryRefPoly<DEGREE_PLUS_ONE>>
     #[inline(always)]
     fn from(value: &BinaryRefPoly<DEGREE_PLUS_ONE>) -> Self {
         Self::from_ref(value)
+    }
+}
+
+impl<const DEGREE_PLUS_ONE: usize> BinaryRefPoly<DEGREE_PLUS_ONE> {
+    #[inline(always)]
+    pub fn iter(&'_ self) -> std::slice::Iter<'_, Boolean> {
+        self.0.iter()
+    }
+
+    #[inline(always)]
+    pub fn iter_mut(&'_ mut self) -> std::slice::IterMut<'_, Boolean> {
+        self.0.iter_mut()
+    }
+}
+
+impl<const DEGREE_PLUS_ONE: usize> Deref for BinaryRefPoly<DEGREE_PLUS_ONE> {
+    type Target = [Boolean];
+
+    #[inline(always)]
+    fn deref(&self) -> &Self::Target {
+        self.0.deref()
+    }
+}
+
+impl<const DEGREE_PLUS_ONE: usize> DerefMut for BinaryRefPoly<DEGREE_PLUS_ONE> {
+    #[inline(always)]
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        self.0.deref_mut()
     }
 }
 

--- a/poly/src/univariate/binary_ref.rs
+++ b/poly/src/univariate/binary_ref.rs
@@ -318,12 +318,12 @@ impl<const DEGREE_PLUS_ONE: usize> From<&BinaryRefPoly<DEGREE_PLUS_ONE>>
 
 impl<const DEGREE_PLUS_ONE: usize> BinaryRefPoly<DEGREE_PLUS_ONE> {
     #[inline(always)]
-    pub fn iter(&'_ self) -> std::slice::Iter<'_, Boolean> {
+    pub fn iter(&self) -> std::slice::Iter<'_, Boolean> {
         self.0.iter()
     }
 
     #[inline(always)]
-    pub fn iter_mut(&'_ mut self) -> std::slice::IterMut<'_, Boolean> {
+    pub fn iter_mut(&mut self) -> std::slice::IterMut<'_, Boolean> {
         self.0.iter_mut()
     }
 }

--- a/poly/src/univariate/binary_u64.rs
+++ b/poly/src/univariate/binary_u64.rs
@@ -12,7 +12,7 @@ use std::{
     hash::Hash,
     iter::{Product, Sum},
     marker::PhantomData,
-    ops::{Add, AddAssign, Mul, MulAssign, Sub, SubAssign},
+    ops::{Add, AddAssign, Deref, Mul, MulAssign, Sub, SubAssign},
 };
 use zinc_transcript::traits::ConstTranscribable;
 use zinc_utils::{
@@ -365,6 +365,40 @@ impl<const DEGREE_PLUS_ONE: usize> From<&BinaryU64Poly<DEGREE_PLUS_ONE>>
     #[inline(always)]
     fn from(value: &BinaryU64Poly<DEGREE_PLUS_ONE>) -> Self {
         Self::from_ref(value)
+    }
+}
+
+pub struct BinaryU64PolyIter<'a, const DEGREE_PLUS_ONE: usize> {
+    i: usize,
+    poly: &'a BinaryU64Poly<DEGREE_PLUS_ONE>,
+}
+
+impl<'a, const DEGREE_PLUS_ONE: usize> BinaryU64PolyIter<'a, DEGREE_PLUS_ONE> {
+    pub fn new(poly: &'a BinaryU64Poly<DEGREE_PLUS_ONE>) -> Self {
+        Self { i: 0, poly }
+    }
+}
+
+impl<'a, const DEGREE_PLUS_ONE: usize> Iterator for BinaryU64PolyIter<'a, DEGREE_PLUS_ONE> {
+    type Item = Boolean;
+
+    #[allow(clippy::arithmetic_side_effects)]
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.i < DEGREE_PLUS_ONE {
+            let i = self.i;
+
+            self.i += 1;
+
+            Some((!(self.poly.0 & (1 << i)).is_zero()).into())
+        } else {
+            None
+        }
+    }
+}
+
+impl<const DEGREE_PLUS_ONE: usize> BinaryU64Poly<DEGREE_PLUS_ONE> {
+    pub fn iter(&'_ self) -> BinaryU64PolyIter<'_, DEGREE_PLUS_ONE> {
+        BinaryU64PolyIter::new(self)
     }
 }
 

--- a/poly/src/univariate/binary_u64.rs
+++ b/poly/src/univariate/binary_u64.rs
@@ -397,7 +397,7 @@ impl<'a, const DEGREE_PLUS_ONE: usize> Iterator for BinaryU64PolyIter<'a, DEGREE
 }
 
 impl<const DEGREE_PLUS_ONE: usize> BinaryU64Poly<DEGREE_PLUS_ONE> {
-    pub fn iter(&'_ self) -> BinaryU64PolyIter<'_, DEGREE_PLUS_ONE> {
+    pub fn iter(&self) -> BinaryU64PolyIter<'_, DEGREE_PLUS_ONE> {
         BinaryU64PolyIter::new(self)
     }
 }

--- a/poly/src/univariate/binary_u64.rs
+++ b/poly/src/univariate/binary_u64.rs
@@ -12,7 +12,7 @@ use std::{
     hash::Hash,
     iter::{Product, Sum},
     marker::PhantomData,
-    ops::{Add, AddAssign, Deref, Mul, MulAssign, Sub, SubAssign},
+    ops::{Add, AddAssign, Mul, MulAssign, Sub, SubAssign},
 };
 use zinc_transcript::traits::ConstTranscribable;
 use zinc_utils::{

--- a/poly/src/univariate/dense.rs
+++ b/poly/src/univariate/dense.rs
@@ -610,12 +610,12 @@ impl<R: Semiring, const DEGREE_PLUS_ONE: usize> CoefficientProjectable<R, DEGREE
 
 impl<R, const DEGREE_PLUS_ONE: usize> DensePolynomial<R, DEGREE_PLUS_ONE> {
     #[inline(always)]
-    pub fn iter(&'_ self) -> std::slice::Iter<'_, R> {
+    pub fn iter(&self) -> std::slice::Iter<'_, R> {
         self.coeffs.iter()
     }
 
     #[inline(always)]
-    pub fn iter_mut(&'_ mut self) -> std::slice::IterMut<'_, R> {
+    pub fn iter_mut(&mut self) -> std::slice::IterMut<'_, R> {
         self.coeffs.iter_mut()
     }
 }

--- a/poly/src/univariate/dense.rs
+++ b/poly/src/univariate/dense.rs
@@ -16,7 +16,7 @@ use std::{
     hash::Hash,
     iter::{Product, Sum},
     marker::PhantomData,
-    ops::{Add, AddAssign, Mul, MulAssign, Neg, Sub, SubAssign},
+    ops::{Add, AddAssign, Deref, DerefMut, Mul, MulAssign, Neg, Sub, SubAssign},
 };
 use zinc_transcript::traits::ConstTranscribable;
 use zinc_utils::{
@@ -608,6 +608,29 @@ impl<R: Semiring, const DEGREE_PLUS_ONE: usize> CoefficientProjectable<R, DEGREE
     }
 }
 
+impl<R, const DEGREE_PLUS_ONE: usize> DensePolynomial<R, DEGREE_PLUS_ONE> {
+    #[inline(always)]
+    pub fn iter(&'_ self) -> std::slice::Iter<'_, R> {
+        self.coeffs.iter()
+    }
+
+    #[inline(always)]
+    pub fn iter_mut(&'_ mut self) -> std::slice::IterMut<'_, R> {
+        self.coeffs.iter_mut()
+    }
+}
+
+impl<R, const DEGREE_PLUS_ONE: usize> IntoIterator for DensePolynomial<R, DEGREE_PLUS_ONE> {
+    type Item = R;
+
+    type IntoIter = std::array::IntoIter<R, DEGREE_PLUS_ONE>;
+
+    #[inline(always)]
+    fn into_iter(self) -> Self::IntoIter {
+        self.coeffs.into_iter()
+    }
+}
+
 impl<'a, R, const DEGREE_PLUS_ONE: usize> IntoIterator for &'a DensePolynomial<R, DEGREE_PLUS_ONE> {
     type Item = &'a R;
 
@@ -621,6 +644,20 @@ impl<'a, R, const DEGREE_PLUS_ONE: usize> IntoIterator for &'a DensePolynomial<R
 impl<R, const DEGREE_PLUS_ONE: usize> AsRef<[R]> for DensePolynomial<R, DEGREE_PLUS_ONE> {
     fn as_ref(&self) -> &[R] {
         self.coeffs.as_slice()
+    }
+}
+
+impl<R, const DEGREE_PLUS_ONE: usize> Deref for DensePolynomial<R, DEGREE_PLUS_ONE> {
+    type Target = [R];
+
+    fn deref(&self) -> &Self::Target {
+        self.coeffs.as_slice()
+    }
+}
+
+impl<R, const DEGREE_PLUS_ONE: usize> DerefMut for DensePolynomial<R, DEGREE_PLUS_ONE> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.coeffs
     }
 }
 

--- a/poly/src/univariate/dynamic/over_field.rs
+++ b/poly/src/univariate/dynamic/over_field.rs
@@ -277,6 +277,15 @@ impl<F: PrimeField> EvaluatablePolynomial<F, F> for DynamicPolynomialF<F> {
     }
 }
 
+impl<F: PrimeField> FromIterator<F> for DynamicPolynomialF<F> {
+    #[inline(always)]
+    fn from_iter<T: IntoIterator<Item = F>>(iter: T) -> Self {
+        Self {
+            coeffs: iter.into_iter().collect(),
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use crypto_bigint::{Odd, modular::MontyParams};


### PR DESCRIPTION
The main change here actually is `iter()` method for univariate polynomials to easily use `.map()` and other benefits of iterators with polynomials