### PR TITLE
End-to-end Zinc+ PIOP protocol: Public input columns

### DIFF
--- a/piop/src/combined_poly_resolver.rs
+++ b/piop/src/combined_poly_resolver.rs
@@ -379,6 +379,7 @@ impl<F: PrimeField> From<SumCheckError<F>> for CombinedPolyResolverError<F> {
 
 #[cfg(test)]
 mod tests {
+    use super::*;
     use crate::{
         ideal_check::IdealCheckProtocol,
         projections::{evaluate_trace_to_column_mles, project_scalars_to_field},
@@ -397,8 +398,6 @@ mod tests {
         ideal::{Ideal, IdealCheck, degree_one::DegreeOneIdeal},
         ideal_collector::IdealOrZero,
     };
-
-    use super::*;
 
     // TODO(Ilia): These tests are absolute joke.
     //             Once we have time we need to create a comprehensive test suite

--- a/piop/src/multipoint_eval.rs
+++ b/piop/src/multipoint_eval.rs
@@ -26,7 +26,7 @@
 use std::marker::PhantomData;
 
 use crate::sumcheck::{
-    MLSumcheck, SumCheckError, SumcheckProof, verifier::SubClaim as SumcheckSubclaim,
+    MLSumcheck, SumCheckError, SumcheckProof, verifier::Subclaim as SumcheckSubclaim,
 };
 use crypto_primitives::{FromPrimitiveWithConfig, PrimeField};
 use num_traits::Zero;
@@ -58,7 +58,7 @@ pub struct ProverState<F: PrimeField> {
 
 /// Verifier subclaim after the multi-point evaluation sumcheck.
 ///
-/// Carries the inner sumcheck [`SubClaim`] plus the intermediate values
+/// Carries the inner sumcheck [`Subclaim`] plus the intermediate values
 /// needed to finalize the check via [`MultipointEval::verify_subclaim`]
 /// once the caller has assembled the `open_evals` (e.g. after computing
 /// public lifted evaluations from public data at `r_0`).

--- a/piop/src/multipoint_eval.rs
+++ b/piop/src/multipoint_eval.rs
@@ -12,10 +12,11 @@
 //! ```
 //!
 //! where `\alpha` batches the two evaluation kernels and `\gamma_j` batch
-//! across columns. After the sumcheck reduces to point `r_0`, the caller
-//! provides `open_evals` (the F_q-valued MLE evaluations at `r_0`, typically
-//! derived from polynomial-valued `lifted_evals` via `\psi_a`) and the
-//! verifier checks the sumcheck consistency.
+//! across columns. After the sumcheck reduces to point `r_0`, the verifier
+//! calls [`MultipointEval::verify_subclaim`] with the `open_evals`
+//! (the F_q-valued MLE evaluations at `r_0`, typically derived from
+//! polynomial-valued `lifted_evals` via `\psi_a`) to check the final
+//! consistency equation.
 //!
 //! This corresponds to the T=2 case of Pi_{BMLE} in the paper. Following
 //! the paper, the prover sends only the polynomial-valued lifted evaluations
@@ -24,7 +25,9 @@
 
 use std::marker::PhantomData;
 
-use crate::sumcheck::{MLSumcheck, SumCheckError, SumcheckProof};
+use crate::sumcheck::{
+    MLSumcheck, SumCheckError, SumcheckProof, verifier::SubClaim as SumcheckSubclaim,
+};
 use crypto_primitives::{FromPrimitiveWithConfig, PrimeField};
 use num_traits::Zero;
 use thiserror::Error;
@@ -53,11 +56,22 @@ pub struct ProverState<F: PrimeField> {
     pub eval_point: Vec<F>,
 }
 
-/// Verifier subclaim after the multi-point evaluation protocol.
+/// Verifier subclaim after the multi-point evaluation sumcheck.
+///
+/// Carries the inner sumcheck [`SubClaim`] plus the intermediate values
+/// needed to finalize the check via [`MultipointEval::verify_subclaim`]
+/// once the caller has assembled the `open_evals` (e.g. after computing
+/// public lifted evaluations from public data at `r_0`).
 #[derive(Clone, Debug)]
 pub struct Subclaim<F: PrimeField> {
-    /// The combined evaluation point r_0.
-    pub eval_point: Vec<F>,
+    /// Inner sumcheck subclaim. Its `point` field is `r_0`; its
+    /// `expected_evaluation` is the value that `verify_subclaim` checks
+    /// against `selector_at_r0 * batched(open_evals)`.
+    pub sumcheck_subclaim: SumcheckSubclaim<F>,
+    /// Column batching coefficients \gamma_j sampled during the protocol.
+    pub gammas: Vec<F>,
+    /// Combined selector value at r_0: `eq(r_0, r') + \alpha * next(r', r_0)`.
+    pub selector_at_r0: F,
 }
 
 //
@@ -147,32 +161,27 @@ where
         ))
     }
 
-    /// Multi-point evaluation protocol verifier.
+    /// Multi-point evaluation protocol verifier (sumcheck phase).
     ///
-    /// Verifies the sumcheck and checks the final-round consistency using
-    /// the caller-provided `open_evals` (typically derived from
-    /// `lifted_evals` via `\psi_a`). Returns the evaluation point `r_0`.
-    #[allow(clippy::arithmetic_side_effects, clippy::too_many_arguments)]
+    /// Runs the sumcheck verification and computes the intermediate values
+    /// needed for the open-eval consistency check. Returns a [`Subclaim`]
+    /// carrying `r_0`, `gammas`, `selector_at_r0`, and
+    /// `expected_evaluation`. The caller finalizes via
+    /// [`verify_subclaim`](Self::verify_subclaim) once `open_evals` are
+    /// available.
+    #[allow(clippy::arithmetic_side_effects)]
     pub fn verify_as_subprotocol(
         transcript: &mut impl Transcript,
         proof: Proof<F>,
         eval_point: &[F],
         up_evals: &[F],
         down_evals: &[F],
-        open_evals: &[F],
         num_vars: usize,
         field_cfg: &F::Config,
     ) -> Result<Subclaim<F>, MultipointEvalError<F>> {
         let num_cols = up_evals.len();
         let zero = F::zero_with_cfg(field_cfg);
         let one = F::one_with_cfg(field_cfg);
-
-        if open_evals.len() != num_cols {
-            return Err(MultipointEvalError::WrongOpenEvalsNumber {
-                got: open_evals.len(),
-                expected: num_cols,
-            });
-        }
 
         // Step 1: Sample \alpha and \gamma_j (must match prover).
         let alpha: F = transcript.get_field_challenge(field_cfg);
@@ -190,7 +199,7 @@ where
         }
 
         // Step 3: Verify the sumcheck.
-        let subclaim = MLSumcheck::verify_as_subprotocol(
+        let sumcheck_subclaim = MLSumcheck::verify_as_subprotocol(
             transcript,
             num_vars,
             2,
@@ -198,7 +207,7 @@ where
             field_cfg,
         )?;
 
-        let r_0 = &subclaim.point;
+        let r_0 = &sumcheck_subclaim.point;
 
         // Step 4: Recompute the combined selector at r_0.
         //   selector(r_0) = eq(r_0, r') + \alpha * next(r', r_0)
@@ -207,28 +216,54 @@ where
         let mut r_prime_r0 = Vec::with_capacity(2 * num_vars);
         r_prime_r0.extend_from_slice(eval_point);
         r_prime_r0.extend_from_slice(r_0);
-        let next_at_r0 = zinc_poly::utils::next_mle_eval(&r_prime_r0, zero.clone(), one);
+        let next_at_r0 = zinc_poly::utils::next_mle_eval(&r_prime_r0, zero, one);
 
         let selector_at_r0 = eq_at_r0 + alpha * &next_at_r0;
 
-        // Check consistency with provided open_evals.
-        let batched_eval: F = gammas
+        Ok(Subclaim {
+            sumcheck_subclaim,
+            gammas,
+            selector_at_r0,
+        })
+    }
+
+    /// Finalize the multi-point evaluation check given `open_evals`.
+    ///
+    /// Verifies that `selector_at_r0 * \sum_j(gamma_j * open_eval_j)`
+    /// equals the sumcheck's expected evaluation. This is a pure arithmetic
+    /// check with no transcript interaction.
+    #[allow(clippy::arithmetic_side_effects)]
+    pub fn verify_subclaim(
+        subclaim: &Subclaim<F>,
+        open_evals: &[F],
+        field_cfg: &F::Config,
+    ) -> Result<(), MultipointEvalError<F>> {
+        let num_cols = subclaim.gammas.len();
+
+        if open_evals.len() != num_cols {
+            return Err(MultipointEvalError::WrongOpenEvalsNumber {
+                got: open_evals.len(),
+                expected: num_cols,
+            });
+        }
+
+        let zero = F::zero_with_cfg(field_cfg);
+        let batched_eval: F = subclaim
+            .gammas
             .iter()
             .zip(open_evals.iter())
             .fold(zero, |acc, (g, v)| acc + g.clone() * v);
 
-        let expected_evaluation = selector_at_r0 * &batched_eval;
+        let expected_evaluation = subclaim.selector_at_r0.clone() * &batched_eval;
 
-        if expected_evaluation != subclaim.expected_evaluation {
+        if expected_evaluation != subclaim.sumcheck_subclaim.expected_evaluation {
             return Err(MultipointEvalError::ClaimMismatch {
-                got: subclaim.expected_evaluation,
+                got: subclaim.sumcheck_subclaim.expected_evaluation.clone(),
                 expected: expected_evaluation,
             });
         }
 
-        Ok(Subclaim {
-            eval_point: subclaim.point,
-        })
+        Ok(())
     }
 }
 
@@ -383,16 +418,19 @@ mod tests {
         public: &PublicInput,
         msg: &ProverMessage,
     ) -> Result<Subclaim<F>, MultipointEvalError<F>> {
-        MultipointEval::<F>::verify_as_subprotocol(
+        let subclaim = MultipointEval::<F>::verify_as_subprotocol(
             &mut make_transcript(),
             msg.proof.clone(),
             &public.eval_point,
             &public.up_evals,
             &public.down_evals,
-            &msg.open_evals,
             public.num_vars,
             &(),
-        )
+        )?;
+
+        MultipointEval::<F>::verify_subclaim(&subclaim, &msg.open_evals, &())?;
+
+        Ok(subclaim)
     }
 
     /// Convenience: build trace, prove, return (public, message).
@@ -408,7 +446,7 @@ mod tests {
     fn honest_prove_verify_multi_column() {
         let (public, msg) = honest_interaction(3, 3);
         let subclaim = run_verifier(&public, &msg).unwrap();
-        assert_eq!(subclaim.eval_point.len(), public.num_vars);
+        assert_eq!(subclaim.sumcheck_subclaim.point.len(), public.num_vars);
     }
 
     #[test]

--- a/piop/src/random_field_sumcheck.rs
+++ b/piop/src/random_field_sumcheck.rs
@@ -14,7 +14,7 @@ use zinc_utils::{
 };
 
 use crate::sumcheck::{
-    MLSumcheck, SumCheckError, SumcheckProof, prover::ProverState, verifier::SubClaim,
+    MLSumcheck, SumCheckError, SumcheckProof, prover::ProverState, verifier::Subclaim,
 };
 
 pub struct RFSumcheck<F, R>(PhantomData<(F, R)>);
@@ -114,7 +114,7 @@ impl<F: FromPrimitiveWithConfig, R: Semiring + ProjectableToField<F>> RFSumcheck
         degree: usize,
         proof: &RFSumcheckProof<F, R>,
         field_cfg: F::Config,
-    ) -> Result<SubClaim<F>, RFSumcheckError<F>>
+    ) -> Result<Subclaim<F>, RFSumcheckError<F>>
     where
         F::Inner: ConstTranscribable + ConstIntSemiring,
         F::Modulus: ConstTranscribable,

--- a/piop/src/sumcheck.rs
+++ b/piop/src/sumcheck.rs
@@ -10,7 +10,7 @@ use zinc_utils::inner_transparent_field::InnerTransparentField;
 
 use crate::sumcheck::{prover::ProverMsg, verifier::VerifierState};
 
-use self::verifier::SubClaim;
+use self::verifier::Subclaim;
 
 pub mod prover;
 // pub mod utils;
@@ -148,7 +148,7 @@ impl<F: FromPrimitiveWithConfig> MLSumcheck<F> {
     /// $$
     ///
     /// It is designed to be used as a subprotocol within a larger system.
-    /// If successful, it returns a **SubClaim**, a final equation that the
+    /// If successful, it returns a **Subclaim**, a final equation that the
     /// outer protocol must satisfy for the overall proof to be valid.
     ///
     /// ---
@@ -171,8 +171,8 @@ impl<F: FromPrimitiveWithConfig> MLSumcheck<F> {
     ///
     /// A `Result` which is:
     ///
-    /// * `Ok(SubClaim<F>)`: If the Sumcheck protocol passes successfully, it
-    ///   returns a `SubClaim`. This claim consists of:
+    /// * `Ok(Subclaim<F>)`: If the Sumcheck protocol passes successfully, it
+    ///   returns a `Subclaim`. This claim consists of:
     ///     1. The final random challenge point $r \in
     ///        \text{F}^{\text{num\\_vars}}$.
     ///     2. The expected evaluation $v$ of the combined polynomial $G(r)$ at
@@ -192,7 +192,7 @@ impl<F: FromPrimitiveWithConfig> MLSumcheck<F> {
         degree: usize,
         proof: &SumcheckProof<F>,
         config: &F::Config,
-    ) -> Result<SubClaim<F>, SumCheckError<F>>
+    ) -> Result<Subclaim<F>, SumCheckError<F>>
     where
         F::Inner: ConstTranscribable,
         F::Modulus: ConstTranscribable,

--- a/piop/src/sumcheck/verifier.rs
+++ b/piop/src/sumcheck/verifier.rs
@@ -48,7 +48,7 @@ impl<F: PrimeField> VerifierState<F> {
 }
 
 /// Subclaim when verifier is convinced
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub struct SubClaim<F> {
     /// The multi-dimensional point that this multilinear extension is evaluated
     /// at.

--- a/piop/src/sumcheck/verifier.rs
+++ b/piop/src/sumcheck/verifier.rs
@@ -49,7 +49,7 @@ impl<F: PrimeField> VerifierState<F> {
 
 /// Subclaim when verifier is convinced
 #[derive(Clone, Debug)]
-pub struct SubClaim<F> {
+pub struct Subclaim<F> {
     /// The multi-dimensional point that this multilinear extension is evaluated
     /// at.
     pub point: Vec<F>,
@@ -104,7 +104,7 @@ impl<F: FromPrimitiveWithConfig> VerifierState<F> {
     pub fn check_and_generate_subclaim(
         self,
         asserted_sum: F,
-    ) -> Result<SubClaim<F>, SumCheckError<F>> {
+    ) -> Result<Subclaim<F>, SumCheckError<F>> {
         if !self.finished {
             panic!("Verifier has not finished.");
         }
@@ -140,7 +140,7 @@ impl<F: FromPrimitiveWithConfig> VerifierState<F> {
             expected = reconstructed_poly.evaluate_at_point(&self.randomness[i])?;
         }
 
-        Ok(SubClaim {
+        Ok(Subclaim {
             point: self.randomness,
             expected_evaluation: expected,
         })

--- a/piop/src/test_utils.rs
+++ b/piop/src/test_utils.rs
@@ -1,7 +1,9 @@
 use std::collections::HashMap;
 
 use crate::{
-    ideal_check::{IdealCheckProtocol, Proof, ProverState},
+    ideal_check::{
+        IdealCheckProtocol, Proof as IdealCheckProof, ProverState as IdealCheckProverState,
+    },
     projections::{
         ColumnMajorTrace, RowMajorTrace, project_scalars, project_trace_coeffs_column_major,
         project_trace_coeffs_row_major,
@@ -38,8 +40,8 @@ pub fn run_ideal_check_prover_linear<U, const DEGREE_PLUS_ONE: usize>(
     trace: &[DenseMultilinearExtension<DensePolynomial<Int<5>, DEGREE_PLUS_ONE>>],
     transcript: &mut impl Transcript,
 ) -> (
-    Proof<F>,
-    ProverState<F>,
+    IdealCheckProof<F>,
+    IdealCheckProverState<F>,
     HashMap<U::Scalar, DynamicPolynomialF<F>>,
     ColumnMajorTrace<F>,
 )
@@ -50,7 +52,8 @@ where
     F: FromWithConfig<Int<5>>,
 {
     assert!(
-        U::signature().binary_poly_cols.is_zero() && U::signature().int_cols.is_zero(),
+        U::signature().witness_binary_poly_cols.is_zero()
+            && U::signature().witness_int_cols.is_zero(),
         "the signature should be single typed"
     );
 
@@ -93,8 +96,8 @@ pub fn run_ideal_check_prover_combined<U, const DEGREE_PLUS_ONE: usize>(
     trace: &[DenseMultilinearExtension<DensePolynomial<Int<5>, DEGREE_PLUS_ONE>>],
     transcript: &mut impl Transcript,
 ) -> (
-    Proof<F>,
-    ProverState<F>,
+    IdealCheckProof<F>,
+    IdealCheckProverState<F>,
     HashMap<U::Scalar, DynamicPolynomialF<F>>,
     RowMajorTrace<F>,
 )
@@ -105,7 +108,8 @@ where
     F: FromWithConfig<Int<5>>,
 {
     assert!(
-        U::signature().binary_poly_cols.is_zero() && U::signature().int_cols.is_zero(),
+        U::signature().witness_binary_poly_cols.is_zero()
+            && U::signature().witness_int_cols.is_zero(),
         "the signature should be single typed"
     );
 

--- a/poly/src/univariate/binary_ref.rs
+++ b/poly/src/univariate/binary_ref.rs
@@ -285,16 +285,27 @@ impl<const DEGREE_PLUS_ONE: usize> Named for BinaryRefPoly<DEGREE_PLUS_ONE> {
 }
 
 impl<const DEGREE_PLUS_ONE: usize> ConstTranscribable for BinaryRefPoly<DEGREE_PLUS_ONE> {
-    const NUM_BYTES: usize = DensePolynomial::<Boolean, DEGREE_PLUS_ONE>::NUM_BYTES;
+    const NUM_BYTES: usize = u64::NUM_BYTES;
 
     #[inline(always)]
     fn read_transcription_bytes(bytes: &[u8]) -> Self {
-        Self(DensePolynomial::read_transcription_bytes(bytes))
+        let value = u64::read_transcription_bytes(bytes);
+        Self(DensePolynomial {
+            coeffs: array::from_fn(|i| Boolean::new(value & (1 << i) != 0)),
+        })
     }
 
     #[inline(always)]
     fn write_transcription_bytes(&self, buf: &mut [u8]) {
-        self.0.write_transcription_bytes(buf);
+        let mut value: u64 = 0;
+
+        self.0.coeffs.iter().enumerate().for_each(|(i, coeff)| {
+            if coeff.inner() {
+                value |= 1 << i;
+            }
+        });
+
+        value.write_transcription_bytes(buf);
     }
 }
 
@@ -412,5 +423,17 @@ mod tests {
 
             assert_eq!(result, i);
         }
+    }
+
+    #[test]
+    fn transcribable() {
+        let original =
+            BinaryRefPoly::<4>::new([true.into(), false.into(), true.into(), false.into()]);
+        let mut bytes = [0u8; BinaryRefPoly::<4>::NUM_BYTES];
+        assert_eq!(bytes.len(), u64::NUM_BYTES);
+
+        original.write_transcription_bytes(&mut bytes);
+        let deserialized = BinaryRefPoly::<4>::read_transcription_bytes(&bytes);
+        assert_eq!(original, deserialized);
     }
 }

--- a/poly/src/univariate/binary_u64.rs
+++ b/poly/src/univariate/binary_u64.rs
@@ -337,7 +337,7 @@ impl<const DEGREE_PLUS_ONE: usize> Named for BinaryU64Poly<DEGREE_PLUS_ONE> {
 }
 
 impl<const DEGREE_PLUS_ONE: usize> ConstTranscribable for BinaryU64Poly<DEGREE_PLUS_ONE> {
-    const NUM_BYTES: usize = DensePolynomial::<Boolean, DEGREE_PLUS_ONE>::NUM_BYTES;
+    const NUM_BYTES: usize = u64::NUM_BYTES;
 
     #[inline(always)]
     fn read_transcription_bytes(bytes: &[u8]) -> Self {
@@ -693,6 +693,19 @@ mod tests {
             assert_eq!(result, i);
         }
     }
+
+    #[test]
+    fn transcribable() {
+        let original =
+            BinaryU64Poly::<4>::new([true.into(), false.into(), true.into(), false.into()]);
+        let mut bytes = [0u8; BinaryU64Poly::<4>::NUM_BYTES];
+        assert_eq!(bytes.len(), u64::NUM_BYTES);
+
+        original.write_transcription_bytes(&mut bytes);
+        let deserialized = BinaryU64Poly::<4>::read_transcription_bytes(&bytes);
+        assert_eq!(original, deserialized);
+    }
+
     fn widen_ref<const DEGREE_PLUS_ONE: usize>(
         poly: &BinaryU64Poly<DEGREE_PLUS_ONE>,
         scalar: i64,

--- a/protocol/benches/e2e.rs
+++ b/protocol/benches/e2e.rs
@@ -23,8 +23,8 @@ use zinc_poly::{
 use zinc_primality::{MillerRabin, PrimalityTest};
 use zinc_protocol::{Proof, ZincPlusPiop, ZincTypes};
 use zinc_test_uair::{
-    BigLinearUair, BinaryDecompositionUair, GenerateMultiTypeWitness, GenerateSingleTypeWitness,
-    TestAirNoMultiplication,
+    BigLinearUair, BigLinearUairWithPublicInput, BinaryDecompositionUair, GenerateMultiTypeWitness,
+    GenerateSingleTypeWitness, TestAirNoMultiplication,
 };
 use zinc_transcript::traits::ConstTranscribable;
 use zinc_uair::{
@@ -341,6 +341,11 @@ fn bench_prove_verify<Zt, U, IdealOverF>(
         <zinc_plus!()>::prove::<CHECKED>(&pp, bin, arb, int, num_vars, project_scalar)
             .expect("proof generation for verifier bench");
 
+    let sig = U::signature();
+    let public_bin = &bin[..sig.public_binary_poly_cols];
+    let public_arb = &arb[..sig.public_arbitrary_poly_cols];
+    let public_int = &int[..sig.public_int_cols];
+
     group.bench_function(BenchmarkId::new("Verify", &params), |bench| {
         bench.iter_batched(
             || proof.clone(),
@@ -348,6 +353,9 @@ fn bench_prove_verify<Zt, U, IdealOverF>(
                 black_box(<zinc_plus!()>::verify::<_, CHECKED>(
                     &pp,
                     proof,
+                    public_bin,
+                    public_arb,
+                    public_int,
                     num_vars,
                     project_scalar,
                     project_ideal,
@@ -441,6 +449,10 @@ fn bench_big_linear(group: &mut BenchmarkGroup<WallTime>, num_vars: usize) {
     bench_uair_generic_multi::<BigLinearUair<i64>>(group, "BigLinear", num_vars);
 }
 
+fn bench_big_linear_public_input(group: &mut BenchmarkGroup<WallTime>, num_vars: usize) {
+    bench_uair_generic_multi::<BigLinearUairWithPublicInput<i64>>(group, "BigLinearPI", num_vars);
+}
+
 //
 // Criterion entry point
 //
@@ -459,6 +471,10 @@ fn e2e_benches(c: &mut Criterion) {
     bench_big_linear(&mut group, 8);
     bench_big_linear(&mut group, 10);
     bench_big_linear(&mut group, 12);
+
+    bench_big_linear_public_input(&mut group, 8);
+    bench_big_linear_public_input(&mut group, 10);
+    bench_big_linear_public_input(&mut group, 12);
 
     group.finish();
 }

--- a/protocol/src/lib.rs
+++ b/protocol/src/lib.rs
@@ -164,7 +164,7 @@ pub enum ProtocolError<F: PrimeField, I: Ideal> {
     #[error("multi-point evaluation failed: {0}")]
     MultipointEval(#[from] MultipointEvalError<F>),
     #[error("lifted eval psi_a projection failed: {0}")]
-    LiftedEvalProjection(#[from] PolyEvaluationError),
+    LiftedEvalProjection(PolyEvaluationError),
     #[error("PCS error: {0}")]
     Pcs(#[from] ZipError),
     #[error("PCS verification failed at column {0}: {1}")]

--- a/protocol/src/lib.rs
+++ b/protocol/src/lib.rs
@@ -19,6 +19,9 @@
 pub mod prover;
 pub mod verifier;
 
+#[cfg(feature = "parallel")]
+use rayon::prelude::*;
+
 use crypto_primitives::{ConstIntRing, ConstIntSemiring, FromWithConfig, PrimeField};
 use std::marker::PhantomData;
 use thiserror::Error;
@@ -26,17 +29,19 @@ use zinc_piop::{
     combined_poly_resolver::{CombinedPolyResolverError, Proof as CombinedPolyResolverProof},
     ideal_check::{IdealCheckError, Proof as IdealCheckProof},
     multipoint_eval::{MultipointEvalError, Proof as MultipointEvalProof},
+    projections::RowMajorTrace,
 };
 use zinc_poly::{
-    ConstCoeffBitWidth,
+    ConstCoeffBitWidth, EvaluationError as PolyEvaluationError,
+    mle::DenseMultilinearExtension,
     univariate::{
         binary::BinaryPoly, dense::DensePolynomial, dynamic::over_field::DynamicPolynomialF,
     },
 };
 use zinc_primality::PrimalityTest;
-use zinc_transcript::traits::ConstTranscribable;
+use zinc_transcript::traits::{ConstTranscribable, Transcript};
 use zinc_uair::{Uair, ideal::Ideal};
-use zinc_utils::named::Named;
+use zinc_utils::{cfg_into_iter, cfg_iter, named::Named};
 use zip_plus::{
     ZipError,
     code::LinearCode,
@@ -47,33 +52,27 @@ use zip_plus::{
 // Data structures
 //
 
-/// Proof produced by the Zinc+ PIOP for UCS.
-///
-/// Contains subproofs from Steps 2, 4, 5, 6, and 7:
-/// - `ideal_check`:    MLE evaluations in F_q[X] and ideal membership (Step 2)
-/// - `resolver`:       F_q sumcheck proof + up/down evaluation claims (Step 4)
-/// - `multipoint_eval`: multi-point eval sumcheck reducing claims to r_0 (Step
-///   5)
-/// - `lifted_evals`:   unprojected polynomial MLE evaluations at r_0 (Step 6)
-/// - `zip`:            Zip+ PCS proof at r_0 (Step 7)
+/// Full proof produced by the Zinc+ PIOP for UCS.
 #[derive(Clone, Debug)]
 pub struct Proof<F: PrimeField> {
     /// Zip+ commitments to the witness columns.
     pub commitments: (ZipPlusCommitment, ZipPlusCommitment, ZipPlusCommitment),
     /// Serialized PCS proof data (Zip+ proving transcripts).
     pub zip: Vec<u8>,
-    /// Step 2: randomized ideal check proof.
+    /// Randomized ideal check proof.
     pub ideal_check: IdealCheckProof<F>,
-    /// Step 4: combined polynomial resolver proof (F_q sumcheck).
+    /// Combined polynomial resolver proof (F_q sumcheck).
     pub resolver: CombinedPolyResolverProof<F>,
-    /// Step 5: multi-point evaluation sumcheck proof (combines up_evals and
+    /// Multi-point evaluation sumcheck proof (combines up_evals and
     /// down_evals at r' into a single evaluation point r_0).
     pub multipoint_eval: MultipointEvalProof<F>,
-    /// Step 6: per-column polynomial MLE evaluations at r_0 in F_q[X]
-    /// (after \phi_q, before \psi_a). The verifier derives scalar
-    /// open_eval_j = \psi_a(lifted_eval_j) for the sumcheck consistency
-    /// check, then supplies these to Zip+ for alpha-projection.
-    pub lifted_evals: Vec<DynamicPolynomialF<F>>,
+    /// Witness-only polynomial MLE evaluations at r_0 in F_q[X]
+    /// (after \phi_q, before \psi_a), ordered as
+    /// `[wit_bin..., wit_arb..., wit_int...]`.
+    /// The verifier recomputes public lifted_evals from public data,
+    /// interleaves them with these, and derives scalar open_evals via
+    /// \psi_a for the sumcheck consistency check and Zip+ PCS verify.
+    pub witness_lifted_evals: Vec<DynamicPolynomialF<F>>,
 }
 
 /// Trait bundling the various type parameters for the public inputs (NYI),
@@ -81,7 +80,7 @@ pub struct Proof<F: PrimeField> {
 pub trait ZincTypes<const DEGREE_PLUS_ONE: usize> {
     /// Main integer type for the protocol, used as a coefficient type for the
     /// arbitrary polynomial trace columns and for the integer trace columns.
-    type Int: Named + ConstCoeffBitWidth + Default + Clone + Send + Sync;
+    type Int: ConstTranscribable + ConstCoeffBitWidth + Named + Default + Clone + Send + Sync;
 
     /// Projecting element to project Zip+ evaluations and UAIR scalars to the
     /// field.
@@ -143,8 +142,8 @@ pub trait ZincTypes<const DEGREE_PLUS_ONE: usize> {
 /// Main struct for the Zinc+ PIOP. The protocol is implemented as associated
 /// functions on it.
 ///
-/// Note that type parameters are further constrained in the impl blocks for the
-/// prover and verifier.
+/// (Note that type parameters are further constrained in the impl blocks for
+/// the prover and verifier)
 #[derive(Copy, Clone, Default, Debug)]
 pub struct ZincPlusPiop<Zt, U, F, const DEGREE_PLUS_ONE: usize>(PhantomData<(Zt, U, F)>)
 where
@@ -161,19 +160,96 @@ pub enum ProtocolError<F: PrimeField, I: Ideal> {
     #[error("combined poly resolver failed: {0}")]
     Resolver(#[from] CombinedPolyResolverError<F>),
     #[error("scalar projection failed: {0}")]
-    ScalarProjection(zinc_poly::EvaluationError),
+    ScalarProjection(PolyEvaluationError),
     #[error("multi-point evaluation failed: {0}")]
     MultipointEval(#[from] MultipointEvalError<F>),
     #[error("lifted eval psi_a projection failed: {0}")]
-    LiftedEvalProjection(zinc_poly::EvaluationError),
+    LiftedEvalProjection(#[from] PolyEvaluationError),
     #[error("PCS error: {0}")]
     Pcs(#[from] ZipError),
     #[error("PCS verification failed at column {0}: {1}")]
     PcsVerification(usize, ZipError),
 }
 
-/// Helper: project a DensePolynomial scalar to DynamicPolynomialF
-/// by projecting each coefficient via \phi_q.
+//
+// Helper functions
+//
+
+/// Absorb public column entries into the Fiat-Shamir transcript.
+///
+/// Each entry is serialized via `ConstTranscribable::write_transcription_bytes`
+/// and absorbed. This must be called in the same order by both prover and
+/// verifier, after commitments and before the random prime draw.
+fn absorb_public_columns<T: ConstTranscribable>(
+    transcript: &mut impl Transcript,
+    cols: &[DenseMultilinearExtension<T>],
+) {
+    let mut buf = vec![0u8; T::NUM_BYTES];
+    for col in cols {
+        for entry in col.iter() {
+            entry.write_transcription_bytes(&mut buf);
+            transcript.absorb_slice(&buf);
+        }
+    }
+}
+
+/// Compute per-column lifted MLE evaluations at `point`.
+///
+/// For each column j, returns `\sum_b eq(b, point) * v_j(b)` as a polynomial
+/// in `F_q[X]` (coefficient-wise MLE evaluation).
+///
+/// Binary columns exploit the 0/1 structure for conditional additions only.
+/// The `eq(point, *)` table is built once and reused across all columns.
+#[allow(clippy::arithmetic_side_effects)]
+fn compute_lifted_evals<F: PrimeField, const D: usize>(
+    point: &[F],
+    trace_bin_poly: &[DenseMultilinearExtension<BinaryPoly<D>>],
+    projected_trace: &RowMajorTrace<F>,
+    field_cfg: &F::Config,
+) -> Vec<DynamicPolynomialF<F>> {
+    let eq_table = zinc_poly::utils::build_eq_x_r_vec(point, field_cfg)
+        .expect("compute_lifted_evals: eq table build failed");
+
+    let n_bin = trace_bin_poly.len();
+    let num_cols = projected_trace.first().map(|r| r.len()).unwrap_or(0);
+    let zero = F::zero_with_cfg(field_cfg);
+
+    cfg_iter!(trace_bin_poly)
+        .map(|col| {
+            let mut coeffs = vec![zero.clone(); D];
+            for (b, entry) in col.iter().enumerate() {
+                for (l, coeff) in entry.iter().enumerate() {
+                    if coeff.into_inner() {
+                        coeffs[l] += &eq_table[b];
+                    }
+                }
+            }
+            coeffs
+        })
+        .chain(cfg_into_iter!(n_bin..num_cols).map(|col_idx| {
+            let num_coeffs = projected_trace
+                .iter()
+                .map(|row| row[col_idx].coeffs.len())
+                .max()
+                .unwrap_or(0);
+
+            let mut coeffs = vec![zero.clone(); num_coeffs];
+            for (b, row) in projected_trace.iter().enumerate() {
+                let entry = &row[col_idx];
+                for (l, coeff) in entry.coeffs.iter().enumerate() {
+                    let mut term = eq_table[b].clone();
+                    term *= coeff;
+                    coeffs[l] += &term;
+                }
+            }
+            coeffs
+        }))
+        .map(DynamicPolynomialF::new_trimmed)
+        .collect()
+}
+
+/// Project a DensePolynomial scalar to DynamicPolynomialF by projecting each
+/// coefficient via \phi_q.
 pub fn project_scalar_fn<R, F, const D: usize>(
     scalar: &DensePolynomial<R, D>,
     field_cfg: &F::Config,
@@ -202,8 +278,9 @@ mod tests {
     use zinc_poly::univariate::{binary::BinaryPolyInnerProduct, dense::DensePolyInnerProduct};
     use zinc_primality::MillerRabin;
     use zinc_test_uair::{
-        BigLinearUair, BinaryDecompositionUair, GenerateMultiTypeWitness,
-        GenerateSingleTypeWitness, TestAirNoMultiplication, TestUairSimpleMultiplication,
+        BigLinearUair, BigLinearUairWithPublicInput, BinaryDecompositionUair,
+        GenerateMultiTypeWitness, GenerateSingleTypeWitness, TestAirNoMultiplication,
+        TestUairSimpleMultiplication,
     };
     use zinc_uair::{ideal::degree_one::DegreeOneIdeal, ideal_collector::IdealOrZero};
     use zinc_utils::{
@@ -300,10 +377,12 @@ mod tests {
         type ArrCombRDotChal = MBSInnerProduct;
     }
 
+    type ZtInt = i64;
+
     pub struct IntZipTypes {}
     impl ZipTypes for IntZipTypes {
         const NUM_COLUMN_OPENINGS: usize = 200;
-        type Eval = i64;
+        type Eval = ZtInt;
         type Cw = i128;
         type Fmod = Uint<K>;
         type PrimeTest = MillerRabin;
@@ -319,7 +398,7 @@ mod tests {
     struct TestZincTypesIprs;
 
     impl ZincTypes<DEGREE_PLUS_ONE> for TestZincTypesIprs {
-        type Int = i64;
+        type Int = ZtInt;
         type Chal = i128;
         type Pt = i128;
         type CombR = Int<M>;
@@ -389,6 +468,49 @@ mod tests {
         )
     }
 
+    fn do_test_multi_witness<U>()
+    where
+        U: Uair<Ideal = DegreeOneIdeal<ZtInt>, Scalar = DensePolynomial<ZtInt, DEGREE_PLUS_ONE>>
+            + GenerateMultiTypeWitness<PolyCoeff = ZtInt, Int = ZtInt>
+            + 'static,
+        F: for<'a> FromWithConfig<&'a ZtInt>,
+    {
+        let mut rng = rng();
+        let num_vars = 8;
+        let pp = setup_pp::<TestZincTypesIprs>(num_vars);
+
+        let (bin_trace, arb_trace, int_trace) = U::generate_witness(num_vars, &mut rng);
+
+        let sig = U::signature();
+        let public_bin = &bin_trace[..sig.public_binary_poly_cols];
+        let public_arb = &arb_trace[..sig.public_arbitrary_poly_cols];
+        let public_int = &int_trace[..sig.public_int_cols];
+
+        // Prover: pass full trace (public first, then witness)
+        let proof = ZincPlusPiop::<TestZincTypesIprs, U, F, DEGREE_PLUS_ONE>::prove::<CHECKED>(
+            &pp,
+            &bin_trace,
+            &arb_trace,
+            &int_trace,
+            num_vars,
+            project_scalar_fn,
+        )
+        .expect("Prover failed");
+
+        // Verifier: pass only public columns separately
+        ZincPlusPiop::<TestZincTypesIprs, U, F, DEGREE_PLUS_ONE>::verify::<_, CHECKED>(
+            &pp,
+            proof,
+            public_bin,
+            public_arb,
+            public_int,
+            num_vars,
+            project_scalar_fn,
+            |ideal, field_cfg| ideal.map(|i| DegreeOneIdeal::from_with_cfg(i, field_cfg)),
+        )
+        .expect("Verifier failed");
+    }
+
     /// End-to-end test: TestAirNoMultiplication.
     ///
     /// UAIR constraint: a + b - c \in (X - 2)
@@ -414,6 +536,9 @@ mod tests {
         Piop::verify::<_, CHECKED>(
             &pp,
             proof,
+            &[],
+            &[],
+            &[],
             num_vars,
             project_scalar_fn,
             |ideal, field_cfg| ideal.map(|i| DegreeOneIdeal::from_with_cfg(i, field_cfg)),
@@ -453,6 +578,9 @@ mod tests {
         Piop::verify::<_, CHECKED>(
             &pp,
             proof,
+            &[],
+            &[],
+            &[],
             num_vars,
             project_scalar_fn,
             |_ideal, _field_cfg| IdealOrZero::<DegreeOneIdeal<F>>::zero(),
@@ -492,6 +620,9 @@ mod tests {
         Piop::verify::<_, CHECKED>(
             &pp,
             proof,
+            &[],
+            &[],
+            &[],
             num_vars,
             project_scalar_fn,
             |ideal, field_cfg| ideal.map(|i| DegreeOneIdeal::from_with_cfg(i, field_cfg)),
@@ -508,37 +639,16 @@ mod tests {
     ///   up.binary_poly[i] - down.binary_poly[i] = 0, for i=1..15
     #[test]
     fn test_e2e_big_linear() {
-        let mut rng = rng();
-        let num_vars = 8;
-        let pp = setup_pp::<TestZincTypesIprs>(num_vars);
+        do_test_multi_witness::<BigLinearUair<ZtInt>>();
+    }
 
-        type TestUair = BigLinearUair<i64>;
-
-        type Piop = ZincPlusPiop<TestZincTypesIprs, TestUair, F, DEGREE_PLUS_ONE>;
-
-        // Generate a valid witness satisfying the UAIR constraints.
-        let (binary_trace, arb_trace, int_trace) = TestUair::generate_witness(num_vars, &mut rng);
-
-        // Prover
-        let proof = Piop::prove::<CHECKED>(
-            &pp,
-            &binary_trace,
-            &arb_trace,
-            &int_trace,
-            num_vars,
-            project_scalar_fn,
-        )
-        .expect("Prover failed");
-
-        // Verifier
-        Piop::verify::<_, CHECKED>(
-            &pp,
-            proof,
-            num_vars,
-            project_scalar_fn,
-            |ideal, field_cfg| ideal.map(|i| DegreeOneIdeal::from_with_cfg(i, field_cfg)),
-        )
-        .expect("Verifier failed");
+    /// End-to-end test: BigLinearUairWithPublicInput.
+    ///
+    /// Same as [`BigLinearUair`], but with the first few binary_poly columns as
+    /// public inputs.
+    #[test]
+    fn test_e2e_big_linear_with_public_input() {
+        do_test_multi_witness::<BigLinearUairWithPublicInput<ZtInt>>();
     }
 
     //
@@ -564,6 +674,9 @@ mod tests {
         Piop::verify::<_, CHECKED>(
             &pp,
             proof,
+            &[],
+            &[],
+            &[],
             num_vars,
             project_scalar_fn,
             |ideal, field_cfg| ideal.map(|i| DegreeOneIdeal::from_with_cfg(i, field_cfg)),
@@ -574,7 +687,7 @@ mod tests {
     #[test]
     fn test_big_linear_tamper_lifted_evals() {
         big_linear_verify_tampered(|proof| {
-            proof.lifted_evals.swap(0, 1);
+            proof.witness_lifted_evals.swap(0, 1);
         });
     }
 

--- a/protocol/src/prover.rs
+++ b/protocol/src/prover.rs
@@ -1,6 +1,3 @@
-#[cfg(feature = "parallel")]
-use rayon::prelude::*;
-
 use super::*;
 use crypto_primitives::{ConstIntSemiring, FromPrimitiveWithConfig, FromWithConfig};
 use num_traits::Zero;
@@ -9,7 +6,7 @@ use zinc_piop::{
     ideal_check::IdealCheckProtocol,
     multipoint_eval::MultipointEval,
     projections::{
-        RowMajorTrace, evaluate_trace_to_column_mles, project_scalars, project_scalars_to_field,
+        evaluate_trace_to_column_mles, project_scalars, project_scalars_to_field,
         project_trace_coeffs_row_major,
     },
 };
@@ -19,7 +16,7 @@ use zinc_poly::{
 use zinc_transcript::traits::{ConstTranscribable, Transcript};
 use zinc_uair::{Uair, constraint_counter::count_constraints, degree_counter::count_max_degree};
 use zinc_utils::{
-    cfg_into_iter, cfg_iter, from_ref::FromRef, inner_transparent_field::InnerTransparentField,
+    add, from_ref::FromRef, inner_transparent_field::InnerTransparentField,
     mul_by_scalar::MulByScalar, projectable_to_field::ProjectableToField,
 };
 use zip_plus::{
@@ -50,11 +47,15 @@ where
 {
     /// Zinc+ full PIOP prover.
     ///
+    /// The trace arrays contain public columns first, then witness columns,
+    /// within each type group. The split is derived from `U::signature()`.
+    ///
     /// # Protocol steps
     ///
-    /// 0. **Commit**: commit each witness column via Zip+ PCS, absorb roots.
+    /// 0. **Commit**: commit only *witness* columns via Zip+ PCS, absorb roots
+    ///    and public data.
     /// 1. **Prime projection** (`\phi_q`: `Z[X] -> F_q[X]`): sample random
-    ///    prime q, project trace and scalars.
+    ///    prime q, project full trace and scalars.
     /// 2. **Ideal check**: sample `r in F_q^mu`, prover sends MLE evaluations,
     ///    verifier checks ideal membership.
     /// 3. **Evaluation projection** (`\psi_a`: `F_q[X] -> F_q`): sample `a in
@@ -67,7 +68,8 @@ where
     ///    are derived from the polynomial-valued `lifted_evals` in Step 6.
     /// 6. **Lift-and-project**: compute per-column polynomial MLE evaluations
     ///    at `r_0` (in `F_q[X]`, before `\psi_a`). Absorb into transcript.
-    /// 7. **PCS open**: Zip+ prove for each committed column at `r_0`.
+    /// 7. **PCS open**: Zip+ prove for each committed *witness* column at
+    ///    `r_0`.
     #[allow(clippy::too_many_arguments, clippy::type_complexity)]
     pub fn prove<const CHECK_FOR_OVERFLOW: bool>(
         (pp_bin, pp_arb, pp_int): &(
@@ -81,7 +83,16 @@ where
         num_vars: usize,
         project_scalar: impl Fn(&U::Scalar, &F::Config) -> DynamicPolynomialF<F>,
     ) -> Result<Proof<F>, ProtocolError<F, U::Ideal>> {
-        // === Step 0: Commit ===
+        let sig = U::signature();
+        let num_pub_bin = sig.public_binary_poly_cols;
+        let num_pub_arb = sig.public_arbitrary_poly_cols;
+        let num_pub_int = sig.public_int_cols;
+
+        let witness_bin = &trace_bin_poly[num_pub_bin..];
+        let witness_arb = &trace_arb_poly[num_pub_arb..];
+        let witness_int = &trace_int[num_pub_int..];
+
+        // === Step 0: Commit only witness columns ===
         macro_rules! commit_optionally {
             ($pp:expr, $trace:expr) => {
                 if $trace.is_empty() {
@@ -98,15 +109,23 @@ where
                 }
             };
         }
-        let (hint_bin, commitment_bin) = commit_optionally!(pp_bin, trace_bin_poly);
-        let (hint_arb, commitment_arb) = commit_optionally!(pp_arb, trace_arb_poly);
-        let (hint_int, commitment_int) = commit_optionally!(pp_int, trace_int);
+        let (hint_bin, commitment_bin) = commit_optionally!(pp_bin, witness_bin);
+        let (hint_arb, commitment_arb) = commit_optionally!(pp_arb, witness_arb);
+        let (hint_int, commitment_int) = commit_optionally!(pp_int, witness_int);
 
         let mut pcs_transcript = PcsProverTranscript::new_from_commitments(
             [&commitment_bin, &commitment_arb, &commitment_int].into_iter(),
         );
-        // TODO: Absorb public inputs as well once they are part of the protocol,
-        //       or this will open up a soundness vulnerability!
+
+        absorb_public_columns(
+            &mut pcs_transcript.fs_transcript,
+            &trace_bin_poly[..num_pub_bin],
+        );
+        absorb_public_columns(
+            &mut pcs_transcript.fs_transcript,
+            &trace_arb_poly[..num_pub_arb],
+        );
+        absorb_public_columns(&mut pcs_transcript.fs_transcript, &trace_int[..num_pub_int]);
 
         // === Step 1: Prime projection (\phi_q: Z[X] -> F_q[X]) ===
 
@@ -190,16 +209,12 @@ where
                 .absorb_random_field_slice(&bar_u.coeffs, &mut transcription_buf);
         }
 
-        // === Step 7: PCS open at r_0 ===
-        //
-        // TODO: Once we add public inputs, the verifier will compute public
-        //       input MLE evaluations at the sumcheck point directly from
-        //       public data. The PCS only covers witness columns.
+        // === Step 7: PCS open at r_0 (witness columns only) ===
         if let Some(hint_bin) = &hint_bin {
             let _ = ZipPlus::<Zt::BinaryZt, Zt::BinaryLc>::prove_f::<_, CHECK_FOR_OVERFLOW>(
                 &mut pcs_transcript,
                 pp_bin,
-                trace_bin_poly,
+                witness_bin,
                 r_0,
                 hint_bin,
                 &field_cfg,
@@ -209,7 +224,7 @@ where
             let _ = ZipPlus::<Zt::ArbitraryZt, Zt::ArbitraryLc>::prove_f::<_, CHECK_FOR_OVERFLOW>(
                 &mut pcs_transcript,
                 pp_arb,
-                trace_arb_poly,
+                witness_arb,
                 r_0,
                 hint_arb,
                 &field_cfg,
@@ -219,7 +234,7 @@ where
             let _ = ZipPlus::<Zt::IntZt, Zt::IntLc>::prove_f::<_, CHECK_FOR_OVERFLOW>(
                 &mut pcs_transcript,
                 pp_int,
-                trace_int,
+                witness_int,
                 r_0,
                 hint_int,
                 &field_cfg,
@@ -229,71 +244,26 @@ where
         let zip_proof = pcs_transcript.stream.into_inner();
         let commitments = (commitment_bin, commitment_arb, commitment_int);
 
+        // Remember that the public columns come first in the input trace arrays
+        let num_total_bin = sig.total_binary_poly_cols();
+        let num_total_arb = sig.total_arbitrary_poly_cols();
+        let witness_arb_offset = add!(num_total_bin, num_pub_arb);
+        let witness_arb_end = add!(witness_arb_offset, sig.witness_arbitrary_poly_cols);
+        let witness_int_offset = add!(add!(num_total_bin, num_total_arb), num_pub_int);
+        let witness_lifted_evals: Vec<_> = lifted_evals[num_pub_bin..num_total_bin]
+            .iter()
+            .chain(&lifted_evals[witness_arb_offset..witness_arb_end])
+            .chain(&lifted_evals[witness_int_offset..])
+            .cloned()
+            .collect();
+
         Ok(Proof {
             commitments,
             ideal_check: ic_proof,
             resolver: cpr_proof,
             multipoint_eval: mp_proof,
             zip: zip_proof,
-            lifted_evals,
+            witness_lifted_evals,
         })
     }
-}
-
-/// Compute per-column lifted MLE evaluations at `point`.
-///
-/// For each column j, returns `\sum_b eq(b, point) * v_j(b)` as a polynomial
-/// in `F_q[X]` (coefficient-wise MLE evaluation).
-///
-/// Binary columns exploit the 0/1 structure for conditional additions only.
-/// The `eq(point, *)` table is built once and reused across all columns.
-#[allow(clippy::arithmetic_side_effects)]
-fn compute_lifted_evals<F, const D: usize>(
-    point: &[F],
-    trace_bin_poly: &[DenseMultilinearExtension<BinaryPoly<D>>],
-    projected_trace: &RowMajorTrace<F>,
-    field_cfg: &F::Config,
-) -> Vec<DynamicPolynomialF<F>>
-where
-    F: InnerTransparentField,
-{
-    let eq_table = zinc_poly::utils::build_eq_x_r_vec(point, field_cfg)
-        .expect("compute_lifted_evals: eq table build failed");
-
-    let n_bin = trace_bin_poly.len();
-    let num_cols = projected_trace.first().map(|r| r.len()).unwrap_or(0);
-    let zero = F::zero_with_cfg(field_cfg);
-
-    cfg_iter!(trace_bin_poly)
-        .map(|col| {
-            let mut coeffs = vec![zero.clone(); D];
-            for (b, entry) in col.iter().enumerate() {
-                for (l, coeff) in entry.iter().enumerate() {
-                    if coeff.into_inner() {
-                        coeffs[l] += &eq_table[b];
-                    }
-                }
-            }
-            coeffs
-        })
-        .chain(cfg_into_iter!(n_bin..num_cols).map(|col_idx| {
-            let num_coeffs = projected_trace
-                .iter()
-                .map(|row| row[col_idx].coeffs.len())
-                .max()
-                .unwrap_or(0);
-
-            let mut coeffs = vec![zero.clone(); num_coeffs];
-            for (b, row) in projected_trace.iter().enumerate() {
-                let entry = &row[col_idx];
-                for (l, coeff) in entry.coeffs.iter().enumerate() {
-                    let mut term = eq_table[b].clone();
-                    term *= coeff;
-                    coeffs[l] += &term;
-                }
-            }
-            coeffs
-        }))
-        .map(DynamicPolynomialF::new_trimmed)
-        .collect()
 }

--- a/protocol/src/verifier.rs
+++ b/protocol/src/verifier.rs
@@ -6,9 +6,12 @@ use zinc_piop::{
     combined_poly_resolver::CombinedPolyResolver,
     ideal_check::IdealCheckProtocol,
     multipoint_eval::MultipointEval,
-    projections::{project_scalars, project_scalars_to_field},
+    projections::{project_scalars, project_scalars_to_field, project_trace_coeffs_row_major},
 };
-use zinc_poly::{EvaluatablePolynomial, univariate::dynamic::over_field::DynamicPolynomialF};
+use zinc_poly::{
+    EvaluatablePolynomial, mle::DenseMultilinearExtension,
+    univariate::dynamic::over_field::DynamicPolynomialF,
+};
 use zinc_transcript::{
     KeccakTranscript,
     traits::{ConstTranscribable, Transcript},
@@ -39,6 +42,7 @@ where
     <Zt::IntZt as ZipTypes>::Cw: ProjectableToField<F>,
     F: InnerTransparentField
         + FromPrimitiveWithConfig
+        + FromWithConfig<Zt::Int>
         + for<'a> FromWithConfig<&'a Zt::CombR>
         + for<'a> FromWithConfig<&'a Zt::Chal>
         + for<'a> MulByScalar<&'a F>
@@ -54,10 +58,11 @@ where
     ///
     /// `up_evals` and `down_evals` from the F_q sumcheck (Step 4) are reduced
     /// via the multi-point evaluation sumcheck (Step 5) to a single evaluation
-    /// point `r_0`. The scalar `open_evals` at `r_0` are derived from the
-    /// polynomial-valued `lifted_evals` via `\psi_a`, then used
-    /// to check the sumcheck consistency. A single Zip+ PCS invocation
-    /// (Step 6) confirms the `lifted_evals`.
+    /// point `r_0`. The verifier recomputes public `lifted_evals` from public
+    /// data at `r_0`, interleaves them with the witness `lifted_evals` from
+    /// the proof, derives scalar `open_evals` via `\psi_a`, and checks the
+    /// multipoint eval consistency. A Zip+ PCS invocation (Step 7) confirms
+    /// the witness `lifted_evals`.
     #[allow(clippy::too_many_arguments, clippy::type_complexity)]
     pub fn verify<IdealOverF, const CHECK_FOR_OVERFLOW: bool>(
         (vp_bin, vp_arb, vp_int): &(
@@ -66,6 +71,9 @@ where
             ZipPlusParams<Zt::IntZt, Zt::IntLc>,
         ),
         proof: Proof<F>,
+        public_bin: &[DenseMultilinearExtension<<Zt::BinaryZt as ZipTypes>::Eval>],
+        public_arb: &[DenseMultilinearExtension<<Zt::ArbitraryZt as ZipTypes>::Eval>],
+        public_int: &[DenseMultilinearExtension<<Zt::IntZt as ZipTypes>::Eval>],
         num_vars: usize,
         project_scalar: impl Fn(&U::Scalar, &F::Config) -> DynamicPolynomialF<F>,
         project_ideal: impl Fn(&IdealOrZero<U::Ideal>, &F::Config) -> IdealOverF,
@@ -73,7 +81,7 @@ where
     where
         IdealOverF: Ideal + IdealCheck<DynamicPolynomialF<F>>,
     {
-        // === Step 0: Reconstruct transcript from commitments ===
+        // === Step 0: Reconstruct transcript from commitments + public data ===
         let mut pcs_transcript = PcsVerifierTranscript {
             fs_transcript: KeccakTranscript::default(),
             stream: Cursor::new(proof.zip),
@@ -86,6 +94,10 @@ where
             pcs_transcript.fs_transcript.absorb_slice(&comm.root);
         }
 
+        absorb_public_columns(&mut pcs_transcript.fs_transcript, public_bin);
+        absorb_public_columns(&mut pcs_transcript.fs_transcript, public_arb);
+        absorb_public_columns(&mut pcs_transcript.fs_transcript, public_int);
+
         // === Step 1: Prime projection ===
         let field_cfg = pcs_transcript
             .fs_transcript
@@ -94,7 +106,7 @@ where
         let num_constraints = count_constraints::<U>();
 
         // === Step 2: Ideal check ===
-        let ic_subclaim = U::verify_as_subprotocol::<F, IdealOverF, _>(
+        let ic_subclaim = U::verify_as_subprotocol::<_, IdealOverF, _>(
             &mut pcs_transcript.fs_transcript,
             proof.ideal_check,
             num_constraints,
@@ -128,39 +140,72 @@ where
         )?;
 
         // === Step 5: Multi-point evaluation sumcheck ===
-        // Derive scalar open_evals from lifted_evals via \psi_a, then pass
-        // them to the multipoint eval verifier for the consistency check.
-        let open_evals: Vec<F> = proof
-            .lifted_evals
-            .iter()
-            .map(|bar_u| bar_u.evaluate_at_point(&projecting_element_f))
-            .collect::<Result<Vec<_>, _>>()
-            .map_err(ProtocolError::LiftedEvalProjection)?;
-
         let mp_subclaim = MultipointEval::verify_as_subprotocol(
             &mut pcs_transcript.fs_transcript,
             proof.multipoint_eval,
             &cpr_subclaim.evaluation_point,
             &cpr_subclaim.up_evals,
             &cpr_subclaim.down_evals,
-            &open_evals,
             num_vars,
             &field_cfg,
         )?;
 
-        // Absorb lifted_evals into transcript
+        let r_0 = &mp_subclaim.sumcheck_subclaim.point;
+
+        // === Step 6: Recompute public lifted_evals, assemble full set ===
+        //
+        // The proof carries only witness lifted_evals. The verifier
+        // independently computes public lifted_evals from public data at r_0,
+        // then interleaves them with the witness portion to reconstruct the
+        // full lifted_evals in canonical order:
+        //   [pub_bin, wit_bin, pub_arb, wit_arb, pub_int, wit_int]
+        let sig = U::signature();
+        let num_pub_bin = sig.public_binary_poly_cols;
+        let num_pub_arb = sig.public_arbitrary_poly_cols;
+        let num_pub_int = sig.public_int_cols;
+
+        let (num_wit_bin, num_wit_arb) = (
+            sig.witness_binary_poly_cols,
+            sig.witness_arbitrary_poly_cols,
+        );
+
+        let public_lifted = if add!(add!(num_pub_bin, num_pub_arb), num_pub_int) > 0 {
+            let projected_public = project_trace_coeffs_row_major::<F, Zt::Int, Zt::Int, D>(
+                public_bin, public_arb, public_int, &field_cfg,
+            );
+            compute_lifted_evals::<F, D>(r_0, public_bin, &projected_public, &field_cfg)
+        } else {
+            Vec::new()
+        };
+
+        let all_lifted_evals: Vec<_> = public_lifted[..num_pub_bin]
+            .iter()
+            .chain(&proof.witness_lifted_evals[..num_wit_bin])
+            .chain(&public_lifted[num_pub_bin..add!(num_pub_bin, num_pub_arb)])
+            .chain(&proof.witness_lifted_evals[num_wit_bin..add!(num_wit_bin, num_wit_arb)])
+            .chain(&public_lifted[add!(num_pub_bin, num_pub_arb)..])
+            .chain(&proof.witness_lifted_evals[add!(num_wit_bin, num_wit_arb)..])
+            .cloned()
+            .collect();
+
+        // Derive scalar open_evals via \psi_a and finalize the multipoint
+        // eval consistency check.
+        let open_evals: Vec<F> = all_lifted_evals
+            .iter()
+            .map(|bar_u| bar_u.evaluate_at_point(&projecting_element_f))
+            .collect::<Result<Vec<_>, _>>()?;
+
+        MultipointEval::<F>::verify_subclaim(&mp_subclaim, &open_evals, &field_cfg)?;
+
+        // Absorb all lifted_evals into transcript (same order as prover).
         let mut transcription_buf: Vec<u8> = vec![0; F::Inner::NUM_BYTES];
-        for bar_u in &proof.lifted_evals {
+        for bar_u in &all_lifted_evals {
             pcs_transcript
                 .fs_transcript
                 .absorb_random_field_slice(&bar_u.coeffs, &mut transcription_buf);
         }
 
-        // === Step 6: PCS verify at r_0 ===
-        //
-        // TODO: Once we add public inputs, compute public input MLE evaluations
-        //       at cpr_subclaim.evaluation_point directly from public data here,
-        //       then include them in the constraint recomputation check.
+        // === Step 7: PCS verify at r_0 (witness columns only) ===
 
         macro_rules! verify_pcs_batch {
             ($Zt:ty, $Lc:ty, $vp:expr, $idx:tt, [$evals_range:expr]) => {{
@@ -171,7 +216,7 @@ where
                         comm.batch_size,
                     );
                     let mut eval_f = F::zero_with_cfg(&field_cfg);
-                    for (bar_u, alphas) in proof.lifted_evals[$evals_range]
+                    for (bar_u, alphas) in all_lifted_evals[$evals_range]
                         .iter()
                         .zip(per_poly_alphas.iter())
                     {
@@ -186,7 +231,7 @@ where
                         $vp,
                         comm,
                         &field_cfg,
-                        &mp_subclaim.eval_point,
+                        r_0,
                         &eval_f,
                         &per_poly_alphas,
                     )
@@ -195,17 +240,29 @@ where
             }};
         }
 
-        let sig = U::signature();
-        let (n_bin, n_arb, _n_int) = (sig.binary_poly_cols, sig.arbitrary_poly_cols, sig.int_cols);
-        verify_pcs_batch!(Zt::BinaryZt, Zt::BinaryLc, vp_bin, 0, [..n_bin]);
+        let num_total_bin = sig.total_binary_poly_cols();
+        let num_total_arb = sig.total_arbitrary_poly_cols();
+        verify_pcs_batch!(
+            Zt::BinaryZt,
+            Zt::BinaryLc,
+            vp_bin,
+            0,
+            [num_pub_bin..num_total_bin]
+        );
         verify_pcs_batch!(
             Zt::ArbitraryZt,
             Zt::ArbitraryLc,
             vp_arb,
             1,
-            [n_bin..add!(n_bin, n_arb)]
+            [add!(num_total_bin, num_pub_arb)..add!(num_total_bin, num_total_arb)]
         );
-        verify_pcs_batch!(Zt::IntZt, Zt::IntLc, vp_int, 2, [add!(n_bin, n_arb)..]);
+        verify_pcs_batch!(
+            Zt::IntZt,
+            Zt::IntLc,
+            vp_int,
+            2,
+            [add!(add!(num_total_bin, num_total_arb), num_pub_int)..]
+        );
 
         Ok(())
     }

--- a/protocol/src/verifier.rs
+++ b/protocol/src/verifier.rs
@@ -193,7 +193,8 @@ where
         let open_evals: Vec<F> = all_lifted_evals
             .iter()
             .map(|bar_u| bar_u.evaluate_at_point(&projecting_element_f))
-            .collect::<Result<Vec<_>, _>>()?;
+            .collect::<Result<Vec<_>, _>>()
+            .map_err(ProtocolError::LiftedEvalProjection)?;
 
         MultipointEval::<F>::verify_subclaim(&mp_subclaim, &open_evals, &field_cfg)?;
 

--- a/test-uair/src/generate_witness.rs
+++ b/test-uair/src/generate_witness.rs
@@ -7,6 +7,8 @@ use zinc_uair::Uair;
 
 /// A trait for UAIRs for generating single-typed witness,
 /// e.g. consisting of only arbitrary polynomials.
+// TODO(alex): Using this is extremely inconvenient, so maybe just use
+//             multi-type generation and remove this
 pub trait GenerateSingleTypeWitness: Uair {
     type Witness;
 

--- a/test-uair/src/lib.rs
+++ b/test-uair/src/lib.rs
@@ -6,8 +6,8 @@ use std::marker::PhantomData;
 use crypto_primitives::{ConstSemiring, FixedSemiring, Semiring, boolean::Boolean};
 use num_traits::Zero;
 use rand::{
-    Rng,
     distr::{Distribution, StandardUniform},
+    prelude::*,
 };
 use zinc_poly::{
     EvaluatablePolynomial,
@@ -36,9 +36,8 @@ where
 
     fn signature() -> UairSignature {
         UairSignature {
-            binary_poly_cols: 0,
-            arbitrary_poly_cols: 3,
-            int_cols: 0,
+            witness_arbitrary_poly_cols: 3,
+            ..Default::default()
         }
     }
 
@@ -128,7 +127,7 @@ where
     }
 }
 
-pub struct TestAirNoMultiplication<R>(PhantomData<R>);
+pub struct TestAirNoMultiplication<R>(PhantomData<R>); // TODO: Rename to XxxUairXxx
 
 impl<R> Uair for TestAirNoMultiplication<R>
 where
@@ -139,9 +138,8 @@ where
 
     fn signature() -> UairSignature {
         UairSignature {
-            binary_poly_cols: 0,
-            arbitrary_poly_cols: 3,
-            int_cols: 0,
+            witness_arbitrary_poly_cols: 3,
+            ..Default::default()
         }
     }
 
@@ -211,9 +209,8 @@ where
 
     fn signature() -> UairSignature {
         UairSignature {
-            binary_poly_cols: 0,
-            arbitrary_poly_cols: 3,
-            int_cols: 0,
+            witness_arbitrary_poly_cols: 3,
+            ..Default::default()
         }
     }
 
@@ -262,9 +259,9 @@ where
 
     fn signature() -> UairSignature {
         UairSignature {
-            binary_poly_cols: 1,
-            arbitrary_poly_cols: 0,
-            int_cols: 1,
+            witness_binary_poly_cols: 1,
+            witness_int_cols: 1,
+            ..Default::default()
         }
     }
 
@@ -329,9 +326,9 @@ where
 
     fn signature() -> UairSignature {
         UairSignature {
-            binary_poly_cols: 16,
-            arbitrary_poly_cols: 0,
-            int_cols: 1,
+            witness_binary_poly_cols: 16,
+            witness_int_cols: 1,
+            ..Default::default()
         }
     }
 
@@ -429,6 +426,62 @@ where
         );
 
         (binary_poly_cols, vec![], vec![int_col])
+    }
+}
+
+pub struct BigLinearUairWithPublicInput<R>(PhantomData<R>);
+
+impl<R> Uair for BigLinearUairWithPublicInput<R>
+where
+    R: ConstSemiring + From<u32> + 'static,
+{
+    type Ideal = <BigLinearUair<R> as Uair>::Ideal;
+    type Scalar = <BigLinearUair<R> as Uair>::Scalar;
+
+    fn signature() -> UairSignature {
+        const NUM_PUBLIC_COLS: usize = 4;
+
+        let src_sig = BigLinearUair::<R>::signature();
+        UairSignature {
+            public_binary_poly_cols: NUM_PUBLIC_COLS,
+            witness_binary_poly_cols: src_sig.witness_binary_poly_cols - NUM_PUBLIC_COLS,
+            ..src_sig
+        }
+    }
+
+    fn constrain_general<B, FromR, MulByScalar, IFromR>(
+        b: &mut B,
+        up: TraceRow<B::Expr>,
+        down: TraceRow<B::Expr>,
+        from_ref: FromR,
+        mbs: MulByScalar,
+        ideal_from_ref: IFromR,
+    ) where
+        B: ConstraintBuilder,
+        FromR: Fn(&Self::Scalar) -> B::Expr,
+        MulByScalar: Fn(&B::Expr, &Self::Scalar) -> Option<B::Expr>,
+        IFromR: Fn(&Self::Ideal) -> B::Ideal,
+    {
+        BigLinearUair::<R>::constrain_general(b, up, down, from_ref, mbs, ideal_from_ref)
+    }
+}
+
+impl<R> GenerateMultiTypeWitness for BigLinearUairWithPublicInput<R>
+where
+    R: ConstSemiring + From<u32> + 'static,
+{
+    type PolyCoeff = <BigLinearUair<R> as GenerateMultiTypeWitness>::PolyCoeff;
+    type Int = <BigLinearUair<R> as GenerateMultiTypeWitness>::Int;
+
+    fn generate_witness<Rng: RngCore + ?Sized>(
+        num_vars: usize,
+        rng: &mut Rng,
+    ) -> (
+        Vec<DenseMultilinearExtension<BinaryPoly<32>>>,
+        Vec<DenseMultilinearExtension<DensePolynomial<Self::PolyCoeff, 32>>>,
+        Vec<DenseMultilinearExtension<Self::Int>>,
+    ) {
+        BigLinearUair::<R>::generate_witness(num_vars, rng)
     }
 }
 

--- a/uair/src/lib.rs
+++ b/uair/src/lib.rs
@@ -37,33 +37,60 @@ pub trait ConstraintBuilder {
 /// each of the types: binary polynomials,
 /// polynomials with arbitrary coefficients,
 /// and integers.
+///
+/// Public columns precede witness columns within each type group.
+/// The flattened trace ordering is:
+/// `[pub_bin, wit_bin, pub_arb, wit_arb, pub_int, wit_int]`.
+#[derive(Default)]
 pub struct UairSignature {
-    /// Number of columns with binary polynomial elements.
-    pub binary_poly_cols: usize,
-    /// Number of columns with arbitrary polynomial elements.
-    pub arbitrary_poly_cols: usize,
-    /// Number of columns with integers.
-    pub int_cols: usize,
+    /// Number of public columns with binary polynomial elements.
+    pub public_binary_poly_cols: usize,
+    /// Number of witness columns with binary polynomial elements.
+    pub witness_binary_poly_cols: usize,
+    /// Number of public columns with arbitrary polynomial elements.
+    pub public_arbitrary_poly_cols: usize,
+    /// Number of witness columns with arbitrary polynomial elements.
+    pub witness_arbitrary_poly_cols: usize,
+    /// Number of public columns with integers.
+    pub public_int_cols: usize,
+    /// Number of witness columns with integers.
+    pub witness_int_cols: usize,
 }
 
+#[allow(clippy::arithmetic_side_effects)]
 impl UairSignature {
-    /// Maximum number of columns across the three types.
+    pub fn total_binary_poly_cols(&self) -> usize {
+        self.public_binary_poly_cols + self.witness_binary_poly_cols
+    }
+
+    pub fn total_arbitrary_poly_cols(&self) -> usize {
+        self.public_arbitrary_poly_cols + self.witness_arbitrary_poly_cols
+    }
+
+    pub fn total_int_cols(&self) -> usize {
+        self.public_int_cols + self.witness_int_cols
+    }
+
+    pub fn total_public_cols(&self) -> usize {
+        self.public_binary_poly_cols + self.public_arbitrary_poly_cols + self.public_int_cols
+    }
+
+    /// Maximum number of columns across the three types (public + witness per
+    /// type).
     pub fn max_cols(&self) -> usize {
         [
-            self.binary_poly_cols,
-            self.arbitrary_poly_cols,
-            self.int_cols,
+            self.total_binary_poly_cols(),
+            self.total_arbitrary_poly_cols(),
+            self.total_int_cols(),
         ]
         .into_iter()
         .max()
         .expect("the iterator is not empty")
     }
 
-    /// The sum of the numbers of columns across
-    /// all types.
-    #[allow(clippy::arithmetic_side_effects)] // we don't have that many columns
+    /// The sum of the numbers of columns across all types (public + witness).
     pub fn total_cols(&self) -> usize {
-        self.binary_poly_cols + self.arbitrary_poly_cols + self.int_cols
+        self.total_binary_poly_cols() + self.total_arbitrary_poly_cols() + self.total_int_cols()
     }
 }
 
@@ -83,11 +110,12 @@ impl<'a, Expr> TraceRow<'a, Expr> {
     /// Subdivides the slice according to the given signature `signature`.
     #[allow(clippy::arithmetic_side_effects)]
     pub fn from_slice_with_signature(row: &'a [Expr], signature: &UairSignature) -> Self {
+        let nb = signature.total_binary_poly_cols();
+        let na = signature.total_arbitrary_poly_cols();
         Self {
-            binary_poly: &row[0..signature.binary_poly_cols],
-            arbitrary_poly: &row[signature.binary_poly_cols
-                ..signature.binary_poly_cols + signature.arbitrary_poly_cols],
-            int: &row[signature.binary_poly_cols + signature.arbitrary_poly_cols..],
+            binary_poly: &row[0..nb],
+            arbitrary_poly: &row[nb..nb + na],
+            int: &row[nb + na..],
         }
     }
 }


### PR DESCRIPTION
Resolves #108

* UAIR signature now specifies how many columns are public (they always come first in every category).
* PIOP prover new sends lifted evaluations only for witness columns. Verifier computes them for public columns on its own.
* Mutipoint evaluation subprotocol verification has been tweaked to work in two stages, to return `r0` point before finally validating open evaluations. This is used by PIOP verifier to reconstruct open evaluations at `r0`.
* Added a variant of `BigLinearUair` that has first 4 binary columns marked as public. It's added to tests and benchmark as well.
* Additionally, fixed an issue with binary polynomial being incorrectly transcribed, added a regression test for it.