### PR TITLE
feat: add rate-1/4 IPRS configurations for F65537

### DIFF
--- a/zip-plus/src/code/iprs.rs
+++ b/zip-plus/src/code/iprs.rs
@@ -12,7 +12,12 @@ use crate::{
 };
 use crypto_primitives::{FromPrimitiveWithConfig, FromWithConfig};
 use num_traits::{CheckedAdd, CheckedMul};
-pub use pntt::radix8::params::{PnttConfigF2_16_1, PnttInt, Radix8PnttParams};
+pub use pntt::radix8::params::{
+    PnttConfigF2_16_1,
+    PnttConfigF2_16R4B1, PnttConfigF2_16R4B2, PnttConfigF2_16R4B4,
+    PnttConfigF2_16R4B16, PnttConfigF2_16R4B32, PnttConfigF2_16R4B64,
+    PnttInt, Radix8PnttParams,
+};
 use std::{
     fmt::Debug,
     iter::Sum,

--- a/zip-plus/src/code/iprs/pntt/radix8/params.rs
+++ b/zip-plus/src/code/iprs/pntt/radix8/params.rs
@@ -192,6 +192,131 @@ impl<const DEPTH: usize> Config for PnttConfigF2_16_1<DEPTH> {
     }
 }
 
+// ==================== F65537 rate 1/4 configurations ====================
+
+/// Pseudo NTT configuration for F65537 (2^16 + 1) with BASE_LEN=1, BASE_DIM=4 (rate 1/4).
+/// NTT domain up to 2^16. Row lengths: 8 (D=1), 64 (D=2), 512 (D=3).
+#[derive(Clone, Copy)]
+pub struct PnttConfigF2_16R4B1<const DEPTH: usize>;
+
+/// Pseudo NTT configuration for F65537 (2^16 + 1) with BASE_LEN=2, BASE_DIM=8 (rate 1/4).
+/// NTT domain up to 2^16. Row lengths: 16 (D=1), 128 (D=2), 1024 (D=3).
+#[derive(Clone, Copy)]
+pub struct PnttConfigF2_16R4B2<const DEPTH: usize>;
+
+/// Pseudo NTT configuration for F65537 (2^16 + 1) with BASE_LEN=4, BASE_DIM=16 (rate 1/4).
+/// NTT domain up to 2^16. Row lengths: 32 (D=1), 256 (D=2), 2048 (D=3).
+#[derive(Clone, Copy)]
+pub struct PnttConfigF2_16R4B4<const DEPTH: usize>;
+
+/// Pseudo NTT configuration for F65537 (2^16 + 1) with BASE_LEN=16, BASE_DIM=64 (rate 1/4).
+/// NTT domain up to 2^16, enabling row lengths up to 2^13.
+/// Row lengths: 128 (D=1), 1024 (D=2), 8192 (D=3).
+#[derive(Clone, Copy)]
+pub struct PnttConfigF2_16R4B16<const DEPTH: usize>;
+
+/// Pseudo NTT configuration for F65537 (2^16 + 1) with BASE_LEN=32, BASE_DIM=128 (rate 1/4).
+/// NTT domain up to 2^16, enabling row lengths up to 2^11.
+/// Row lengths: 256 (D=1), 2048 (D=2).
+#[derive(Clone, Copy)]
+pub struct PnttConfigF2_16R4B32<const DEPTH: usize>;
+
+/// Pseudo NTT configuration for F65537 (2^16 + 1) with BASE_LEN=64, BASE_DIM=256 (rate 1/4).
+/// NTT domain up to 2^16, enabling row lengths up to 2^12.
+/// Row lengths: 512 (D=1), 4096 (D=2).
+#[derive(Clone, Copy)]
+pub struct PnttConfigF2_16R4B64<const DEPTH: usize>;
+
+impl<const DEPTH: usize> Config for PnttConfigF2_16R4B1<DEPTH> {
+    type Field = fq::Fq;
+    const FIELD_MODULUS: u32 = fq::MODULUS;
+    const BASE_LEN: usize = 1;
+    const BASE_DIM: usize = 4;
+    const DEPTH: usize = DEPTH;
+    const BASE_TWIDDLES: [PnttInt; 8] = [1, 4096, -256, 16, -1, -4096, 256, -16];
+
+    fn field_to_int_normalized(x: Self::Field) -> PnttInt {
+        let big_int = fq::FqBackend::into_bigint(x);
+
+        precompute::normalize_field_element(big_int.0[0], Self::FIELD_MODULUS)
+    }
+}
+
+impl<const DEPTH: usize> Config for PnttConfigF2_16R4B2<DEPTH> {
+    type Field = fq::Fq;
+    const FIELD_MODULUS: u32 = fq::MODULUS;
+    const BASE_LEN: usize = 2;
+    const BASE_DIM: usize = 8;
+    const DEPTH: usize = DEPTH;
+    const BASE_TWIDDLES: [PnttInt; 8] = [1, 4096, -256, 16, -1, -4096, 256, -16];
+
+    fn field_to_int_normalized(x: Self::Field) -> PnttInt {
+        let big_int = fq::FqBackend::into_bigint(x);
+
+        precompute::normalize_field_element(big_int.0[0], Self::FIELD_MODULUS)
+    }
+}
+
+impl<const DEPTH: usize> Config for PnttConfigF2_16R4B4<DEPTH> {
+    type Field = fq::Fq;
+    const FIELD_MODULUS: u32 = fq::MODULUS;
+    const BASE_LEN: usize = 4;
+    const BASE_DIM: usize = 16;
+    const DEPTH: usize = DEPTH;
+    const BASE_TWIDDLES: [PnttInt; 8] = [1, 4096, -256, 16, -1, -4096, 256, -16];
+
+    fn field_to_int_normalized(x: Self::Field) -> PnttInt {
+        let big_int = fq::FqBackend::into_bigint(x);
+
+        precompute::normalize_field_element(big_int.0[0], Self::FIELD_MODULUS)
+    }
+}
+
+impl<const DEPTH: usize> Config for PnttConfigF2_16R4B16<DEPTH> {
+    type Field = fq::Fq;
+    const FIELD_MODULUS: u32 = fq::MODULUS;
+    const BASE_LEN: usize = 16;
+    const BASE_DIM: usize = 64;
+    const DEPTH: usize = DEPTH;
+    const BASE_TWIDDLES: [PnttInt; 8] = [1, 4096, -256, 16, -1, -4096, 256, -16];
+
+    fn field_to_int_normalized(x: Self::Field) -> PnttInt {
+        let big_int = fq::FqBackend::into_bigint(x);
+
+        precompute::normalize_field_element(big_int.0[0], Self::FIELD_MODULUS)
+    }
+}
+
+impl<const DEPTH: usize> Config for PnttConfigF2_16R4B32<DEPTH> {
+    type Field = fq::Fq;
+    const FIELD_MODULUS: u32 = fq::MODULUS;
+    const BASE_LEN: usize = 32;
+    const BASE_DIM: usize = 128;
+    const DEPTH: usize = DEPTH;
+    const BASE_TWIDDLES: [PnttInt; 8] = [1, 4096, -256, 16, -1, -4096, 256, -16];
+
+    fn field_to_int_normalized(x: Self::Field) -> PnttInt {
+        let big_int = fq::FqBackend::into_bigint(x);
+
+        precompute::normalize_field_element(big_int.0[0], Self::FIELD_MODULUS)
+    }
+}
+
+impl<const DEPTH: usize> Config for PnttConfigF2_16R4B64<DEPTH> {
+    type Field = fq::Fq;
+    const FIELD_MODULUS: u32 = fq::MODULUS;
+    const BASE_LEN: usize = 64;
+    const BASE_DIM: usize = 256;
+    const DEPTH: usize = DEPTH;
+    const BASE_TWIDDLES: [PnttInt; 8] = [1, 4096, -256, 16, -1, -4096, 256, -16];
+
+    fn field_to_int_normalized(x: Self::Field) -> PnttInt {
+        let big_int = fq::FqBackend::into_bigint(x);
+
+        precompute::normalize_field_element(big_int.0[0], Self::FIELD_MODULUS)
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -206,7 +331,13 @@ mod tests {
     }
 
     #[test]
-    fn check_twiddles() {
+    fn check_twiddles_f65537() {
         check_twiddles_generic::<PnttConfigF2_16_1<1>>();
+        check_twiddles_generic::<PnttConfigF2_16R4B1<1>>();
+        check_twiddles_generic::<PnttConfigF2_16R4B2<1>>();
+        check_twiddles_generic::<PnttConfigF2_16R4B4<1>>();
+        check_twiddles_generic::<PnttConfigF2_16R4B16<1>>();
+        check_twiddles_generic::<PnttConfigF2_16R4B32<1>>();
+        check_twiddles_generic::<PnttConfigF2_16R4B64<1>>();
     }
 }


### PR DESCRIPTION
## Summary

Add six new rate-1/4 IPRS code configurations for the Fermat prime field F65537 = 2^16 + 1.

## New configurations

| Config struct | BASE_LEN | BASE_DIM | Row lengths (D=1 / D=2 / D=3) |
|---|---|---|---|
| `PnttConfigF2_16R4B1` | 1 | 4 | 8 / 64 / 512 |
| `PnttConfigF2_16R4B2` | 2 | 8 | 16 / 128 / 1024 |
| `PnttConfigF2_16R4B4` | 4 | 16 | 32 / 256 / 2048 |
| `PnttConfigF2_16R4B16` | 16 | 64 | 128 / 1024 / 8192 |
| `PnttConfigF2_16R4B32` | 32 | 128 | 256 / 2048 / — |
| `PnttConfigF2_16R4B64` | 64 | 256 | 512 / 4096 / — |

All use rate 1/4 (`BASE_DIM = 4 * BASE_LEN`) and share the same 8th-roots-of-unity twiddle factors as the existing `PnttConfigF2_16_1`.

## Changes
- `zip-plus/src/code/iprs/pntt/radix8/params.rs`: struct definitions, `Config` trait implementations, twiddle tests
- `zip-plus/src/code/iprs.rs`: re-exports
