### PR TITLE
Generalize shifts to arbitrary per-column amounts

### DIFF
--- a/piop/benches/multipoint_eval.rs
+++ b/piop/benches/multipoint_eval.rs
@@ -11,6 +11,7 @@ use zinc_piop::multipoint_eval::MultipointEval;
 use zinc_poly::mle::{DenseMultilinearExtension, MultilinearExtensionWithConfig};
 use zinc_primality::MillerRabin;
 use zinc_transcript::{KeccakTranscript, traits::Transcript};
+use zinc_uair::ShiftSpec;
 
 const FIELD_LIMBS: usize = 4;
 type F = MontyField<FIELD_LIMBS>;
@@ -49,12 +50,17 @@ fn bench_multipoint_eval(c: &mut Criterion, num_vars: usize, num_cols: usize) {
         })
         .collect();
 
+    // All columns shift by 1.
+    let shifts: Vec<ShiftSpec> = (0..num_cols).map(|i| ShiftSpec::new(i, 1)).collect();
+
     // Compute down_evals = v_j^{down}(r') (shift by one position).
-    let down_evals: Vec<F> = trace_mles
+    let down_evals: Vec<F> = shifts
         .iter()
-        .map(|mle| {
-            let mut shifted = mle.evaluations[1..].to_vec();
-            shifted.push(zero_inner);
+        .map(|spec| {
+            let mle = &trace_mles[spec.source_col()];
+            let c = spec.shift_amount();
+            let mut shifted = mle.evaluations[c..].to_vec();
+            shifted.extend(vec![zero_inner; c]);
             let shifted_mle =
                 DenseMultilinearExtension::from_evaluations_vec(num_vars, shifted, zero_inner);
             shifted_mle
@@ -81,6 +87,7 @@ fn bench_multipoint_eval(c: &mut Criterion, num_vars: usize, num_cols: usize) {
                         &eval_point,
                         &up_evals,
                         &down_evals,
+                        &shifts,
                         &field_cfg,
                     )
                     .expect("prover failed"),
@@ -100,6 +107,7 @@ fn bench_multipoint_eval(c: &mut Criterion, num_vars: usize, num_cols: usize) {
         &eval_point,
         &up_evals,
         &down_evals,
+        &shifts,
         &field_cfg,
     )
     .expect("prover failed");
@@ -123,12 +131,13 @@ fn bench_multipoint_eval(c: &mut Criterion, num_vars: usize, num_cols: usize) {
                     &eval_point,
                     &up_evals,
                     &down_evals,
+                    &shifts,
                     num_vars,
                     &field_cfg,
                 )
                 .expect("verifier failed");
-                MultipointEval::<F>::verify_subclaim(&subclaim, &open_evals, &field_cfg)
-                    .expect("verifier failed");
+                MultipointEval::<F>::verify_subclaim(&subclaim, &open_evals, &shifts, &field_cfg)
+                    .expect("subclaim check failed");
             },
             BatchSize::SmallInput,
         );
@@ -144,7 +153,7 @@ pub fn multipoint_eval_benches(c: &mut Criterion) {
     }
 
     // Vary column count at fixed size — this is the key axis for the
-    // precombine optimisation: costs become constant (3 MLEs) after precombine
+    // precombine optimisation: costs become constant (4 MLEs) after precombine
     // instead of scaling with J
     for num_cols in [1, 3, 10, 25, 50, 100] {
         bench_multipoint_eval(c, 14, num_cols);

--- a/piop/src/combined_poly_resolver.rs
+++ b/piop/src/combined_poly_resolver.rs
@@ -82,14 +82,24 @@ impl<F: InnerTransparentField + FromPrimitiveWithConfig + Send + Sync> CombinedP
         let zero = F::zero_with_cfg(field_cfg);
         let one = F::one_with_cfg(field_cfg);
 
-        // Shifted trace. Just take the trace, drop the first row
-        // and append 0 to the end. Note, that the latter happens
-        // thanks to the FromIterator implementation for `DenseMultilinearExtension`
-        // as it always pads to the next power of two.
-        // It might lead to a problem when `num_vars = 1` but that is not going to
-        // happen on real world traces.
-        let down: Vec<DenseMultilinearExtension<F::Inner>> = cfg_iter!(trace_matrix)
-            .map(|column| column[1..].iter().cloned().collect())
+        // Shifted trace: for each ShiftSpec, take the source column,
+        // drop the first `shift_amount` rows, and zero-pad to the full
+        // domain size so the MLE keeps the correct `num_vars`.
+        // TODO consider working with pointers since down cols are virtual cols until
+        // folded in sumcheck - virtual MLE trait needed in sumcheck.
+        let uair_sig = U::signature();
+        let down_layout = uair_sig.down_cols().as_column_layout();
+        let zero_inner = zero.clone().into_inner();
+        let n = 1usize << num_vars;
+        let down: Vec<DenseMultilinearExtension<F::Inner>> = cfg_iter!(uair_sig.shifts())
+            .map(|spec| {
+                let mut evals = trace_matrix[spec.source_col()][spec.shift_amount()..].to_vec();
+                evals.resize(n, zero_inner.clone());
+                DenseMultilinearExtension {
+                    evaluations: evals,
+                    num_vars,
+                }
+            })
             .collect();
 
         let eq_r = build_eq_x_r_inner(evaluation_point, field_cfg)?;
@@ -112,9 +122,9 @@ impl<F: InnerTransparentField + FromPrimitiveWithConfig + Send + Sync> CombinedP
             powers(folding_challenge, one.clone(), num_constraints);
 
         let num_cols = trace_matrix.len();
-
+        let num_down_cols = down.len();
         let mles: Vec<DenseMultilinearExtension<F::Inner>> = {
-            let mut mles = Vec::with_capacity(2 * num_cols + 2);
+            let mut mles = Vec::with_capacity(2 + num_cols + num_down_cols);
 
             mles.push(last_row_selector);
             mles.push(eq_r);
@@ -125,7 +135,7 @@ impl<F: InnerTransparentField + FromPrimitiveWithConfig + Send + Sync> CombinedP
             mles
         };
 
-        let sig = U::signature();
+        let up_layout = uair_sig.total_cols().as_column_layout();
 
         let (sumcheck_proof, sumcheck_prover_state) = MLSumcheck::prove_as_subprotocol(
             transcript,
@@ -149,8 +159,8 @@ impl<F: InnerTransparentField + FromPrimitiveWithConfig + Send + Sync> CombinedP
 
                 U::constrain_general(
                     &mut folder,
-                    TraceRow::from_slice_with_signature(&mle_values[2..num_cols + 2], &sig),
-                    TraceRow::from_slice_with_signature(&mle_values[num_cols + 2..], &sig),
+                    TraceRow::from_slice_with_layout(&mle_values[2..num_cols + 2], up_layout),
+                    TraceRow::from_slice_with_layout(&mle_values[num_cols + 2..], down_layout),
                     project,
                     |x, y| Some(project(y) * x),
                     ImpossibleIdeal::from_ref,
@@ -232,8 +242,10 @@ impl<F: InnerTransparentField + FromPrimitiveWithConfig + Send + Sync> CombinedP
         F::Modulus: ConstTranscribable,
         U: Uair,
     {
-        let sig = U::signature();
-        proof.validate_evaluation_sizes(sig.total_cols())?;
+        let uair_sig = U::signature();
+        let down_layout = uair_sig.down_cols().as_column_layout();
+        proof
+            .validate_evaluation_sizes(uair_sig.total_cols().cols(), uair_sig.down_cols().cols())?;
 
         let zero = F::zero_with_cfg(field_cfg);
         let one = F::one_with_cfg(field_cfg);
@@ -308,8 +320,11 @@ impl<F: InnerTransparentField + FromPrimitiveWithConfig + Send + Sync> CombinedP
 
         U::constrain_general(
             &mut folder,
-            TraceRow::from_slice_with_signature(&proof.up_evals, &sig),
-            TraceRow::from_slice_with_signature(&proof.down_evals, &sig),
+            TraceRow::from_slice_with_layout(
+                &proof.up_evals,
+                uair_sig.total_cols().as_column_layout(),
+            ),
+            TraceRow::from_slice_with_layout(&proof.down_evals, down_layout),
             project,
             |x, y| Some(project(y) * x),
             ImpossibleIdeal::from_ref,

--- a/piop/src/combined_poly_resolver/structs.rs
+++ b/piop/src/combined_poly_resolver/structs.rs
@@ -21,6 +21,7 @@ impl<F: PrimeField> Proof<F> {
     pub fn validate_evaluation_sizes(
         &self,
         num_cols: usize,
+        num_down_cols: usize,
     ) -> Result<(), CombinedPolyResolverError<F>> {
         if self.up_evals.len() != num_cols {
             return Err(CombinedPolyResolverError::WrongUpEvalsNumber {
@@ -29,10 +30,10 @@ impl<F: PrimeField> Proof<F> {
             });
         }
 
-        if self.down_evals.len() != num_cols {
+        if self.down_evals.len() != num_down_cols {
             return Err(CombinedPolyResolverError::WrongDownEvalsNumber {
                 got: self.down_evals.len(),
-                expected: num_cols,
+                expected: num_down_cols,
             });
         }
 

--- a/piop/src/ideal_check/combined_poly_builder.rs
+++ b/piop/src/ideal_check/combined_poly_builder.rs
@@ -12,7 +12,7 @@ use zinc_poly::{
     univariate::dynamic::over_field::DynamicPolynomialF,
 };
 use zinc_uair::{
-    ConstraintBuilder, TraceRow, Uair,
+    ColumnLayout, ConstraintBuilder, TraceRow, Uair,
     degree_counter::{count_constraint_degrees, count_max_degree},
     ideal::ImpossibleIdeal,
 };
@@ -39,6 +39,8 @@ where
     U: Uair,
 {
     let field_zero = F::zero_with_cfg(field_cfg);
+    let uair_sig = U::signature();
+    let down_layout = uair_sig.down_cols().as_column_layout();
 
     let num_rows = trace_matrix.len();
 
@@ -46,13 +48,25 @@ where
         cfg_into_iter!(0..num_rows - 1)
             .map(|row_idx| {
                 let up = &trace_matrix[row_idx];
-                let down = &trace_matrix[row_idx + 1];
+
+                let down: Vec<DynamicPolynomialF<F>> = uair_sig
+                    .shifts()
+                    .iter()
+                    .map(|spec| {
+                        if row_idx + spec.shift_amount() < num_rows {
+                            trace_matrix[row_idx + spec.shift_amount()][spec.source_col()].clone()
+                        } else {
+                            DynamicPolynomialF::new([]) // zero padding
+                        }
+                    })
+                    .collect();
 
                 combine_rows_and_get_max_degree::<F, U>(
                     up,
-                    down,
+                    &down,
                     num_constraints,
                     projected_scalars,
+                    down_layout,
                 )
             })
             .collect();
@@ -92,12 +106,12 @@ fn combine_rows_and_get_max_degree<F, U>(
     down: &[DynamicPolynomialF<F>],
     num_constraints: usize,
     projected_scalars: &HashMap<U::Scalar, DynamicPolynomialF<F>>,
+    down_layout: &ColumnLayout,
 ) -> (usize, Vec<DynamicPolynomialF<F>>)
 where
     F: PrimeField,
     U: Uair,
 {
-    let sig = U::signature();
     let mut constraint_builder = CombinedPolyRowBuilder::new(num_constraints);
 
     let project = |x: &U::Scalar| {
@@ -109,8 +123,8 @@ where
 
     U::constrain_general(
         &mut constraint_builder,
-        TraceRow::from_slice_with_signature(up, &sig),
-        TraceRow::from_slice_with_signature(down, &sig),
+        TraceRow::from_slice_with_layout(up, U::signature().total_cols().as_column_layout()),
+        TraceRow::from_slice_with_layout(down, down_layout),
         &project,
         |x, y| Some(project(y) * x),
         ImpossibleIdeal::from_ref,
@@ -175,7 +189,8 @@ fn prepare_coefficient_mles<F: PrimeField>(
 ///
 /// `trace_matrix` is column-indexed: `trace_matrix[col]` is an MLE.
 ///
-/// Does `2 * num_columns * max_num_coeffs` evaluations of MLEs.
+/// Does `(num_columns + num_shifted_columns) * max_num_coeffs` evaluations of
+/// MLEs.
 #[allow(clippy::arithmetic_side_effects)]
 pub fn evaluate_combined_polynomials<F, U>(
     trace_matrix: &ColumnMajorTrace<F>,
@@ -192,7 +207,6 @@ where
     let zero_inner = field_zero.inner().clone();
     let num_rows = trace_matrix.first().map(|c| c.len()).unwrap_or(0);
     let num_vars = evaluation_point.len();
-    let sig = U::signature();
 
     // Sanity check: this approach only works for linear constraints
     if count_max_degree::<U>() > 1 {
@@ -209,52 +223,60 @@ where
         .max()
         .unwrap_or(0);
 
-    // Evaluate "up" and "down" versions of each trace column at the evaluation
-    // point, these match the semantics of compute_combined_polynomials.
-    // With column-indexed format, each column is already an MLE.
-    let column_evals: Vec<(DynamicPolynomialF<F>, DynamicPolynomialF<F>)> = cfg_iter!(trace_matrix)
-        .map(|col| {
-            let mut up_coeffs = Vec::with_capacity(max_num_coeffs);
-            let mut down_coeffs = Vec::with_capacity(max_num_coeffs);
+    let uair_sig = U::signature();
+    let down_layout = uair_sig.down_cols().as_column_layout();
 
-            for d in 0..max_num_coeffs {
-                macro_rules! make_coeff_evals {
-                    ($coeffs_vec:ident, $row_shift:literal) => {
-                        let coeff_evals: Vec<F::Inner> = (0..num_rows)
-                            .map(|i| {
-                                if i < num_rows - 1 {
-                                    col.evaluations[i + $row_shift]
-                                        .coeffs
-                                        .get(d)
-                                        .map(|c| c.inner().clone())
-                                        .unwrap_or_else(|| zero_inner.clone())
-                                } else {
-                                    zero_inner.clone()
-                                }
-                            })
-                            .collect();
-
-                        let coeff_mle = DenseMultilinearExtension {
-                            evaluations: coeff_evals,
-                            num_vars,
-                        };
-                        $coeffs_vec
-                            .push(coeff_mle.evaluate_with_config(evaluation_point, field_cfg)?);
-                    };
+    // Helper: evaluate one column's coefficient-d MLE at `evaluation_point`,
+    // reading row `i + shift` (zero-padded beyond trace length).
+    let eval_coeff_mle = |col: &DenseMultilinearExtension<DynamicPolynomialF<F>>,
+                          d: usize,
+                          shift: usize|
+     -> Result<F, EvaluationError> {
+        let coeff_evals: Vec<F::Inner> = (0..num_rows)
+            .map(|i| {
+                // Two conditions needed:
+                // 1. i < num_rows - 1: zero out the last row for all columns (both up and down)
+                //    to match the combined poly builder's explicit zero-padding at row N-1.
+                // 2. i + shift < num_rows: prevent OOB access for shifts > 0.
+                if i < num_rows - 1 && i + shift < num_rows {
+                    col.evaluations[i + shift]
+                        .coeffs
+                        .get(d)
+                        .map(|c| c.inner().clone())
+                        .unwrap_or_else(|| zero_inner.clone())
+                } else {
+                    zero_inner.clone()
                 }
+            })
+            .collect();
+        let coeff_mle = DenseMultilinearExtension {
+            evaluations: coeff_evals,
+            num_vars,
+        };
+        coeff_mle.evaluate_with_config(evaluation_point, field_cfg)
+    };
 
-                make_coeff_evals!(up_coeffs, 0);
-                make_coeff_evals!(down_coeffs, 1);
-            }
-
-            Ok((
-                DynamicPolynomialF::new_trimmed(up_coeffs),
-                DynamicPolynomialF::new_trimmed(down_coeffs),
-            ))
+    // Evaluate up (all columns, shift=0).
+    let up_evals: Vec<DynamicPolynomialF<F>> = cfg_iter!(trace_matrix)
+        .map(|col| {
+            let coeffs: Vec<F> = (0..max_num_coeffs)
+                .map(|d| eval_coeff_mle(col, d, 0))
+                .collect::<Result<_, _>>()?;
+            Ok(DynamicPolynomialF::new_trimmed(coeffs))
         })
         .collect::<Result<Vec<_>, EvaluationError>>()?;
 
-    let (up_evals, down_evals): (Vec<_>, Vec<_>) = column_evals.into_iter().unzip();
+    // Evaluate down (only shifted columns, per-spec shift amount).
+    let sorted_shifts = uair_sig.shifts();
+    let down_evals: Vec<DynamicPolynomialF<F>> = cfg_iter!(sorted_shifts)
+        .map(|spec| {
+            let col = &trace_matrix[spec.source_col()];
+            let coeffs: Vec<F> = (0..max_num_coeffs)
+                .map(|d| eval_coeff_mle(col, d, spec.shift_amount()))
+                .collect::<Result<_, _>>()?;
+            Ok(DynamicPolynomialF::new_trimmed(coeffs))
+        })
+        .collect::<Result<Vec<_>, EvaluationError>>()?;
 
     // Apply UAIR constraints to the evaluated trace values
     let mut constraint_builder = CombinedPolyRowBuilder::new(num_constraints);
@@ -268,8 +290,8 @@ where
 
     U::constrain_general(
         &mut constraint_builder,
-        TraceRow::from_slice_with_signature(&up_evals, &sig),
-        TraceRow::from_slice_with_signature(&down_evals, &sig),
+        TraceRow::from_slice_with_layout(&up_evals, uair_sig.total_cols().as_column_layout()),
+        TraceRow::from_slice_with_layout(&down_evals, down_layout),
         &project,
         |x, y| Some(project(y) * x),
         ImpossibleIdeal::from_ref,

--- a/piop/src/ideal_check/combined_poly_builder.rs
+++ b/piop/src/ideal_check/combined_poly_builder.rs
@@ -1,3 +1,4 @@
+use num_traits::Zero;
 #[cfg(feature = "parallel")]
 use rayon::prelude::*;
 
@@ -56,7 +57,7 @@ where
                         if row_idx + spec.shift_amount() < num_rows {
                             trace_matrix[row_idx + spec.shift_amount()][spec.source_col()].clone()
                         } else {
-                            DynamicPolynomialF::new([]) // zero padding
+                            DynamicPolynomialF::zero() // zero padding
                         }
                     })
                     .collect();

--- a/piop/src/lib.rs
+++ b/piop/src/lib.rs
@@ -3,6 +3,7 @@ pub mod ideal_check;
 pub mod multipoint_eval;
 pub mod projections;
 pub mod random_field_sumcheck;
+pub mod shift_predicate;
 pub mod sumcheck;
 #[cfg(test)]
 pub mod test_utils;

--- a/piop/src/multipoint_eval.rs
+++ b/piop/src/multipoint_eval.rs
@@ -397,7 +397,7 @@ mod tests {
 
     /// Data known to both prover and verifier from earlier protocol steps.
     #[derive(Clone)]
-    struct PublicInput {
+    struct SharedSubprotocolInput {
         eval_point: Vec<F>,
         up_evals: Vec<F>,
         down_evals: Vec<F>,
@@ -424,7 +424,7 @@ mod tests {
         shifts: &[ShiftSpec],
     ) -> (
         Vec<DenseMultilinearExtension<<F as crypto_primitives::Field>::Inner>>,
-        PublicInput,
+        SharedSubprotocolInput,
     ) {
         let n = 1usize << num_vars;
         let zero_inner = F::ZERO.into_inner();
@@ -458,7 +458,7 @@ mod tests {
             })
             .collect();
 
-        let public = PublicInput {
+        let public = SharedSubprotocolInput {
             eval_point,
             up_evals,
             down_evals,
@@ -471,7 +471,7 @@ mod tests {
     /// Prover: has access to the trace, produces a proof and open_evals.
     fn run_prover(
         trace_mles: &[DenseMultilinearExtension<<F as crypto_primitives::Field>::Inner>],
-        public: &PublicInput,
+        public: &SharedSubprotocolInput,
     ) -> ProverMessage {
         let mut transcript = make_transcript();
         let (proof, prover_state) = MultipointEval::<F>::prove_as_subprotocol(
@@ -496,7 +496,7 @@ mod tests {
 
     /// Verifier: only receives the proof + open_evals + public data.
     fn run_verifier(
-        public: &PublicInput,
+        public: &SharedSubprotocolInput,
         msg: &ProverMessage,
     ) -> Result<Subclaim<F>, MultipointEvalError<F>> {
         let subclaim = MultipointEval::<F>::verify_as_subprotocol(
@@ -520,7 +520,7 @@ mod tests {
         num_vars: usize,
         num_cols: usize,
         shifts: &[ShiftSpec],
-    ) -> (PublicInput, ProverMessage) {
+    ) -> (SharedSubprotocolInput, ProverMessage) {
         let (trace, public) = build_trace(num_vars, num_cols, shifts);
         let msg = run_prover(&trace, &public);
         (public, msg)

--- a/piop/src/multipoint_eval.rs
+++ b/piop/src/multipoint_eval.rs
@@ -131,7 +131,7 @@ where
 
         // Step 2: Build the two selector MLEs:
         //   eq_r(b)   = eq(b, r')
-        //   next_r(b) = next_tilde(r', b)
+        //   next_c_r_mle(b) = next_c_mle(r', b)
         let eq_r = build_eq_x_r_inner(eval_point, field_cfg)?;
         let (next_mles, down_cols): (Vec<_>, Vec<_>) = shifts
             .iter()

--- a/piop/src/multipoint_eval.rs
+++ b/piop/src/multipoint_eval.rs
@@ -10,13 +10,14 @@
 //! the prover works with only 3 MLEs (`eq`, `next`, `precombined`) regardless
 //! of the number of columns. The sumcheck proves:
 //! ```text
-//! \sum_b [eq(b, r') + \alpha * next(r', b)] * precombined(b)
-//!   = \sum_j \gamma_j * (up_eval_j + \alpha * down_eval_j)
+//! \sum_b [eq(b, r') * \sum_j \gamma_j * v_j(b)
+//!         + \sum_k \alpha_k * next_{c_k}(r', b) * v_{src_k}(b)]
+//!   = \sum_j \gamma_j * up_eval_j + \sum_k \alpha_k * down_eval_k
 //! ```
 //!
-//! where `\alpha` batches the two evaluation kernels and `\gamma_j` batch
-//! across columns. After the sumcheck reduces to point `r_0`, the verifier
-//! calls [`MultipointEval::verify_subclaim`] with the `open_evals`
+//! where `\alpha_k` batch the per-shift evaluation kernels and `\gamma_j`
+//! batch across columns. After the sumcheck reduces to point `r_0`, the
+//! verifier calls [`MultipointEval::verify_subclaim`] with the `open_evals`
 //! (the F_q-valued MLE evaluations at `r_0`, typically derived from
 //! polynomial-valued `lifted_evals` via `\psi_a`) to check the final
 //! consistency equation.
@@ -26,17 +27,23 @@
 //! (alpha'_j in F_q[X]); the scalar open_evals are derived by the verifier
 //! via \psi_a rather than being sent as a separate proof element.
 
-use std::marker::PhantomData;
-
-use crate::sumcheck::{
-    MLSumcheck, SumCheckError, SumcheckProof, verifier::Subclaim as SumcheckSubclaim,
+use crate::{
+    shift_predicate::eval_shift_predicate,
+    sumcheck::{MLSumcheck, SumCheckError, SumcheckProof, verifier::Subclaim as SumcheckSubclaim},
 };
 use crypto_primitives::{FromPrimitiveWithConfig, PrimeField};
 use num_traits::Zero;
+#[cfg(feature = "parallel")]
+use rayon::prelude::*;
+use std::marker::PhantomData;
 use thiserror::Error;
-use zinc_poly::{mle::DenseMultilinearExtension, utils::ArithErrors};
+use zinc_poly::{
+    mle::DenseMultilinearExtension,
+    utils::{ArithErrors, build_eq_x_r_inner, build_next_c_r_mle},
+};
 use zinc_transcript::traits::{ConstTranscribable, Transcript};
-use zinc_utils::inner_transparent_field::InnerTransparentField;
+use zinc_uair::ShiftSpec;
+use zinc_utils::{cfg_into_iter, inner_transparent_field::InnerTransparentField};
 
 //
 // Data structures
@@ -61,7 +68,7 @@ pub struct ProverState<F: PrimeField> {
 
 /// Verifier subclaim after the multi-point evaluation sumcheck.
 ///
-/// Carries the inner sumcheck [`Subclaim`] plus the intermediate values
+/// Carries the inner sumcheck [`SumcheckSubclaim`] plus the intermediate values
 /// needed to finalize the check via [`MultipointEval::verify_subclaim`]
 /// once the caller has assembled the `open_evals` (e.g. after computing
 /// public lifted evaluations from public data at `r_0`).
@@ -69,12 +76,17 @@ pub struct ProverState<F: PrimeField> {
 pub struct Subclaim<F: PrimeField> {
     /// Inner sumcheck subclaim. Its `point` field is `r_0`; its
     /// `expected_evaluation` is the value that `verify_subclaim` checks
-    /// against `selector_at_r0 * batched(open_evals)`.
+    /// against the batched open_evals.
     pub sumcheck_subclaim: SumcheckSubclaim<F>,
     /// Column batching coefficients \gamma_j sampled during the protocol.
     pub gammas: Vec<F>,
-    /// Combined selector value at r_0: `eq(r_0, r') + \alpha * next(r', r_0)`.
-    pub selector_at_r0: F,
+    /// Per-shift batching coefficients \alpha_k sampled during the protocol.
+    pub alphas: Vec<F>,
+    /// `eq(r_0, r')` — the equality selector at the sumcheck output point.
+    pub eq_at_r0: F,
+    /// Per-shift selector values at r_0:
+    /// `shifts_at_r0[k] = next_{c_k}(r', r_0)`.
+    pub shifts_at_r0: Vec<F>,
 }
 
 //
@@ -92,10 +104,10 @@ where
     /// Multi-point evaluation protocol prover.
     ///
     /// Runs the combined sumcheck over
-    /// `[eq(b, r') + \alpha * next(r', b)] * \sum_j(\gamma_j * v_j(b))`.
-    /// Returns only the sumcheck proof and
-    /// the challenge point `r_0`; the caller is responsible for computing
-    /// and sending `lifted_evals` at `r_0`.
+    /// `eq(b, r') * \sum_j(\gamma_j * v_j(b)) + \sum_k \alpha_k *
+    /// next_{c_k}(r', b) * v_{src_k}(b)`. Returns only the sumcheck proof
+    /// and the challenge point `r_0`; the caller is responsible for
+    /// computing and sending `lifted_evals` at `r_0`.
     #[allow(clippy::arithmetic_side_effects)]
     pub fn prove_as_subprotocol(
         transcript: &mut impl Transcript,
@@ -103,27 +115,38 @@ where
         eval_point: &[F],
         up_evals: &[F],
         down_evals: &[F],
+        shifts: &[ShiftSpec],
         field_cfg: &F::Config,
     ) -> Result<(Proof<F>, ProverState<F>), MultipointEvalError<F>> {
         let num_cols = trace_mles.len();
+        let num_down_cols = shifts.len();
         let num_vars = eval_point.len();
         let zero = F::zero_with_cfg(field_cfg);
         let zero_inner = zero.inner();
 
         // Step 1: Sample multi-point batching coefficient \alpha and column
         // batching coefficients \gamma_1,...,\gamma_J.
-        let alpha: F = transcript.get_field_challenge(field_cfg);
+        let alphas: Vec<F> = transcript.get_field_challenges(num_down_cols, field_cfg);
         let gammas: Vec<F> = transcript.get_field_challenges(num_cols, field_cfg);
 
         // Step 2: Build the two selector MLEs:
         //   eq_r(b)   = eq(b, r')
         //   next_r(b) = next_tilde(r', b)
-        let eq_r = zinc_poly::utils::build_eq_x_r_inner(eval_point, field_cfg)?;
-        let next_r = zinc_poly::utils::build_next_r_mle(eval_point, field_cfg)?;
+        let eq_r = build_eq_x_r_inner(eval_point, field_cfg)?;
+        let (next_mles, down_cols): (Vec<_>, Vec<_>) = shifts
+            .iter()
+            .map(|spec| {
+                let next = build_next_c_r_mle(eval_point, spec.shift_amount(), field_cfg)?;
+                let col = trace_mles[spec.source_col()].clone();
+                Ok((next, col))
+            })
+            .collect::<Result<Vec<_>, ArithErrors>>()?
+            .into_iter()
+            .unzip();
 
         // Precombine up cols with gammas, precombined[b] = Σ_j γ_j trace[j][b]
         let precombined = {
-            let evaluations = (0..1 << num_vars)
+            let evaluations: Vec<_> = cfg_into_iter!(0..1 << num_vars)
                 .map(|b| {
                     gammas
                         .iter()
@@ -145,13 +168,17 @@ where
             )
         };
 
-        // Step 3: Pack MLEs: [eq_r, next_r, precombined]
-        let mles = vec![eq_r, next_r, precombined];
+        // Step 3: Pack MLEs: [eq_r, next_mles[..], precombined, down_cols[..]]
+        let mut mles = Vec::with_capacity(2 + 2 * num_down_cols);
+        mles.push(eq_r);
+        mles.extend(next_mles);
+        mles.push(precombined);
+        mles.extend(down_cols);
 
         // Step 4: Run sumcheck with degree=2.
 
-        // comb_fn([eq_r, next_r, precombined]) =
-        //     (eq_r + \alpha * next_r) * precombined
+        // comb_fn([eq_r, next_mles[..], precombined, down_cols[..]]) =
+        //     eq_r * precombined + \alphas[i] * next_mle[i] * down_cols[i]
         let (sumcheck_proof, sumcheck_prover_state) = MLSumcheck::prove_as_subprotocol(
             transcript,
             mles,
@@ -159,9 +186,15 @@ where
             2,
             |mle_values: &[F]| {
                 let eq_val = &mle_values[0];
-                let next_val = &mle_values[1];
-                let selector = eq_val.clone() + alpha.clone() * next_val;
-                selector * &mle_values[2]
+                let precombined = &mle_values[num_down_cols + 1];
+                alphas
+                    .iter()
+                    .enumerate()
+                    .fold(eq_val.clone() * precombined, |acc, (i, alpha)| {
+                        let next = &mle_values[1 + i];
+                        let down_col = &mle_values[num_down_cols + 2 + i];
+                        acc + alpha.clone() * next * down_col
+                    })
             },
             field_cfg,
         );
@@ -169,7 +202,7 @@ where
         // Sanity check
         debug_assert_eq!(
             sumcheck_proof.claimed_sum,
-            compute_expected_sum(up_evals, down_evals, &gammas, &alpha, zero)
+            compute_expected_sum(up_evals, down_evals, &gammas, &alphas, zero)
         );
 
         Ok((
@@ -184,31 +217,33 @@ where
     ///
     /// Runs the sumcheck verification and computes the intermediate values
     /// needed for the open-eval consistency check. Returns a [`Subclaim`]
-    /// carrying `r_0`, `gammas`, `selector_at_r0`, and
-    /// `expected_evaluation`. The caller finalizes via
+    /// carrying `r_0`, `gammas`, `alphas`, `eq_at_r0`, and
+    /// `shifts_at_r0`. The caller finalizes via
     /// [`verify_subclaim`](Self::verify_subclaim) once `open_evals` are
     /// available.
-    #[allow(clippy::arithmetic_side_effects)]
+    #[allow(clippy::arithmetic_side_effects, clippy::too_many_arguments)]
     pub fn verify_as_subprotocol(
         transcript: &mut impl Transcript,
         proof: Proof<F>,
         eval_point: &[F],
         up_evals: &[F],
         down_evals: &[F],
+        shifts: &[ShiftSpec],
         num_vars: usize,
         field_cfg: &F::Config,
     ) -> Result<Subclaim<F>, MultipointEvalError<F>> {
         let num_cols = up_evals.len();
+        let num_down_cols = shifts.len();
         let zero = F::zero_with_cfg(field_cfg);
         let one = F::one_with_cfg(field_cfg);
 
-        // Step 1: Sample \alpha and \gamma_j (must match prover).
-        let alpha: F = transcript.get_field_challenge(field_cfg);
+        // Step 1: Sample \alpha_k and \gamma_j (must match prover).
+        let alphas: Vec<F> = transcript.get_field_challenges(num_down_cols, field_cfg);
         let gammas: Vec<F> = transcript.get_field_challenges(num_cols, field_cfg);
 
         // Step 2: Compute expected sum
         let expected_sum: F =
-            compute_expected_sum(up_evals, down_evals, &gammas, &alpha, zero.clone());
+            compute_expected_sum(up_evals, down_evals, &gammas, &alphas, zero.clone());
 
         if proof.sumcheck_proof.claimed_sum != expected_sum {
             return Err(MultipointEvalError::WrongSumcheckSum {
@@ -228,33 +263,34 @@ where
 
         let r_0 = &sumcheck_subclaim.point;
 
-        // Step 4: Recompute the combined selector at r_0.
-        //   selector(r_0) = eq(r_0, r') + \alpha * next(r', r_0)
-        let eq_at_r0 = zinc_poly::utils::eq_eval(r_0, eval_point, one.clone())?;
-
-        let mut r_prime_r0 = Vec::with_capacity(2 * num_vars);
-        r_prime_r0.extend_from_slice(eval_point);
-        r_prime_r0.extend_from_slice(r_0);
-        let next_at_r0 = zinc_poly::utils::next_mle_eval(&r_prime_r0, zero, one);
-
-        let selector_at_r0 = eq_at_r0 + alpha * &next_at_r0;
+        // Step 4: Recompute the selectors at r_0.
+        let eq_at_r0 = zinc_poly::utils::eq_eval(r_0, eval_point, one)?;
+        let shifts_at_r0: Vec<F> = shifts
+            .iter()
+            .map(|spec| eval_shift_predicate(eval_point, r_0, spec.shift_amount(), field_cfg))
+            .collect();
 
         Ok(Subclaim {
             sumcheck_subclaim,
             gammas,
-            selector_at_r0,
+            alphas,
+            eq_at_r0,
+            shifts_at_r0,
         })
     }
 
     /// Finalize the multi-point evaluation check given `open_evals`.
     ///
-    /// Verifies that `selector_at_r0 * \sum_j(gamma_j * open_eval_j)`
-    /// equals the sumcheck's expected evaluation. This is a pure arithmetic
-    /// check with no transcript interaction.
+    /// Verifies that
+    /// `eq_at_r0 * \sum_j(gamma_j * open_eval_j) + \sum_k(alpha_k *
+    /// shift_at_r0_k * open_eval[source_col_k])` equals the sumcheck's
+    /// expected evaluation. This is a pure arithmetic check with no
+    /// transcript interaction.
     #[allow(clippy::arithmetic_side_effects)]
     pub fn verify_subclaim(
         subclaim: &Subclaim<F>,
         open_evals: &[F],
+        shifts: &[ShiftSpec],
         field_cfg: &F::Config,
     ) -> Result<(), MultipointEvalError<F>> {
         let num_cols = subclaim.gammas.len();
@@ -267,13 +303,29 @@ where
         }
 
         let zero = F::zero_with_cfg(field_cfg);
-        let batched_eval: F = subclaim
+
+        let batched_up: F = subclaim
             .gammas
             .iter()
             .zip(open_evals.iter())
-            .fold(zero, |acc, (g, v)| acc + g.clone() * v);
+            .fold(zero.clone(), |acc, (gamma, eval)| {
+                acc + gamma.clone() * eval
+            });
 
-        let expected_evaluation = subclaim.selector_at_r0.clone() * &batched_eval;
+        // open_evals[j] = trace_col_j(r_0) for all committed (up) columns.
+        // Shifted columns reuse the same opening: the shift is captured by
+        // the shift_at_r0 selector, so we index by source_col into open_evals.
+        let batched_down: F = subclaim
+            .alphas
+            .iter()
+            .enumerate()
+            .zip(subclaim.shifts_at_r0.iter())
+            .fold(zero, |acc, ((k, alpha), shift_at_r0)| {
+                let src_col = shifts[k].source_col();
+                acc + alpha.clone() * shift_at_r0 * &open_evals[src_col]
+            });
+
+        let expected_evaluation = subclaim.eq_at_r0.clone() * &batched_up + batched_down;
 
         if expected_evaluation != subclaim.sumcheck_subclaim.expected_evaluation {
             return Err(MultipointEvalError::ClaimMismatch {
@@ -286,20 +338,24 @@ where
     }
 }
 
-/// `expected_sum = \sum_j \gamma_j * (up_eval_j + \alpha * down_eval_j)`
+/// `expected_sum = \sum_j \gamma_j * up_eval_j + \sum_k \alpha_k *
+/// down_eval_k`
 fn compute_expected_sum<F: PrimeField>(
     up_evals: &[F],
     down_evals: &[F],
     gammas: &[F],
-    alpha: &F,
+    alphas: &[F],
     zero: F,
 ) -> F {
-    gammas
+    let up_sum = gammas
         .iter()
-        .zip(up_evals.iter().zip(down_evals.iter()))
-        .fold(zero, |acc, (gamma, (up, down))| {
-            acc + gamma.clone() * &(up.clone() + alpha.clone() * down)
-        })
+        .zip(up_evals.iter())
+        .fold(zero, |acc, (gamma, up)| acc + gamma.clone() * up);
+
+    alphas
+        .iter()
+        .zip(down_evals.iter())
+        .fold(up_sum, |acc, (alpha, down)| acc + alpha.clone() * down)
 }
 
 //
@@ -345,6 +401,7 @@ mod tests {
         eval_point: Vec<F>,
         up_evals: Vec<F>,
         down_evals: Vec<F>,
+        shifts: Vec<ShiftSpec>,
         num_vars: usize,
     }
 
@@ -364,6 +421,7 @@ mod tests {
     fn build_trace(
         num_vars: usize,
         num_cols: usize,
+        shifts: &[ShiftSpec],
     ) -> (
         Vec<DenseMultilinearExtension<<F as crypto_primitives::Field>::Inner>>,
         PublicInput,
@@ -387,11 +445,13 @@ mod tests {
             .map(|mle| mle.clone().evaluate_with_config(&eval_point, &()).unwrap())
             .collect();
 
-        let down_evals: Vec<F> = trace_mles
+        let down_evals: Vec<F> = shifts
             .iter()
-            .map(|mle| {
-                let mut shifted = mle.evaluations[1..].to_vec();
-                shifted.push(zero_inner);
+            .map(|spec| {
+                let mle = &trace_mles[spec.source_col()];
+                let c = spec.shift_amount();
+                let mut shifted = mle.evaluations[c..].to_vec();
+                shifted.extend(vec![zero_inner; c]);
                 let shifted_mle =
                     DenseMultilinearExtension::from_evaluations_vec(num_vars, shifted, zero_inner);
                 shifted_mle.evaluate_with_config(&eval_point, &()).unwrap()
@@ -402,6 +462,7 @@ mod tests {
             eval_point,
             up_evals,
             down_evals,
+            shifts: shifts.to_vec(),
             num_vars,
         };
         (trace_mles, public)
@@ -419,6 +480,7 @@ mod tests {
             &public.eval_point,
             &public.up_evals,
             &public.down_evals,
+            &public.shifts,
             &(),
         )
         .expect("prover should succeed");
@@ -443,48 +505,100 @@ mod tests {
             &public.eval_point,
             &public.up_evals,
             &public.down_evals,
+            &public.shifts,
             public.num_vars,
             &(),
         )?;
 
-        MultipointEval::<F>::verify_subclaim(&subclaim, &msg.open_evals, &())?;
+        MultipointEval::<F>::verify_subclaim(&subclaim, &msg.open_evals, &public.shifts, &())?;
 
         Ok(subclaim)
     }
 
     /// Convenience: build trace, prove, return (public, message).
-    fn honest_interaction(num_vars: usize, num_cols: usize) -> (PublicInput, ProverMessage) {
-        let (trace, public) = build_trace(num_vars, num_cols);
+    fn honest_interaction(
+        num_vars: usize,
+        num_cols: usize,
+        shifts: &[ShiftSpec],
+    ) -> (PublicInput, ProverMessage) {
+        let (trace, public) = build_trace(num_vars, num_cols, shifts);
         let msg = run_prover(&trace, &public);
         (public, msg)
+    }
+
+    /// Helper: all-columns shift-by-1
+    fn all_shift_by_1(num_cols: usize) -> Vec<ShiftSpec> {
+        (0..num_cols).map(|i| ShiftSpec::new(i, 1)).collect()
     }
 
     // --- Happy-path ---
 
     #[test]
-    fn honest_prove_verify_multi_column() {
-        let (public, msg) = honest_interaction(3, 3);
-        let subclaim = run_verifier(&public, &msg).unwrap();
-        assert_eq!(subclaim.sumcheck_subclaim.point.len(), public.num_vars);
-    }
-
-    #[test]
     fn honest_prove_verify_single_column() {
-        let (public, msg) = honest_interaction(4, 1);
+        let shifts = all_shift_by_1(1);
+        let (public, msg) = honest_interaction(4, 1, &shifts);
         run_verifier(&public, &msg).unwrap();
     }
 
     #[test]
     fn honest_prove_verify_many_columns() {
-        let (public, msg) = honest_interaction(3, 10);
+        let shifts = all_shift_by_1(10);
+        let (public, msg) = honest_interaction(3, 10, &shifts);
         run_verifier(&public, &msg).unwrap();
+    }
+
+    #[test]
+    fn honest_prove_verify_no_shifts() {
+        let (public, msg) = honest_interaction(3, 3, &[]);
+        run_verifier(&public, &msg).unwrap();
+    }
+
+    #[test]
+    fn honest_prove_verify_mixed_shifts() {
+        let shifts = vec![ShiftSpec::new(0, 1), ShiftSpec::new(1, 3)];
+        let (public, msg) = honest_interaction(4, 3, &shifts);
+        run_verifier(&public, &msg).unwrap();
+    }
+
+    #[test]
+    fn honest_prove_verify_shift_by_3() {
+        let shifts = vec![
+            ShiftSpec::new(0, 3),
+            ShiftSpec::new(1, 3),
+            ShiftSpec::new(2, 3),
+        ];
+        let (public, msg) = honest_interaction(4, 3, &shifts);
+        run_verifier(&public, &msg).unwrap();
+    }
+
+    #[test]
+    fn honest_prove_verify_same_col_different_shifts() {
+        // Column 0 shifted by 2 and by 5
+        let shifts = vec![ShiftSpec::new(0, 2), ShiftSpec::new(0, 5)];
+        let (public, msg) = honest_interaction(4, 3, &shifts);
+        run_verifier(&public, &msg).unwrap();
+    }
+
+    // --- Failure: corrupted down_evals with mixed shifts ---
+
+    #[test]
+    fn bad_down_eval_rejected_mixed_shifts() {
+        let shifts = vec![ShiftSpec::new(0, 1), ShiftSpec::new(1, 3)];
+        let (mut public, msg) = honest_interaction(4, 3, &shifts);
+        public.down_evals[0] += F::ONE;
+        let err = run_verifier(&public, &msg).unwrap_err();
+        assert!(
+            matches!(err, MultipointEvalError::WrongSumcheckSum { .. }),
+            "expected WrongSumcheckSum, got {err:?}",
+        );
     }
 
     // --- Failure: wrong number of open_evals ---
 
     #[test]
     fn wrong_open_evals_count() {
-        let (public, msg) = honest_interaction(3, 3);
+        let shifts = all_shift_by_1(3);
+        let (public, msg) = honest_interaction(3, 3, &shifts);
 
         let mut msg_short = msg.clone();
         msg_short.open_evals.pop();
@@ -508,7 +622,8 @@ mod tests {
 
     #[test]
     fn wrong_claimed_sum_via_corrupted_up_evals() {
-        let (mut public, msg) = honest_interaction(3, 3);
+        let shifts = all_shift_by_1(3);
+        let (mut public, msg) = honest_interaction(3, 3, &shifts);
         public.up_evals[0] += F::ONE;
         let err = run_verifier(&public, &msg).unwrap_err();
         assert!(
@@ -519,7 +634,8 @@ mod tests {
 
     #[test]
     fn wrong_claimed_sum_via_corrupted_down_evals() {
-        let (mut public, msg) = honest_interaction(3, 3);
+        let shifts = all_shift_by_1(3);
+        let (mut public, msg) = honest_interaction(3, 3, &shifts);
         public.down_evals[1] += F::ONE;
         let err = run_verifier(&public, &msg).unwrap_err();
         assert!(
@@ -532,7 +648,8 @@ mod tests {
 
     #[test]
     fn wrong_open_eval_value() {
-        let (public, mut msg) = honest_interaction(3, 3);
+        let shifts = all_shift_by_1(3);
+        let (public, mut msg) = honest_interaction(3, 3, &shifts);
         msg.open_evals[0] += F::ONE;
         let err = run_verifier(&public, &msg).unwrap_err();
         assert!(
@@ -543,7 +660,8 @@ mod tests {
 
     #[test]
     fn all_open_evals_zeroed() {
-        let (public, mut msg) = honest_interaction(3, 3);
+        let shifts = all_shift_by_1(3);
+        let (public, mut msg) = honest_interaction(3, 3, &shifts);
         for e in &mut msg.open_evals {
             *e = F::ZERO;
         }
@@ -554,11 +672,54 @@ mod tests {
         );
     }
 
+    // --- Failure: mixed shifts ---
+
+    fn mixed_shifts() -> Vec<ShiftSpec> {
+        vec![ShiftSpec::new(0, 1), ShiftSpec::new(1, 3)]
+    }
+
+    #[test]
+    fn mixed_shifts_corrupted_up_eval() {
+        let (mut public, msg) = honest_interaction(4, 3, &mixed_shifts());
+        public.up_evals[2] += F::ONE; // corrupt unshifted column
+        let err = run_verifier(&public, &msg).unwrap_err();
+        assert!(
+            matches!(err, MultipointEvalError::WrongSumcheckSum { .. }),
+            "expected WrongSumcheckSum, got {err:?}",
+        );
+    }
+
+    #[test]
+    fn mixed_shifts_wrong_open_eval() {
+        let (public, mut msg) = honest_interaction(4, 3, &mixed_shifts());
+        msg.open_evals[1] += F::ONE; // corrupt a shifted column's opening
+        let err = run_verifier(&public, &msg).unwrap_err();
+        assert!(
+            matches!(err, MultipointEvalError::ClaimMismatch { .. }),
+            "expected ClaimMismatch, got {err:?}",
+        );
+    }
+
+    #[test]
+    fn mixed_shifts_tampered_sumcheck() {
+        let (public, mut msg) = honest_interaction(4, 3, &mixed_shifts());
+        msg.proof.sumcheck_proof.messages[0].0.tail_evaluations[0] += F::ONE;
+        let err = run_verifier(&public, &msg).unwrap_err();
+        assert!(
+            matches!(
+                err,
+                MultipointEvalError::SumcheckError(_) | MultipointEvalError::ClaimMismatch { .. }
+            ),
+            "expected sumcheck or consistency error, got {err:?}",
+        );
+    }
+
     // --- Failure: tampered sumcheck round messages ---
 
     #[test]
     fn tampered_sumcheck_round_message() {
-        let (public, mut msg) = honest_interaction(3, 3);
+        let shifts = all_shift_by_1(3);
+        let (public, mut msg) = honest_interaction(3, 3, &shifts);
         msg.proof.sumcheck_proof.messages[0].0.tail_evaluations[0] += F::ONE;
         let err = run_verifier(&public, &msg).unwrap_err();
         assert!(

--- a/piop/src/shift_predicate.rs
+++ b/piop/src/shift_predicate.rs
@@ -9,8 +9,8 @@ use zinc_poly::utils::next_mle_eval;
 /// Evaluate the shift predicate `S_c(x, y)` at arbitrary field points.
 ///
 /// Uses the high/low decomposition:
-///   `S_c(x, y) = L_0(x_lo, y_lo) · eq*(x_hi, y_hi)
-///              + L_1(x_lo, y_lo) · Next*(x_hi, y_hi)`
+///   `S_c(x, y) = L_0(x_lo, y_lo) · eq(x_hi, y_hi)
+///              + L_1(x_lo, y_lo) · next_mle(x_hi, y_hi)`
 ///
 /// where `k = ceil(log2(2c))` determines the split point.
 ///
@@ -22,12 +22,12 @@ pub fn eval_shift_predicate<F: PrimeField>(x: &[F], y: &[F], c: usize, cfg: &F::
     let zero = F::zero_with_cfg(cfg);
     let one = F::one_with_cfg(cfg);
 
-    // S_0(x, y) = eq*(x, y): identity shift.
+    // S_0(x, y) = eq(x, y): identity shift.
     if c == 0 {
         return eval_eq_poly(x, y, &one);
     }
 
-    // S_1(x, y) = Next*(x, y): the successor predicate is exactly shift-by-1.
+    // S_1(x, y) = next_mle(x, y): the successor predicate is exactly shift-by-1.
     if c == 1 {
         return next_mle_eval(x, y, zero, one);
     }
@@ -50,7 +50,7 @@ pub fn eval_shift_predicate<F: PrimeField>(x: &[F], y: &[F], c: usize, cfg: &F::
     l0 * eq + l1 * next
 }
 
-/// `eq*(u, v) = prod_i (u_i * v_i + (1 - u_i)(1 - v_i))`
+/// `eq(u, v) = prod_i (u_i * v_i + (1 - u_i)(1 - v_i))`
 ///
 /// Evaluates the Multilinear polynomial for eq polynomial
 pub(crate) fn eval_eq_poly<F: PrimeField>(u: &[F], v: &[F], one: &F) -> F {
@@ -60,7 +60,7 @@ pub(crate) fn eval_eq_poly<F: PrimeField>(u: &[F], v: &[F], one: &F) -> F {
         .fold(one.clone(), |acc, term| acc * term)
 }
 
-/// `delta_{bin_k(a)}(u) = eq*(u, bin_k(a))`.
+/// `delta_{bin_k(a)}(u) = eq(u, bin_k(a))`.
 ///
 /// Evaluates the Lagrange basis polynomial for the binary encoding of `a`
 /// with `k` bits at the point `u`.
@@ -194,7 +194,7 @@ mod tests {
         }
     }
 
-    /// Verify the Next* successor predicate on all Boolean inputs.
+    /// Verify the next_mle on all Boolean inputs.
     #[test]
     fn test_next_boolean() {
         let cfg = test_config();

--- a/piop/src/shift_predicate.rs
+++ b/piop/src/shift_predicate.rs
@@ -1,0 +1,401 @@
+//! Shift predicate evaluation.
+//!
+//! Evaluates `S_c(x, y)` — the multilinear extension of the shift-by-c
+//! indicator — at arbitrary field points.
+
+use crypto_primitives::PrimeField;
+use zinc_poly::utils::next_mle_eval;
+
+/// Evaluate the shift predicate `S_c(x, y)` at arbitrary field points.
+///
+/// Uses the high/low decomposition:
+///   `S_c(x, y) = L_0(x_lo, y_lo) · eq*(x_hi, y_hi)
+///              + L_1(x_lo, y_lo) · Next*(x_hi, y_hi)`
+///
+/// where `k = ceil(log2(2c))` determines the split point.
+///
+/// Cost: O(m + c · log c) field operations.
+#[allow(clippy::arithmetic_side_effects)]
+pub fn eval_shift_predicate<F: PrimeField>(x: &[F], y: &[F], c: usize, cfg: &F::Config) -> F {
+    let m = x.len();
+    assert_eq!(y.len(), m);
+    let zero = F::zero_with_cfg(cfg);
+    let one = F::one_with_cfg(cfg);
+
+    // S_0(x, y) = eq*(x, y): identity shift.
+    if c == 0 {
+        return eval_eq_poly(x, y, &one);
+    }
+
+    // S_1(x, y) = Next*(x, y): the successor predicate is exactly shift-by-1.
+    if c == 1 {
+        return next_mle_eval(x, y, zero, one);
+    }
+
+    assert!(c < (1usize << m), "shift c must satisfy c < 2^m");
+    // k = ceil(log2(2*c))
+    let k = (2 * c).next_power_of_two().trailing_zeros() as usize;
+    if k >= m {
+        return eval_shift_small(x, y, c, m, &zero, &one);
+    }
+
+    // LE convention: x[0..k] are the low bits, x[k..] are the high bits.
+    let (x_lo, x_hi) = x.split_at(k);
+    let (y_lo, y_hi) = y.split_at(k);
+
+    let l0 = eval_l0(x_lo, y_lo, c, k, &zero, &one);
+    let l1 = eval_l1(x_lo, y_lo, c, k, &zero, &one);
+    let eq = eval_eq_poly(x_hi, y_hi, &one);
+    let next = next_mle_eval(x_hi, y_hi, zero, one);
+    l0 * eq + l1 * next
+}
+
+/// `eq*(u, v) = prod_i (u_i * v_i + (1 - u_i)(1 - v_i))`
+///
+/// Evaluates the Multilinear polynomial for eq polynomial
+pub(crate) fn eval_eq_poly<F: PrimeField>(u: &[F], v: &[F], one: &F) -> F {
+    u.iter()
+        .zip(v.iter())
+        .map(|(u_i, v_i)| u_i.clone() * v_i + (one.clone() - u_i) * (one.clone() - v_i))
+        .fold(one.clone(), |acc, term| acc * term)
+}
+
+/// `delta_{bin_k(a)}(u) = eq*(u, bin_k(a))`.
+///
+/// Evaluates the Lagrange basis polynomial for the binary encoding of `a`
+/// with `k` bits at the point `u`.
+///
+/// LE convention: `u[i]` corresponds to bit `i` (LSB = index 0).
+pub(crate) fn eval_delta<F: PrimeField>(u: &[F], a: usize, k: usize, one: &F) -> F {
+    let mut result = one.clone();
+    for (i, u) in u.iter().take(k).enumerate() {
+        let bit = (a >> i) & 1;
+        if bit == 1 {
+            result *= u;
+        } else {
+            result *= one.clone() - u
+        }
+    }
+    result
+}
+
+/// `L_0^{(c)}(x_lo, y_lo)` — no-carry component.
+///
+/// `sum_{a=0}^{2^k - 1 - c} delta(x_lo, a) * delta(y_lo, a + c)`
+///
+/// On Booleans: 1 iff `Val(y_lo) = Val(x_lo) + c` with no carry into the high
+/// block.
+#[allow(clippy::arithmetic_side_effects)]
+pub(crate) fn eval_l0<F: PrimeField>(
+    x_lo: &[F],
+    y_lo: &[F],
+    c: usize,
+    k: usize,
+    zero: &F,
+    one: &F,
+) -> F {
+    let upper = (1 << k) - c;
+    (0..upper).fold(zero.clone(), |acc, a| {
+        acc + eval_delta(x_lo, a, k, one) * eval_delta(y_lo, a + c, k, one)
+    })
+}
+
+/// `L_1^{(c)}(x_lo, y_lo)` — carry component.
+///
+/// `sum_{a=2^k-c}^{2^k-1} delta(x_lo, a) * delta(y_lo, a + c - 2^k)`
+///
+/// On Booleans: 1 iff the addition carries into the high block.
+#[allow(clippy::arithmetic_side_effects)]
+pub(crate) fn eval_l1<F: PrimeField>(
+    x_lo: &[F],
+    y_lo: &[F],
+    c: usize,
+    k: usize,
+    zero: &F,
+    one: &F,
+) -> F {
+    let two_k = 1 << k;
+    ((two_k - c)..two_k).fold(zero.clone(), |acc, a| {
+        acc + eval_delta(x_lo, a, k, one) * eval_delta(y_lo, a + c - two_k, k, one)
+    })
+}
+
+/// Special case when `k >= m`: no high block, direct evaluation.
+///
+/// `sum_{a=0}^{n-1-c} delta(x, a, m) * delta(y, a+c, m)`
+#[allow(clippy::arithmetic_side_effects)]
+fn eval_shift_small<F: PrimeField>(x: &[F], y: &[F], c: usize, m: usize, zero: &F, one: &F) -> F {
+    let upper = (1 << m) - c;
+    (0..upper).fold(zero.clone(), |acc, a| {
+        acc + eval_delta(x, a, m, one) * eval_delta(y, a + c, m, one)
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::test_utils::test_config;
+    use crypto_primitives::{Field, FromWithConfig, crypto_bigint_monty::MontyField};
+    use rand::Rng;
+    use zinc_poly::utils::{build_eq_x_r_inner, build_next_c_r_mle};
+
+    type F = MontyField<4>;
+
+    /// LE convention: to_bin(val, i) = bit i of val (LSB = index 0).
+    fn to_bin(val: usize, bit: usize, cfg: &<F as PrimeField>::Config) -> F {
+        if (val >> bit) & 1 == 1 {
+            F::one_with_cfg(cfg)
+        } else {
+            F::zero_with_cfg(cfg)
+        }
+    }
+
+    /// Convert F::Inner back to F.
+    fn from_inner(inner: <F as Field>::Inner, cfg: &<F as PrimeField>::Config) -> F {
+        let mut f = F::zero_with_cfg(cfg);
+        *f.inner_mut() = inner;
+        f
+    }
+
+    fn rand_field(rng: &mut impl Rng, cfg: &<F as PrimeField>::Config) -> F {
+        F::from_with_cfg(rng.random::<u32>(), cfg)
+    }
+
+    /// Check S_c on Boolean inputs: S_c(bin(a), bin(a+c)) = 1,
+    /// and S_c(bin(a), bin(b)) = 0 for b != a+c.
+    #[test]
+    fn test_shift_predicate_boolean() {
+        let cfg = test_config();
+        let m = 4;
+        let n = 1usize << m;
+
+        for c in [1, 2, 5] {
+            for a in 0..n {
+                for b in 0..n {
+                    let x: Vec<F> = (0..m).map(|i| to_bin(a, i, &cfg)).collect();
+                    let y: Vec<F> = (0..m).map(|i| to_bin(b, i, &cfg)).collect();
+                    let val = eval_shift_predicate(&x, &y, c, &cfg);
+
+                    if b == a + c && a + c < n {
+                        assert_eq!(
+                            val,
+                            F::one_with_cfg(&cfg),
+                            "S_c({a},{b}) should be 1 for c={c}"
+                        );
+                    } else {
+                        assert_eq!(
+                            val,
+                            F::zero_with_cfg(&cfg),
+                            "S_c({a},{b}) should be 0 for c={c}"
+                        );
+                    }
+                }
+            }
+        }
+    }
+
+    /// Verify the Next* successor predicate on all Boolean inputs.
+    #[test]
+    fn test_next_boolean() {
+        let cfg = test_config();
+        let m = 4;
+        let n = 1usize << m;
+        for a in 0..n {
+            for b in 0..n {
+                let u: Vec<F> = (0..m).map(|i| to_bin(a, i, &cfg)).collect();
+                let v: Vec<F> = (0..m).map(|i| to_bin(b, i, &cfg)).collect();
+                let val = next_mle_eval(&u, &v, F::zero_with_cfg(&cfg), F::one_with_cfg(&cfg));
+
+                if b == a + 1 && a + 1 < n {
+                    assert_eq!(val, F::one_with_cfg(&cfg), "Next({a},{b}) should be 1");
+                } else {
+                    assert_eq!(val, F::zero_with_cfg(&cfg), "Next({a},{b}) should be 0");
+                }
+            }
+        }
+    }
+
+    /// Check verifier (`eval_shift_predicate`) against prover
+    /// (`build_next_c_r_mle`) at Boolean points:
+    ///   eval_shift_predicate(r, bin(b), c) == build_next_c_r_mle(r, c)[b]
+    #[test]
+    fn test_shift_predicate_vs_prover_mle() {
+        let cfg = test_config();
+        let mut rng = rand::rng();
+        let m = 4;
+        let n = 1usize << m;
+        let c = 3;
+
+        let r: Vec<F> = (0..m).map(|_| rand_field(&mut rng, &cfg)).collect();
+        let next_c = build_next_c_r_mle(&r, c, &cfg).unwrap();
+
+        for b in 0..n {
+            let b_bin: Vec<F> = (0..m).map(|i| to_bin(b, i, &cfg)).collect();
+            let val = eval_shift_predicate(&r, &b_bin, c, &cfg);
+            let expected = from_inner(next_c.evaluations[b], &cfg);
+            assert_eq!(val, expected, "S_{c}(r, bin({b})) mismatch with prover MLE");
+        }
+    }
+
+    /// Check at random field points via MLE summation:
+    ///   eval_shift_predicate(r, y, c) == sum_b build_next_c_r_mle(r, c)[b] *
+    /// eq(b, y)
+    #[test]
+    fn test_shift_predicate_random_points() {
+        let cfg = test_config();
+        let mut rng = rand::rng();
+        let m = 4;
+        let c = 3;
+
+        for _ in 0..8 {
+            let r: Vec<F> = (0..m).map(|_| rand_field(&mut rng, &cfg)).collect();
+            let y: Vec<F> = (0..m).map(|_| rand_field(&mut rng, &cfg)).collect();
+
+            let next_c = build_next_c_r_mle(&r, c, &cfg).unwrap();
+            let eq_y = build_eq_x_r_inner(&y, &cfg).unwrap();
+            let zero = F::zero_with_cfg(&cfg);
+            let rhs = next_c
+                .evaluations
+                .iter()
+                .zip(eq_y.evaluations.iter())
+                .fold(zero, |acc, (ni, ei)| {
+                    acc + from_inner(*ni, &cfg) * from_inner(*ei, &cfg)
+                });
+            let lhs = eval_shift_predicate(&r, &y, c, &cfg);
+
+            assert_eq!(lhs, rhs, "random-point MLE mismatch");
+        }
+    }
+
+    /// Test c=0 (identity) and c=1 (successor) fast paths at random points,
+    /// and verify predicate vs prover MLE consistency across multiple shift
+    /// amounts.
+    #[test]
+    fn test_fast_paths_and_multi_c() {
+        let cfg = test_config();
+        let mut rng = rand::rng();
+        let m = 4;
+        let n = 1usize << m;
+
+        for c in [0, 1, 2, 5, 7] {
+            let r: Vec<F> = (0..m).map(|_| rand_field(&mut rng, &cfg)).collect();
+            let next_c = build_next_c_r_mle(&r, c, &cfg).unwrap();
+
+            // Predicate vs prover MLE at Boolean y
+            for b in 0..n {
+                let b_bin: Vec<F> = (0..m).map(|i| to_bin(b, i, &cfg)).collect();
+                let val = eval_shift_predicate(&r, &b_bin, c, &cfg);
+                let expected = from_inner(next_c.evaluations[b], &cfg);
+                assert_eq!(val, expected, "S_{c}(r, bin({b})) mismatch with prover MLE");
+            }
+
+            // Predicate vs prover MLE at random y (MLE consistency)
+            for _ in 0..4 {
+                let y: Vec<F> = (0..m).map(|_| rand_field(&mut rng, &cfg)).collect();
+                let eq_y = build_eq_x_r_inner(&y, &cfg).unwrap();
+                let zero = F::zero_with_cfg(&cfg);
+                let rhs = next_c
+                    .evaluations
+                    .iter()
+                    .zip(eq_y.evaluations.iter())
+                    .fold(zero.clone(), |acc, (ni, ei)| {
+                        acc + from_inner(*ni, &cfg) * from_inner(*ei, &cfg)
+                    });
+                let lhs = eval_shift_predicate(&r, &y, c, &cfg);
+                assert_eq!(lhs, rhs, "random-point MLE mismatch for c={c}");
+            }
+        }
+    }
+
+    /// Boundary test: large c values where most rows shift beyond the domain.
+    #[test]
+    fn test_shift_predicate_boundary() {
+        let cfg = test_config();
+        let m = 3;
+        let n = 1usize << m; // 8
+
+        for c in [n / 2, n - 1] {
+            // Boolean correctness: S_c(bin(a), bin(b)) = 1 iff b == a+c < n
+            for a in 0..n {
+                for b in 0..n {
+                    let x: Vec<F> = (0..m).map(|i| to_bin(a, i, &cfg)).collect();
+                    let y: Vec<F> = (0..m).map(|i| to_bin(b, i, &cfg)).collect();
+                    let val = eval_shift_predicate(&x, &y, c, &cfg);
+
+                    if b == a + c && a + c < n {
+                        assert_eq!(
+                            val,
+                            F::one_with_cfg(&cfg),
+                            "S_{c}(bin({a}), bin({b})) should be 1"
+                        );
+                    } else {
+                        assert_eq!(
+                            val,
+                            F::zero_with_cfg(&cfg),
+                            "S_{c}(bin({a}), bin({b})) should be 0"
+                        );
+                    }
+                }
+            }
+
+            // Prover MLE: first c entries zero, rest match eq(r, b-c)
+            let mut rng = rand::rng();
+            let r: Vec<F> = (0..m).map(|_| rand_field(&mut rng, &cfg)).collect();
+            let next_c = build_next_c_r_mle(&r, c, &cfg).unwrap();
+            let zero_inner = *F::zero_with_cfg(&cfg).inner();
+
+            // First c entries must be zero
+            for b in 0..c {
+                assert_eq!(
+                    next_c.evaluations[b], zero_inner,
+                    "next_c[{b}] should be zero for c={c}"
+                );
+            }
+            // Remaining entries should be nonzero (with overwhelming probability)
+            let nonzero_count = next_c.evaluations[c..]
+                .iter()
+                .filter(|e| **e != zero_inner)
+                .count();
+            assert_eq!(
+                nonzero_count,
+                n - c,
+                "expected {} nonzero entries for c={c}",
+                n - c
+            );
+        }
+    }
+
+    /// Check that build_next_c_r_mle correctly reproduces MLE[shift_c(v)](r)
+    /// via inner product: sum_b next_c(b) * v[b] == sum_b eq(r, b-c) * v[b].
+    #[test]
+    fn test_prover_mle_inner_product() {
+        let cfg = test_config();
+        let mut rng = rand::rng();
+        let m = 4;
+        let n = 1usize << m;
+
+        for c in [1, 2, 3, 7] {
+            let v: Vec<F> = (0..n).map(|_| rand_field(&mut rng, &cfg)).collect();
+            let r: Vec<F> = (0..m).map(|_| rand_field(&mut rng, &cfg)).collect();
+
+            // Ground truth: sum_{b>=c} eq(r, b-c) * v[b]
+            let eq_r = build_eq_x_r_inner(&r, &cfg).unwrap();
+            let zero = F::zero_with_cfg(&cfg);
+            let expected = (c..n).fold(zero.clone(), |acc, b| {
+                acc + from_inner(eq_r.evaluations[b - c], &cfg) * &v[b]
+            });
+
+            // Via prover MLE: sum_b next_c[b] * v[b]
+            let next_c = build_next_c_r_mle(&r, c, &cfg).unwrap();
+            let got = next_c
+                .evaluations
+                .iter()
+                .zip(v.iter())
+                .fold(zero, |acc, (ni, vi)| {
+                    acc + vi.clone() * from_inner(*ni, &cfg)
+                });
+
+            assert_eq!(got, expected, "prover MLE inner product mismatch for c={c}");
+        }
+    }
+}

--- a/piop/src/test_utils.rs
+++ b/piop/src/test_utils.rs
@@ -49,8 +49,8 @@ where
     F: FromWithConfig<Int<5>>,
 {
     assert!(
-        U::signature().witness_binary_poly_cols.is_zero()
-            && U::signature().witness_int_cols.is_zero(),
+        U::signature().witness_cols().binary_poly_cols().is_zero()
+            && U::signature().witness_cols().int_cols().is_zero(),
         "the signature should be single typed"
     );
 
@@ -100,8 +100,8 @@ where
     F: FromWithConfig<Int<5>>,
 {
     assert!(
-        U::signature().witness_binary_poly_cols.is_zero()
-            && U::signature().witness_int_cols.is_zero(),
+        U::signature().witness_cols().binary_poly_cols().is_zero()
+            && U::signature().witness_cols().int_cols().is_zero(),
         "the signature should be single typed"
     );
 

--- a/piop/src/test_utils.rs
+++ b/piop/src/test_utils.rs
@@ -49,8 +49,11 @@ where
     F: FromWithConfig<Int<5>>,
 {
     assert!(
-        U::signature().witness_cols().binary_poly_cols().is_zero()
-            && U::signature().witness_cols().int_cols().is_zero(),
+        U::signature()
+            .witness_cols()
+            .num_binary_poly_cols()
+            .is_zero()
+            && U::signature().witness_cols().num_int_cols().is_zero(),
         "the signature should be single typed"
     );
 
@@ -100,8 +103,11 @@ where
     F: FromWithConfig<Int<5>>,
 {
     assert!(
-        U::signature().witness_cols().binary_poly_cols().is_zero()
-            && U::signature().witness_cols().int_cols().is_zero(),
+        U::signature()
+            .witness_cols()
+            .num_binary_poly_cols()
+            .is_zero()
+            && U::signature().witness_cols().num_int_cols().is_zero(),
         "the signature should be single typed"
     );
 

--- a/poly/src/utils.rs
+++ b/poly/src/utils.rs
@@ -195,14 +195,14 @@ where
     Ok(())
 }
 
-/// Build the shift selector MLE `next_c_tilde(r, *)` with the first `num_vars`
+/// Build the shift selector MLE `next_c_mle(r, *)` with the first `num_vars`
 /// variables fixed to `r`.
 ///
 /// For each `b in {0,1}^{num_vars}`:
-///   next_c_tilde(b) = eq(r, b - c)   if b >= c
-///   next_c_tilde(b) = 0              if b < c
+///   next_c_mle(b) = eq(r, b - c)   if b >= c
+///   next_c_mle(b) = 0              if b < c
 ///
-/// Uses the identity `next_c_tilde(r, b) = eq(r, b - c)` for `b >= c` and
+/// Uses the identity `next_c_mle(r, b) = eq(r, b - c)` for `b >= c` and
 /// `0` for `b < c`.
 pub fn build_next_c_r_mle<F>(
     r: &[F],
@@ -223,9 +223,10 @@ where
         return Ok(eq_r);
     }
 
-    // next_c_tilde(r, 0) = 0 for b < c
-    // next_c_tilde(r, b - c) = eq(r, b - c) for b >= c
-    let mut evaluations = vec![zero_inner; c];
+    // next_c_mle(r, 0) = 0 for b < c
+    // next_c_mle(r, b - c) = eq(r, b - c) for b >= c
+    let mut evaluations = Vec::with_capacity(n);
+    evaluations.resize(c, zero_inner);
     evaluations.extend_from_slice(&eq_r.evaluations[..sub!(n, c)]);
 
     Ok(DenseMultilinearExtension {
@@ -318,7 +319,7 @@ pub fn next_mle_inner<F: Field>(
 ///
 /// Improved from O(n²) approach here: https://github.com/TomWambsgans/Whirlaway/blob/9e3592b/crates/air/src/utils.rs#L92
 ///
-/// `Next*(u, v) = 1` iff `Val(v) = Val(u) + 1` and `Val(u) < 2^n - 1`.
+/// `next_mle(u, v) = 1` iff `Val(v) = Val(u) + 1` and `Val(u) < 2^n - 1`.
 ///
 /// # Arguments
 /// - `u`: first n-bit vector (LE convention: index 0 = LSB).
@@ -326,10 +327,10 @@ pub fn next_mle_inner<F: Field>(
 ///
 /// # Algorithm
 /// Uses prefix/suffix products for O(n) evaluation:
-///   `Next*(u, v) = sum_{j=0}^{n-1}
+///   `next_mle(u, v) = sum_{j=0}^{n-1}
 ///       [prod_{i<j} u_i * (1 - v_i)]      -- bits below j: were 1, flip to 0
 ///     * (1 - u_j) * v_j                   -- bit j: 0 → 1
-///     * [prod_{i>j} eq*(u_i, v_i)]`       -- bits above j: unchanged
+///     * [prod_{i>j} eq(u_i, v_i)]`        -- bits above j: unchanged
 ///
 /// # Panics
 /// Panics if `u.len() != v.len()`.
@@ -341,7 +342,7 @@ pub fn next_mle_eval<R: Semiring>(u: &[R], v: &[R], zero: R, one: R) -> R {
         return zero;
     }
 
-    // suffix_eq[j] = prod_{i=j}^{n-1} eq*(u_i, v_i)
+    // suffix_eq[j] = prod_{i=j}^{n-1} eq(u_i, v_i)
     let mut suffix_eq = vec![one.clone(); n + 1];
     for i in (0..n).rev() {
         suffix_eq[i] = suffix_eq[i + 1].clone()

--- a/poly/src/utils.rs
+++ b/poly/src/utils.rs
@@ -195,16 +195,18 @@ where
     Ok(())
 }
 
-/// Build the shift selector MLE `next_tilde(r, *)` with the first `num_vars`
+/// Build the shift selector MLE `next_c_tilde(r, *)` with the first `num_vars`
 /// variables fixed to `r`.
 ///
-/// For each `b \in {0,1}^{num_vars}`:
-///   `next_r(b) = next_tilde(r, b)`
+/// For each `b in {0,1}^{num_vars}`:
+///   next_c_tilde(b) = eq(r, b - c)   if b >= c
+///   next_c_tilde(b) = 0              if b < c
 ///
-/// Uses the identity `next_tilde(r, b) = eq(r, b-1)` for `b > 0` and
-/// `0` for `b = 0`.
-pub fn build_next_r_mle<F>(
+/// Uses the identity `next_c_tilde(r, b) = eq(r, b - c)` for `b >= c` and
+/// `0` for `b < c`.
+pub fn build_next_c_r_mle<F>(
     r: &[F],
+    c: usize,
     field_cfg: &F::Config,
 ) -> Result<DenseMultilinearExtension<F::Inner>, ArithErrors>
 where
@@ -213,15 +215,18 @@ where
 {
     let num_vars = r.len();
     let n = 1 << num_vars;
+    assert!(c < n, "shift c={c} must be < domain size {n}");
     let zero_inner = F::zero_with_cfg(field_cfg).into_inner();
 
     let eq_r = build_eq_x_r_inner(r, field_cfg)?;
+    if c == 0 {
+        return Ok(eq_r);
+    }
 
-    // next_tilde(r, 0) = 0
-    // next_tilde(r, b) = eq(r, b-1) for b > 0
-    let mut evaluations = Vec::with_capacity(n);
-    evaluations.push(zero_inner);
-    evaluations.extend_from_slice(&eq_r.evaluations[..sub!(n, 1)]);
+    // next_c_tilde(r, 0) = 0 for b < c
+    // next_c_tilde(r, b - c) = eq(r, b - c) for b >= c
+    let mut evaluations = vec![zero_inner; c];
+    evaluations.extend_from_slice(&eq_r.evaluations[..sub!(n, c)]);
 
     Ok(DenseMultilinearExtension {
         num_vars,
@@ -308,79 +313,53 @@ pub fn next_mle_inner<F: Field>(
     Ok(mle)
 }
 
-/// Evaluates the next MLE at the point `point` in log-time.
+/// Evaluates the next MLE in O(n), by reusing suffix equality and prefix carry
+/// products across carry positions.
+///
+/// Improved from O(n²) approach here: https://github.com/TomWambsgans/Whirlaway/blob/9e3592b/crates/air/src/utils.rs#L92
+///
+/// `Next*(u, v) = 1` iff `Val(v) = Val(u) + 1` and `Val(u) < 2^n - 1`.
 ///
 /// # Arguments
-/// - `point`: A slice of 2n field elements representing two n-bit vectors
-///   concatenated. The first n elements are `x` (original vector), the last n
-///   are `y` (candidate successor).
+/// - `u`: first n-bit vector (LE convention: index 0 = LSB).
+/// - `v`: second n-bit vector. Must have `v.len() == u.len()`.
 ///
-/// # Behavior
-/// Constructs a polynomial P(x, y) such that:
-/// \begin{equation}
-///     P(x, y) = 1 \quad \text{if and only if} \quad y = x + 1.
-/// \end{equation}
-///
-/// The polynomial sums contributions for each possible carry position `k`,
-/// ensuring that:
-/// 1. Bits to the left of `k` (more significant) match.
-/// 2. Bit at position `k` transitions from 0 (in x) to 1 (in y).
-/// 3. Bits to the right of `k` are 1 in x and 0 in y (simulating the carry
-///    propagation).
+/// # Algorithm
+/// Uses prefix/suffix products for O(n) evaluation:
+///   `Next*(u, v) = sum_{j=0}^{n-1}
+///       [prod_{i<j} u_i * (1 - v_i)]      -- bits below j: were 1, flip to 0
+///     * (1 - u_j) * v_j                   -- bit j: 0 → 1
+///     * [prod_{i>j} eq*(u_i, v_i)]`       -- bits above j: unchanged
 ///
 /// # Panics
-/// Panics if `point.len()` is not even.
-///
-/// # Returns
-/// Field element: 1 if y = x + 1, 0 otherwise.
-///
-/// Adapted from <https://github.com/TomWambsgans/Whirlaway/blob/9e3592b5b5c3702fe3a1728be758506a7ee9283b/crates/air/src/utils.rs#L92>
+/// Panics if `u.len() != v.len()`.
 #[allow(clippy::arithmetic_side_effects)]
-pub fn next_mle_eval<R: Semiring>(point: &[R], zero: R, one: R) -> R {
-    // Check that the point length is even: we split into x and y of equal length.
-    assert_eq!(
-        point.len() % 2,
-        0,
-        "Input point must have an even number of variables."
-    );
-    let n = point.len() / 2;
+pub fn next_mle_eval<R: Semiring>(u: &[R], v: &[R], zero: R, one: R) -> R {
+    let n = u.len();
+    assert_eq!(n, v.len(), "u and v must have the same length");
+    if n == 0 {
+        return zero;
+    }
 
-    // Split point into x (first n) and y (last n).
-    let (x, y) = point.split_at(n);
+    // suffix_eq[j] = prod_{i=j}^{n-1} eq*(u_i, v_i)
+    let mut suffix_eq = vec![one.clone(); n + 1];
+    for i in (0..n).rev() {
+        suffix_eq[i] = suffix_eq[i + 1].clone()
+            * (u[i].clone() * &v[i] + (one.clone() - &u[i]) * (one.clone() - &v[i]));
+    }
 
-    // Sum contributions for each possible carry position k = 0..n-1.
-    (0..n)
-        .map(|k| {
-            // Term 1: bits to the left of k match
-            //
-            // For i > k, enforce x_i == y_i.
-            // Using equality polynomial: x_i * y_i + (1 - x_i)*(1 - y_i).
-            let eq_high_bits = (k + 1..n)
-                .map(|i| x[i].clone() * &y[i] + (one.clone() - &x[i]) * (one.clone() - &y[i]))
-                .fold(one.clone(), |acc, next| acc * next);
-
-            // Term 2: carry bit at position k
-            //
-            // Enforce x_k = 0 and y_k = 1.
-            // Condition: (1 - x_k) * y_k.
-            let carry_bit = (one.clone() - &x[k]) * &y[k];
-
-            // Term 3: bits to the right of k are 1 in x and 0 in y
-            //
-            // For i < k, enforce x_i = 1 and y_i = 0.
-            // Condition: x_i * (1 - y_i).
-            let low_bits_are_one_zero = (0..k)
-                .map(|i| (one.clone() - &y[i]) * &x[i])
-                .fold(one.clone(), |acc, next| acc * next);
-
-            // Multiply the three terms for this k, representing one "carry pattern".
-            eq_high_bits * carry_bit * low_bits_are_one_zero
-        })
-        // Sum over all carry positions: any valid "k" gives contribution 1.
-        .fold(zero, |acc, next| acc + next)
+    // prefix_carry accumulates prod_{i<j} u_i * (1 - v_i)
+    let mut prefix_carry = one.clone();
+    let mut result = zero;
+    for j in 0..n {
+        result += prefix_carry.clone() * (one.clone() - &u[j]) * &v[j] * &suffix_eq[j + 1];
+        prefix_carry *= u[j].clone() * (one.clone() - &v[j]);
+    }
+    result
 }
 
 #[cfg(test)]
+#[allow(clippy::arithmetic_side_effects, clippy::cast_possible_truncation)]
 mod tests {
     use crypto_bigint::{U128, const_monty_params};
     use crypto_primitives::{IntoWithConfig, crypto_bigint_const_monty::ConstMontyField};
@@ -473,9 +452,10 @@ mod tests {
                 }
             }));
 
+            let (u, v) = point.split_at(NUM_VARS as usize / 2);
             assert_eq!(
                 next_mle.clone().evaluate_with_config(&point, &()),
-                Ok(next_mle_eval(&point, F::zero(), F::one()))
+                Ok(next_mle_eval(u, v, F::zero(), F::one()))
             );
         }
     }
@@ -485,10 +465,90 @@ mod tests {
     fn prop_next_mle_eval_coincides_with_next_mle_evaluate_at_point(r in point_n(NUM_VARS as usize)) {
         let next_mle = next_mle_inner(NUM_VARS, F::zero(), F::one()).unwrap();
 
+        let (u, v) = r.split_at(NUM_VARS as usize / 2);
         prop_assert_eq!(
             next_mle.evaluate_with_config(&r, &()),
-            Ok(next_mle_eval(&r, F::zero(), F::one()))
+            Ok(next_mle_eval(u, v, F::zero(), F::one()))
         );
+    }
+    }
+
+    #[test]
+    fn next_c_r_mle_c1_matches_shift_by_1() {
+        // c=1 should give the same result as the original build_next_r_mle
+        let num_vars: usize = 4;
+        let r: Vec<F> = (0..num_vars).map(|i| F::from((i + 3) as u32)).collect();
+
+        let next_1 = build_next_c_r_mle(&r, 1, &()).unwrap();
+
+        // Manually build shift-by-1: evaluations[0] = 0, evaluations[b] = eq(r, b-1)
+        let eq_r = build_eq_x_r_inner(&r, &()).unwrap();
+        let n = 1 << num_vars;
+        let mut expected = vec![F::zero().into_inner(); 1];
+        expected.extend_from_slice(&eq_r.evaluations[..n - 1]);
+
+        assert_eq!(next_1.evaluations, expected);
+    }
+
+    #[test]
+    fn next_c_r_mle_c0_is_eq() {
+        // c=0 should return eq(r, b)
+        let num_vars: usize = 4;
+        let r: Vec<F> = (0..num_vars).map(|i| F::from((i + 7) as u32)).collect();
+
+        let next_0 = build_next_c_r_mle(&r, 0, &()).unwrap();
+        let eq_r = build_eq_x_r_inner(&r, &()).unwrap();
+
+        assert_eq!(next_0.evaluations, eq_r.evaluations);
+    }
+
+    #[test]
+    fn next_c_r_mle_has_correct_structure() {
+        // For any c, evaluations[b] should be:
+        //   0 for b < c
+        //   eq(r, b-c) for b >= c
+        let num_vars: usize = 4;
+        let n = 1 << num_vars;
+        let r: Vec<F> = (0..num_vars).map(|i| F::from((i + 5) as u32)).collect();
+
+        for c in [2, 3, 5, 7] {
+            let next_c = build_next_c_r_mle(&r, c, &()).unwrap();
+            let eq_r = build_eq_x_r_inner(&r, &()).unwrap();
+
+            // First c entries should be zero
+            for b in 0..c {
+                assert!(
+                    next_c.evaluations[b].is_zero(),
+                    "c={c}, b={b}: expected zero"
+                );
+            }
+            // Remaining entries should match eq(r, b-c)
+            for b in c..n {
+                assert_eq!(
+                    next_c.evaluations[b],
+                    eq_r.evaluations[b - c],
+                    "c={c}, b={b}: mismatch"
+                );
+            }
+        }
+    }
+
+    proptest! {
+    #[test]
+    fn prop_next_c_r_mle_evaluates_correctly(r in point_n(4), c in 1..15usize) {
+        // build_next_c_r_mle(r, c) evaluated at random point should equal
+        // the shift-c predicate: sum_b next_c(b) * eq(b, point)
+        let next_c = build_next_c_r_mle(&r, c, &()).unwrap();
+        let eq_r = build_eq_x_r_inner(&r, &()).unwrap();
+
+        // Verify the table structure holds
+        let n = 1 << r.len();
+        for b in 0..c.min(n) {
+            prop_assert!(next_c.evaluations[b].is_zero());
+        }
+        for b in c..n {
+            prop_assert_eq!(&next_c.evaluations[b], &eq_r.evaluations[b - c]);
+        }
     }
     }
 }

--- a/protocol/src/lib.rs
+++ b/protocol/src/lib.rs
@@ -618,8 +618,8 @@ mod tests {
     /// Constraints: a[i+1] = a[i] + b[i], c[i] = b[i+2].
     #[test]
     fn test_e2e_mixed_shifts() {
-        do_test::<TestZincTypesRaa, TestUairMixedShifts<ZtInt>>(
-            3,
+        do_test::<TestZincTypesIprs, TestUairMixedShifts<ZtInt>>(
+            8,
             |_ideal, _field_cfg| IdealOrZero::<DegreeOneIdeal<F>>::zero(),
             |_| {},
             |res| res.unwrap(),

--- a/protocol/src/lib.rs
+++ b/protocol/src/lib.rs
@@ -309,11 +309,14 @@ mod tests {
         Field, crypto_bigint_int::Int, crypto_bigint_monty::MontyField, crypto_bigint_uint::Uint,
     };
     use rand::rng;
+    use zinc_piop::{
+        combined_poly_resolver::CombinedPolyResolverError, multipoint_eval::MultipointEvalError,
+    };
     use zinc_poly::univariate::{binary::BinaryPolyInnerProduct, dense::DensePolyInnerProduct};
     use zinc_primality::MillerRabin;
     use zinc_test_uair::{
         BigLinearUair, BigLinearUairWithPublicInput, BinaryDecompositionUair, GenerateRandomTrace,
-        TestAirNoMultiplication, TestUairSimpleMultiplication,
+        TestAirNoMultiplication, TestUairMixedShifts, TestUairSimpleMultiplication,
     };
     use zinc_uair::{
         degree_counter::count_max_degree, ideal::degree_one::DegreeOneIdeal,
@@ -609,6 +612,20 @@ mod tests {
         );
     }
 
+    /// End-to-end test: TestUairMixedShifts.
+    ///
+    /// Uses mixed shift amounts (col a: shift 1, col b: shift 2).
+    /// Constraints: a[i+1] = a[i] + b[i], c[i] = b[i+2].
+    #[test]
+    fn test_e2e_mixed_shifts() {
+        do_test::<TestZincTypesRaa, TestUairMixedShifts<ZtInt>>(
+            3,
+            |_ideal, _field_cfg| IdealOrZero::<DegreeOneIdeal<F>>::zero(),
+            |_| {},
+            |res| res.unwrap(),
+        );
+    }
+
     /// End-to-end test: BinaryDecompositionUair.
     ///
     /// Uses binary_poly (1 col) and int (1 col) trace types.
@@ -655,7 +672,8 @@ mod tests {
     }
 
     //
-    // Negative tests for BigLinearUair: verify that proof tampering is detected.
+    // Negative tests for BigLinearUairWithPublicInput: verify that proof
+    // tampering is detected.
     //
 
     #[test]
@@ -665,7 +683,10 @@ mod tests {
             default_project_ideal!(),
             |proof| proof.witness_lifted_evals.swap(0, 1),
             |res| {
-                res.unwrap_err();
+                assert!(matches!(
+                    res.unwrap_err(),
+                    ProtocolError::MultipointEval(MultipointEvalError::ClaimMismatch { .. })
+                ));
             },
         );
     }
@@ -677,7 +698,12 @@ mod tests {
             default_project_ideal!(),
             |proof| proof.resolver.up_evals.swap(0, 1),
             |res| {
-                res.unwrap_err();
+                assert!(matches!(
+                    res.unwrap_err(),
+                    ProtocolError::Resolver(
+                        CombinedPolyResolverError::ClaimValueDoesNotMatch { .. }
+                    )
+                ));
             },
         );
     }
@@ -689,11 +715,19 @@ mod tests {
             default_project_ideal!(),
             |proof| proof.resolver.down_evals.swap(0, 1),
             |res| {
-                res.unwrap_err();
+                assert!(matches!(
+                    res.unwrap_err(),
+                    ProtocolError::Resolver(
+                        CombinedPolyResolverError::ClaimValueDoesNotMatch { .. }
+                    )
+                ));
             },
         );
     }
 
+    // Tampering the commitment root causes the verifier to sample different
+    // challenges. The ideal check fails first because the prover's
+    // combined_mle_values were computed under the original transcript.
     #[test]
     fn test_big_linear_tamper_commitment() {
         do_test::<TestZincTypesIprs, BigLinearUairWithPublicInput<ZtInt>>(
@@ -701,7 +735,7 @@ mod tests {
             default_project_ideal!(),
             |proof| proof.commitments.0.root = Default::default(),
             |res| {
-                res.unwrap_err();
+                assert!(matches!(res.unwrap_err(), ProtocolError::IdealCheck(..)));
             },
         );
     }
@@ -713,7 +747,7 @@ mod tests {
             default_project_ideal!(),
             |proof| proof.ideal_check.combined_mle_values.swap(0, 1),
             |res| {
-                res.unwrap_err();
+                assert!(matches!(res.unwrap_err(), ProtocolError::IdealCheck(..)));
             },
         );
     }

--- a/protocol/src/prover.rs
+++ b/protocol/src/prover.rs
@@ -180,12 +180,14 @@ where
         // === Step 5: Multi-point evaluation sumcheck ===
         // Combines up_evals and down_evals at r' into a single evaluation
         // point r_0 via one sumcheck.
+        let uair_sig = U::signature();
         let (mp_proof, mp_prover_state) = MultipointEval::prove_as_subprotocol(
             &mut pcs_transcript.fs_transcript,
             &projected_trace_f,
             &cpr_prover_state.evaluation_point,
             &cpr_proof.up_evals,
             &cpr_proof.down_evals,
+            uair_sig.shifts(),
             &field_cfg,
         )?;
 
@@ -241,14 +243,17 @@ where
         let zip_proof = pcs_transcript.stream.into_inner();
         let commitments = (commitment_bin, commitment_arb, commitment_int);
 
-        // Remember that the public columns come first in the input trace arrays
-        let num_pub_bin = sig.public_binary_poly_cols;
-        let num_pub_arb = sig.public_arbitrary_poly_cols;
-        let num_pub_int = sig.public_int_cols;
-        let num_total_bin = sig.total_binary_poly_cols();
-        let num_total_arb = sig.total_arbitrary_poly_cols();
+        // Extract witness-only lifted evals (public columns come first in trace).
+        let pub_cols = sig.public_cols();
+        let num_pub_bin = pub_cols.binary_poly_cols();
+        let num_pub_arb = pub_cols.arbitrary_poly_cols();
+        let num_pub_int = pub_cols.int_cols();
+        let total = sig.total_cols();
+        let num_total_bin = total.binary_poly_cols();
+        let num_total_arb = total.arbitrary_poly_cols();
+        let witness = sig.witness_cols();
         let witness_arb_offset = add!(num_total_bin, num_pub_arb);
-        let witness_arb_end = add!(witness_arb_offset, sig.witness_arbitrary_poly_cols);
+        let witness_arb_end = add!(witness_arb_offset, witness.arbitrary_poly_cols());
         let witness_int_offset = add!(add!(num_total_bin, num_total_arb), num_pub_int);
         let witness_lifted_evals: Vec<_> = lifted_evals[num_pub_bin..num_total_bin]
             .iter()

--- a/protocol/src/prover.rs
+++ b/protocol/src/prover.rs
@@ -245,15 +245,15 @@ where
 
         // Extract witness-only lifted evals (public columns come first in trace).
         let pub_cols = sig.public_cols();
-        let num_pub_bin = pub_cols.binary_poly_cols();
-        let num_pub_arb = pub_cols.arbitrary_poly_cols();
-        let num_pub_int = pub_cols.int_cols();
+        let num_pub_bin = pub_cols.num_binary_poly_cols();
+        let num_pub_arb = pub_cols.num_arbitrary_poly_cols();
+        let num_pub_int = pub_cols.num_int_cols();
         let total = sig.total_cols();
-        let num_total_bin = total.binary_poly_cols();
-        let num_total_arb = total.arbitrary_poly_cols();
+        let num_total_bin = total.num_binary_poly_cols();
+        let num_total_arb = total.num_arbitrary_poly_cols();
         let witness = sig.witness_cols();
         let witness_arb_offset = add!(num_total_bin, num_pub_arb);
-        let witness_arb_end = add!(witness_arb_offset, witness.arbitrary_poly_cols());
+        let witness_arb_end = add!(witness_arb_offset, witness.num_arbitrary_poly_cols());
         let witness_int_offset = add!(add!(num_total_bin, num_total_arb), num_pub_int);
         let witness_lifted_evals: Vec<_> = lifted_evals[num_pub_bin..num_total_bin]
             .iter()

--- a/protocol/src/verifier.rs
+++ b/protocol/src/verifier.rs
@@ -140,12 +140,14 @@ where
         )?;
 
         // === Step 5: Multi-point evaluation sumcheck ===
+        let uair_sig = U::signature();
         let mp_subclaim = MultipointEval::verify_as_subprotocol(
             &mut pcs_transcript.fs_transcript,
             proof.multipoint_eval,
             &cpr_subclaim.evaluation_point,
             &cpr_subclaim.up_evals,
             &cpr_subclaim.down_evals,
+            uair_sig.shifts(),
             num_vars,
             &field_cfg,
         )?;
@@ -159,15 +161,14 @@ where
         // then interleaves them with the witness portion to reconstruct the
         // full lifted_evals in canonical order:
         //   [pub_bin, wit_bin, pub_arb, wit_arb, pub_int, wit_int]
-        let sig = U::signature();
-        let num_pub_bin = sig.public_binary_poly_cols;
-        let num_pub_arb = sig.public_arbitrary_poly_cols;
-        let num_pub_int = sig.public_int_cols;
+        let pub_cols = uair_sig.public_cols();
+        let num_pub_bin = pub_cols.binary_poly_cols();
+        let num_pub_arb = pub_cols.arbitrary_poly_cols();
+        let num_pub_int = pub_cols.int_cols();
 
-        let (num_wit_bin, num_wit_arb) = (
-            sig.witness_binary_poly_cols,
-            sig.witness_arbitrary_poly_cols,
-        );
+        let wit_cols = uair_sig.witness_cols();
+        let num_wit_bin = wit_cols.binary_poly_cols();
+        let num_wit_arb = wit_cols.arbitrary_poly_cols();
 
         let public_lifted = if add!(add!(num_pub_bin, num_pub_arb), num_pub_int) > 0 {
             let projected_public =
@@ -200,7 +201,7 @@ where
             .collect::<Result<Vec<_>, _>>()
             .map_err(ProtocolError::LiftedEvalProjection)?;
 
-        MultipointEval::<F>::verify_subclaim(&mp_subclaim, &open_evals, &field_cfg)?;
+        MultipointEval::verify_subclaim(&mp_subclaim, &open_evals, uair_sig.shifts(), &field_cfg)?;
 
         // Absorb all lifted_evals into transcript (same order as prover).
         let mut transcription_buf: Vec<u8> = vec![0; F::Inner::NUM_BYTES];
@@ -245,8 +246,9 @@ where
             }};
         }
 
-        let num_total_bin = sig.total_binary_poly_cols();
-        let num_total_arb = sig.total_arbitrary_poly_cols();
+        let total = uair_sig.total_cols();
+        let num_total_bin = total.binary_poly_cols();
+        let num_total_arb = total.arbitrary_poly_cols();
         verify_pcs_batch!(
             Zt::BinaryZt,
             Zt::BinaryLc,

--- a/protocol/src/verifier.rs
+++ b/protocol/src/verifier.rs
@@ -162,13 +162,13 @@ where
         // full lifted_evals in canonical order:
         //   [pub_bin, wit_bin, pub_arb, wit_arb, pub_int, wit_int]
         let pub_cols = uair_sig.public_cols();
-        let num_pub_bin = pub_cols.binary_poly_cols();
-        let num_pub_arb = pub_cols.arbitrary_poly_cols();
-        let num_pub_int = pub_cols.int_cols();
+        let num_pub_bin = pub_cols.num_binary_poly_cols();
+        let num_pub_arb = pub_cols.num_arbitrary_poly_cols();
+        let num_pub_int = pub_cols.num_int_cols();
 
         let wit_cols = uair_sig.witness_cols();
-        let num_wit_bin = wit_cols.binary_poly_cols();
-        let num_wit_arb = wit_cols.arbitrary_poly_cols();
+        let num_wit_bin = wit_cols.num_binary_poly_cols();
+        let num_wit_arb = wit_cols.num_arbitrary_poly_cols();
 
         let public_lifted = if add!(add!(num_pub_bin, num_pub_arb), num_pub_int) > 0 {
             let projected_public =
@@ -247,8 +247,8 @@ where
         }
 
         let total = uair_sig.total_cols();
-        let num_total_bin = total.binary_poly_cols();
-        let num_total_arb = total.arbitrary_poly_cols();
+        let num_total_bin = total.num_binary_poly_cols();
+        let num_total_arb = total.num_arbitrary_poly_cols();
         verify_pcs_batch!(
             Zt::BinaryZt,
             Zt::BinaryLc,

--- a/test-uair/src/lib.rs
+++ b/test-uair/src/lib.rs
@@ -552,7 +552,7 @@ where
             if i + 2 < n {
                 c_col.push(b_col[i + 2].clone());
             } else {
-                c_col.push(DynamicPolynomialFS::new(vec![]));
+                c_col.push(DynamicPolynomialFS::zero());
             }
         }
 

--- a/test-uair/src/lib.rs
+++ b/test-uair/src/lib.rs
@@ -19,7 +19,8 @@ use zinc_poly::{
     },
 };
 use zinc_uair::{
-    ConstraintBuilder, TraceRow, Uair, UairSignature, UairTrace,
+    ConstraintBuilder, PublicColumnLayout, ShiftSpec, TotalColumnLayout, TraceRow, Uair,
+    UairSignature, UairTrace,
     ideal::{ImpossibleIdeal, degree_one::DegreeOneIdeal},
 };
 use zinc_utils::from_ref::FromRef;
@@ -34,10 +35,9 @@ where
     type Scalar = DensePolynomial<R, 32>;
 
     fn signature() -> UairSignature {
-        UairSignature {
-            witness_arbitrary_poly_cols: 3,
-            ..Default::default()
-        }
+        let total = TotalColumnLayout::new(0, 3, 0);
+        let shifts = (0..3).map(|i| ShiftSpec::new(i, 1)).collect();
+        UairSignature::new(total, PublicColumnLayout::default(), shifts)
     }
 
     fn constrain_general<B, FromR, MulByScalar, IFromR>(
@@ -142,10 +142,8 @@ where
     type Scalar = DensePolynomial<R, 32>;
 
     fn signature() -> UairSignature {
-        UairSignature {
-            witness_arbitrary_poly_cols: 3,
-            ..Default::default()
-        }
+        let total = TotalColumnLayout::new(0, 3, 0);
+        UairSignature::new(total, PublicColumnLayout::default(), vec![])
     }
 
     fn constrain_general<B, FromR, MulByScalar, IFromR>(
@@ -217,10 +215,8 @@ where
     type Scalar = DensePolynomial<R, 32>;
 
     fn signature() -> UairSignature {
-        UairSignature {
-            witness_arbitrary_poly_cols: 3,
-            ..Default::default()
-        }
+        let total = TotalColumnLayout::new(0, 3, 0);
+        UairSignature::new(total, PublicColumnLayout::default(), vec![])
     }
 
     fn constrain_general<B, FromR, MulByScalar, IFromR>(
@@ -267,11 +263,8 @@ where
     type Scalar = DensePolynomial<R, 32>;
 
     fn signature() -> UairSignature {
-        UairSignature {
-            witness_binary_poly_cols: 1,
-            witness_int_cols: 1,
-            ..Default::default()
-        }
+        let total = TotalColumnLayout::new(1, 0, 1);
+        UairSignature::new(total, PublicColumnLayout::default(), vec![])
     }
 
     fn constrain_general<B, FromR, MulByScalar, IFromR>(
@@ -334,11 +327,9 @@ where
     type Scalar = DensePolynomial<R, 32>;
 
     fn signature() -> UairSignature {
-        UairSignature {
-            witness_binary_poly_cols: 16,
-            witness_int_cols: 1,
-            ..Default::default()
-        }
+        let total = TotalColumnLayout::new(16, 0, 1);
+        let shifts = (0..16).map(|i| ShiftSpec::new(i, 1)).collect();
+        UairSignature::new(total, PublicColumnLayout::default(), shifts)
     }
 
     fn constrain_general<B, FromR, MulByScalar, IFromR>(
@@ -448,14 +439,10 @@ where
     type Scalar = <BigLinearUair<R> as Uair>::Scalar;
 
     fn signature() -> UairSignature {
-        const NUM_PUBLIC_COLS: usize = 4;
-
-        let src_sig = BigLinearUair::<R>::signature();
-        UairSignature {
-            public_binary_poly_cols: NUM_PUBLIC_COLS,
-            witness_binary_poly_cols: src_sig.witness_binary_poly_cols - NUM_PUBLIC_COLS,
-            ..src_sig
-        }
+        let total = TotalColumnLayout::new(16, 0, 1);
+        let public = PublicColumnLayout::new(4, 0, 0);
+        let shifts = (0..16).map(|i| ShiftSpec::new(i, 1)).collect();
+        UairSignature::new(total, public, shifts)
     }
 
     fn constrain_general<B, FromR, MulByScalar, IFromR>(
@@ -490,6 +477,98 @@ where
     }
 }
 
+/// Test UAIR with mixed shift amounts.
+/// 3 columns (a, b, c): column a shifts by 1, column b shifts by 2.
+/// Constraints are linear (degree 1).
+pub struct TestUairMixedShifts<R>(PhantomData<R>);
+
+impl<R> Uair for TestUairMixedShifts<R>
+where
+    R: Semiring + 'static,
+{
+    type Ideal = ImpossibleIdeal;
+    type Scalar = DensePolynomial<R, 32>;
+
+    fn signature() -> UairSignature {
+        let total = TotalColumnLayout::new(0, 3, 0);
+        let shifts = vec![
+            ShiftSpec::new(0, 1), // a shifted by 1
+            ShiftSpec::new(1, 2), // b shifted by 2
+        ];
+        UairSignature::new(total, PublicColumnLayout::default(), shifts)
+    }
+
+    // Constraints:
+    //   a[i+1] = a[i] + b[i]  →  down[0] - up[0] - up[1] = 0
+    //   c[i]   = b[i+2]       →  up[2] - down[1] = 0
+    fn constrain_general<B, FromR, MulByScalar, IFromR>(
+        builder: &mut B,
+        up: TraceRow<B::Expr>,
+        down: TraceRow<B::Expr>,
+        _from_ref: FromR,
+        _mbs: MulByScalar,
+        _ideal_from_ref: IFromR,
+    ) where
+        B: ConstraintBuilder,
+    {
+        let up = up.arbitrary_poly;
+        let down = down.arbitrary_poly;
+
+        builder.assert_zero(down[0].clone() - &up[0] - &up[1]);
+        builder.assert_zero(up[2].clone() - &down[1]);
+    }
+}
+
+impl<R> GenerateRandomTrace<32> for TestUairMixedShifts<R>
+where
+    R: FixedSemiring + From<i8> + 'static,
+    StandardUniform: Distribution<R>,
+{
+    type PolyCoeff = R;
+    type Int = R;
+
+    // Witness: random b, derive a from a[i+1] = a[i] + b[i], set c[i] = b[i+2].
+    fn generate_random_trace<Rng: rand::RngCore + ?Sized>(
+        num_vars: usize,
+        rng: &mut Rng,
+    ) -> UairTrace<'static, R, R, 32> {
+        let n = 1 << num_vars;
+
+        // Random b column (degree-0 polynomials to stay under degree 32)
+        let b_col: Vec<DynamicPolynomialFS<R>> = (0..n)
+            .map(|_| DynamicPolynomialFS::new(vec![R::from(rng.random::<i8>())]))
+            .collect();
+
+        // a[0] random, a[i+1] = a[i] + b[i]
+        let mut a_col: Vec<DynamicPolynomialFS<R>> =
+            vec![DynamicPolynomialFS::new(vec![R::from(rng.random::<i8>())])];
+        for i in 0..n - 1 {
+            a_col.push(a_col[i].clone() + &b_col[i]);
+        }
+
+        // c[i] = b[i+2], zero-padded for last 2 entries
+        let mut c_col: Vec<DynamicPolynomialFS<R>> = Vec::with_capacity(n);
+        for i in 0..n {
+            if i + 2 < n {
+                c_col.push(b_col[i + 2].clone());
+            } else {
+                c_col.push(DynamicPolynomialFS::new(vec![]));
+            }
+        }
+
+        let to_mle = |col: Vec<DynamicPolynomialFS<R>>| -> DenseMultilinearExtension<DensePolynomial<R, 32>> {
+            col.into_iter()
+                .map(|x| DensePolynomial::new(x.coeffs))
+                .collect()
+        };
+
+        UairTrace {
+            arbitrary_poly: vec![to_mle(a_col), to_mle(b_col), to_mle(c_col)].into(),
+            ..Default::default()
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use crypto_primitives::crypto_bigint_int::Int;
@@ -519,6 +598,7 @@ mod tests {
         assert_uair_shape::<TestAirScalarMultiplications<Int<LIMBS>>>(&[1]);
         assert_uair_shape::<BinaryDecompositionUair<u32>>(&[1]);
         assert_uair_shape::<BigLinearUair<u32>>(&[1; 17]);
+        assert_uair_shape::<TestUairMixedShifts<Int<LIMBS>>>(&[1, 1]);
     }
 
     #[test]

--- a/uair/src/collect_scalars.rs
+++ b/uair/src/collect_scalars.rs
@@ -11,18 +11,16 @@ use crate::{
 pub fn collect_scalars<U: Uair>() -> HashSet<U::Scalar> {
     let scalars = RefCell::new(HashSet::new());
 
-    let dummy_up_and_down = vec![DummySemiring; U::signature().max_cols()];
-
-    let trace_row = TraceRow {
-        binary_poly: &dummy_up_and_down,
-        arbitrary_poly: &dummy_up_and_down,
-        int: &dummy_up_and_down,
-    };
+    let sig = U::signature();
+    let (up_dummy, down_dummy) = sig.dummy_rows(DummySemiring);
+    let up_row = TraceRow::from_slice_with_layout(&up_dummy, sig.total_cols().as_column_layout());
+    let down_row =
+        TraceRow::from_slice_with_layout(&down_dummy, sig.down_cols().as_column_layout());
 
     U::constrain_general(
         &mut DoNothingBuilder,
-        trace_row,
-        trace_row,
+        up_row,
+        down_row,
         |x| {
             scalars.borrow_mut().insert(x.clone());
             DummySemiring

--- a/uair/src/constraint_counter.rs
+++ b/uair/src/constraint_counter.rs
@@ -6,15 +6,13 @@ use crate::{
 pub fn count_constraints<U: Uair>() -> usize {
     let mut cc = ConstraintCounter::new();
 
-    let dummy_up_and_down = vec![DummySemiring; U::signature().max_cols()];
+    let sig = U::signature();
+    let (up_dummy, down_dummy) = sig.dummy_rows(DummySemiring);
+    let up_row = TraceRow::from_slice_with_layout(&up_dummy, sig.total_cols().as_column_layout());
+    let down_row =
+        TraceRow::from_slice_with_layout(&down_dummy, sig.down_cols().as_column_layout());
 
-    let trace_row = TraceRow {
-        binary_poly: &dummy_up_and_down,
-        arbitrary_poly: &dummy_up_and_down,
-        int: &dummy_up_and_down,
-    };
-
-    U::constrain(&mut cc, trace_row, trace_row);
+    U::constrain(&mut cc, up_row, down_row);
 
     cc.0
 }

--- a/uair/src/degree_counter.rs
+++ b/uair/src/degree_counter.rs
@@ -23,18 +23,16 @@ pub fn count_max_degree<U: Uair>() -> usize {
 pub fn count_constraint_degrees<U: Uair>() -> Vec<usize> {
     let mut dc = ConstraintDegreeCollector::default();
 
-    let up_and_down = vec![DegreeCountingSemiring::var(); U::signature().max_cols()];
-
-    let trace_row = TraceRow {
-        binary_poly: &up_and_down,
-        arbitrary_poly: &up_and_down,
-        int: &up_and_down,
-    };
+    let sig = U::signature();
+    let (up_dummy, down_dummy) = sig.dummy_rows(DegreeCountingSemiring::var());
+    let up_row = TraceRow::from_slice_with_layout(&up_dummy, sig.total_cols().as_column_layout());
+    let down_row =
+        TraceRow::from_slice_with_layout(&down_dummy, sig.down_cols().as_column_layout());
 
     U::constrain_general(
         &mut dc,
-        trace_row,
-        trace_row,
+        up_row,
+        down_row,
         |_| DegreeCountingSemiring::scalar(),
         |x, _| Some(*x),
         |_| ImpossibleIdeal,

--- a/uair/src/ideal_collector.rs
+++ b/uair/src/ideal_collector.rs
@@ -29,14 +29,12 @@ impl<I: Ideal> IdealCollector<I> {
 pub fn collect_ideals<U: Uair>(num_constraints: usize) -> IdealCollector<U::Ideal> {
     let mut ideal_collector = IdealCollector::new(num_constraints);
 
-    let dummy_up_and_down = vec![DummySemiring; U::signature().max_cols()];
-
-    let trace_row = TraceRow {
-        binary_poly: &dummy_up_and_down,
-        arbitrary_poly: &dummy_up_and_down,
-        int: &dummy_up_and_down,
-    };
-    U::constrain(&mut ideal_collector, trace_row, trace_row);
+    let sig = U::signature();
+    let (up_dummy, down_dummy) = sig.dummy_rows(DummySemiring);
+    let up_row = TraceRow::from_slice_with_layout(&up_dummy, sig.total_cols().as_column_layout());
+    let down_row =
+        TraceRow::from_slice_with_layout(&down_dummy, sig.down_cols().as_column_layout());
+    U::constrain(&mut ideal_collector, up_row, down_row);
 
     ideal_collector
 }

--- a/uair/src/lib.rs
+++ b/uair/src/lib.rs
@@ -14,7 +14,7 @@ use zinc_poly::{
     mle::DenseMultilinearExtension,
     univariate::{binary::BinaryPoly, dense::DensePolynomial},
 };
-use zinc_utils::{UNCHECKED, from_ref::FromRef, mul_by_scalar::MulByScalar};
+use zinc_utils::{UNCHECKED, add, from_ref::FromRef, mul_by_scalar::MulByScalar};
 
 use crate::ideal::{Ideal, IdealCheck};
 
@@ -37,67 +37,253 @@ pub trait ConstraintBuilder {
     fn assert_zero(&mut self, expr: Self::Expr);
 }
 
-/// The signature of a UAIR.
-/// Contains the number of columns of
-/// each of the types: binary polynomials,
-/// polynomials with arbitrary coefficients,
-/// and integers.
+/// Specifies a shifted column
+/// `ShiftSpec { source_col: 0, shift_amount: 3 }` means
+/// "virtual column whose row i is the value of column 0 at row i+3
+/// (zero-padded beyond trace length)."
 ///
-/// Public columns precede witness columns within each type group.
-/// The flattened trace ordering is:
-/// `[pub_bin, wit_bin, pub_arb, wit_arb, pub_int, wit_int]`.
-#[derive(Default)]
-pub struct UairSignature {
-    /// Number of public columns with binary polynomial elements.
-    pub public_binary_poly_cols: usize,
-    /// Number of witness columns with binary polynomial elements.
-    pub witness_binary_poly_cols: usize,
-    /// Number of public columns with arbitrary polynomial elements.
-    pub public_arbitrary_poly_cols: usize,
-    /// Number of witness columns with arbitrary polynomial elements.
-    pub witness_arbitrary_poly_cols: usize,
-    /// Number of public columns with integers.
-    pub public_int_cols: usize,
-    /// Number of witness columns with integers.
-    pub witness_int_cols: usize,
+/// Multiple ShiftSpecs may reference the same source_col with
+/// different shift amounts.
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+pub struct ShiftSpec {
+    /// Index of the committed column in the flattened trace
+    /// (binary_poly || arbitrary_poly || int, same indexing as
+    /// TraceRow::from_slice_with_layout).
+    source_col: usize,
+    /// Number of rows to shift by.
+    shift_amount: usize,
 }
 
-#[allow(clippy::arithmetic_side_effects)]
-impl UairSignature {
-    pub fn total_binary_poly_cols(&self) -> usize {
-        self.public_binary_poly_cols + self.witness_binary_poly_cols
+impl ShiftSpec {
+    pub fn new(source_col: usize, shift_amount: usize) -> Self {
+        assert!(shift_amount > 0, "shift must be non-zero");
+        Self {
+            source_col,
+            shift_amount,
+        }
     }
 
-    pub fn total_arbitrary_poly_cols(&self) -> usize {
-        self.public_arbitrary_poly_cols + self.witness_arbitrary_poly_cols
+    pub fn source_col(&self) -> usize {
+        self.source_col
     }
 
-    pub fn total_int_cols(&self) -> usize {
-        self.public_int_cols + self.witness_int_cols
+    pub fn shift_amount(&self) -> usize {
+        self.shift_amount
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Column layout types
+// ---------------------------------------------------------------------------
+
+/// Column counts per type (binary_poly, arbitrary_poly, int).
+/// Shared internals for the semantic newtype wrappers (Total, Public, Virtual,
+/// Witness)
+#[derive(Clone, Debug, Default)]
+pub struct ColumnLayout {
+    binary_poly_cols: usize,
+    arbitrary_poly_cols: usize,
+    int_cols: usize,
+}
+
+impl ColumnLayout {
+    pub fn new(binary_poly_cols: usize, arbitrary_poly_cols: usize, int_cols: usize) -> Self {
+        Self {
+            binary_poly_cols,
+            arbitrary_poly_cols,
+            int_cols,
+        }
     }
 
-    pub fn total_public_cols(&self) -> usize {
-        self.public_binary_poly_cols + self.public_arbitrary_poly_cols + self.public_int_cols
+    pub fn binary_poly_cols(&self) -> usize {
+        self.binary_poly_cols
     }
 
-    /// Maximum number of columns across the three types (public + witness per
-    /// type).
+    pub fn arbitrary_poly_cols(&self) -> usize {
+        self.arbitrary_poly_cols
+    }
+
+    pub fn int_cols(&self) -> usize {
+        self.int_cols
+    }
+
+    /// Maximum number of columns across the three types.
     pub fn max_cols(&self) -> usize {
         [
-            self.total_binary_poly_cols(),
-            self.total_arbitrary_poly_cols(),
-            self.total_int_cols(),
+            self.binary_poly_cols,
+            self.arbitrary_poly_cols,
+            self.int_cols,
         ]
         .into_iter()
         .max()
         .expect("the iterator is not empty")
     }
 
-    /// The sum of the numbers of columns across all types (public + witness).
-    pub fn total_cols(&self) -> usize {
-        self.total_binary_poly_cols() + self.total_arbitrary_poly_cols() + self.total_int_cols()
+    /// The sum of the numbers of columns across all types.
+    #[allow(clippy::arithmetic_side_effects)]
+    pub fn cols(&self) -> usize {
+        self.binary_poly_cols + self.arbitrary_poly_cols + self.int_cols
     }
 }
+
+macro_rules! column_layout_wrapper {
+    ($(#[$meta:meta])* $name:ident) => {
+        $(#[$meta])*
+        #[derive(Clone, Debug, Default)]
+        pub struct $name(ColumnLayout);
+
+        impl $name {
+            pub fn new(binary_poly_cols: usize, arbitrary_poly_cols: usize, int_cols: usize) -> Self {
+                Self(ColumnLayout::new(binary_poly_cols, arbitrary_poly_cols, int_cols))
+            }
+
+            pub fn binary_poly_cols(&self) -> usize { self.0.binary_poly_cols() }
+            pub fn arbitrary_poly_cols(&self) -> usize { self.0.arbitrary_poly_cols() }
+            pub fn int_cols(&self) -> usize { self.0.int_cols() }
+            pub fn max_cols(&self) -> usize { self.0.max_cols() }
+            pub fn cols(&self) -> usize { self.0.cols() }
+            pub fn as_column_layout(&self) -> &ColumnLayout { &self.0 }
+        }
+    };
+}
+
+column_layout_wrapper!(/// Layout of all trace columns (public + witness) per type.
+    TotalColumnLayout);
+column_layout_wrapper!(/// Layout of the public column subset.
+    PublicColumnLayout);
+column_layout_wrapper!(/// Layout of the virtual (shifted/down) columns.
+    VirtualColumnLayout);
+column_layout_wrapper!(/// Layout of the witness (total minus public) columns.
+    WitnessColumnLayout);
+
+// ---------------------------------------------------------------------------
+// UairSignature
+// ---------------------------------------------------------------------------
+
+/// The signature of a UAIR.
+///
+/// Public columns precede witness columns within each type group.
+/// The flattened trace ordering is:
+/// `[pub_bin, wit_bin, pub_arb, wit_arb, pub_int, wit_int]`.
+pub struct UairSignature {
+    /// Column-type layout of all (public + witness) columns.
+    total_cols: TotalColumnLayout,
+    /// Public column subset.
+    public_cols: PublicColumnLayout,
+    /// Shifted columns info sorted by `source_col`.
+    shifts: Vec<ShiftSpec>,
+    /// Column-type layout of the shifted (down) row.
+    down_cols: VirtualColumnLayout,
+}
+
+impl UairSignature {
+    /// Create a new signature, sorting `shifts` by `source_col`.
+    pub fn new(
+        total_cols: TotalColumnLayout,
+        public_cols: PublicColumnLayout,
+        mut shifts: Vec<ShiftSpec>,
+    ) -> Self {
+        for (name, pub_n, tot_n) in [
+            (
+                "binary_poly",
+                public_cols.binary_poly_cols(),
+                total_cols.binary_poly_cols(),
+            ),
+            (
+                "arbitrary_poly",
+                public_cols.arbitrary_poly_cols(),
+                total_cols.arbitrary_poly_cols(),
+            ),
+            ("int", public_cols.int_cols(), total_cols.int_cols()),
+        ] {
+            assert!(
+                pub_n <= tot_n,
+                "public {name}_cols ({pub_n}) > total ({tot_n})"
+            );
+        }
+
+        let num_cols = total_cols.cols();
+        for spec in &shifts {
+            assert!(
+                spec.source_col() < num_cols,
+                "ShiftSpec source_col {} out of range (total_cols = {}). \
+                 source_col uses flat indexing: binary_poly || arbitrary_poly || int.",
+                spec.source_col(),
+                num_cols,
+            );
+        }
+
+        shifts.sort_by_key(|spec| spec.source_col());
+        let down_cols = Self::compute_down_layout(&total_cols, &shifts);
+        Self {
+            total_cols,
+            public_cols,
+            shifts,
+            down_cols,
+        }
+    }
+
+    fn compute_down_layout(
+        total_cols: &TotalColumnLayout,
+        shifts: &[ShiftSpec],
+    ) -> VirtualColumnLayout {
+        let bp_end = total_cols.binary_poly_cols();
+        let ap_end = add!(bp_end, total_cols.arbitrary_poly_cols());
+        let mut bp = 0usize;
+        let mut ap = 0usize;
+        let mut ic = 0usize;
+        for spec in shifts {
+            if spec.source_col() < bp_end {
+                bp = add!(bp, 1);
+            } else if spec.source_col() < ap_end {
+                ap = add!(ap, 1);
+            } else {
+                ic = add!(ic, 1);
+            }
+        }
+        VirtualColumnLayout::new(bp, ap, ic)
+    }
+
+    pub fn total_cols(&self) -> &TotalColumnLayout {
+        &self.total_cols
+    }
+
+    pub fn public_cols(&self) -> &PublicColumnLayout {
+        &self.public_cols
+    }
+
+    pub fn shifts(&self) -> &[ShiftSpec] {
+        &self.shifts
+    }
+
+    /// Column-type layout of the shifted (down) row.
+    pub fn down_cols(&self) -> &VirtualColumnLayout {
+        &self.down_cols
+    }
+
+    /// Build correctly-sized dummy up and down `TraceRow`s for static
+    /// analysis (constraint counting, degree counting, scalar/ideal
+    /// collection).
+    pub fn dummy_rows<T: Clone>(&self, val: T) -> (Vec<T>, Vec<T>) {
+        let up_size = self.total_cols.cols();
+        let down_size = self.down_cols.cols();
+        (vec![val.clone(); up_size], vec![val; down_size])
+    }
+
+    /// Witness column counts (total minus public) per type.
+    #[allow(clippy::arithmetic_side_effects)]
+    pub fn witness_cols(&self) -> WitnessColumnLayout {
+        WitnessColumnLayout::new(
+            self.total_cols.binary_poly_cols() - self.public_cols.binary_poly_cols(),
+            self.total_cols.arbitrary_poly_cols() - self.public_cols.arbitrary_poly_cols(),
+            self.total_cols.int_cols() - self.public_cols.int_cols(),
+        )
+    }
+}
+
+// ---------------------------------------------------------------------------
+// UairTrace
+// ---------------------------------------------------------------------------
 
 /// The trace of a UAIR execution (pre-projection).
 /// If owned, it contains the full trace, otherwise it contains a view on the
@@ -110,26 +296,30 @@ pub struct UairTrace<'a, PolyCoeff: Clone, Int: Clone, const D: usize> {
 }
 
 impl<PolyCoeff: Clone, Int: Clone, const D: usize> UairTrace<'static, PolyCoeff, Int, D> {
-    /// Returns a sub-trace containing only public columns.
-    /// Returned trace is borrowed from the full trace.
+    /// Returns a layout containing only public columns.
     pub fn public(&self, sig: &UairSignature) -> UairTrace<'_, PolyCoeff, Int, D> {
+        let p = sig.public_cols();
         UairTrace {
-            binary_poly: Cow::Borrowed(&self.binary_poly[0..sig.public_binary_poly_cols]),
-            arbitrary_poly: Cow::Borrowed(&self.arbitrary_poly[0..sig.public_arbitrary_poly_cols]),
-            int: Cow::Borrowed(&self.int[0..sig.public_int_cols]),
+            binary_poly: Cow::Borrowed(&self.binary_poly[0..p.binary_poly_cols()]),
+            arbitrary_poly: Cow::Borrowed(&self.arbitrary_poly[0..p.arbitrary_poly_cols()]),
+            int: Cow::Borrowed(&self.int[0..p.int_cols()]),
         }
     }
 
-    /// Returns a sub-trace containing only witness columns.
-    /// Returned trace is borrowed from the full trace.
+    /// Returns layout containing only witness columns.
     pub fn witness(&self, sig: &UairSignature) -> UairTrace<'_, PolyCoeff, Int, D> {
+        let p = sig.public_cols();
         UairTrace {
-            binary_poly: Cow::Borrowed(&self.binary_poly[sig.public_binary_poly_cols..]),
-            arbitrary_poly: Cow::Borrowed(&self.arbitrary_poly[sig.public_arbitrary_poly_cols..]),
-            int: Cow::Borrowed(&self.int[sig.public_int_cols..]),
+            binary_poly: Cow::Borrowed(&self.binary_poly[p.binary_poly_cols()..]),
+            arbitrary_poly: Cow::Borrowed(&self.arbitrary_poly[p.arbitrary_poly_cols()..]),
+            int: Cow::Borrowed(&self.int[p.int_cols()..]),
         }
     }
 }
+
+// ---------------------------------------------------------------------------
+// TraceRow
+// ---------------------------------------------------------------------------
 
 /// A view on a row of the trace.
 /// Contains references to cells of the trace
@@ -144,18 +334,22 @@ pub struct TraceRow<'a, Expr> {
 impl<'a, Expr> TraceRow<'a, Expr> {
     /// Given a slice that represents a raw row of the trace,
     /// creates a `TraceRow` from it.
-    /// Subdivides the slice according to the given signature `signature`.
+    /// Subdivides the slice according to the given column layout.
     #[allow(clippy::arithmetic_side_effects)]
-    pub fn from_slice_with_signature(row: &'a [Expr], signature: &UairSignature) -> Self {
-        let nb = signature.total_binary_poly_cols();
-        let na = signature.total_arbitrary_poly_cols();
+    pub fn from_slice_with_layout(row: &'a [Expr], layout: &ColumnLayout) -> Self {
+        let bp = layout.binary_poly_cols();
+        let ap = layout.arbitrary_poly_cols();
         Self {
-            binary_poly: &row[0..nb],
-            arbitrary_poly: &row[nb..nb + na],
-            int: &row[nb + na..],
+            binary_poly: &row[0..bp],
+            arbitrary_poly: &row[bp..bp + ap],
+            int: &row[bp + ap..],
         }
     }
 }
+
+// ---------------------------------------------------------------------------
+// Uair trait
+// ---------------------------------------------------------------------------
 
 /// The trait that a universal AIR description has to implement.
 /// This must include all the constraint description logic of an UAIR.
@@ -190,9 +384,10 @@ pub trait Uair {
     ///   must implement `FromRef<Self::Ideal>` trait.
     /// - `up`: a `TraceRow` of expressions representing the current row of
     ///   UAIR.
-    /// - `down`: a `TraceRow` of expressions representing the next row of UAIR.
-    ///   It is safe to assume all the members have the same lengths as
-    ///   corresponding members of `up`.
+    /// - `down`: a `TraceRow` of expressions representing the shifted (down)
+    ///   row of the UAIR. Its layout matches `UairSignature::down()`, which may
+    ///   have fewer columns than `up` when only a subset of columns are
+    ///   shifted.
     /// - `from_ref`: a closure that turns the underlying ring `R` into
     ///   `B::Expr`. Sometimes (e.g. when dealing with random fields) it is
     ///   convenient to provide a closure instead of a `FromRef` implementation.

--- a/uair/src/lib.rs
+++ b/uair/src/lib.rs
@@ -390,6 +390,11 @@ pub trait Uair {
     type Scalar: Semiring;
 
     /// Signature of the UAIR.
+    ///
+    /// TODO: Consider caching the signature to avoid recomputing it at every
+    /// call site. Currently negligible since shifts are small (e.g. ~12 for
+    /// SHA/ECDSA), but may matter if signatures grow more expensive to
+    /// construct.
     fn signature() -> UairSignature;
 
     /// A general method for describing constraints.

--- a/uair/src/lib.rs
+++ b/uair/src/lib.rs
@@ -14,7 +14,7 @@ use zinc_poly::{
     mle::DenseMultilinearExtension,
     univariate::{binary::BinaryPoly, dense::DensePolynomial},
 };
-use zinc_utils::{UNCHECKED, add, from_ref::FromRef, mul_by_scalar::MulByScalar};
+use zinc_utils::{UNCHECKED, add, from_ref::FromRef, mul_by_scalar::MulByScalar, sub};
 
 use crate::ideal::{Ideal, IdealCheck};
 
@@ -81,38 +81,42 @@ impl ShiftSpec {
 /// Witness)
 #[derive(Clone, Debug, Default)]
 pub struct ColumnLayout {
-    binary_poly_cols: usize,
-    arbitrary_poly_cols: usize,
-    int_cols: usize,
+    num_binary_poly_cols: usize,
+    num_arbitrary_poly_cols: usize,
+    num_int_cols: usize,
 }
 
 impl ColumnLayout {
-    pub fn new(binary_poly_cols: usize, arbitrary_poly_cols: usize, int_cols: usize) -> Self {
+    pub fn new(
+        num_binary_poly_cols: usize,
+        num_arbitrary_poly_cols: usize,
+        num_int_cols: usize,
+    ) -> Self {
         Self {
-            binary_poly_cols,
-            arbitrary_poly_cols,
-            int_cols,
+            num_binary_poly_cols,
+            num_arbitrary_poly_cols,
+            num_int_cols,
         }
     }
 
-    pub fn binary_poly_cols(&self) -> usize {
-        self.binary_poly_cols
+    pub fn num_binary_poly_cols(&self) -> usize {
+        self.num_binary_poly_cols
     }
 
-    pub fn arbitrary_poly_cols(&self) -> usize {
-        self.arbitrary_poly_cols
+    pub fn num_arbitrary_poly_cols(&self) -> usize {
+        self.num_arbitrary_poly_cols
     }
 
-    pub fn int_cols(&self) -> usize {
-        self.int_cols
+    pub fn num_int_cols(&self) -> usize {
+        self.num_int_cols
     }
 
     /// Maximum number of columns across the three types.
     pub fn max_cols(&self) -> usize {
         [
-            self.binary_poly_cols,
-            self.arbitrary_poly_cols,
-            self.int_cols,
+            self.num_binary_poly_cols,
+            self.num_arbitrary_poly_cols,
+            self.num_int_cols,
         ]
         .into_iter()
         .max()
@@ -122,7 +126,7 @@ impl ColumnLayout {
     /// The sum of the numbers of columns across all types.
     #[allow(clippy::arithmetic_side_effects)]
     pub fn cols(&self) -> usize {
-        self.binary_poly_cols + self.arbitrary_poly_cols + self.int_cols
+        self.num_binary_poly_cols + self.num_arbitrary_poly_cols + self.num_int_cols
     }
 }
 
@@ -133,13 +137,13 @@ macro_rules! column_layout_wrapper {
         pub struct $name(ColumnLayout);
 
         impl $name {
-            pub fn new(binary_poly_cols: usize, arbitrary_poly_cols: usize, int_cols: usize) -> Self {
-                Self(ColumnLayout::new(binary_poly_cols, arbitrary_poly_cols, int_cols))
+            pub fn new(num_binary_poly_cols: usize, num_arbitrary_poly_cols: usize, num_int_cols: usize) -> Self {
+                Self(ColumnLayout::new(num_binary_poly_cols, num_arbitrary_poly_cols, num_int_cols))
             }
 
-            pub fn binary_poly_cols(&self) -> usize { self.0.binary_poly_cols() }
-            pub fn arbitrary_poly_cols(&self) -> usize { self.0.arbitrary_poly_cols() }
-            pub fn int_cols(&self) -> usize { self.0.int_cols() }
+            pub fn num_binary_poly_cols(&self) -> usize { self.0.num_binary_poly_cols() }
+            pub fn num_arbitrary_poly_cols(&self) -> usize { self.0.num_arbitrary_poly_cols() }
+            pub fn num_int_cols(&self) -> usize { self.0.num_int_cols() }
             pub fn max_cols(&self) -> usize { self.0.max_cols() }
             pub fn cols(&self) -> usize { self.0.cols() }
             pub fn as_column_layout(&self) -> &ColumnLayout { &self.0 }
@@ -170,6 +174,8 @@ pub struct UairSignature {
     total_cols: TotalColumnLayout,
     /// Public column subset.
     public_cols: PublicColumnLayout,
+    /// Witness column counts (total minus public) per type.
+    witness_cols: WitnessColumnLayout,
     /// Shifted columns info sorted by `source_col`.
     shifts: Vec<ShiftSpec>,
     /// Column-type layout of the shifted (down) row.
@@ -186,15 +192,15 @@ impl UairSignature {
         for (name, pub_n, tot_n) in [
             (
                 "binary_poly",
-                public_cols.binary_poly_cols(),
-                total_cols.binary_poly_cols(),
+                public_cols.num_binary_poly_cols(),
+                total_cols.num_binary_poly_cols(),
             ),
             (
                 "arbitrary_poly",
-                public_cols.arbitrary_poly_cols(),
-                total_cols.arbitrary_poly_cols(),
+                public_cols.num_arbitrary_poly_cols(),
+                total_cols.num_arbitrary_poly_cols(),
             ),
-            ("int", public_cols.int_cols(), total_cols.int_cols()),
+            ("int", public_cols.num_int_cols(), total_cols.num_int_cols()),
         ] {
             assert!(
                 pub_n <= tot_n,
@@ -215,11 +221,24 @@ impl UairSignature {
 
         shifts.sort_by_key(|spec| spec.source_col());
         let down_cols = Self::compute_down_layout(&total_cols, &shifts);
+        let witness_cols = WitnessColumnLayout::new(
+            sub!(
+                total_cols.num_binary_poly_cols(),
+                public_cols.num_binary_poly_cols()
+            ),
+            sub!(
+                total_cols.num_arbitrary_poly_cols(),
+                public_cols.num_arbitrary_poly_cols()
+            ),
+            sub!(total_cols.num_int_cols(), public_cols.num_int_cols()),
+        );
+
         Self {
             total_cols,
             public_cols,
             shifts,
             down_cols,
+            witness_cols,
         }
     }
 
@@ -227,21 +246,21 @@ impl UairSignature {
         total_cols: &TotalColumnLayout,
         shifts: &[ShiftSpec],
     ) -> VirtualColumnLayout {
-        let bp_end = total_cols.binary_poly_cols();
-        let ap_end = add!(bp_end, total_cols.arbitrary_poly_cols());
-        let mut bp = 0usize;
-        let mut ap = 0usize;
-        let mut ic = 0usize;
+        let binary_poly_end = total_cols.num_binary_poly_cols();
+        let arbitrary_poly_end = add!(binary_poly_end, total_cols.num_arbitrary_poly_cols());
+        let mut num_binary_poly = 0usize;
+        let mut num_arbitrary_poly = 0usize;
+        let mut num_int = 0usize;
         for spec in shifts {
-            if spec.source_col() < bp_end {
-                bp = add!(bp, 1);
-            } else if spec.source_col() < ap_end {
-                ap = add!(ap, 1);
+            if spec.source_col() < binary_poly_end {
+                num_binary_poly = add!(num_binary_poly, 1);
+            } else if spec.source_col() < arbitrary_poly_end {
+                num_arbitrary_poly = add!(num_arbitrary_poly, 1);
             } else {
-                ic = add!(ic, 1);
+                num_int = add!(num_int, 1);
             }
         }
-        VirtualColumnLayout::new(bp, ap, ic)
+        VirtualColumnLayout::new(num_binary_poly, num_arbitrary_poly, num_int)
     }
 
     pub fn total_cols(&self) -> &TotalColumnLayout {
@@ -250,6 +269,11 @@ impl UairSignature {
 
     pub fn public_cols(&self) -> &PublicColumnLayout {
         &self.public_cols
+    }
+
+    /// Witness column counts (total minus public) per type.
+    pub fn witness_cols(&self) -> &WitnessColumnLayout {
+        &self.witness_cols
     }
 
     pub fn shifts(&self) -> &[ShiftSpec] {
@@ -269,16 +293,6 @@ impl UairSignature {
         let down_size = self.down_cols.cols();
         (vec![val.clone(); up_size], vec![val; down_size])
     }
-
-    /// Witness column counts (total minus public) per type.
-    #[allow(clippy::arithmetic_side_effects)]
-    pub fn witness_cols(&self) -> WitnessColumnLayout {
-        WitnessColumnLayout::new(
-            self.total_cols.binary_poly_cols() - self.public_cols.binary_poly_cols(),
-            self.total_cols.arbitrary_poly_cols() - self.public_cols.arbitrary_poly_cols(),
-            self.total_cols.int_cols() - self.public_cols.int_cols(),
-        )
-    }
 }
 
 // ---------------------------------------------------------------------------
@@ -296,23 +310,25 @@ pub struct UairTrace<'a, PolyCoeff: Clone, Int: Clone, const D: usize> {
 }
 
 impl<PolyCoeff: Clone, Int: Clone, const D: usize> UairTrace<'static, PolyCoeff, Int, D> {
-    /// Returns a layout containing only public columns.
+    /// Returns a sub-trace containing only public columns.
+    /// Returned trace is borrowed from the full trace.
     pub fn public(&self, sig: &UairSignature) -> UairTrace<'_, PolyCoeff, Int, D> {
         let p = sig.public_cols();
         UairTrace {
-            binary_poly: Cow::Borrowed(&self.binary_poly[0..p.binary_poly_cols()]),
-            arbitrary_poly: Cow::Borrowed(&self.arbitrary_poly[0..p.arbitrary_poly_cols()]),
-            int: Cow::Borrowed(&self.int[0..p.int_cols()]),
+            binary_poly: Cow::Borrowed(&self.binary_poly[0..p.num_binary_poly_cols()]),
+            arbitrary_poly: Cow::Borrowed(&self.arbitrary_poly[0..p.num_arbitrary_poly_cols()]),
+            int: Cow::Borrowed(&self.int[0..p.num_int_cols()]),
         }
     }
 
-    /// Returns layout containing only witness columns.
+    /// Returns a sub-trace containing only witness columns.
+    /// Returned trace is borrowed from the full trace.
     pub fn witness(&self, sig: &UairSignature) -> UairTrace<'_, PolyCoeff, Int, D> {
         let p = sig.public_cols();
         UairTrace {
-            binary_poly: Cow::Borrowed(&self.binary_poly[p.binary_poly_cols()..]),
-            arbitrary_poly: Cow::Borrowed(&self.arbitrary_poly[p.arbitrary_poly_cols()..]),
-            int: Cow::Borrowed(&self.int[p.int_cols()..]),
+            binary_poly: Cow::Borrowed(&self.binary_poly[p.num_binary_poly_cols()..]),
+            arbitrary_poly: Cow::Borrowed(&self.arbitrary_poly[p.num_arbitrary_poly_cols()..]),
+            int: Cow::Borrowed(&self.int[p.num_int_cols()..]),
         }
     }
 }
@@ -337,12 +353,12 @@ impl<'a, Expr> TraceRow<'a, Expr> {
     /// Subdivides the slice according to the given column layout.
     #[allow(clippy::arithmetic_side_effects)]
     pub fn from_slice_with_layout(row: &'a [Expr], layout: &ColumnLayout) -> Self {
-        let bp = layout.binary_poly_cols();
-        let ap = layout.arbitrary_poly_cols();
+        let num_binary_poly = layout.num_binary_poly_cols();
+        let num_arbitrary_poly = layout.num_arbitrary_poly_cols();
         Self {
-            binary_poly: &row[0..bp],
-            arbitrary_poly: &row[bp..bp + ap],
-            int: &row[bp + ap..],
+            binary_poly: &row[0..num_binary_poly],
+            arbitrary_poly: &row[num_binary_poly..num_binary_poly + num_arbitrary_poly],
+            int: &row[num_binary_poly + num_arbitrary_poly..],
         }
     }
 }


### PR DESCRIPTION
## Summary

- Add `ShiftSpec`, `ColumnLayout` on `UairSignature` for per-column shift declarations
- Sparse down-trace in CPR and ideal check via `shifts()` / `down_layout()`
- Add `eval_shift_predicate` for shift-by-c MLE evaluation
- Add `build_next_c_r_mle` for shift-by-c selector MLE construction
- Generalize multipoint_eval from shift-by-1 to arbitrary per-column shift amounts with separate up/down challenge batching
- Add `TestUairMixedShifts` with shift-by-1 and shift-by-2
- End-to-end protocol test with mixed shifts through full pipeline
-  Improve `next_mle_eval` from O(n²) to O(n)
- Tightened negative tests in E2E to assert specific error variants, ensuring each tamper is caught at the expected protocol step

## Context

Makes the down-trace sparse: each UAIR declares which columns are shifted and by how much via `ShiftSpec`. The multipoint_eval now proves: `Σ_j γ_j · up_j + Σ_k α_k · down_k` with one `next_c` kernel per shifted column (ungrouped). A follow-up can group by shift amount to reduce MLE count from `2+2K` to `2(s+1)`.

## Test plan

- [x] `cargo test -p zinc-poly` — `build_next_c_r_mle` + `next_mle_eval` tests
- [x] `cargo test -p zinc-piop -- multipoint_eval` — 16 unit tests (happy path + negative, mixed shifts)
- [x] `cargo test -p zinc-piop -- shift_predicate` — predicate tests
- [x] `cargo test -p zinc-test-uair` — all test UAIRs including `TestUairMixedShifts`
- [x] `cargo test -p zinc-protocol` — 10 e2e tests including `test_e2e_mixed_shifts`

🤖 Generated with [Claude Code](https://claude.com/claude-code)