### PR TITLE
bench: add FiveConstraint ideal check benchmarks

### DIFF
--- a/piop/benches/ideal_check.rs
+++ b/piop/benches/ideal_check.rs
@@ -16,8 +16,9 @@ use zinc_piop::{
 use zinc_poly::univariate::{dense::DensePolynomial, ideal::DegreeOneIdeal};
 use zinc_primality::{MillerRabin, PrimalityTest};
 use zinc_test_uair::{
-    BigLinearUair, BinaryDecompositionUair, GenerateMultiTypeWitness, GenerateSingleTypeWitness,
-    TestAirNoMultiplication, TestUairSimpleMultiplication,
+    BigLinearUair, BinaryDecompositionUair, FiveConstraintDecompositionUair,
+    FiveConstraintQuadraticUair, FiveConstraintSimpleUair, GenerateMultiTypeWitness,
+    GenerateSingleTypeWitness, TestAirNoMultiplication, TestUairSimpleMultiplication,
 };
 use zinc_transcript::{
     KeccakTranscript,
@@ -436,6 +437,315 @@ fn bench_big_linear_uair<const FIELD_LIMBS: usize>(
     );
 }
 
+#[allow(clippy::arithmetic_side_effects)]
+fn bench_five_constraint_decomposition<const FIELD_LIMBS: usize>(
+    group: &mut BenchmarkGroup<WallTime>,
+    witness_size: usize,
+) where
+    <F<FIELD_LIMBS> as Field>::Inner: ConstIntSemiring + ConstTranscribable,
+    MillerRabin: PrimalityTest<<F<FIELD_LIMBS> as Field>::Inner>,
+{
+    let mut rng = rng();
+    let num_vars = zinc_utils::log2(witness_size) as usize;
+    let (binary_poly_trace, _, int_trace) =
+        FiveConstraintDecompositionUair::generate_witness(num_vars, &mut rng);
+
+    let params = format!(
+        "FiveConstraintDecomposition/LIMBS={}/nvars={}",
+        FIELD_LIMBS, num_vars
+    );
+
+    let num_constraints = count_constraints::<FiveConstraintDecompositionUair>();
+
+    let prove = |field_cfg: &<F<FIELD_LIMBS> as PrimeField>::Config,
+                 binary_poly_trace: &[_],
+                 int_trace: &[_],
+                 transcript: &mut KeccakTranscript|
+     -> Proof<F<FIELD_LIMBS>> {
+        let trace =
+            project_trace_coeffs::<_, u32, u32, _>(binary_poly_trace, &[], int_trace, field_cfg);
+
+        let projected_scalars =
+            project_scalars::<F<FIELD_LIMBS>, FiveConstraintDecompositionUair>(|scalar| {
+                scalar
+                    .iter()
+                    .map(|coeff| F::from_with_cfg(coeff, field_cfg))
+                    .collect()
+            });
+
+        IdealCheckProtocol::prove_as_subprotocol::<FiveConstraintDecompositionUair>(
+            transcript,
+            &trace,
+            &projected_scalars,
+            num_constraints,
+            num_vars,
+            field_cfg,
+        )
+        .expect("Prover failed")
+        .0
+    };
+
+    group.bench_with_input(
+        BenchmarkId::new("Ideal Check Prover", &params),
+        &(&binary_poly_trace, &int_trace),
+        |bench, (binary_poly_trace, int_trace)| {
+            let mut transcript = KeccakTranscript::new();
+            let field_cfg = transcript.get_random_field_cfg::<F<FIELD_LIMBS>, _, MillerRabin>();
+            bench.iter_batched(
+                || (&field_cfg, binary_poly_trace, int_trace, transcript.clone()),
+                |(field_cfg, binary_poly_trace, int_trace, mut transcript)| {
+                    let _ = black_box(prove(
+                        field_cfg,
+                        binary_poly_trace,
+                        int_trace,
+                        &mut transcript,
+                    ));
+                },
+                BatchSize::SmallInput,
+            );
+        },
+    );
+
+    group.bench_with_input(
+        BenchmarkId::new("Ideal Check Verifier", &params),
+        &(&binary_poly_trace, &int_trace),
+        |bench, (binary_poly_trace, int_trace)| {
+            let mut transcript = KeccakTranscript::new();
+            let field_cfg = transcript.get_random_field_cfg::<F<FIELD_LIMBS>, _, MillerRabin>();
+            let proof = prove(&field_cfg, binary_poly_trace, int_trace, &mut transcript);
+
+            bench.iter_batched(
+                || (proof.clone(), transcript.clone()),
+                |(proof, mut transcript)| {
+                    let _ = black_box(IdealCheckProtocol::verify_as_subprotocol::<
+                        FiveConstraintDecompositionUair,
+                        _,
+                        _,
+                    >(
+                        &mut transcript,
+                        proof,
+                        num_constraints,
+                        num_vars,
+                        |ideal_over_ring| {
+                            ideal_over_ring.map(|ideal_over_ring| {
+                                DegreeOneIdeal::from_with_cfg(ideal_over_ring, &field_cfg)
+                            })
+                        },
+                        &field_cfg,
+                    ))
+                    .expect("Failed to verify");
+                },
+                BatchSize::SmallInput,
+            );
+        },
+    );
+}
+
+#[allow(clippy::arithmetic_side_effects)]
+fn bench_five_constraint_simple<const FIELD_LIMBS: usize>(
+    group: &mut BenchmarkGroup<WallTime>,
+    witness_size: usize,
+) where
+    <F<FIELD_LIMBS> as Field>::Inner: ConstIntSemiring + ConstTranscribable,
+    MillerRabin: PrimalityTest<<F<FIELD_LIMBS> as Field>::Inner>,
+{
+    let mut rng = rng();
+    let num_vars = zinc_utils::log2(witness_size) as usize;
+    let (binary_poly_trace, _, int_trace) =
+        FiveConstraintSimpleUair::generate_witness(num_vars, &mut rng);
+
+    let params = format!(
+        "FiveConstraintSimple/LIMBS={}/nvars={}",
+        FIELD_LIMBS, num_vars
+    );
+
+    let num_constraints = count_constraints::<FiveConstraintSimpleUair>();
+
+    let prove = |field_cfg: &<F<FIELD_LIMBS> as PrimeField>::Config,
+                 binary_poly_trace: &[_],
+                 int_trace: &[_],
+                 transcript: &mut KeccakTranscript|
+     -> Proof<F<FIELD_LIMBS>> {
+        let trace =
+            project_trace_coeffs::<_, u32, u32, _>(binary_poly_trace, &[], int_trace, field_cfg);
+
+        let projected_scalars =
+            project_scalars::<F<FIELD_LIMBS>, FiveConstraintSimpleUair>(|scalar| {
+                scalar
+                    .iter()
+                    .map(|coeff| F::from_with_cfg(coeff, field_cfg))
+                    .collect()
+            });
+
+        IdealCheckProtocol::prove_as_subprotocol::<FiveConstraintSimpleUair>(
+            transcript,
+            &trace,
+            &projected_scalars,
+            num_constraints,
+            num_vars,
+            field_cfg,
+        )
+        .expect("Prover failed")
+        .0
+    };
+
+    group.bench_with_input(
+        BenchmarkId::new("Ideal Check Prover", &params),
+        &(&binary_poly_trace, &int_trace),
+        |bench, (binary_poly_trace, int_trace)| {
+            let mut transcript = KeccakTranscript::new();
+            let field_cfg = transcript.get_random_field_cfg::<F<FIELD_LIMBS>, _, MillerRabin>();
+            bench.iter_batched(
+                || (&field_cfg, binary_poly_trace, int_trace, transcript.clone()),
+                |(field_cfg, binary_poly_trace, int_trace, mut transcript)| {
+                    let _ = black_box(prove(
+                        field_cfg,
+                        binary_poly_trace,
+                        int_trace,
+                        &mut transcript,
+                    ));
+                },
+                BatchSize::SmallInput,
+            );
+        },
+    );
+
+    group.bench_with_input(
+        BenchmarkId::new("Ideal Check Verifier", &params),
+        &(&binary_poly_trace, &int_trace),
+        |bench, (binary_poly_trace, int_trace)| {
+            let mut transcript = KeccakTranscript::new();
+            let field_cfg = transcript.get_random_field_cfg::<F<FIELD_LIMBS>, _, MillerRabin>();
+            let proof = prove(&field_cfg, binary_poly_trace, int_trace, &mut transcript);
+
+            bench.iter_batched(
+                || (proof.clone(), transcript.clone()),
+                |(proof, mut transcript)| {
+                    let _ = black_box(IdealCheckProtocol::verify_as_subprotocol::<
+                        FiveConstraintSimpleUair,
+                        _,
+                        _,
+                    >(
+                        &mut transcript,
+                        proof,
+                        num_constraints,
+                        num_vars,
+                        |ideal_over_ring| {
+                            ideal_over_ring.map(|ideal_over_ring| {
+                                DegreeOneIdeal::from_with_cfg(ideal_over_ring, &field_cfg)
+                            })
+                        },
+                        &field_cfg,
+                    ))
+                    .expect("Failed to verify");
+                },
+                BatchSize::SmallInput,
+            );
+        },
+    );
+}
+
+#[allow(clippy::arithmetic_side_effects)]
+fn bench_five_constraint_quadratic<const FIELD_LIMBS: usize>(
+    group: &mut BenchmarkGroup<WallTime>,
+    witness_size: usize,
+) where
+    <F<FIELD_LIMBS> as Field>::Inner: ConstIntSemiring + ConstTranscribable,
+    MillerRabin: PrimalityTest<<F<FIELD_LIMBS> as Field>::Inner>,
+{
+    let mut rng = rng();
+    let num_vars = zinc_utils::log2(witness_size) as usize;
+    let (_, _, int_trace) = FiveConstraintQuadraticUair::generate_witness(num_vars, &mut rng);
+
+    let params = format!(
+        "FiveConstraintQuadratic/LIMBS={}/nvars={}",
+        FIELD_LIMBS, num_vars
+    );
+
+    let num_constraints = count_constraints::<FiveConstraintQuadraticUair>();
+
+    let prove = |field_cfg: &<F<FIELD_LIMBS> as PrimeField>::Config,
+                 int_trace: &[_],
+                 transcript: &mut KeccakTranscript|
+     -> Proof<F<FIELD_LIMBS>> {
+        let trace =
+            project_trace_coeffs::<_, u32, u32, 32>(&[], &[], int_trace, field_cfg);
+
+        let projected_scalars =
+            project_scalars::<F<FIELD_LIMBS>, FiveConstraintQuadraticUair>(|scalar| {
+                scalar
+                    .iter()
+                    .map(|coeff| F::from_with_cfg(coeff, field_cfg))
+                    .collect()
+            });
+
+        IdealCheckProtocol::prove_as_subprotocol::<FiveConstraintQuadraticUair>(
+            transcript,
+            &trace,
+            &projected_scalars,
+            num_constraints,
+            num_vars,
+            field_cfg,
+        )
+        .expect("Prover failed")
+        .0
+    };
+
+    group.bench_with_input(
+        BenchmarkId::new("Ideal Check Prover", &params),
+        &&int_trace,
+        |bench, int_trace| {
+            let mut transcript = KeccakTranscript::new();
+            let field_cfg = transcript.get_random_field_cfg::<F<FIELD_LIMBS>, _, MillerRabin>();
+            bench.iter_batched(
+                || (&field_cfg, *int_trace, transcript.clone()),
+                |(field_cfg, int_trace, mut transcript)| {
+                    let _ = black_box(prove(
+                        field_cfg,
+                        int_trace,
+                        &mut transcript,
+                    ));
+                },
+                BatchSize::SmallInput,
+            );
+        },
+    );
+
+    group.bench_with_input(
+        BenchmarkId::new("Ideal Check Verifier", &params),
+        &&int_trace,
+        |bench, int_trace| {
+            let mut transcript = KeccakTranscript::new();
+            let field_cfg = transcript.get_random_field_cfg::<F<FIELD_LIMBS>, _, MillerRabin>();
+            let proof = prove(&field_cfg, int_trace, &mut transcript);
+
+            bench.iter_batched(
+                || (proof.clone(), transcript.clone()),
+                |(proof, mut transcript)| {
+                    let _ = black_box(IdealCheckProtocol::verify_as_subprotocol::<
+                        FiveConstraintQuadraticUair,
+                        _,
+                        _,
+                    >(
+                        &mut transcript,
+                        proof,
+                        num_constraints,
+                        num_vars,
+                        |ideal_over_ring| {
+                            ideal_over_ring.map(|ideal_over_ring| {
+                                DegreeOneIdeal::from_with_cfg(ideal_over_ring, &field_cfg)
+                            })
+                        },
+                        &field_cfg,
+                    ))
+                    .expect("Failed to verify");
+                },
+                BatchSize::SmallInput,
+            );
+        },
+    );
+}
+
 /// Before/after diff for combined_poly_builder (parallel vs sequential):
 ///   1. cargo bench -p zinc-piop --bench ideal_check -- "Ideal Check Prover"
 ///      --save-baseline sequential
@@ -471,6 +781,27 @@ pub fn ideal_check_benches(c: &mut Criterion) {
     bench_binary_decomposition::<4>(&mut group, 1 << 16);
     bench_binary_decomposition::<3>(&mut group, 1 << 17);
     bench_binary_decomposition::<4>(&mut group, 1 << 17);
+
+    bench_five_constraint_decomposition::<3>(&mut group, 1 << 10);
+    bench_five_constraint_decomposition::<4>(&mut group, 1 << 10);
+    bench_five_constraint_decomposition::<3>(&mut group, 1 << 12);
+    bench_five_constraint_decomposition::<4>(&mut group, 1 << 12);
+    bench_five_constraint_decomposition::<3>(&mut group, 1 << 14);
+    bench_five_constraint_decomposition::<4>(&mut group, 1 << 14);
+
+    bench_five_constraint_simple::<3>(&mut group, 1 << 10);
+    bench_five_constraint_simple::<4>(&mut group, 1 << 10);
+    bench_five_constraint_simple::<3>(&mut group, 1 << 12);
+    bench_five_constraint_simple::<4>(&mut group, 1 << 12);
+    bench_five_constraint_simple::<3>(&mut group, 1 << 14);
+    bench_five_constraint_simple::<4>(&mut group, 1 << 14);
+
+    bench_five_constraint_quadratic::<3>(&mut group, 1 << 10);
+    bench_five_constraint_quadratic::<4>(&mut group, 1 << 10);
+    bench_five_constraint_quadratic::<3>(&mut group, 1 << 12);
+    bench_five_constraint_quadratic::<4>(&mut group, 1 << 12);
+    bench_five_constraint_quadratic::<3>(&mut group, 1 << 14);
+    bench_five_constraint_quadratic::<4>(&mut group, 1 << 14);
 
     bench_big_linear_uair::<3>(&mut group, 1 << 12);
     bench_big_linear_uair::<4>(&mut group, 1 << 12);

--- a/test-uair/src/lib.rs
+++ b/test-uair/src/lib.rs
@@ -297,6 +297,259 @@ impl GenerateMultiTypeWitness for BinaryDecompositionUair {
     }
 }
 
+/// A UAIR with 5 linear constraints: 24 int columns split into
+/// 5 groups (of sizes 5, 5, 5, 5, 4), each group summed and checked against
+/// its own binary poly column modulo the ideal (X - 2).
+pub struct FiveConstraintDecompositionUair;
+
+impl Uair for FiveConstraintDecompositionUair {
+    type Ideal = DegreeOneIdeal<u32>;
+    type Scalar = DensePolynomial<u32, 32>;
+
+    fn signature() -> UairSignature {
+        UairSignature {
+            binary_poly_cols: 5,
+            arbitrary_poly_cols: 0,
+            int_cols: 24,
+        }
+    }
+
+    fn constrain_general<B, FromR, MulByScalar, IFromR>(
+        b: &mut B,
+        up: TraceRow<B::Expr>,
+        _down: TraceRow<B::Expr>,
+        _from_ref: FromR,
+        _mbs: MulByScalar,
+        ideal_from_ref: IFromR,
+    ) where
+        B: ConstraintBuilder,
+        FromR: Fn(&Self::Scalar) -> B::Expr,
+        MulByScalar: Fn(&B::Expr, &Self::Scalar) -> Option<B::Expr>,
+        IFromR: Fn(&Self::Ideal) -> B::Ideal,
+    {
+        let ideal = ideal_from_ref(&DegreeOneIdeal::new(2));
+        let group_sizes = [5, 5, 5, 5, 4];
+        let mut int_offset = 0;
+        for (group, &size) in group_sizes.iter().enumerate() {
+            let sum = up.int[int_offset + 1..int_offset + size]
+                .iter()
+                .fold(up.int[int_offset].clone(), |acc, next| acc + next);
+            b.assert_in_ideal(up.binary_poly[group].clone() - &sum, &ideal);
+            int_offset += size;
+        }
+    }
+}
+
+impl GenerateMultiTypeWitness for FiveConstraintDecompositionUair {
+    type PolyCoeff = u32;
+    type Int = u32;
+
+    fn generate_witness<Rng: rand::RngCore + ?Sized>(
+        num_vars: usize,
+        rng: &mut Rng,
+    ) -> (
+        Vec<DenseMultilinearExtension<BinaryPoly<32>>>,
+        Vec<DenseMultilinearExtension<DensePolynomial<Self::PolyCoeff, 32>>>,
+        Vec<DenseMultilinearExtension<Self::Int>>,
+    ) {
+        let num_rows = 1 << num_vars;
+        let group_sizes: [usize; 5] = [5, 5, 5, 5, 4];
+
+        // Limit each int to 29 bits so that 5 * (2^29 - 1) < 2^32.
+        let mask = (1u32 << 29) - 1;
+        let int_cols: Vec<DenseMultilinearExtension<u32>> = (0..24)
+            .map(|_| {
+                (0..num_rows)
+                    .map(|_| rng.random::<u32>() & mask)
+                    .collect()
+            })
+            .collect();
+
+        // 5 binary poly columns, each derived from its group's int sum.
+        let mut int_offset = 0;
+        let binary_poly_cols: Vec<DenseMultilinearExtension<BinaryPoly<32>>> = group_sizes
+            .iter()
+            .map(|&size| {
+                let col = (0..num_rows)
+                    .map(|row| {
+                        let sum: u32 = int_cols[int_offset..int_offset + size]
+                            .iter()
+                            .map(|col| col[row])
+                            .sum();
+                        BinaryPoly::from(sum)
+                    })
+                    .collect();
+                int_offset += size;
+                col
+            })
+            .collect();
+
+        (binary_poly_cols, vec![], int_cols)
+    }
+}
+
+/// A UAIR with 5 linear constraints: 5 binary poly columns and 5 int columns,
+/// each constraint checks that a binary poly column equals its corresponding
+/// int column modulo the ideal (X - 2).
+pub struct FiveConstraintSimpleUair;
+
+impl Uair for FiveConstraintSimpleUair {
+    type Ideal = DegreeOneIdeal<u32>;
+    type Scalar = DensePolynomial<u32, 32>;
+
+    fn signature() -> UairSignature {
+        UairSignature {
+            binary_poly_cols: 5,
+            arbitrary_poly_cols: 0,
+            int_cols: 5,
+        }
+    }
+
+    fn constrain_general<B, FromR, MulByScalar, IFromR>(
+        b: &mut B,
+        up: TraceRow<B::Expr>,
+        _down: TraceRow<B::Expr>,
+        _from_ref: FromR,
+        _mbs: MulByScalar,
+        ideal_from_ref: IFromR,
+    ) where
+        B: ConstraintBuilder,
+        FromR: Fn(&Self::Scalar) -> B::Expr,
+        MulByScalar: Fn(&B::Expr, &Self::Scalar) -> Option<B::Expr>,
+        IFromR: Fn(&Self::Ideal) -> B::Ideal,
+    {
+        let ideal = ideal_from_ref(&DegreeOneIdeal::new(2));
+        for i in 0..5 {
+            b.assert_in_ideal(up.binary_poly[i].clone() - &up.int[i], &ideal);
+        }
+    }
+}
+
+impl GenerateMultiTypeWitness for FiveConstraintSimpleUair {
+    type PolyCoeff = u32;
+    type Int = u32;
+
+    fn generate_witness<Rng: rand::RngCore + ?Sized>(
+        num_vars: usize,
+        rng: &mut Rng,
+    ) -> (
+        Vec<DenseMultilinearExtension<BinaryPoly<32>>>,
+        Vec<DenseMultilinearExtension<DensePolynomial<Self::PolyCoeff, 32>>>,
+        Vec<DenseMultilinearExtension<Self::Int>>,
+    ) {
+        let num_rows = 1 << num_vars;
+
+        let int_cols: Vec<DenseMultilinearExtension<u32>> = (0..5)
+            .map(|_| DenseMultilinearExtension::rand(num_vars, rng))
+            .collect();
+
+        let binary_poly_cols: Vec<DenseMultilinearExtension<BinaryPoly<32>>> = int_cols
+            .iter()
+            .map(|int_col| {
+                (0..num_rows)
+                    .map(|row| BinaryPoly::from(int_col[row]))
+                    .collect()
+            })
+            .collect();
+
+        (binary_poly_cols, vec![], int_cols)
+    }
+}
+
+/// A UAIR with 5 degree-2 constraints over 24 int columns (no polynomial columns).
+/// Columns are split into 5 groups (of sizes 5, 5, 5, 5, 4). In each group,
+/// the first two columns are multiplied, the middle columns are summed in, and
+/// the last column holds the result:
+///   int[start] * int[start+1] + int[start+2] + ... + int[start+size-2] - int[start+size-1] == 0
+pub struct FiveConstraintQuadraticUair;
+
+impl Uair for FiveConstraintQuadraticUair {
+    type Ideal = DegreeOneIdeal<u32>;
+    type Scalar = DensePolynomial<u32, 32>;
+
+    fn signature() -> UairSignature {
+        UairSignature {
+            binary_poly_cols: 0,
+            arbitrary_poly_cols: 0,
+            int_cols: 24,
+        }
+    }
+
+    fn constrain_general<B, FromR, MulByScalar, IFromR>(
+        b: &mut B,
+        up: TraceRow<B::Expr>,
+        _down: TraceRow<B::Expr>,
+        _from_ref: FromR,
+        _mbs: MulByScalar,
+        _ideal_from_ref: IFromR,
+    ) where
+        B: ConstraintBuilder,
+        FromR: Fn(&Self::Scalar) -> B::Expr,
+        MulByScalar: Fn(&B::Expr, &Self::Scalar) -> Option<B::Expr>,
+        IFromR: Fn(&Self::Ideal) -> B::Ideal,
+    {
+        let group_sizes = [5, 5, 5, 5, 4];
+        let mut int_offset = 0;
+        for &size in &group_sizes {
+            let product = up.int[int_offset].clone() * &up.int[int_offset + 1];
+            let linear_sum = up.int[int_offset + 3..int_offset + size - 1]
+                .iter()
+                .fold(up.int[int_offset + 2].clone(), |acc, next| acc + next);
+            b.assert_zero(product + &linear_sum - &up.int[int_offset + size - 1]);
+            int_offset += size;
+        }
+    }
+}
+
+impl GenerateMultiTypeWitness for FiveConstraintQuadraticUair {
+    type PolyCoeff = u32;
+    type Int = u32;
+
+    fn generate_witness<Rng: rand::RngCore + ?Sized>(
+        num_vars: usize,
+        rng: &mut Rng,
+    ) -> (
+        Vec<DenseMultilinearExtension<BinaryPoly<32>>>,
+        Vec<DenseMultilinearExtension<DensePolynomial<Self::PolyCoeff, 32>>>,
+        Vec<DenseMultilinearExtension<Self::Int>>,
+    ) {
+        let num_rows = 1 << num_vars;
+        let group_sizes: [usize; 5] = [5, 5, 5, 5, 4];
+
+        // Limit values to 12 bits so products (24 bits) plus a few sums stay within u32.
+        let mask = (1u32 << 12) - 1;
+
+        let mut int_cols: Vec<DenseMultilinearExtension<u32>> = Vec::with_capacity(24);
+
+        for &size in &group_sizes {
+            // Generate random input columns (all except the last in the group).
+            let input_cols: Vec<DenseMultilinearExtension<u32>> = (0..size - 1)
+                .map(|_| {
+                    (0..num_rows)
+                        .map(|_| rng.random::<u32>() & mask)
+                        .collect()
+                })
+                .collect();
+
+            // Result column: input[0] * input[1] + input[2] + ... + input[size-2].
+            let result_col: DenseMultilinearExtension<u32> = (0..num_rows)
+                .map(|row| {
+                    let product = input_cols[0][row] * input_cols[1][row];
+                    let linear: u32 = input_cols[2..].iter().map(|col| col[row]).sum();
+                    product + linear
+                })
+                .collect();
+
+            for col in input_cols {
+                int_cols.push(col);
+            }
+            int_cols.push(result_col);
+        }
+
+        (vec![], vec![], int_cols)
+    }
+}
+
 pub struct BigLinearUair;
 
 impl Uair for BigLinearUair {


### PR DESCRIPTION
Add three new benchmark UAIRs and their corresponding ideal check benchmarks:

1. FiveConstraintDecompositionUair: 5 binary poly columns, 24 int columns, 5 linear constraints. Resembles the sha256+ecdsa UAIR structure, except that the latter also has non-linear constraints involving the integer columns.

2. FiveConstraintSimpleUair: 5 binary poly columns, 5 int columns, 5 linear constraints. Each constraint checks binary_poly[i] == int[i] modulo (X - 2).

3. FiveConstraintQuadraticUair: 0 poly columns, 24 int columns, 5 degree-2 constraints. Each constraint checks int[a] * int[b] + linear_sum - int[result] == 0.

All benchmarks run at sizes 2^10, 2^12, 2^14 for field limbs 3 and 4.