### PR TITLE
Batched Zip+ PCS with shared Merkle tree and Blake3 leaf hashing optimization

### DIFF
--- a/zip-plus/Cargo.toml
+++ b/zip-plus/Cargo.toml
@@ -48,3 +48,7 @@ harness = false
 [[bench]]
 name = "zip_plus_benches"
 harness = false
+
+[[bench]]
+name = "batched_zip_plus_benches"
+harness = false

--- a/zip-plus/benches/batched_zip_plus_benches.rs
+++ b/zip-plus/benches/batched_zip_plus_benches.rs
@@ -33,6 +33,7 @@ use zip_plus::{
         LinearCode,
         raa::{RaaCode, RaaConfig},
     },
+    merkle::MerkleTree,
     pcs::structs::{ZipPlus, ZipTypes},
 };
 
@@ -268,6 +269,100 @@ fn batched_verify<
     );
 }
 
+/// Benchmark only the Merkle tree construction for a batched commit.
+///
+/// This isolates the cost of `MerkleTree::new` on the concatenated codeword
+/// rows of `batch_size` polynomials.  Encoding is done once in setup so the
+/// measurement captures only the tree building.
+fn batched_merkle_tree<Zt: ZipTypes, Lc: LinearCode<Zt>, const P: usize>(
+    group: &mut BenchmarkGroup<WallTime>,
+    batch_size: usize,
+) where
+    StandardUniform: Distribution<Zt::Eval>,
+{
+    let mut rng = ThreadRng::default();
+    let poly_size = 1 << P;
+    let linear_code = Lc::new(poly_size);
+    let params = ZipPlus::<Zt, Lc>::setup(poly_size, linear_code);
+
+    let row_len = params.linear_code.row_len();
+
+    // Pre-encode all polynomials
+    let cw_matrices: Vec<_> = (0..batch_size)
+        .map(|_| {
+            let poly = DenseMultilinearExtension::rand(P, &mut rng);
+            ZipPlus::<Zt, Lc>::encode_rows(&params, row_len, &poly)
+        })
+        .collect();
+
+    // Collect row slices for MerkleTree::new (same layout as BatchedZipPlus::commit)
+    let all_rows: Vec<&[Zt::Cw]> = cw_matrices
+        .iter()
+        .flat_map(|m| m.to_rows_slices())
+        .collect();
+
+    group.bench_function(
+        format!(
+            "BatchedMerkleTree: Cw={}, poly_size=2^{P}, batch={batch_size}, total_rows={}",
+            Zt::Cw::type_name(),
+            all_rows.len(),
+        ),
+        |b| {
+            b.iter(|| {
+                let tree = MerkleTree::new(&all_rows);
+                black_box(tree.root());
+            })
+        },
+    );
+}
+
+/// Benchmark building `batch_size` separate Merkle trees (one per polynomial)
+/// vs the batched single-tree approach.  This lets us directly compare the
+/// cost of m independent trees against 1 batched tree.
+fn separate_merkle_trees<Zt: ZipTypes, Lc: LinearCode<Zt>, const P: usize>(
+    group: &mut BenchmarkGroup<WallTime>,
+    batch_size: usize,
+) where
+    StandardUniform: Distribution<Zt::Eval>,
+{
+    let mut rng = ThreadRng::default();
+    let poly_size = 1 << P;
+    let linear_code = Lc::new(poly_size);
+    let params = ZipPlus::<Zt, Lc>::setup(poly_size, linear_code);
+
+    let row_len = params.linear_code.row_len();
+
+    // Pre-encode all polynomials
+    let cw_matrices: Vec<_> = (0..batch_size)
+        .map(|_| {
+            let poly = DenseMultilinearExtension::rand(P, &mut rng);
+            ZipPlus::<Zt, Lc>::encode_rows(&params, row_len, &poly)
+        })
+        .collect();
+
+    // Pre-collect row slices per polynomial
+    let per_poly_rows: Vec<Vec<&[Zt::Cw]>> = cw_matrices
+        .iter()
+        .map(|m| m.to_rows_slices().into_iter().collect())
+        .collect();
+
+    group.bench_function(
+        format!(
+            "SeparateMerkleTrees: Cw={}, poly_size=2^{P}, batch={batch_size}, rows_per_tree={}",
+            Zt::Cw::type_name(),
+            per_poly_rows[0].len(),
+        ),
+        |b| {
+            b.iter(|| {
+                for rows in &per_poly_rows {
+                    let tree = MerkleTree::new(rows);
+                    black_box(tree.root());
+                }
+            })
+        },
+    );
+}
+
 /// Run all batched benchmarks for a given ZipTypes/Code/P combination
 /// with several batch sizes.
 fn do_batched_bench<
@@ -286,6 +381,8 @@ fn do_batched_bench<
 {
     for &batch_size in &[1, 2, 5, 10] {
         batched_commit::<Zt, Lc, P>(group, batch_size);
+        batched_merkle_tree::<Zt, Lc, P>(group, batch_size);
+        separate_merkle_trees::<Zt, Lc, P>(group, batch_size);
         batched_test::<Zt, Lc, CHECK_FOR_OVERFLOWS, P>(group, batch_size);
         batched_evaluate::<Zt, Lc, CHECK_FOR_OVERFLOWS, P>(group, batch_size);
         batched_verify::<Zt, Lc, CHECK_FOR_OVERFLOWS, P>(group, batch_size);

--- a/zip-plus/benches/batched_zip_plus_benches.rs
+++ b/zip-plus/benches/batched_zip_plus_benches.rs
@@ -1,0 +1,308 @@
+//! Benchmarks for the Batched Zip+ PCS.
+//!
+//! Measures commit, test, evaluate, and verify for batches of polynomials
+//! using a single shared Merkle tree.
+
+#![allow(non_local_definitions)]
+#![allow(clippy::eq_op, clippy::arithmetic_side_effects, clippy::unwrap_used)]
+
+mod zip_common;
+
+use criterion::{BenchmarkGroup, Criterion, criterion_group, criterion_main, measurement::WallTime};
+use crypto_bigint::U64;
+use crypto_primitives::{
+    Field, FromWithConfig, IntoWithConfig, PrimeField, crypto_bigint_int::Int,
+    crypto_bigint_monty::MontyField, crypto_bigint_uint::Uint,
+};
+use num_traits::One;
+use rand::{distr::StandardUniform, prelude::*};
+use std::{
+    hint::black_box,
+    time::{Duration, Instant},
+};
+use zinc_poly::mle::{DenseMultilinearExtension, MultilinearExtensionRand};
+use zinc_primality::MillerRabin;
+use zinc_transcript::traits::ConstTranscribable;
+use zinc_utils::{
+    UNCHECKED, from_ref::FromRef, inner_product::{MBSInnerProduct, ScalarProduct},
+    named::Named, projectable_to_field::ProjectableToField,
+};
+use zip_plus::{
+    batched_pcs::structs::BatchedZipPlus,
+    code::{
+        LinearCode,
+        raa::{RaaCode, RaaConfig},
+    },
+    pcs::structs::{ZipPlus, ZipTypes},
+};
+
+const INT_LIMBS: usize = U64::LIMBS;
+type F = MontyField<{ INT_LIMBS * 4 }>;
+
+// ---------- ZipTypes for scalar benchmarks ----------
+
+struct BenchZipTypes {}
+impl ZipTypes for BenchZipTypes {
+    const NUM_COLUMN_OPENINGS: usize = 200;
+    type Eval = i32;
+    type Cw = i64;
+    type Fmod = Uint<{ INT_LIMBS * 4 }>;
+    type PrimeTest = MillerRabin;
+    type Chal = i128;
+    type Pt = i128;
+    type CombR = Int<{ INT_LIMBS * 3 }>;
+    type Comb = Self::CombR;
+    type EvalDotChal = ScalarProduct;
+    type CombDotChal = ScalarProduct;
+    type ArrCombRDotChal = MBSInnerProduct;
+}
+
+#[derive(Clone, Copy)]
+struct BenchRaaConfig;
+impl RaaConfig for BenchRaaConfig {
+    const PERMUTE_IN_PLACE: bool = false;
+    const CHECK_FOR_OVERFLOWS: bool = UNCHECKED;
+}
+
+type Code = RaaCode<BenchZipTypes, BenchRaaConfig, 4>;
+
+// ---------- Batched benchmark helpers ----------
+
+/// Benchmark the batched commit phase for a given polynomial size and batch size.
+fn batched_commit<Zt: ZipTypes, Lc: LinearCode<Zt>, const P: usize>(
+    group: &mut BenchmarkGroup<WallTime>,
+    batch_size: usize,
+) where
+    StandardUniform: Distribution<Zt::Eval>,
+{
+    let mut rng = ThreadRng::default();
+    let poly_size = 1 << P;
+    let linear_code = Lc::new(poly_size);
+    let params = ZipPlus::<Zt, Lc>::setup(poly_size, linear_code);
+
+    group.bench_function(
+        format!(
+            "BatchedCommit: Eval={}, Cw={}, poly_size=2^{P}, batch={batch_size}",
+            Zt::Eval::type_name(),
+            Zt::Cw::type_name(),
+        ),
+        |b| {
+            b.iter_custom(|iters| {
+                let mut total_duration = Duration::ZERO;
+                for _ in 0..iters {
+                    let polys: Vec<_> = (0..batch_size)
+                        .map(|_| DenseMultilinearExtension::rand(P, &mut rng))
+                        .collect();
+                    let timer = Instant::now();
+                    let res = BatchedZipPlus::<Zt, Lc>::commit(&params, &polys)
+                        .expect("Batched commit failed");
+                    black_box(res);
+                    total_duration += timer.elapsed();
+                }
+                total_duration
+            })
+        },
+    );
+}
+
+/// Benchmark the batched test phase for a given polynomial size and batch size.
+fn batched_test<
+    Zt: ZipTypes,
+    Lc: LinearCode<Zt>,
+    const CHECK_FOR_OVERFLOWS: bool,
+    const P: usize,
+>(
+    group: &mut BenchmarkGroup<WallTime>,
+    batch_size: usize,
+) where
+    StandardUniform: Distribution<Zt::Eval>,
+{
+    let mut rng = ThreadRng::default();
+    let poly_size = 1 << P;
+    let linear_code = Lc::new(poly_size);
+    let params = ZipPlus::<Zt, Lc>::setup(poly_size, linear_code);
+
+    let polys: Vec<_> = (0..batch_size)
+        .map(|_| DenseMultilinearExtension::rand(P, &mut rng))
+        .collect();
+    let (hint, _) = BatchedZipPlus::<Zt, Lc>::commit(&params, &polys).unwrap();
+
+    group.bench_function(
+        format!(
+            "BatchedTest: Eval={}, Cw={}, Comb={}, poly_size=2^{P}, batch={batch_size}",
+            Zt::Eval::type_name(),
+            Zt::Cw::type_name(),
+            Zt::Comb::type_name(),
+        ),
+        |b| {
+            b.iter(|| {
+                let transcript =
+                    BatchedZipPlus::<Zt, Lc>::test::<CHECK_FOR_OVERFLOWS>(&params, &polys, &hint)
+                        .expect("Batched test phase failed");
+                black_box(transcript);
+            })
+        },
+    );
+}
+
+/// Benchmark the batched evaluate phase.
+fn batched_evaluate<
+    Zt: ZipTypes,
+    Lc: LinearCode<Zt>,
+    const CHECK_FOR_OVERFLOWS: bool,
+    const P: usize,
+>(
+    group: &mut BenchmarkGroup<WallTime>,
+    batch_size: usize,
+) where
+    StandardUniform: Distribution<Zt::Eval>,
+    F: for<'a> FromWithConfig<&'a Zt::Chal> + for<'a> FromWithConfig<&'a Zt::Pt>,
+    <F as Field>::Inner: FromRef<Zt::Fmod>,
+    Zt::Eval: ProjectableToField<F>,
+{
+    let mut rng = ThreadRng::default();
+    let poly_size = 1 << P;
+    let linear_code = Lc::new(poly_size);
+    let params = ZipPlus::<Zt, Lc>::setup(poly_size, linear_code);
+
+    let polys: Vec<_> = (0..batch_size)
+        .map(|_| DenseMultilinearExtension::rand(P, &mut rng))
+        .collect();
+    let (hint, _) = BatchedZipPlus::<Zt, Lc>::commit(&params, &polys).unwrap();
+    let point = vec![Zt::Pt::one(); P];
+
+    let test_transcript =
+        BatchedZipPlus::<Zt, Lc>::test::<CHECK_FOR_OVERFLOWS>(&params, &polys, &hint)
+            .expect("Batched test phase failed");
+
+    group.bench_function(
+        format!(
+            "BatchedEvaluate: Eval={}, Cw={}, Comb={}, poly_size=2^{P}, batch={batch_size}, modulus=({} bits)",
+            Zt::Eval::type_name(),
+            Zt::Cw::type_name(),
+            Zt::Comb::type_name(),
+            Zt::Fmod::NUM_BYTES * 8,
+        ),
+        |b| {
+            b.iter_custom(|iters| {
+                let mut total_duration = Duration::ZERO;
+                for _ in 0..iters {
+                    let transcript = test_transcript.clone();
+                    let timer = Instant::now();
+                    let (evals_f, proof) = BatchedZipPlus::<Zt, Lc>::evaluate::<
+                        F,
+                        CHECK_FOR_OVERFLOWS,
+                    >(
+                        &params, &polys, &point, transcript
+                    )
+                    .expect("Batched evaluate failed");
+                    total_duration += timer.elapsed();
+                    black_box((evals_f, proof));
+                }
+                total_duration
+            })
+        },
+    );
+}
+
+/// Benchmark the batched verify phase.
+fn batched_verify<
+    Zt: ZipTypes,
+    Lc: LinearCode<Zt>,
+    const CHECK_FOR_OVERFLOWS: bool,
+    const P: usize,
+>(
+    group: &mut BenchmarkGroup<WallTime>,
+    batch_size: usize,
+) where
+    StandardUniform: Distribution<Zt::Eval>,
+    F: for<'a> FromWithConfig<&'a Zt::Chal> + for<'a> FromWithConfig<&'a Zt::Pt>,
+    <F as Field>::Inner: FromRef<Zt::Fmod>,
+    Zt::Eval: ProjectableToField<F>,
+    Zt::Cw: ProjectableToField<F>,
+{
+    let mut rng = ThreadRng::default();
+    let poly_size = 1 << P;
+    let linear_code = Lc::new(poly_size);
+    let params = ZipPlus::<Zt, Lc>::setup(poly_size, linear_code);
+
+    let polys: Vec<_> = (0..batch_size)
+        .map(|_| DenseMultilinearExtension::rand(P, &mut rng))
+        .collect();
+    let (hint, commitment) = BatchedZipPlus::<Zt, Lc>::commit(&params, &polys).unwrap();
+    let point = vec![Zt::Pt::one(); P];
+
+    let test_transcript =
+        BatchedZipPlus::<Zt, Lc>::test::<CHECK_FOR_OVERFLOWS>(&params, &polys, &hint)
+            .expect("Batched test phase failed");
+    let (evals_f, proof) = BatchedZipPlus::<Zt, Lc>::evaluate::<F, CHECK_FOR_OVERFLOWS>(
+        &params,
+        &polys,
+        &point,
+        test_transcript,
+    )
+    .expect("Batched evaluate failed");
+    let field_cfg = *evals_f[0].cfg();
+    let point_f: Vec<F> = point.iter().map(|v| v.into_with_cfg(&field_cfg)).collect();
+
+    group.bench_function(
+        format!(
+            "BatchedVerify: Eval={}, Cw={}, Comb={}, poly_size=2^{P}, batch={batch_size}, modulus=({} bits)",
+            Zt::Eval::type_name(),
+            Zt::Cw::type_name(),
+            Zt::Comb::type_name(),
+            Zt::Fmod::NUM_BYTES * 8,
+        ),
+        |b| {
+            b.iter(|| {
+                BatchedZipPlus::<Zt, Lc>::verify::<_, CHECK_FOR_OVERFLOWS>(
+                    &params,
+                    &commitment,
+                    &point_f,
+                    &evals_f,
+                    &proof,
+                )
+                .expect("Batched verification failed");
+            })
+        },
+    );
+}
+
+/// Run all batched benchmarks for a given ZipTypes/Code/P combination
+/// with several batch sizes.
+fn do_batched_bench<
+    Zt: ZipTypes,
+    Lc: LinearCode<Zt>,
+    const CHECK_FOR_OVERFLOWS: bool,
+    const P: usize,
+>(
+    group: &mut BenchmarkGroup<WallTime>,
+) where
+    StandardUniform: Distribution<Zt::Eval> + Distribution<Zt::Cw>,
+    F: for<'a> FromWithConfig<&'a Zt::Chal> + for<'a> FromWithConfig<&'a Zt::Pt>,
+    <F as Field>::Inner: FromRef<Zt::Fmod>,
+    Zt::Eval: ProjectableToField<F>,
+    Zt::Cw: ProjectableToField<F>,
+{
+    for &batch_size in &[1, 2, 5, 10] {
+        batched_commit::<Zt, Lc, P>(group, batch_size);
+        batched_test::<Zt, Lc, CHECK_FOR_OVERFLOWS, P>(group, batch_size);
+        batched_evaluate::<Zt, Lc, CHECK_FOR_OVERFLOWS, P>(group, batch_size);
+        batched_verify::<Zt, Lc, CHECK_FOR_OVERFLOWS, P>(group, batch_size);
+    }
+}
+
+// ---------- Criterion entry point ----------
+
+fn batched_zip_plus_benchmarks(c: &mut Criterion) {
+    let mut group = c.benchmark_group("Batched Zip+");
+
+    do_batched_bench::<BenchZipTypes, Code, UNCHECKED, 12>(&mut group);
+    do_batched_bench::<BenchZipTypes, Code, UNCHECKED, 14>(&mut group);
+    do_batched_bench::<BenchZipTypes, Code, UNCHECKED, 16>(&mut group);
+
+    group.finish();
+}
+
+criterion_group!(benches, batched_zip_plus_benchmarks);
+criterion_main!(benches);

--- a/zip-plus/src/batched_pcs.rs
+++ b/zip-plus/src/batched_pcs.rs
@@ -1,0 +1,5 @@
+mod phase_commit;
+mod phase_evaluate;
+mod phase_verify;
+mod phase_test;
+pub mod structs;

--- a/zip-plus/src/batched_pcs/phase_commit.rs
+++ b/zip-plus/src/batched_pcs/phase_commit.rs
@@ -1,0 +1,181 @@
+use crate::{
+    ZipError,
+    code::LinearCode,
+    merkle::MerkleTree,
+    pcs::{
+        structs::{ZipPlus, ZipTypes},
+        utils::validate_input,
+    },
+};
+use zinc_poly::mle::DenseMultilinearExtension;
+
+use super::structs::{
+    BatchedZipPlus, BatchedZipPlusCommitment, BatchedZipPlusHint, BatchedZipPlusParams,
+};
+
+impl<Zt: ZipTypes, Lc: LinearCode<Zt>> BatchedZipPlus<Zt, Lc> {
+    /// Creates a batched commitment to multiple multilinear polynomials using
+    /// the ZIP PCS scheme with a single shared Merkle tree.
+    ///
+    /// # Algorithm
+    /// 1. Validates each polynomial's number of variables against the
+    ///    parameters.
+    /// 2. Encodes each polynomial's evaluations into a codeword matrix using
+    ///    the linear code.
+    /// 3. Constructs a **single** Merkle tree whose leaves are formed by
+    ///    hashing the concatenated columns across all codeword matrices.
+    ///    Specifically, the leaf at column index `j` is the hash of
+    ///    `(cw_1[0][j], cw_1[1][j], ..., cw_1[n-1][j], cw_2[0][j], ...,
+    ///    cw_m[n-1][j])` where `cw_i` is the codeword matrix for polynomial
+    ///    `i`, and `n` is the number of rows.
+    /// 4. Returns the full commitment data (for the prover) and a compact
+    ///    commitment (for the verifier).
+    ///
+    /// # Parameters
+    /// - `pp`: Public parameters shared across all polynomials in the batch.
+    /// - `polys`: Slice of multilinear polynomials to be committed to.
+    ///
+    /// # Returns
+    /// A `Result` containing a tuple of:
+    /// - `BatchedZipPlusHint`: Full data including encoded rows per polynomial
+    ///   and shared Merkle tree.
+    /// - `BatchedZipPlusCommitment`: The compact commitment (single Merkle
+    ///   root).
+    #[allow(clippy::arithmetic_side_effects)]
+    pub fn commit(
+        pp: &BatchedZipPlusParams<Zt, Lc>,
+        polys: &[DenseMultilinearExtension<Zt::Eval>],
+    ) -> Result<(BatchedZipPlusHint<Zt::Cw>, BatchedZipPlusCommitment), ZipError> {
+        assert!(!polys.is_empty(), "Batch must contain at least one polynomial");
+
+        let row_len = pp.linear_code.row_len();
+        let expected_num_evals = pp.num_rows * row_len;
+
+        // Validate and encode each polynomial
+        let cw_matrices: Vec<_> = polys
+            .iter()
+            .map(|poly| {
+                validate_input::<Zt, Lc, bool>("batched_commit", pp.num_vars, &[poly], &[])?;
+                assert_eq!(
+                    poly.len(),
+                    expected_num_evals,
+                    "Polynomial has an incorrect number of evaluations ({}) for the expected matrix size ({})",
+                    poly.len(),
+                    expected_num_evals
+                );
+                Ok(ZipPlus::<Zt, Lc>::encode_rows(pp, row_len, poly))
+            })
+            .collect::<Result<Vec<_>, ZipError>>()?;
+
+        // Build a single Merkle tree from all matrices' rows concatenated.
+        // The rows are ordered as: all rows of poly 1, then all rows of poly 2, etc.
+        // This means the leaf at column j hashes across all rows of ALL polynomials.
+        let all_rows: Vec<&[Zt::Cw]> = cw_matrices
+            .iter()
+            .flat_map(|m| m.to_rows_slices())
+            .collect();
+
+        let merkle_tree = MerkleTree::new(&all_rows);
+        let root = merkle_tree.root();
+
+        let batch_size = polys.len();
+
+        Ok((
+            BatchedZipPlusHint::new(cw_matrices, merkle_tree),
+            BatchedZipPlusCommitment { root, batch_size },
+        ))
+    }
+}
+
+#[cfg(test)]
+#[allow(
+    clippy::arithmetic_side_effects,
+    clippy::cast_possible_truncation,
+    clippy::cast_possible_wrap
+)]
+mod tests {
+    use super::*;
+    use crate::pcs::test_utils::*;
+    use crypto_bigint::U64;
+    use crypto_primitives::crypto_bigint_int::Int;
+
+    const INT_LIMBS: usize = U64::LIMBS;
+    const N: usize = INT_LIMBS;
+    const K: usize = INT_LIMBS * 4;
+    const M: usize = INT_LIMBS * 8;
+
+    type Zt = TestZipTypes<N, K, M>;
+    type C = crate::code::raa_sign_flip::RaaSignFlippingCode<Zt, TestRaaConfig, 4>;
+    type TestBatchedZip = BatchedZipPlus<Zt, C>;
+
+    #[test]
+    fn batched_commit_single_poly_matches_single_commit() {
+        let num_vars = 4;
+        let (pp, poly) = setup_test_params(num_vars);
+
+        // Batched commit with one polynomial
+        let (batched_hint, batched_comm) =
+            TestBatchedZip::commit(&pp, &[poly.clone()]).unwrap();
+
+        // Single commit
+        let (single_hint, single_comm) =
+            crate::pcs::structs::ZipPlus::<Zt, C>::commit(&pp, &poly).unwrap();
+
+        // Roots should match when there's only one polynomial
+        assert_eq!(batched_comm.root, single_comm.root);
+        assert_eq!(batched_hint.cw_matrices.len(), 1);
+        assert_eq!(batched_hint.cw_matrices[0], single_hint.cw_matrix);
+    }
+
+    #[test]
+    fn batched_commit_produces_different_root_than_individual_commits() {
+        let num_vars = 4;
+        let (pp, _) = setup_test_params::<N, K, M>(num_vars);
+
+        let poly1: DenseMultilinearExtension<_> = (1..=16).map(Int::from).collect();
+        let poly2: DenseMultilinearExtension<_> = (17..=32).map(Int::from).collect();
+
+        let (_, batched_comm) =
+            TestBatchedZip::commit(&pp, &[poly1.clone(), poly2.clone()]).unwrap();
+
+        let (_, comm1) =
+            crate::pcs::structs::ZipPlus::<Zt, C>::commit(&pp, &poly1).unwrap();
+        let (_, comm2) =
+            crate::pcs::structs::ZipPlus::<Zt, C>::commit(&pp, &poly2).unwrap();
+
+        // The batched root should differ from either individual root
+        assert_ne!(batched_comm.root, comm1.root);
+        assert_ne!(batched_comm.root, comm2.root);
+    }
+
+    #[test]
+    fn batched_commit_is_deterministic() {
+        let num_vars = 4;
+        let (pp, _) = setup_test_params::<N, K, M>(num_vars);
+
+        let poly1: DenseMultilinearExtension<_> = (1..=16).map(Int::from).collect();
+        let poly2: DenseMultilinearExtension<_> = (17..=32).map(Int::from).collect();
+
+        let (_, comm_a) = TestBatchedZip::commit(&pp, &[poly1.clone(), poly2.clone()]).unwrap();
+        let (_, comm_b) = TestBatchedZip::commit(&pp, &[poly1, poly2]).unwrap();
+
+        assert_eq!(comm_a.root, comm_b.root);
+    }
+
+    #[test]
+    fn batched_commit_batch_size_is_correct() {
+        let num_vars = 4;
+        let (pp, _) = setup_test_params::<N, K, M>(num_vars);
+
+        let polys: Vec<DenseMultilinearExtension<_>> = (0..5)
+            .map(|offset| {
+                let start = offset * 16 + 1;
+                (start..start + 16).map(Int::from).collect()
+            })
+            .collect();
+
+        let (hint, comm) = TestBatchedZip::commit(&pp, &polys).unwrap();
+        assert_eq!(comm.batch_size, 5);
+        assert_eq!(hint.batch_size(), 5);
+    }
+}

--- a/zip-plus/src/batched_pcs/phase_evaluate.rs
+++ b/zip-plus/src/batched_pcs/phase_evaluate.rs
@@ -1,0 +1,117 @@
+use crate::{
+    ZipError,
+    code::LinearCode,
+    combine_rows,
+    pcs::{
+        structs::ZipTypes,
+        utils::{point_to_tensor, validate_input},
+    },
+    pcs_transcript::PcsTranscript,
+};
+use crypto_primitives::{FromWithConfig, IntoWithConfig, PrimeField};
+use itertools::Itertools;
+use zinc_poly::mle::DenseMultilinearExtension;
+use zinc_transcript::traits::{Transcribable, Transcript};
+use zinc_utils::{
+    UNCHECKED, cfg_iter, cfg_iter_mut,
+    from_ref::FromRef,
+    inner_product::{InnerProduct, MBSInnerProduct},
+    mul_by_scalar::MulByScalar,
+    projectable_to_field::ProjectableToField,
+};
+
+#[cfg(feature = "parallel")]
+use rayon::prelude::*;
+
+use super::structs::{
+    BatchedZipPlus, BatchedZipPlusParams, BatchedZipPlusProof, BatchedZipPlusTestTranscript,
+};
+
+impl<Zt: ZipTypes, Lc: LinearCode<Zt>> BatchedZipPlus<Zt, Lc> {
+    /// Performs the evaluation phase for a batch of polynomials.
+    ///
+    /// All polynomials are evaluated at the **same** point. Produces one field
+    /// evaluation per polynomial, plus a single batched proof.
+    ///
+    /// # Parameters
+    /// - `pp`: Public parameters shared across all polynomials.
+    /// - `polys`: Slice of multilinear polynomials in the batch.
+    /// - `point`: The shared evaluation point (same for all polynomials).
+    /// - `test_transcript`: The transcript from the testing phase.
+    ///
+    /// # Returns
+    /// A tuple `(Vec<F>, BatchedZipPlusProof)` containing one evaluation per
+    /// polynomial and the batched proof.
+    pub fn evaluate<F, const CHECK_FOR_OVERFLOW: bool>(
+        pp: &BatchedZipPlusParams<Zt, Lc>,
+        polys: &[DenseMultilinearExtension<Zt::Eval>],
+        point: &[Zt::Pt],
+        test_transcript: BatchedZipPlusTestTranscript,
+    ) -> Result<(Vec<F>, BatchedZipPlusProof), ZipError>
+    where
+        F: PrimeField
+            + for<'a> FromWithConfig<&'a Zt::Chal>
+            + for<'a> FromWithConfig<&'a Zt::Pt>
+            + for<'a> MulByScalar<&'a F>
+            + FromRef<F>,
+        F::Inner: FromRef<Zt::Fmod> + Transcribable,
+        Zt::Eval: ProjectableToField<F>,
+    {
+        assert!(!polys.is_empty(), "Batch must contain at least one polynomial");
+
+        for poly in polys {
+            validate_input::<Zt, Lc, _>("batched_evaluate", pp.num_vars, &[poly], &[point])?;
+        }
+
+        let mut transcript: PcsTranscript = test_transcript.into();
+
+        let field_cfg = transcript
+            .fs_transcript
+            .get_random_field_cfg::<F, Zt::Fmod, Zt::PrimeTest>();
+        let projecting_element: Zt::Chal = transcript.fs_transcript.get_challenge();
+        let projecting_element: F = (&projecting_element).into_with_cfg(&field_cfg);
+
+        let num_rows = pp.num_rows;
+        let row_len = pp.linear_code.row_len();
+
+        let point_f: Vec<F> = point
+            .iter()
+            .map(|v| v.into_with_cfg(&field_cfg))
+            .collect_vec();
+        let (q_0, q_1) = point_to_tensor(num_rows, &point_f, &field_cfg)?;
+
+        let project = Zt::Eval::prepare_projection(&projecting_element);
+
+        let mut evals_f = Vec::with_capacity(polys.len());
+
+        for poly in polys {
+            let evaluations: Vec<F> = cfg_iter!(poly).map(&project).collect();
+
+            let q_0_combined_row = if num_rows > 1 {
+                combine_rows!(
+                    CHECK_FOR_OVERFLOW,
+                    &q_0,
+                    evaluations.iter(),
+                    Ok::<_, ZipError>,
+                    row_len,
+                    F::zero_with_cfg(&field_cfg)
+                )
+            } else {
+                evaluations
+            };
+
+            transcript.write_field_elements(&q_0_combined_row)?;
+
+            // It is safe to use unchecked inner product since we are in a field.
+            let eval_f = MBSInnerProduct::inner_product::<UNCHECKED>(
+                &q_0_combined_row,
+                &q_1,
+                F::zero_with_cfg(&field_cfg),
+            )?;
+
+            evals_f.push(eval_f);
+        }
+
+        Ok((evals_f, transcript.into()))
+    }
+}

--- a/zip-plus/src/batched_pcs/phase_test.rs
+++ b/zip-plus/src/batched_pcs/phase_test.rs
@@ -1,0 +1,198 @@
+use crate::{
+    ZipError,
+    code::LinearCode,
+    combine_rows,
+    merkle::MerkleProof,
+    pcs::{
+        structs::ZipTypes,
+        utils::validate_input,
+    },
+    pcs_transcript::PcsTranscript,
+};
+use num_traits::{ConstOne, ConstZero, Zero};
+#[cfg(feature = "parallel")]
+use rayon::prelude::*;
+use zinc_poly::{Polynomial, mle::DenseMultilinearExtension};
+use zinc_transcript::traits::{ConstTranscribable, Transcript};
+use zinc_utils::{cfg_iter_mut, inner_product::InnerProduct, mul_by_scalar::MulByScalar};
+
+use super::structs::{
+    BatchedZipPlus, BatchedZipPlusHint, BatchedZipPlusParams, BatchedZipPlusTestTranscript,
+};
+
+impl<Zt: ZipTypes, Lc: LinearCode<Zt>> BatchedZipPlus<Zt, Lc> {
+    /// Performs the testing phase for a batch of committed polynomials.
+    ///
+    /// This mirrors the single-polynomial testing phase but operates on `m`
+    /// polynomials simultaneously. Each polynomial gets its own alphas,
+    /// coefficients, and combined row (sampled and computed sequentially from
+    /// the shared Fiat-Shamir transcript). Column openings are shared: the
+    /// same column indices are queried for all polynomials, and a single
+    /// Merkle proof is produced per column.
+    ///
+    /// # Parameters
+    /// - `pp`: Public parameters shared across all polynomials.
+    /// - `polys`: Slice of multilinear polynomials in the batch.
+    /// - `commit_hint`: The batched commitment hint containing all codeword
+    ///   matrices and the shared Merkle tree.
+    ///
+    /// # Returns
+    /// A `BatchedZipPlusTestTranscript` to be used in the evaluation phase.
+    #[allow(clippy::arithmetic_side_effects)]
+    pub fn test<const CHECK_FOR_OVERFLOW: bool>(
+        pp: &BatchedZipPlusParams<Zt, Lc>,
+        polys: &[DenseMultilinearExtension<Zt::Eval>],
+        commit_hint: &BatchedZipPlusHint<Zt::Cw>,
+    ) -> Result<BatchedZipPlusTestTranscript, ZipError> {
+        let batch_size = polys.len();
+        assert_eq!(
+            batch_size,
+            commit_hint.batch_size(),
+            "Number of polynomials must match batch commit hint"
+        );
+
+        for poly in polys {
+            validate_input::<Zt, Lc, bool>("batched_test", pp.num_vars, &[poly], &[])?;
+        }
+
+        let total_rows_per_poly = pp.num_rows;
+
+        let estimated_transcript_size =
+            // Combined rows: one per polynomial
+            batch_size * pp.linear_code.row_len() * Zt::CombR::NUM_BYTES
+            // Column openings
+            + Zt::NUM_COLUMN_OPENINGS * (
+                // Column values from all m polynomials
+                batch_size * total_rows_per_poly * Zt::Cw::NUM_BYTES
+                // Single Merkle proof per column
+                + MerkleProof::estimate_transcribed_size(commit_hint.merkle_tree.height())
+            );
+        let mut transcript = PcsTranscript::new_with_capacity(estimated_transcript_size);
+
+        // For each polynomial, compute the combined row  (proximity test)
+        if pp.num_rows > 1 {
+            for (poly_idx, poly) in polys.iter().enumerate() {
+                let alphas = if Zt::Comb::DEGREE_BOUND.is_zero() {
+                    vec![Zt::Chal::ONE]
+                } else {
+                    transcript
+                        .fs_transcript
+                        .get_challenges::<Zt::Chal>(Zt::Comb::DEGREE_BOUND + 1)
+                };
+
+                let coeffs = transcript
+                    .fs_transcript
+                    .get_challenges::<Zt::Chal>(pp.num_rows);
+
+                let combined_row = combine_rows!(
+                    CHECK_FOR_OVERFLOW,
+                    &coeffs,
+                    poly.evaluations.iter(),
+                    |eval| Zt::EvalDotChal::inner_product::<CHECK_FOR_OVERFLOW>(
+                        eval,
+                        &alphas,
+                        Zt::CombR::ZERO
+                    ),
+                    pp.linear_code.row_len(),
+                    Zt::CombR::ZERO
+                );
+
+                transcript.write_const_many(&combined_row).map_err(|e| {
+                    ZipError::Serialization(format!(
+                        "Failed to write combined row for poly {poly_idx}: {e}"
+                    ))
+                })?;
+            }
+        }
+
+        // Open Merkle tree for each column drawn — shared across all polynomials
+        for _ in 0..Zt::NUM_COLUMN_OPENINGS {
+            let column = transcript.squeeze_challenge_idx(pp.linear_code.codeword_len());
+            Self::open_merkle_trees_for_column(commit_hint, column, &mut transcript)?;
+        }
+
+        assert_eq!(
+            transcript.stream.get_ref().len(),
+            estimated_transcript_size,
+            "Batched PCS transcript capacity was precalculated incorrectly"
+        );
+
+        Ok(transcript.into())
+    }
+
+    /// Opens a single column of the shared Merkle tree, writing column values
+    /// from **all** codeword matrices followed by a single Merkle proof.
+    pub(super) fn open_merkle_trees_for_column(
+        commit_hint: &BatchedZipPlusHint<Zt::Cw>,
+        column_idx: usize,
+        transcript: &mut PcsTranscript,
+    ) -> Result<(), ZipError> {
+        // Write column values from each cw_matrix in order
+        for cw_matrix in &commit_hint.cw_matrices {
+            let column_values = cw_matrix.as_rows().map(|row| &row[column_idx]);
+            transcript.write_const_many_iter(column_values, cw_matrix.num_rows)?;
+        }
+
+        // Single Merkle proof from the shared tree
+        let merkle_proof = commit_hint
+            .merkle_tree
+            .prove(column_idx)
+            .map_err(|_| ZipError::InvalidPcsOpen("Failed to open batched merkle tree".into()))?;
+        transcript
+            .write_merkle_proof(&merkle_proof)
+            .map_err(|_| {
+                ZipError::InvalidPcsOpen(
+                    "Failed to write batched merkle tree proof".into(),
+                )
+            })?;
+
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+#[allow(
+    clippy::arithmetic_side_effects,
+    clippy::cast_possible_truncation,
+    clippy::cast_possible_wrap
+)]
+mod tests {
+    use super::*;
+    use crate::pcs::test_utils::*;
+    use crypto_bigint::U64;
+    use crypto_primitives::crypto_bigint_int::Int;
+    use zinc_utils::CHECKED;
+
+    const INT_LIMBS: usize = U64::LIMBS;
+    const N: usize = INT_LIMBS;
+    const K: usize = INT_LIMBS * 4;
+    const M: usize = INT_LIMBS * 8;
+
+    type Zt = TestZipTypes<N, K, M>;
+    type C = crate::code::raa_sign_flip::RaaSignFlippingCode<Zt, TestRaaConfig, 4>;
+    type TestBatchedZip = BatchedZipPlus<Zt, C>;
+
+    #[test]
+    fn successful_batched_testing() {
+        let num_vars = 4;
+        let (pp, _) = setup_test_params::<N, K, M>(num_vars);
+
+        let poly1: DenseMultilinearExtension<_> = (1..=16).map(Int::from).collect();
+        let poly2: DenseMultilinearExtension<_> = (17..=32).map(Int::from).collect();
+        let polys = [poly1, poly2];
+
+        let (hint, _comm) = TestBatchedZip::commit(&pp, &polys).unwrap();
+        let result = TestBatchedZip::test::<CHECKED>(&pp, &polys, &hint);
+        assert!(result.is_ok(), "Batched test failed: {result:?}");
+    }
+
+    #[test]
+    fn batched_testing_single_poly() {
+        let num_vars = 4;
+        let (pp, poly) = setup_test_params(num_vars);
+
+        let (hint, _comm) = TestBatchedZip::commit(&pp, &[poly.clone()]).unwrap();
+        let result = TestBatchedZip::test::<CHECKED>(&pp, &[poly], &hint);
+        assert!(result.is_ok(), "Single-poly batched test failed: {result:?}");
+    }
+}

--- a/zip-plus/src/batched_pcs/phase_verify.rs
+++ b/zip-plus/src/batched_pcs/phase_verify.rs
@@ -1,0 +1,403 @@
+use crate::{
+    ZipError,
+    code::LinearCode,
+    merkle::MtHash,
+    pcs::{
+        structs::{ZipPlus, ZipTypes},
+        utils::point_to_tensor,
+    },
+    pcs_transcript::PcsTranscript,
+};
+use crypto_primitives::{FromPrimitiveWithConfig, FromWithConfig, IntoWithConfig};
+use itertools::Itertools;
+use num_traits::{ConstOne, Zero};
+#[cfg(feature = "parallel")]
+use rayon::prelude::*;
+use zinc_poly::Polynomial;
+use zinc_transcript::traits::{Transcribable, Transcript};
+use zinc_utils::{
+    UNCHECKED, cfg_into_iter, cfg_iter,
+    from_ref::FromRef,
+    inner_product::{InnerProduct, MBSInnerProduct},
+    mul_by_scalar::MulByScalar,
+    projectable_to_field::ProjectableToField,
+};
+
+use super::structs::{
+    BatchedZipPlus, BatchedZipPlusCommitment, BatchedZipPlusParams, BatchedZipPlusProof,
+};
+
+impl<Zt: ZipTypes, Lc: LinearCode<Zt>> BatchedZipPlus<Zt, Lc> {
+    /// Verifies a batched ZipPlus proof.
+    ///
+    /// All polynomials are evaluated at the same point. Verification checks
+    /// that the committed batch is consistent with the supplied evaluations.
+    ///
+    /// # Parameters
+    /// - `vp`: Public (verifier) parameters.
+    /// - `comm`: The batched commitment (single Merkle root + batch size).
+    /// - `point_f`: The shared evaluation point in the field.
+    /// - `evals_f`: One evaluation per polynomial.
+    /// - `proof`: The batched proof.
+    pub fn verify<F, const CHECK_FOR_OVERFLOW: bool>(
+        vp: &BatchedZipPlusParams<Zt, Lc>,
+        comm: &BatchedZipPlusCommitment,
+        point_f: &[F],
+        evals_f: &[F],
+        proof: &BatchedZipPlusProof,
+    ) -> Result<(), ZipError>
+    where
+        F: FromPrimitiveWithConfig
+            + FromRef<F>
+            + for<'a> FromWithConfig<&'a Zt::Chal>
+            + for<'a> MulByScalar<&'a F>,
+        F::Inner: FromRef<Zt::Fmod> + Transcribable,
+        Zt::Cw: ProjectableToField<F>,
+    {
+        let batch_size = comm.batch_size;
+        assert_eq!(
+            evals_f.len(),
+            batch_size,
+            "Number of evaluations must match batch size"
+        );
+
+        let mut transcript: PcsTranscript = proof.clone().into();
+
+        // columns_opened: Vec<(column_idx, Vec<Vec<Zt::Cw>>)>
+        // For each opened column, we have a Vec of column values per polynomial.
+        let columns_opened = Self::verify_testing::<CHECK_FOR_OVERFLOW>(
+            vp,
+            &comm.root,
+            batch_size,
+            &mut transcript,
+        )?;
+
+        let field_cfg = transcript
+            .fs_transcript
+            .get_random_field_cfg::<F, Zt::Fmod, Zt::PrimeTest>();
+        let projecting_element: Zt::Chal = transcript.fs_transcript.get_challenge();
+        let projecting_element: F = (&projecting_element).into_with_cfg(&field_cfg);
+
+        Self::verify_evaluation(
+            vp,
+            point_f,
+            evals_f,
+            batch_size,
+            &columns_opened,
+            &mut transcript,
+            projecting_element,
+            &field_cfg,
+        )?;
+
+        Ok(())
+    }
+
+    /// Verifies the testing phase of a batched proof.
+    ///
+    /// Returns a vector of opened columns, where each entry is
+    /// `(column_idx, per_poly_column_values)` with `per_poly_column_values`
+    /// being a `Vec<Vec<Zt::Cw>>` indexed by polynomial index.
+    #[allow(clippy::arithmetic_side_effects, clippy::type_complexity)]
+    fn verify_testing<const CHECK_FOR_OVERFLOW: bool>(
+        vp: &BatchedZipPlusParams<Zt, Lc>,
+        root: &MtHash,
+        batch_size: usize,
+        transcript: &mut PcsTranscript,
+    ) -> Result<Vec<(usize, Vec<Vec<Zt::Cw>>)>, ZipError> {
+        // For each polynomial, gather the encoded combined row for proximity
+        // testing.
+        let encoded_combined_rows: Option<Vec<(Vec<Zt::Chal>, Vec<Zt::Chal>, Vec<Zt::CombR>)>> = {
+            if vp.num_rows > 1 {
+                let mut per_poly = Vec::with_capacity(batch_size);
+                for _ in 0..batch_size {
+                    let alphas = if Zt::Comb::DEGREE_BOUND.is_zero() {
+                        vec![Zt::Chal::ONE]
+                    } else {
+                        transcript
+                            .fs_transcript
+                            .get_challenges::<Zt::Chal>(Zt::Comb::DEGREE_BOUND + 1)
+                    };
+
+                    let coeffs = transcript
+                        .fs_transcript
+                        .get_challenges(vp.num_rows);
+
+                    let combined_row: Vec<Zt::CombR> =
+                        transcript.read_const_many(vp.linear_code.row_len())?;
+
+                    let encoded_combined_row: Vec<Zt::CombR> =
+                        vp.linear_code.encode_wide(&combined_row);
+
+                    per_poly.push((alphas, coeffs, encoded_combined_row));
+                }
+                Some(per_poly)
+            } else {
+                None
+            }
+        };
+
+        // Read column openings from transcript sequentially
+        let columns_and_proofs: Vec<_> = (0..Zt::NUM_COLUMN_OPENINGS)
+            .map(|_| -> Result<_, ZipError> {
+                let column_idx =
+                    transcript.squeeze_challenge_idx(vp.linear_code.codeword_len());
+
+                // Read column values for each polynomial in order
+                let per_poly_column_values: Vec<Vec<Zt::Cw>> = (0..batch_size)
+                    .map(|_| transcript.read_const_many(vp.num_rows))
+                    .try_collect()?;
+
+                let proof = transcript.read_merkle_proof().map_err(|e| {
+                    ZipError::InvalidPcsOpen(format!(
+                        "Failed to read batched Merkle proof: {e}"
+                    ))
+                })?;
+
+                Ok((column_idx, per_poly_column_values, proof))
+            })
+            .try_collect()?;
+
+        let columns_opened: Vec<(usize, Vec<Vec<Zt::Cw>>)> =
+            cfg_into_iter!(columns_and_proofs)
+                .map(
+                    |(column_idx, per_poly_column_values, proof)| -> Result<_, ZipError> {
+                        // Verify proximity for each polynomial
+                        if let Some(ref encoded_per_poly) = encoded_combined_rows {
+                            for (poly_idx, (alphas, coeffs, encoded_combined_row)) in
+                                encoded_per_poly.iter().enumerate()
+                            {
+                                ZipPlus::<Zt, Lc>::verify_column_testing::<CHECK_FOR_OVERFLOW>(
+                                    alphas,
+                                    coeffs,
+                                    encoded_combined_row,
+                                    &per_poly_column_values[poly_idx],
+                                    column_idx,
+                                    vp.num_rows,
+                                )?;
+                            }
+                        }
+
+                        // Verify Merkle proof against the shared root.
+                        // The leaf was hashed from the concatenation of all
+                        // polynomials' column values.
+                        let all_column_values: Vec<Zt::Cw> = per_poly_column_values
+                            .iter()
+                            .flat_map(|v| v.iter().cloned())
+                            .collect();
+
+                        proof
+                            .verify(root, &all_column_values, column_idx)
+                            .map_err(|e| {
+                                ZipError::InvalidPcsOpen(format!(
+                                    "Batched column opening verification failed: {e}"
+                                ))
+                            })?;
+
+                        Ok((column_idx, per_poly_column_values))
+                    },
+                )
+                .collect::<Result<_, _>>()?;
+
+        Ok(columns_opened)
+    }
+
+    /// Verifies the evaluation phase for a batched proof.
+    #[allow(clippy::too_many_arguments)]
+    fn verify_evaluation<F>(
+        vp: &BatchedZipPlusParams<Zt, Lc>,
+        point_f: &[F],
+        evals_f: &[F],
+        batch_size: usize,
+        columns_opened: &[(usize, Vec<Vec<Zt::Cw>>)],
+        transcript: &mut PcsTranscript,
+        projecting_element: F,
+        field_cfg: &F::Config,
+    ) -> Result<(), ZipError>
+    where
+        F: FromPrimitiveWithConfig + FromRef<F> + for<'a> MulByScalar<&'a F>,
+        F::Inner: FromRef<Zt::Fmod> + Transcribable,
+        Zt::Cw: ProjectableToField<F>,
+    {
+        let (q_0, q_1) = point_to_tensor(vp.num_rows, point_f, field_cfg)?;
+        let project = Zt::Cw::prepare_projection(&projecting_element);
+
+        for poly_idx in 0..batch_size {
+            let q_0_combined_row =
+                transcript.read_field_elements(vp.linear_code.row_len())?;
+            let encoded_combined_row: Vec<F> =
+                vp.linear_code.encode_f(&q_0_combined_row);
+
+            // Verify evaluation consistency
+            if MBSInnerProduct::inner_product::<UNCHECKED>(
+                &q_0_combined_row,
+                &q_1,
+                F::zero_with_cfg(field_cfg),
+            )? != evals_f[poly_idx]
+            {
+                return Err(ZipError::InvalidPcsOpen(format!(
+                    "Evaluation consistency failure for polynomial {poly_idx}"
+                )));
+            }
+
+            // Verify proximity for this polynomial against opened columns
+            cfg_iter!(columns_opened).try_for_each(
+                |(column_idx, per_poly_column_values)| {
+                    ZipPlus::<Zt, Lc>::verify_proximity_q_0(
+                        &q_0,
+                        &encoded_combined_row,
+                        &per_poly_column_values[poly_idx],
+                        *column_idx,
+                        vp.num_rows,
+                        &project,
+                        field_cfg,
+                    )
+                },
+            )?;
+        }
+
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+#[allow(
+    clippy::arithmetic_side_effects,
+    clippy::cast_possible_truncation,
+    clippy::cast_possible_wrap
+)]
+mod tests {
+    use super::*;
+    use crate::{
+        batched_pcs::structs::BatchedZipPlus,
+        pcs::test_utils::*,
+    };
+    use crypto_bigint::U64;
+    use crypto_primitives::{
+        PrimeField,
+        crypto_bigint_boxed_monty::BoxedMontyField, crypto_bigint_int::Int,
+    };
+    use zinc_utils::CHECKED;
+
+    const INT_LIMBS: usize = U64::LIMBS;
+    const N: usize = INT_LIMBS;
+    const K: usize = INT_LIMBS * 4;
+    const M: usize = INT_LIMBS * 8;
+
+    type F = BoxedMontyField;
+    type Zt = TestZipTypes<N, K, M>;
+    type C = crate::code::raa_sign_flip::RaaSignFlippingCode<Zt, TestRaaConfig, 4>;
+    type TestBatchedZip = BatchedZipPlus<Zt, C>;
+
+    /// Helper: run full batched protocol and return all outputs for verification
+    fn setup_batched_protocol(
+        num_vars: usize,
+        polys: Vec<zinc_poly::mle::DenseMultilinearExtension<<Zt as ZipTypes>::Eval>>,
+    ) -> (
+        BatchedZipPlusParams<Zt, C>,
+        BatchedZipPlusCommitment,
+        Vec<F>,
+        Vec<F>,
+        BatchedZipPlusProof,
+    ) {
+        let (pp, _) = setup_test_params::<N, K, M>(num_vars);
+
+        let (hint, comm) = TestBatchedZip::commit(&pp, &polys).unwrap();
+
+        let test_transcript =
+            TestBatchedZip::test::<CHECKED>(&pp, &polys, &hint).unwrap();
+
+        // Evaluation point shared across all polynomials
+        let point: Vec<<Zt as ZipTypes>::Pt> =
+            (0..num_vars).map(|i| Int::from(i as i32 + 2)).collect();
+
+        let (field_cfg, _projecting_element) = {
+            let mut t: PcsTranscript = test_transcript.clone().into();
+            let field_cfg = t
+                .fs_transcript
+                .get_random_field_cfg::<F, <Zt as ZipTypes>::Fmod, <Zt as ZipTypes>::PrimeTest>(
+            );
+            let pe: <Zt as ZipTypes>::Chal = t.fs_transcript.get_challenge();
+            let pe_f: F = (&pe).into_with_cfg(&field_cfg);
+            (field_cfg, pe_f)
+        };
+
+        let (evals_f, proof) =
+            TestBatchedZip::evaluate::<F, CHECKED>(&pp, &polys, &point, test_transcript)
+                .unwrap();
+
+        let point_f: Vec<F> = point
+            .iter()
+            .map(|v| v.into_with_cfg(&field_cfg))
+            .collect();
+
+        (pp, comm, point_f, evals_f, proof)
+    }
+
+    #[test]
+    fn successful_batched_verification_single_poly() {
+        let num_vars = 4;
+        let poly: zinc_poly::mle::DenseMultilinearExtension<_> =
+            (1..=16).map(Int::from).collect();
+
+        let (pp, comm, point_f, evals_f, proof) =
+            setup_batched_protocol(num_vars, vec![poly]);
+
+        let result =
+            TestBatchedZip::verify::<F, CHECKED>(&pp, &comm, &point_f, &evals_f, &proof);
+        assert!(result.is_ok(), "Single-poly batched verification failed: {result:?}");
+    }
+
+    #[test]
+    fn successful_batched_verification_multiple_polys() {
+        let num_vars = 4;
+        let poly1: zinc_poly::mle::DenseMultilinearExtension<_> =
+            (1..=16).map(Int::from).collect();
+        let poly2: zinc_poly::mle::DenseMultilinearExtension<_> =
+            (17..=32).map(Int::from).collect();
+
+        let (pp, comm, point_f, evals_f, proof) =
+            setup_batched_protocol(num_vars, vec![poly1, poly2]);
+
+        let result =
+            TestBatchedZip::verify::<F, CHECKED>(&pp, &comm, &point_f, &evals_f, &proof);
+        assert!(result.is_ok(), "Multi-poly batched verification failed: {result:?}");
+    }
+
+    #[test]
+    fn batched_verification_fails_with_wrong_evaluation() {
+        let num_vars = 4;
+        let poly1: zinc_poly::mle::DenseMultilinearExtension<_> =
+            (1..=16).map(Int::from).collect();
+        let poly2: zinc_poly::mle::DenseMultilinearExtension<_> =
+            (17..=32).map(Int::from).collect();
+
+        let (pp, comm, point_f, mut evals_f, proof) =
+            setup_batched_protocol(num_vars, vec![poly1, poly2]);
+
+        // Corrupt the first evaluation
+        let cfg = evals_f[0].cfg().clone();
+        evals_f[0] = evals_f[0].clone() + F::one_with_cfg(&cfg);
+
+        let result =
+            TestBatchedZip::verify::<F, CHECKED>(&pp, &comm, &point_f, &evals_f, &proof);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn batched_verification_five_polynomials() {
+        let num_vars = 4;
+        let polys: Vec<zinc_poly::mle::DenseMultilinearExtension<_>> = (0..5)
+            .map(|offset| {
+                let start = offset * 16 + 1;
+                (start..start + 16).map(Int::from).collect()
+            })
+            .collect();
+
+        let (pp, comm, point_f, evals_f, proof) =
+            setup_batched_protocol(num_vars, polys);
+
+        let result =
+            TestBatchedZip::verify::<F, CHECKED>(&pp, &comm, &point_f, &evals_f, &proof);
+        assert!(result.is_ok(), "5-poly batched verification failed: {result:?}");
+    }
+}

--- a/zip-plus/src/batched_pcs/structs.rs
+++ b/zip-plus/src/batched_pcs/structs.rs
@@ -1,0 +1,92 @@
+use crate::{
+    code::LinearCode,
+    merkle::{MerkleTree, MtHash},
+    pcs::structs::{ZipPlusParams, ZipTypes},
+};
+use crypto_primitives::DenseRowMatrix;
+use std::marker::PhantomData;
+
+/// Batched Zip+ is a Polynomial Commitment Scheme (PCS) that supports
+/// committing to a batch of multilinear polynomials with a single shared
+/// Merkle tree.
+pub struct BatchedZipPlus<Zt: ZipTypes, Lc: LinearCode<Zt>>(PhantomData<(Zt, Lc)>);
+
+/// Full data of a batched zip commitment to multiple multilinear polynomials,
+/// including encoded rows per polynomial and a single shared Merkle tree,
+/// kept by the prover for the testing phase.
+#[derive(Debug)]
+pub struct BatchedZipPlusHint<R> {
+    /// The encoded rows of each polynomial's matrix representation.
+    /// `cw_matrices[i]` is the codeword matrix for the i-th polynomial.
+    pub cw_matrices: Vec<DenseRowMatrix<R>>,
+    /// Single shared Merkle tree built from the concatenated columns of all
+    /// codeword matrices.
+    pub merkle_tree: MerkleTree,
+}
+
+impl<R> BatchedZipPlusHint<R> {
+    pub fn new(
+        cw_matrices: Vec<DenseRowMatrix<R>>,
+        merkle_tree: MerkleTree,
+    ) -> BatchedZipPlusHint<R> {
+        BatchedZipPlusHint {
+            cw_matrices,
+            merkle_tree,
+        }
+    }
+
+    /// Number of polynomials in the batch.
+    pub fn batch_size(&self) -> usize {
+        self.cw_matrices.len()
+    }
+}
+
+/// The compact commitment to a batch of multilinear polynomials, consisting of
+/// the single shared Merkle root, to be sent to the verifier.
+#[derive(Clone, Debug, Default)]
+pub struct BatchedZipPlusCommitment {
+    /// Root of the shared merkle tree of all polynomials' codeword matrices.
+    pub root: MtHash,
+    /// Number of polynomials in the batch.
+    pub batch_size: usize,
+}
+
+/// Proof obtained by the verifier after the testing phase with a batch of
+/// polynomials.
+#[derive(Clone, Debug)]
+pub struct BatchedZipPlusTestTranscript(pub(crate) crate::pcs_transcript::PcsTranscript);
+
+impl From<crate::pcs_transcript::PcsTranscript> for BatchedZipPlusTestTranscript {
+    fn from(transcript: crate::pcs_transcript::PcsTranscript) -> Self {
+        BatchedZipPlusTestTranscript(transcript)
+    }
+}
+
+impl From<BatchedZipPlusTestTranscript> for crate::pcs_transcript::PcsTranscript {
+    fn from(value: BatchedZipPlusTestTranscript) -> Self {
+        value.0
+    }
+}
+
+/// Proof obtained by the verifier after the evaluation phase of a batched PCS.
+#[derive(Clone, Debug)]
+pub struct BatchedZipPlusProof(pub(crate) Vec<u8>);
+
+impl From<crate::pcs_transcript::PcsTranscript> for BatchedZipPlusProof {
+    fn from(transcript: crate::pcs_transcript::PcsTranscript) -> Self {
+        BatchedZipPlusProof(transcript.stream.into_inner())
+    }
+}
+
+impl From<BatchedZipPlusProof> for crate::pcs_transcript::PcsTranscript {
+    fn from(proof: BatchedZipPlusProof) -> Self {
+        Self {
+            fs_transcript: zinc_transcript::KeccakTranscript::default(),
+            stream: std::io::Cursor::new(proof.0),
+        }
+    }
+}
+
+/// Re-use `ZipPlusParams` from the single-polynomial PCS — parameters are
+/// the same for each polynomial in the batch.
+pub type BatchedZipPlusParams<Zt, Lc> = ZipPlusParams<Zt, Lc>;

--- a/zip-plus/src/lib.rs
+++ b/zip-plus/src/lib.rs
@@ -1,3 +1,4 @@
+pub mod batched_pcs;
 pub mod code;
 pub mod pcs;
 pub mod pcs_transcript;

--- a/zip-plus/src/merkle.rs
+++ b/zip-plus/src/merkle.rs
@@ -124,14 +124,31 @@ macro_rules! hash_many {
 
 /// Construct the leaves of the Merkle tree by hashing each column across all
 /// rows.
+///
+/// For each column, serializes all row elements into a single contiguous byte
+/// buffer and feeds it to Blake3 in one `update` call.  This lets Blake3
+/// process full 1 KiB chunks with SIMD, which is significantly faster than
+/// the per-element `update` approach when columns are tall (many rows).
 fn hash_leaves<S>(rows: &[&[S]], m_cols: usize) -> Vec<MtHash>
 where
     S: ConstTranscribable + Send + Sync,
 {
+    let num_rows = rows.len();
+    let elem_bytes = S::NUM_BYTES;
+    let col_bytes = num_rows * elem_bytes;
+
     cfg_into_iter!(0..m_cols)
         .map(|i| {
-            // Hash the i-th column across all rows.
-            hash_many!(rows.iter().map(|row| &row[i]), S)
+            // Serialize the entire column into a contiguous byte buffer.
+            let mut buf = vec![0_u8; col_bytes];
+            for (r, row) in rows.iter().enumerate() {
+                let start = r * elem_bytes;
+                row[i].write_transcription_bytes(&mut buf[start..start + elem_bytes]);
+            }
+            // Hash the contiguous buffer in one call.
+            let mut hasher = blake3::Hasher::new();
+            hasher.update(&buf);
+            hasher.finalize().into()
         })
         .collect()
 }

--- a/zip-plus/src/pcs/phase_verify.rs
+++ b/zip-plus/src/pcs/phase_verify.rs
@@ -148,7 +148,7 @@ impl<Zt: ZipTypes, Lc: LinearCode<Zt>> ZipPlus<Zt, Lc> {
         Ok(columns_opened)
     }
 
-    pub(super) fn verify_column_testing<const CHECK_FOR_OVERFLOW: bool>(
+    pub(crate) fn verify_column_testing<const CHECK_FOR_OVERFLOW: bool>(
         alphas: &[Zt::Chal],
         coeffs: &[Zt::Chal],
         encoded_combined_row: &[Zt::CombR],
@@ -233,7 +233,7 @@ impl<Zt: ZipTypes, Lc: LinearCode<Zt>> ZipPlus<Zt, Lc> {
         Ok(())
     }
 
-    fn verify_proximity_q_0<F>(
+    pub(crate) fn verify_proximity_q_0<F>(
         q_0: &[F],
         encoded_q_0_combined_row: &[F],
         column_entries: &[Zt::Cw],

--- a/zip-plus/src/pcs/utils.rs
+++ b/zip-plus/src/pcs/utils.rs
@@ -13,7 +13,7 @@ fn err_too_many_variates(function: &str, upto: usize, got: usize) -> ZipError {
 }
 
 // Ensures that polynomials and evaluation points are of appropriate size
-pub(super) fn validate_input<Zt: ZipTypes, Lc: LinearCode<Zt>, Pt>(
+pub(crate) fn validate_input<Zt: ZipTypes, Lc: LinearCode<Zt>, Pt>(
     function: &str,
     param_num_vars: usize,
     polys: &[&DenseMultilinearExtension<Zt::Eval>],
@@ -80,7 +80,7 @@ pub(super) fn validate_input<Zt: ZipTypes, Lc: LinearCode<Zt>, Pt>(
 /// into two vectors, `q_0` multiplying on the left and `q_1` multiplying on the
 /// right
 #[allow(clippy::unwrap_used)]
-pub(super) fn point_to_tensor<F>(
+pub(crate) fn point_to_tensor<F>(
     num_rows: usize,
     point: &[F],
     cfg: &F::Config,


### PR DESCRIPTION
## Summary

This PR introduces a **Batched Zip+ PCS** (`batched_pcs` module) that extends the existing single-polynomial Zip+ PCS to support committing to a batch of `m` multilinear polynomials with a **single shared Merkle tree**, and includes a performance optimization to Merkle tree leaf hashing.

## Motivation

When proving statements about multiple polynomials, committing each one independently results in `m` separate Merkle trees and `m` roots. The batched variant reduces this to a single Merkle tree and a single root by concatenating the codeword columns of all polynomials. This reduces:
- **Commitment size**: 1 root instead of `m`.
- **Column opening cost**: 1 Merkle proof per queried column instead of `m`.
- **Hashing cost**: thanks to a Blake3 optimization (see below), hashing one tall column is faster than hashing `m` short columns.

## Batched PCS Design

Given `m` polynomials, each of size `2^n`, the batched scheme works as follows:

### Commit (`phase_commit.rs`)
- Each polynomial is independently encoded into its codeword matrix via `ZipPlus::encode_rows`.
- A **single Merkle tree** is built from the concatenated columns: if each matrix has columns `(v_{i,1}, ..., v_{i,c})`, the tree is built over `(v_{1,1}||...||v_{m,1}, ..., v_{1,c}||...||v_{m,c})` where `||` denotes concatenation.
- The commitment is a single `MtHash` root plus the batch size.

### Test (`phase_test.rs`)
- For each polynomial, independent proximity-test challenges (α coefficients) are sampled and combined rows are computed.
- Column openings write values from **all** `m` polynomials for each queried column, followed by a **single** Merkle proof for that column (since columns are shared across all polynomials).

### Evaluate (`phase_evaluate.rs`)
- All polynomials are evaluated at the **same point** (a requirement of the batched scheme).
- Each polynomial produces its own field evaluation and `q_0_combined_row`.

### Verify (`phase_verify.rs`)
- The verifier reads per-polynomial testing data and verifies proximity independently via `ZipPlus::verify_column_testing`.
- Column Merkle proofs are verified against the **concatenated** values from all polynomials.
- Evaluation consistency is checked per-polynomial via `ZipPlus::verify_proximity_q_0`.

## Merkle Tree Leaf Hashing Optimization

The previous `hash_leaves` implementation called `hasher.update(&buf)` once per element (e.g., 8 bytes for `i64`). This prevented Blake3 from efficiently processing full 1 KiB chunks with SIMD.

The new implementation serializes each column's data into a contiguous byte buffer and feeds it to Blake3 in a single `update` call. This yields a **~1.6x speedup** on leaf hashing across all polynomial sizes, and makes the batched single-tree approach meaningfully faster than building `m` separate trees:

| poly_size | batch | Batched (1 tree) | Separate (m trees) | Speedup |
|-----------|-------|------------------|--------------------|---------|
| 2^12 | 10 | 810 µs | 1.25 ms | **1.54x** |
| 2^14 | 10 | 3.20 ms | 4.89 ms | **1.53x** |
| 2^16 | 2 | 2.31 ms | 3.87 ms | **1.68x** |
| 2^16 | 10 | 14.4 ms | 19.7 ms | **1.37x** |

## Structure

```
zip-plus/src/
├── batched_pcs.rs                  # Module root
├── batched_pcs/
│   ├── structs.rs                  # BatchedZipPlus, BatchedZipPlusHint, BatchedZipPlusCommitment,
│   │                               # BatchedZipPlusTestTranscript, BatchedZipPlusProof
│   ├── phase_commit.rs             # Batched commit (shared Merkle tree)
│   ├── phase_test.rs               # Batched proximity testing
│   ├── phase_evaluate.rs           # Batched evaluation at a shared point
│   └── phase_verify.rs             # Batched verification
└── ...
```

## Reuse

The batched PCS reuses as much as possible from the single-polynomial PCS:
- `ZipPlusParams` is aliased as `BatchedZipPlusParams` (same setup).
- `ZipPlus::setup`, `ZipPlus::encode_rows`, `ZipPlus::verify_column_testing`, and `ZipPlus::verify_proximity_q_0` are called directly.
- Visibility of `validate_input`, `point_to_tensor`, `verify_column_testing`, and `verify_proximity_q_0` was changed from `pub(super)` to `pub(crate)` to enable cross-module access.

## Benchmarks

A Criterion benchmark suite (`benches/batched_zip_plus_benches.rs`) covers:
- **BatchedCommit** — full batched commit (encode + Merkle tree)
- **BatchedMerkleTree** — Merkle tree construction only (isolates hashing cost)
- **SeparateMerkleTrees** — `m` independent trees for comparison
- **BatchedTest** — proximity testing phase
- **BatchedEvaluate** — evaluation phase
- **BatchedVerify** — verification phase

All benchmarks run across batch sizes 1, 2, 5, 10 and polynomial sizes 2^12, 2^14, 2^16.

Configuration: `Eval=i32`, `Cw=i64`, RAA code (repetition factor 4), 256-bit `MontyField`.

```bash
cargo bench -p zip-plus --bench batched_zip_plus_benches
```

## Tests

10 new unit tests covering:
- Single-polynomial batched commit consistency with the unbatched PCS
- Different polynomials produce different roots
- Deterministic commitment
- Batch size tracking
- Multi-polynomial and single-polynomial test/verify round-trips
- Wrong evaluation detection
- Five-polynomial end-to-end verification

All 78 tests pass (68 existing + 10 new):
```bash
cargo test -p zip-plus --lib
```

## Changes

| File | Change |
|------|--------|
| `zip-plus/src/lib.rs` | Added `pub mod batched_pcs` |
| `zip-plus/src/batched_pcs.rs` | New module root |
| `zip-plus/src/batched_pcs/structs.rs` | Core types |
| `zip-plus/src/batched_pcs/phase_commit.rs` | Batched commit + 4 tests |
| `zip-plus/src/batched_pcs/phase_test.rs` | Batched testing + 2 tests |
| `zip-plus/src/batched_pcs/phase_evaluate.rs` | Batched evaluation |
| `zip-plus/src/batched_pcs/phase_verify.rs` | Batched verification + 4 tests |
| `zip-plus/src/merkle.rs` | Contiguous-buffer leaf hashing optimization |
| `zip-plus/src/pcs/utils.rs` | `pub(super)` → `pub(crate)` for `validate_input`, `point_to_tensor` |
| `zip-plus/src/pcs/phase_verify.rs` | `pub(super)` → `pub(crate)` for `verify_column_testing`, `verify_proximity_q_0` |
| `zip-plus/Cargo.toml` | Added bench target |
| `zip-plus/benches/batched_zip_plus_benches.rs` | Criterion benchmarks (all phases + Merkle comparison) |
