### PR TITLE
feat(zip-plus): support arbitrary-shape input matrices

### DIFF
--- a/zip-plus/benches/zip_common.rs
+++ b/zip-plus/benches/zip_common.rs
@@ -93,8 +93,9 @@ pub fn encode_rows<Zt: ZipTypes, Lc: LinearCode<Zt>, const P: usize>(
         ),
         |b| {
             let mut rng = ThreadRng::default();
-            let poly_size = 1 << P;
-            let linear_code = Lc::new(poly_size);
+            let poly_size: usize = 1 << P;
+            let row_len = poly_size.isqrt().next_power_of_two();
+            let linear_code = Lc::new(row_len);
             let params = ZipPlus::setup(poly_size, linear_code);
             let row_len = params.linear_code.row_len();
             let poly = DenseMultilinearExtension::<<Zt as ZipTypes>::Eval>::rand(P, &mut rng);
@@ -112,8 +113,8 @@ pub fn encode_single_row<Zt: ZipTypes, Lc: LinearCode<Zt>, const ROW_LEN: usize>
     StandardUniform: Distribution<Zt::Eval>,
 {
     let mut rng = ThreadRng::default();
-    let poly_size = ROW_LEN * ROW_LEN;
-    let linear_code = Lc::new(poly_size);
+    let _poly_size = ROW_LEN * ROW_LEN;
+    let linear_code = Lc::new(ROW_LEN);
     if linear_code.row_len() != ROW_LEN {
         // TODO(Ilia): Since IPRS codes require
         //             the input size to be known at compile time
@@ -173,8 +174,9 @@ pub fn commit<Zt: ZipTypes, Lc: LinearCode<Zt>, const P: usize>(
     StandardUniform: Distribution<Zt::Eval>,
 {
     let mut rng = ThreadRng::default();
-    let poly_size = 1 << P;
-    let linear_code = Lc::new(poly_size);
+    let poly_size: usize = 1 << P;
+    let row_len = poly_size.isqrt().next_power_of_two();
+    let linear_code = Lc::new(row_len);
     let params = ZipPlus::setup(poly_size, linear_code);
 
     group.bench_function(
@@ -208,8 +210,9 @@ pub fn test<Zt: ZipTypes, Lc: LinearCode<Zt>, const CHECK_FOR_OVERFLOWS: bool, c
 {
     let mut rng = ThreadRng::default();
 
-    let poly_size = 1 << P;
-    let linear_code = Lc::new(poly_size);
+    let poly_size: usize = 1 << P;
+    let row_len = poly_size.isqrt().next_power_of_two();
+    let linear_code = Lc::new(row_len);
     let params = ZipPlus::setup(poly_size, linear_code);
 
     let poly = DenseMultilinearExtension::rand(P, &mut rng);
@@ -242,8 +245,9 @@ pub fn evaluate<Zt: ZipTypes, Lc: LinearCode<Zt>, const CHECK_FOR_OVERFLOWS: boo
 {
     let mut rng = ThreadRng::default();
 
-    let poly_size = 1 << P;
-    let linear_code = Lc::new(poly_size);
+    let poly_size: usize = 1 << P;
+    let row_len = poly_size.isqrt().next_power_of_two();
+    let linear_code = Lc::new(row_len);
     let params = ZipPlus::setup(poly_size, linear_code);
 
     let poly = DenseMultilinearExtension::rand(P, &mut rng);
@@ -289,8 +293,9 @@ pub fn verify<Zt: ZipTypes, Lc: LinearCode<Zt>, const CHECK_FOR_OVERFLOWS: bool,
     Zt::Cw: ProjectableToField<F>,
 {
     let mut rng = ThreadRng::default();
-    let poly_size = 1 << P;
-    let linear_code = Lc::new(poly_size);
+    let poly_size: usize = 1 << P;
+    let row_len = poly_size.isqrt().next_power_of_two();
+    let linear_code = Lc::new(row_len);
     let params = ZipPlus::setup(poly_size, linear_code);
 
     let poly = DenseMultilinearExtension::rand(P, &mut rng);

--- a/zip-plus/src/code.rs
+++ b/zip-plus/src/code.rs
@@ -15,7 +15,7 @@ pub trait LinearCode<Zt: ZipTypes>: Sync + Send {
     /// makes using it too much of a hassle.
     const REPETITION_FACTOR: usize;
 
-    fn new(poly_size: usize) -> Self;
+    fn new(row_len: usize) -> Self;
 
     /// Length of each input row before encoding
     fn row_len(&self) -> usize;

--- a/zip-plus/src/code/iprs.rs
+++ b/zip-plus/src/code/iprs.rs
@@ -107,12 +107,12 @@ where
     const REPETITION_FACTOR: usize = Config::OUTPUT_LEN / Config::INPUT_LEN;
 
     #[allow(clippy::arithmetic_side_effects)]
-    fn new(poly_size: usize) -> Self {
+    fn new(row_len: usize) -> Self {
         assert_eq!(
-            poly_size % Config::INPUT_LEN,
-            0,
-            "Polynomial size {} is not a multiple of row length {}",
-            poly_size,
+            row_len,
+            Config::INPUT_LEN,
+            "Row length {} does not match expected row length {}",
+            row_len,
             Config::INPUT_LEN
         );
 

--- a/zip-plus/src/code/raa.rs
+++ b/zip-plus/src/code/raa.rs
@@ -77,35 +77,27 @@ impl<Zt: ZipTypes, Config: RaaConfig, const REP: usize> LinearCode<Zt>
 {
     const REPETITION_FACTOR: usize = REP;
 
-    fn new(poly_size: usize) -> Self {
+    fn new(row_len: usize) -> Self {
         assert!(
             REP.is_power_of_two(),
             "Repetition factor must be a power of two"
         );
-
-        // Taken from original Zip codes
-        let num_vars = poly_size.ilog2();
-        let two_pow_num_vars = 1_usize
-            .checked_shl(num_vars)
-            .expect("2 ** num_vars overflows");
-        let row_len: usize = two_pow_num_vars
-            .isqrt()
-            .checked_next_power_of_two()
-            .expect("row_len overflow");
+        assert!(
+            row_len.is_power_of_two(),
+            "Row length must be a power of two"
+        );
 
         // Width of each entry in codeword vector, in bits.
-        // For RAA it's initial_bits + 2*log(repetition_factor) + num_variables
+        // For RAA it's initial_bits + 2*log2(codeword_len),
+        // where codeword_len = row_len * REP and the factor of 2
+        // comes from the two accumulation steps.
         let codeword_width_bits = {
             let initial_bits =
                 u32::try_from(Zt::Eval::COEFF_BIT_WIDTH).expect("Size of EvalR type is too large");
 
+            let row_len_log = row_len.ilog2();
             let rep_factor_log = REP.ilog2();
-            let num_vars_even = if num_vars.is_multiple_of(2) {
-                num_vars
-            } else {
-                add!(num_vars, 1)
-            };
-            add!(initial_bits, add!(num_vars_even, mul!(rep_factor_log, 2)))
+            add!(initial_bits, add!(mul!(row_len_log, 2), mul!(rep_factor_log, 2)))
         };
         let codeword_type_bits =
             u32::try_from(Zt::Cw::COEFF_BIT_WIDTH).expect("Size of CwR type is too large");
@@ -253,16 +245,16 @@ mod tests {
     }
 
     macro_rules! test_raa {
-        ($zt:ty, $poly_size:expr, $f:expr) => {
-            test_raa!($zt, $poly_size, $f, RaaConfigGeneric<false, false>);
-            test_raa!($zt, $poly_size, $f, RaaConfigGeneric<false, true>);
-            test_raa!($zt, $poly_size, $f, RaaConfigGeneric<true, false>);
-            test_raa!($zt, $poly_size, $f, RaaConfigGeneric<true, true>);
+        ($zt:ty, $row_len:expr, $f:expr) => {
+            test_raa!($zt, $row_len, $f, RaaConfigGeneric<false, false>);
+            test_raa!($zt, $row_len, $f, RaaConfigGeneric<false, true>);
+            test_raa!($zt, $row_len, $f, RaaConfigGeneric<true, false>);
+            test_raa!($zt, $row_len, $f, RaaConfigGeneric<true, true>);
         };
 
-        ($zt:ty, $poly_size:expr, $f:expr, $config:ty) => {
+        ($zt:ty, $row_len:expr, $f:expr, $config:ty) => {
             {
-                let code = RaaCode::<$zt, $config, REPETITION_FACTOR>::new($poly_size);
+                let code = RaaCode::<$zt, $config, REPETITION_FACTOR>::new($row_len);
                 $f(&code)
             }
         };
@@ -355,7 +347,7 @@ mod tests {
     #[test]
     #[allow(clippy::arithmetic_side_effects)] // False alert
     fn encoding_preserves_linearity() {
-        test_raa!(TestZipTypes<N, K, M>, 16, |code: &RaaCode<_, _, _>| {
+        test_raa!(TestZipTypes<N, K, M>, 4, |code: &RaaCode<_, _, _>| {
             let a: Vec<Int<N>> = (1..=4).map(Int::<N>::from).collect();
             let b: Vec<Int<N>> = (5..=8).map(Int::<N>::from).collect();
             let sum_ab: Vec<Int<N>> = a.iter().zip(b.iter()).map(|(x, y)| *x + y).collect();
@@ -380,7 +372,7 @@ mod tests {
     fn encoding_produces_predictable_results() {
         let a: Vec<Int<N>> = (1..=4).map(Int::<N>::from).collect();
 
-        test_raa!(TestZipTypes<N, K, M>, 16, |code: &RaaCode<_, _, _>| {
+        test_raa!(TestZipTypes<N, K, M>, 4, |code: &RaaCode<_, _, _>| {
             let encode_a: Vec<Int<K>> = code.encode(&a);
             assert_eq!(
                 encode_a,
@@ -395,7 +387,7 @@ mod tests {
 
     #[test]
     fn encoding_zero_vector_results_in_zero_codeword() {
-        test_raa!(TestZipTypes<N, K, M>, 16, |code: &RaaCode<_, _, _>| {
+        test_raa!(TestZipTypes<N, K, M>, 4, |code: &RaaCode<_, _, _>| {
             let zero_vector: Vec<_> = vec![Int::<N>::zero(); code.row_len()];
             let encoded_vector: Vec<Int<K>> = code.encode(&zero_vector);
 
@@ -411,13 +403,13 @@ mod tests {
     #[test]
     fn in_place_permutation_should_not_affect_order() {
         let data: Vec<Int<N>> = (1..=1024).map(Int::<N>::from).collect();
-        let poly_size = data.len() * data.len();
+        let row_len = data.len();
         let codeword_1: Vec<Int<K>> = {
             let code_in_place = RaaCode::<
                 TestZipTypes<N, K, M>,
                 RaaConfigGeneric<true, true>,
                 REPETITION_FACTOR,
-            >::new(poly_size);
+            >::new(row_len);
             code_in_place.encode(&data)
         };
 
@@ -426,7 +418,7 @@ mod tests {
                 TestZipTypes<N, K, M>,
                 RaaConfigGeneric<false, true>,
                 REPETITION_FACTOR,
-            >::new(poly_size);
+            >::new(row_len);
             code_cloning.encode(&data)
         };
         assert_eq!(
@@ -445,14 +437,14 @@ mod tests {
             TestZipTypes<N, K, N>,
             RaaConfigGeneric<false, true>,
             REPETITION_FACTOR,
-        >::new(1 << 30);
+        >::new(1 << 15);
     }
 
     #[test]
     #[should_panic(expected = "Row length must match the code's row length")]
     #[cfg(debug_assertions)]
     fn encode_panics_on_mismatched_row_length() {
-        test_raa!(TestZipTypes<N, K, M>, 16, |code: &RaaCode<_, _, _>| {
+        test_raa!(TestZipTypes<N, K, M>, 4, |code: &RaaCode<_, _, _>| {
             let incorrect_row = vec![Int::<N>::from(1), Int::<N>::from(2), Int::<N>::from(3)];
             let _: Vec<Int<K>> = code.encode(&incorrect_row);
         });

--- a/zip-plus/src/code/raa_sign_flip.rs
+++ b/zip-plus/src/code/raa_sign_flip.rs
@@ -71,9 +71,9 @@ where
 {
     const REPETITION_FACTOR: usize = REP;
 
-    fn new(poly_size: usize) -> Self {
+    fn new(row_len: usize) -> Self {
         Self {
-            raa: RaaCode::new(poly_size),
+            raa: RaaCode::new(row_len),
         }
     }
 

--- a/zip-plus/src/pcs/phase_commit.rs
+++ b/zip-plus/src/pcs/phase_commit.rs
@@ -67,7 +67,7 @@ impl<Zt: ZipTypes, Lc: LinearCode<Zt>> ZipPlus<Zt, Lc> {
         pp: &ZipPlusParams<Zt, Lc>,
         poly: &DenseMultilinearExtension<Zt::Eval>,
     ) -> Result<(ZipPlusHint<Zt::Cw>, ZipPlusCommitment), ZipError> {
-        validate_input::<Zt, Lc, bool>("commit", pp.num_vars, &[poly], &[])?;
+        validate_input::<Zt, Lc, bool>("commit", pp.num_vars, pp.linear_code.row_len(), &[poly], &[])?;
 
         let expected_num_evals = pp.num_rows * pp.linear_code.row_len();
         assert_eq!(
@@ -111,7 +111,7 @@ impl<Zt: ZipTypes, Lc: LinearCode<Zt>> ZipPlus<Zt, Lc> {
         pp: &ZipPlusParams<Zt, Lc>,
         poly: &DenseMultilinearExtension<Zt::Eval>,
     ) -> Result<DenseRowMatrix<Zt::Cw>, ZipError> {
-        validate_input::<Zt, Lc, bool>("commit", pp.num_vars, &[poly], &[])?;
+        validate_input::<Zt, Lc, bool>("commit", pp.num_vars, pp.linear_code.row_len(), &[poly], &[])?;
 
         let row_len = pp.linear_code.row_len();
 
@@ -264,7 +264,7 @@ mod tests {
 
     #[test]
     fn commit_succeeds_for_small_polynomial() {
-        let code = C::new(16);
+        let code = C::new(4);
         let pp = ZipPlusParams::new(4, 4, code);
 
         let evaluations = vec![Int::from(42); 16];
@@ -276,7 +276,7 @@ mod tests {
 
     #[test]
     fn commit_succeeds_for_two_variables() {
-        let code = C::new(4);
+        let code = C::new(2);
         let pp = ZipPlusParams::new(2, 2, code);
 
         let evaluations = vec![Int::from(1), Int::from(2), Int::from(3), Int::from(4)];
@@ -405,8 +405,9 @@ mod tests {
         let results: Vec<Vec<Vec<Int<4>>>> = (0..10)
             .into_par_iter()
             .map(|_| {
-                let code = C::new(poly_size);
-                let pp = ZipPlusParams::new(num_vars, 8, code);
+                let row_len = 1usize << (num_vars / 2);
+                let code = C::new(row_len);
+                let pp = ZipPlusParams::new(num_vars, poly_size / row_len, code);
 
                 let rows = TestZip::encode_rows(&pp, pp.linear_code.row_len(), &poly.evaluations);
                 let rows: Vec<Vec<_>> = rows
@@ -610,8 +611,9 @@ mod tests {
 
         let mut rng = rng();
         let num_vars = 4;
-        let poly_size = 1 << num_vars;
-        let linear_code = C::new(poly_size);
+        let poly_size: usize = 1 << num_vars;
+        let row_len = poly_size.isqrt().next_power_of_two();
+        let linear_code = C::new(row_len);
         let param = TestZip::setup(poly_size, linear_code);
         let evaluations: Vec<_> = (0..poly_size)
             .map(|_| <Zt as ZipTypes>::Eval::from(rng.random::<i8>()))

--- a/zip-plus/src/pcs/phase_evaluate.rs
+++ b/zip-plus/src/pcs/phase_evaluate.rs
@@ -40,7 +40,7 @@ impl<Zt: ZipTypes, Lc: LinearCode<Zt>> ZipPlus<Zt, Lc> {
         F::Inner: FromRef<Zt::Fmod> + Transcribable,
         Zt::Eval: ProjectableToField<F>,
     {
-        validate_input::<Zt, Lc, _>("evaluate", pp.num_vars, &[poly], &[point])?;
+        validate_input::<Zt, Lc, _>("evaluate", pp.num_vars, pp.linear_code.row_len(), &[poly], &[point])?;
 
         let mut transcript: PcsTranscript = test_transcript.into();
 

--- a/zip-plus/src/pcs/phase_test.rs
+++ b/zip-plus/src/pcs/phase_test.rs
@@ -24,7 +24,7 @@ impl<Zt: ZipTypes, Lc: LinearCode<Zt>> ZipPlus<Zt, Lc> {
         poly: &DenseMultilinearExtension<Zt::Eval>,
         commit_hint: &ZipPlusHint<Zt::Cw>,
     ) -> Result<ZipPlusTestTranscript, ZipError> {
-        validate_input::<Zt, Lc, bool>("test", pp.num_vars, &[poly], &[])?;
+        validate_input::<Zt, Lc, bool>("test", pp.num_vars, pp.linear_code.row_len(), &[poly], &[])?;
 
         let estimated_transcript_size =
             // Combined rows

--- a/zip-plus/src/pcs/phase_verify.rs
+++ b/zip-plus/src/pcs/phase_verify.rs
@@ -40,7 +40,7 @@ impl<Zt: ZipTypes, Lc: LinearCode<Zt>> ZipPlus<Zt, Lc> {
         F::Inner: FromRef<Zt::Fmod> + Transcribable,
         Zt::Cw: ProjectableToField<F>,
     {
-        validate_input::<Zt, Lc, _>("verify", vp.num_vars, &[], &[point_f])?;
+        validate_input::<Zt, Lc, _>("verify", vp.num_vars, vp.linear_code.row_len(), &[], &[point_f])?;
 
         let mut transcript: PcsTranscript = proof.clone().into();
 
@@ -589,9 +589,10 @@ mod tests {
 
     #[test]
     fn verification_fails_if_proximity_check_is_invalid() {
-        let poly_size = 8; // row_len=4, num_rows=2 -> proximity checks are active
+        let poly_size: usize = 8; // row_len=4, num_rows=2 -> proximity checks are active
 
-        let linear_code = C::new(poly_size);
+        let row_len = poly_size.isqrt().next_power_of_two();
+        let linear_code = C::new(row_len);
         let pp = TestZip::setup(poly_size, linear_code);
 
         let mle: DenseMultilinearExtension<_> = (0..poly_size as i32)
@@ -674,8 +675,9 @@ mod tests {
         let mut rng = ThreadRng::default();
 
         let n = 3;
-        let poly_size = 1 << n;
-        let linear_code: C = C::new(poly_size);
+        let poly_size: usize = 1 << n;
+        let row_len = poly_size.isqrt().next_power_of_two();
+        let linear_code: C = C::new(row_len);
         let pp = TestZip::setup(poly_size, linear_code);
         let mle: DenseMultilinearExtension<_> = (0..poly_size)
             .map(|_| <Zt as ZipTypes>::Eval::from(rng.random::<i8>()))
@@ -705,8 +707,9 @@ mod tests {
 
     #[test]
     fn verification_fails_if_evaluation_consistency_check_is_invalid() {
-        let poly_size = 8;
-        let linear_code = C::new(poly_size);
+        let poly_size: usize = 8;
+        let row_len = poly_size.isqrt().next_power_of_two();
+        let linear_code = C::new(row_len);
         let pp = TestZip::setup(poly_size, linear_code);
 
         let mle: DenseMultilinearExtension<_> =
@@ -750,8 +753,9 @@ mod tests {
 
     #[test]
     fn verification_succeeds_for_zero_polynomial() {
-        let poly_size = 8;
-        let linear_code = C::new(poly_size);
+        let poly_size: usize = 8;
+        let row_len = poly_size.isqrt().next_power_of_two();
+        let linear_code = C::new(row_len);
         let pp = TestZip::setup(poly_size, linear_code);
 
         let mle: DenseMultilinearExtension<_> = (0..poly_size).map(|_| Int::ZERO).collect();
@@ -779,8 +783,9 @@ mod tests {
     #[test]
     fn verification_succeeds_at_zero_point() {
         let num_vars = 3;
-        let poly_size = 1 << num_vars;
-        let linear_code = C::new(poly_size);
+        let poly_size: usize = 1 << num_vars;
+        let row_len = poly_size.isqrt().next_power_of_two();
+        let linear_code = C::new(row_len);
         let pp = TestZip::setup(poly_size, linear_code);
 
         let mle: DenseMultilinearExtension<_> =
@@ -871,8 +876,9 @@ mod tests {
 
     #[test]
     fn verification_fails_if_proximity_values_are_too_large() {
-        let poly_size = 8;
-        let linear_code = C::new(poly_size);
+        let poly_size: usize = 8;
+        let row_len = poly_size.isqrt().next_power_of_two();
+        let linear_code = C::new(row_len);
         let pp = TestZip::setup(poly_size, linear_code);
 
         let mle: DenseMultilinearExtension<_> =
@@ -916,8 +922,9 @@ mod tests {
         fn inner<const P: usize>() {
             let mut rng = ThreadRng::default();
             // Match the benchmark’s transcript usage for linear code construction
-            let poly_size = 1 << P;
-            let linear_code = C::new(poly_size);
+            let poly_size: usize = 1 << P;
+            let row_len = poly_size.isqrt().next_power_of_two();
+            let linear_code = C::new(row_len);
             let pp = TestZip::setup(poly_size, linear_code);
 
             let mle = DenseMultilinearExtension::rand(P, &mut rng);
@@ -955,8 +962,9 @@ mod tests {
         fn inner<const P: usize>() {
             let mut rng = ThreadRng::default();
             // Match the benchmark’s transcript usage for linear code construction
-            let poly_size = 1 << P;
-            let linear_code = PolyC::new(poly_size);
+            let poly_size: usize = 1 << P;
+            let row_len = poly_size.isqrt().next_power_of_two();
+            let linear_code = PolyC::new(row_len);
             let pp = TestPolyZip::setup(poly_size, linear_code);
 
             let mle = DenseMultilinearExtension::rand(P, &mut rng);

--- a/zip-plus/src/pcs/structs.rs
+++ b/zip-plus/src/pcs/structs.rs
@@ -73,7 +73,16 @@ where
     pub fn setup(poly_size: usize, linear_code: Lc) -> ZipPlusParams<Zt, Lc> {
         assert!(poly_size.is_power_of_two());
         let num_vars = poly_size.ilog2() as usize;
-        let num_rows = ((1 << num_vars) / linear_code.row_len()).next_power_of_two();
+        let row_len = linear_code.row_len();
+        assert!(
+            row_len > 0 && poly_size % row_len == 0,
+            "poly_size ({poly_size}) must be divisible by row_len ({row_len})"
+        );
+        let num_rows = poly_size / row_len;
+        assert!(
+            num_rows.is_power_of_two(),
+            "num_rows ({num_rows}) must be a power of two"
+        );
         ZipPlusParams::new(num_vars, num_rows, linear_code)
     }
 }

--- a/zip-plus/src/pcs/test_utils.rs
+++ b/zip-plus/src/pcs/test_utils.rs
@@ -132,9 +132,10 @@ fn setup_test_params_inner<Zt: ZipTypes, Lc: LinearCode<Zt>>(
     prepare_evaluations: impl FnOnce(usize) -> Vec<Zt::Eval>,
 ) -> (ZipPlusParams<Zt, Lc>, DenseMultilinearExtension<Zt::Eval>) {
     let poly_size = 1 << num_vars;
-    let num_rows = 1 << num_vars.div_ceil(2);
+    let row_len = 1usize << (num_vars / 2);
+    let num_rows = poly_size / row_len;
 
-    let code = Lc::new(poly_size);
+    let code = Lc::new(row_len);
     let pp = ZipPlusParams::new(num_vars, num_rows, code);
 
     let evaluations = prepare_evaluations(poly_size);

--- a/zip-plus/src/pcs/utils.rs
+++ b/zip-plus/src/pcs/utils.rs
@@ -4,7 +4,7 @@ use zinc_poly::{
     ConstCoeffBitWidth, Polynomial, mle::DenseMultilinearExtension, utils::build_eq_x_r,
 };
 use zinc_transcript::traits::ConstTranscribable;
-use zinc_utils::{add, div, ilog_round_up, mul, sub};
+use zinc_utils::{add, ilog_round_up, mul, sub};
 
 fn err_too_many_variates(function: &str, upto: usize, got: usize) -> ZipError {
     ZipError::InvalidPcsParam(format!(
@@ -16,15 +16,16 @@ fn err_too_many_variates(function: &str, upto: usize, got: usize) -> ZipError {
 pub(super) fn validate_input<Zt: ZipTypes, Lc: LinearCode<Zt>, Pt>(
     function: &str,
     param_num_vars: usize,
+    row_len: usize,
     polys: &[&DenseMultilinearExtension<Zt::Eval>],
     points: &[&[Pt]],
 ) -> Result<(), ZipError> {
     // Check bit-width of the linear combinations
     {
-        // Inner ring should be at most+ 2*log_2(\rho^{-1}*d) + \log_2(d) +
-        // challenge_bits + eval_elem_bits - 1, where d is the size of the messages
-        // being encoded - so num_vars / 2
-        let d = div!(param_num_vars, 2);
+        // Inner ring should be at most 2*log_2(\rho^{-1}*d) + \log_2(d) +
+        // challenge_bits + eval_elem_bits - 1, where d is the log of the size
+        // of the messages being encoded (i.e. log2(row_len)).
+        let d = row_len.ilog2() as usize;
         let codeword_bits = ilog_round_up!(mul!(Lc::REPETITION_FACTOR, d), usize);
         let mut challenge_bits = Zt::Chal::NUM_BITS;
         if Zt::Comb::DEGREE_BOUND > 0 {


### PR DESCRIPTION
## Summary

This PR decouples the `zip-plus` PCS from the assumption that input matrices are square, allowing arbitrary matrix shapes (i.e. any number of rows and columns, as long as both are powers of two and their product equals the polynomial size).

## Motivation

Previously, `LinearCode::new()` received `poly_size` and internally computed `row_len = isqrt(poly_size).next_power_of_two()`, forcing a square matrix layout. This made it impossible to use non-square matrix arrangements — for example, encoding a polynomial of size $2^{15}$ into a matrix with 64 rows and 512 columns.

## Changes

### Core API change
- **`LinearCode::new(poly_size)` → `LinearCode::new(row_len)`**: The trait method now takes the row length directly. Callers decide the matrix shape.

### Linear code implementations
- **`RaaCode::new()`**: No longer derives `row_len` via `isqrt()`; receives it as a parameter. The codeword bit-width calculation is updated to use `2 * row_len.ilog2() + 2 * rep_factor.ilog2()` instead of the old `num_vars`-based formula.
- **`RaaSignFlippingCode::new()`**: Delegates to `RaaCode::new(row_len)`.
- **`IprsCode::new()`**: Asserts `row_len == Config::INPUT_LEN` instead of checking `poly_size % Config::INPUT_LEN == 0`.

### PCS setup & validation
- **`ZipPlus::setup()`**: Computes `num_rows = poly_size / row_len` with assertions that both dimensions are powers of two and the division is exact — replacing the old `next_power_of_two()` rounding.
- **`validate_input()`**: Now accepts `row_len` as a parameter and computes the bit-width bound `d` from `row_len.ilog2()` rather than hard-coding `d = num_vars / 2` (the square matrix assumption).

### Call sites
- All phase files (commit, test, evaluate, verify) pass `pp.linear_code.row_len()` to `validate_input()`.
- All tests and benchmarks construct codes with `Lc::new(row_len)` instead of `Lc::new(poly_size)`.

## Backward compatibility

Existing callers that used `ZipPlus::setup(poly_size, linear_code)` continue to work — `setup()` now derives `num_rows` from `poly_size / linear_code.row_len()`. The only breaking change is in `LinearCode::new()`, which now takes `row_len` instead of `poly_size`.

## Testing

All 68 existing tests pass. No new tests were required since the existing test suite already covers the full protocol (commit → test → evaluate → verify) and exercises various matrix dimensions.
