### PR TITLE
Accommodate crypto-primitives change

### DIFF
--- a/piop/benches/sumcheck.rs
+++ b/piop/benches/sumcheck.rs
@@ -30,7 +30,8 @@ pub fn bench_simple_product<F, const LIMBS: usize>(
 ) where
     F: FromPrimitiveWithConfig + InnerTransparentField + FromRef<F> + 'static,
     F::Inner: FromRef<F::Inner> + ConstTranscribable + ConstIntSemiring,
-    MillerRabin: PrimalityTest<F::Inner>,
+    F::Modulus: FromRef<F::Modulus> + ConstTranscribable + ConstIntSemiring,
+    MillerRabin: PrimalityTest<F::Modulus>,
     for<'a> &'a F: Mul<&'a F, Output = F>,
 {
     let mut rng = rng();
@@ -66,7 +67,7 @@ pub fn bench_simple_product<F, const LIMBS: usize>(
     let transcript = KeccakTranscript::new();
 
     let prove = |(a, b, c, mut transcript):(_,_,_,KeccakTranscript)| -> RFSumcheckProof<F, BinaryPoly<32>> {
-        let field_cfg = transcript.get_random_field_cfg::<F, <F as Field>::Inner, MillerRabin>();
+        let field_cfg = transcript.get_random_field_cfg::<F, <F as Field>::Modulus, MillerRabin>();
 
         let eq_r = build_eq_x_r_inner(&vec![F::from_with_cfg(2u32, &field_cfg); nvars], &field_cfg)
             .expect("Failed to build eq_r");
@@ -107,7 +108,7 @@ pub fn bench_simple_product<F, const LIMBS: usize>(
                 || (proof.clone(), transcript.clone()),
                 |(proof, mut transcript)| {
                     let field_cfg =
-                        transcript.get_random_field_cfg::<F, <F as Field>::Inner, MillerRabin>();
+                        transcript.get_random_field_cfg::<F, <F as Field>::Modulus, MillerRabin>();
 
                     let _ = black_box(
                         RFSumcheck::<F, _>::verify_as_subprotocol(

--- a/piop/src/combined_poly_resolver.rs
+++ b/piop/src/combined_poly_resolver.rs
@@ -71,6 +71,7 @@ impl<F: InnerTransparentField + FromPrimitiveWithConfig + Send + Sync> CombinedP
     ) -> Result<(Proof<F>, ProverState<F>), CombinedPolyResolverError<F>>
     where
         F::Inner: ConstTranscribable + Send + Sync + Zero + Default,
+        F::Modulus: ConstTranscribable,
         U: Uair,
     {
         debug_assert_ne!(
@@ -225,6 +226,7 @@ impl<F: InnerTransparentField + FromPrimitiveWithConfig + Send + Sync> CombinedP
     ) -> Result<VerifierSubclaim<F>, CombinedPolyResolverError<F>>
     where
         F::Inner: ConstTranscribable,
+        F::Modulus: ConstTranscribable,
         U: Uair,
     {
         proof.validate_evaluation_sizes(U::signature().total_cols())?;

--- a/piop/src/ideal_check.rs
+++ b/piop/src/ideal_check.rs
@@ -60,6 +60,7 @@ impl<F: InnerTransparentField> IdealCheckProtocol<F> {
     where
         U: Uair,
         F::Inner: ConstTranscribable,
+        F::Modulus: ConstTranscribable,
     {
         let combined_mles = combined_poly_builder::compute_combined_polynomials::<_, U>(
             trace,
@@ -136,6 +137,7 @@ impl<F: InnerTransparentField> IdealCheckProtocol<F> {
     where
         U: Uair,
         F::Inner: ConstTranscribable,
+        F::Modulus: ConstTranscribable,
         IdealOverF: Ideal + IdealCheck<DynamicPolynomialF<F>>,
         IdealOverFFromRef: Fn(&IdealOrZero<U::Ideal>) -> IdealOverF,
     {

--- a/piop/src/projections.rs
+++ b/piop/src/projections.rs
@@ -112,7 +112,7 @@ where
         result,
         cfg_iter!(binary_poly_trace).map(|column| {
             cfg_iter!(column)
-                .map(|poly| binary_poly_projection(poly).inner().clone())
+                .map(|poly| binary_poly_projection(poly).into_inner())
                 .collect()
         })
     );

--- a/piop/src/random_field_sumcheck.rs
+++ b/piop/src/random_field_sumcheck.rs
@@ -72,8 +72,9 @@ impl<F: FromPrimitiveWithConfig, R: Semiring + ProjectableToField<F>> RFSumcheck
         field_cfg: &F::Config,
     ) -> (RFSumcheckProof<F, R>, RFProverState<F, R>)
     where
-        F::Inner: ConstTranscribable + ConstIntSemiring + FromRef<F::Inner>,
         F: InnerTransparentField,
+        F::Inner: ConstTranscribable + ConstIntSemiring + FromRef<F::Inner>,
+        F::Modulus: ConstTranscribable,
     {
         let projecting_element: F = transcript.get_field_challenge(field_cfg);
 
@@ -116,6 +117,7 @@ impl<F: FromPrimitiveWithConfig, R: Semiring + ProjectableToField<F>> RFSumcheck
     ) -> Result<SubClaim<F>, RFSumcheckError<F>>
     where
         F::Inner: ConstTranscribable + ConstIntSemiring,
+        F::Modulus: ConstTranscribable,
     {
         // Simulate getting the projecting element
         // Verifier does not use that element as it verifies only over RC,

--- a/piop/src/sumcheck.rs
+++ b/piop/src/sumcheck.rs
@@ -90,8 +90,9 @@ impl<F: FromPrimitiveWithConfig> MLSumcheck<F> {
         config: &F::Config,
     ) -> (SumcheckProof<F>, ProverState<F>)
     where
-        F::Inner: ConstTranscribable + Zero,
         F: InnerTransparentField,
+        F::Inner: ConstTranscribable + Zero,
+        F::Modulus: ConstTranscribable,
     {
         if nvars == 0 {
             panic!("Attempt to prove a constant")
@@ -194,6 +195,7 @@ impl<F: FromPrimitiveWithConfig> MLSumcheck<F> {
     ) -> Result<SubClaim<F>, SumCheckError<F>>
     where
         F::Inner: ConstTranscribable,
+        F::Modulus: ConstTranscribable,
     {
         if num_vars == 0 {
             panic!("Attempt to verify a sumcheck claim for 0 variables")

--- a/piop/src/sumcheck/tests/utils.rs
+++ b/piop/src/sumcheck/tests/utils.rs
@@ -47,7 +47,7 @@ pub(crate) fn rand_poly<F: PrimeField + Random, Rn: RngCore>(
             evaluations: mle
                 .evaluations
                 .into_iter()
-                .map(|x| x.inner().clone())
+                .map(|x| x.into_inner())
                 .collect(),
             num_vars: mle.num_vars,
         })

--- a/poly/src/mle/dense.rs
+++ b/poly/src/mle/dense.rs
@@ -478,7 +478,7 @@ pub fn project_coeffs<F: PrimeField, R: ProjectableToField<F> + Send + Sync>(
 
     DenseMultilinearExtension {
         evaluations: cfg_into_iter!(mle.evaluations)
-            .map(|x| projection(&x).inner().clone())
+            .map(|x| projection(&x).into_inner())
             .collect(),
         num_vars: mle.num_vars,
     }

--- a/poly/src/utils.rs
+++ b/poly/src/utils.rs
@@ -169,7 +169,7 @@ where
         return Err(ArithErrors::InvalidParameters("r length is 0".into()));
     } else if r.len() == 1 {
         // initializing the buffer with [1-r_0, r_0]
-        buf.push((one - &r[0]).inner().clone());
+        buf.push((one - &r[0]).into_inner());
         buf.push(r[0].inner().clone());
     } else {
         build_eq_x_r_inner_helper(&r[1..], buf, cfg)?;
@@ -186,9 +186,9 @@ where
                 *bi.inner_mut() = buf[i >> 1].clone();
                 let tmp = r[0].clone() * &bi;
                 if (i & 1) == 0 {
-                    (bi.clone() - &tmp).inner().clone()
+                    (bi.clone() - &tmp).into_inner()
                 } else {
-                    tmp.inner().clone()
+                    tmp.into_inner()
                 }
             })
             .collect();

--- a/transcript/src/lib.rs
+++ b/transcript/src/lib.rs
@@ -92,11 +92,19 @@ impl Transcript for KeccakTranscript {
     /// Absorbs a field element into the transcript.
     /// Delegates to the field element's implementation of
     /// absorb_into_transcript.
+    // Note: Currently this only works for fields whose modulus and inner element
+    // have the same byte length
     fn absorb_random_field<F>(&mut self, v: &F, buf: &mut [u8])
     where
         F: PrimeField,
         F::Inner: Transcribable,
+        F::Modulus: Transcribable,
     {
+        debug_assert_eq!(F::Inner::LENGTH_NUM_BYTES, F::Modulus::LENGTH_NUM_BYTES);
+        debug_assert_eq!(
+            F::Inner::get_num_bytes(v.inner()),
+            F::Modulus::get_num_bytes(&v.modulus())
+        );
         self.absorb(&[0x3]);
         v.modulus().write_transcription_bytes(buf);
         self.absorb(buf);

--- a/transcript/src/traits.rs
+++ b/transcript/src/traits.rs
@@ -111,12 +111,12 @@ pub trait Transcript {
     where
         F: PrimeField,
         FMod: ConstTranscribable + ConstIntSemiring,
-        F::Inner: FromRef<FMod>,
+        F::Modulus: FromRef<FMod>,
         T: PrimalityTest<FMod>,
     {
         let prime = self.get_prime::<FMod, T>();
 
-        F::make_cfg(&F::Inner::from_ref(&prime)).expect("prime is guaranteed to be prime")
+        F::make_cfg(&F::Modulus::from_ref(&prime)).expect("prime is guaranteed to be prime")
     }
 
     /// Absorbs a byte slice into the hash sponge.
@@ -128,7 +128,8 @@ pub trait Transcript {
     fn absorb_random_field<F>(&mut self, v: &F, buf: &mut [u8])
     where
         F: PrimeField,
-        F::Inner: Transcribable;
+        F::Inner: Transcribable,
+        F::Modulus: Transcribable;
 
     /// Absorbs a slice of field element into the transcript.
     /// Delegates to the field element's implementation of
@@ -137,6 +138,7 @@ pub trait Transcript {
     where
         F: PrimeField,
         F::Inner: Transcribable,
+        F::Modulus: Transcribable,
     {
         v.iter().for_each(|x| self.absorb_random_field(x, buf));
     }

--- a/zip-plus/src/pcs/phase_evaluate.rs
+++ b/zip-plus/src/pcs/phase_evaluate.rs
@@ -37,7 +37,8 @@ impl<Zt: ZipTypes, Lc: LinearCode<Zt>> ZipPlus<Zt, Lc> {
             + for<'a> FromWithConfig<&'a Zt::Pt>
             + for<'a> MulByScalar<&'a F>
             + FromRef<F>,
-        F::Inner: FromRef<Zt::Fmod> + Transcribable,
+        F::Inner: Transcribable,
+        F::Modulus: FromRef<Zt::Fmod> + Transcribable,
         Zt::Eval: ProjectableToField<F>,
     {
         validate_input::<Zt, Lc, _>("evaluate", pp.num_vars, &[poly], &[point])?;

--- a/zip-plus/src/pcs/phase_verify.rs
+++ b/zip-plus/src/pcs/phase_verify.rs
@@ -37,7 +37,8 @@ impl<Zt: ZipTypes, Lc: LinearCode<Zt>> ZipPlus<Zt, Lc> {
             + FromRef<F>
             + for<'a> FromWithConfig<&'a Zt::Chal>
             + for<'a> MulByScalar<&'a F>,
-        F::Inner: FromRef<Zt::Fmod> + Transcribable,
+        F::Inner: Transcribable,
+        F::Modulus: FromRef<Zt::Fmod> + Transcribable,
         Zt::Cw: ProjectableToField<F>,
     {
         validate_input::<Zt, Lc, _>("verify", vp.num_vars, &[], &[point_f])?;
@@ -198,7 +199,8 @@ impl<Zt: ZipTypes, Lc: LinearCode<Zt>> ZipPlus<Zt, Lc> {
     ) -> Result<(), ZipError>
     where
         F: FromPrimitiveWithConfig + FromRef<F> + for<'a> MulByScalar<&'a F>,
-        F::Inner: FromRef<Zt::Fmod> + Transcribable,
+        F::Inner: Transcribable,
+        F::Modulus: FromRef<Zt::Fmod> + Transcribable,
         Zt::Cw: ProjectableToField<F>,
     {
         let q_0_combined_row = transcript.read_field_elements(vp.linear_code.row_len())?;

--- a/zip-plus/src/pcs/test_utils.rs
+++ b/zip-plus/src/pcs/test_utils.rs
@@ -165,7 +165,8 @@ where
         + for<'a> FromWithConfig<&'a <TestZipTypes<N, K, M> as ZipTypes>::CombR>
         + for<'a> MulByScalar<&'a F>
         + FromRef<F>,
-    F::Inner: FromRef<<TestZipTypes<N, K, M> as ZipTypes>::Fmod> + Transcribable,
+    F::Inner: Transcribable,
+    F::Modulus: FromRef<<TestZipTypes<N, K, M> as ZipTypes>::Fmod> + Transcribable,
     <TestZipTypes<N, K, M> as ZipTypes>::Eval: ProjectableToField<F>,
     <TestZipTypes<N, K, M> as ZipTypes>::Comb: ProjectableToField<F>,
 {
@@ -199,7 +200,9 @@ where
         + for<'a> MulByScalar<&'a F>
         + FromRef<F>
         + 'static,
-    F::Inner: FromRef<<TestPolyZipTypes<K, M, DEGREE_PLUS_ONE> as ZipTypes>::Fmod> + Transcribable,
+    F::Inner: Transcribable,
+    F::Modulus:
+        FromRef<<TestPolyZipTypes<K, M, DEGREE_PLUS_ONE> as ZipTypes>::Fmod> + Transcribable,
 {
     setup_full_protocol_inner::<_, _, _, N>(num_vars, setup_poly_test_params, || {
         (0..num_vars).map(|i| i as i128 + 2).collect()
@@ -225,7 +228,8 @@ where
         + for<'a> FromWithConfig<&'a Zt::Pt>
         + for<'a> MulByScalar<&'a F>
         + FromRef<F>,
-    F::Inner: FromRef<Zt::Fmod> + Transcribable,
+    F::Inner: Transcribable,
+    F::Modulus: FromRef<Zt::Fmod> + Transcribable,
     Zt::Comb: for<'a> MulByScalar<&'a Zt::Pt>,
     Zt::Eval: ProjectableToField<F>,
     Zt::Comb: ProjectableToField<F>,

--- a/zip-plus/src/pcs_transcript.rs
+++ b/zip-plus/src/pcs_transcript.rs
@@ -52,14 +52,20 @@ impl PcsTranscript {
         }
     }
 
+    // Note: Currently this only works for fields whose modulus and inner element
+    // have the same byte length
+    //
     // TODO if we change this to an iterator we may be able to save some memory
     pub fn write_field_elements<F>(&mut self, elems: &[F]) -> Result<(), ZipError>
     where
         F: PrimeField,
         F::Inner: Transcribable,
+        F::Modulus: Transcribable,
     {
         if !elems.is_empty() {
+            debug_assert_eq!(F::Inner::LENGTH_NUM_BYTES, F::Modulus::LENGTH_NUM_BYTES);
             let num_bytes = F::Inner::get_num_bytes(elems[0].inner());
+            debug_assert_eq!(num_bytes, F::Modulus::get_num_bytes(&elems[0].modulus()));
             let num_bytes_arr = num_bytes
                 .to_le_bytes()
                 .into_iter()
@@ -76,15 +82,20 @@ impl PcsTranscript {
         Ok(())
     }
 
+    // Note: Currently this only works for fields whose modulus and inner element
+    // have the same byte length
     pub fn read_field_elements<F>(&mut self, n: usize) -> Result<Vec<F>, ZipError>
     where
         F: PrimeField,
         F::Inner: Transcribable,
+        F::Modulus: Transcribable,
     {
         if n > 0 {
+            debug_assert_eq!(F::Inner::LENGTH_NUM_BYTES, F::Modulus::LENGTH_NUM_BYTES);
             let mut buf = vec![0; F::Inner::LENGTH_NUM_BYTES];
             self.stream.read_exact(&mut buf)?;
             let num_bytes = F::Inner::read_num_bytes(&buf);
+            debug_assert_eq!(num_bytes, F::Modulus::read_num_bytes(&buf));
 
             let mut buf = vec![0; num_bytes];
             (0..n)
@@ -104,11 +115,12 @@ impl PcsTranscript {
     where
         F: PrimeField,
         F::Inner: Transcribable,
+        F::Modulus: Transcribable,
     {
         self.stream.read_exact(buf)?;
         let inner = F::Inner::read_transcription_bytes(buf);
         self.stream.read_exact(buf)?;
-        let modulus = F::Inner::read_transcription_bytes(buf);
+        let modulus = F::Modulus::read_transcription_bytes(buf);
         let field_cfg = F::make_cfg(&modulus)?;
         let fe = F::new_unchecked_with_cfg(inner, &field_cfg);
         self.fs_transcript.absorb_random_field(&fe, buf);
@@ -124,6 +136,7 @@ impl PcsTranscript {
     where
         F: PrimeField,
         F::Inner: Transcribable,
+        F::Modulus: Transcribable,
     {
         self.fs_transcript.absorb_random_field(fe, buf);
         fe.inner().write_transcription_bytes(buf);


### PR DESCRIPTION
This is an update to accommodate changes made in https://github.com/NethermindEth/crypto-primitives/pull/31:
* `Field::Modulus` is now separate from `Field::Inner`
* Switched to `into_inner()` to avoid `inner().clone()` where it's trivial to do