### PR TITLE
Precombine trace columns before multipoint eval sumcheck

### DIFF
--- a/piop/Cargo.toml
+++ b/piop/Cargo.toml
@@ -49,3 +49,7 @@ harness = false
 name = "combined_poly_resolver"
 harness = false
 
+[[bench]]
+name = "multipoint_eval"
+harness = false
+

--- a/piop/benches/multipoint_eval.rs
+++ b/piop/benches/multipoint_eval.rs
@@ -1,0 +1,170 @@
+#![allow(clippy::arithmetic_side_effects)]
+
+use std::hint::black_box;
+
+use criterion::{
+    BatchSize, BenchmarkId, Criterion, criterion_group,
+    criterion_main,
+};
+use crypto_primitives::{FromWithConfig, crypto_bigint_monty::MontyField, crypto_bigint_uint::Uint};
+use rand::{Rng, rng};
+use zinc_piop::multipoint_eval::MultipointEval;
+use zinc_poly::mle::{DenseMultilinearExtension, MultilinearExtensionWithConfig};
+use zinc_primality::MillerRabin;
+use zinc_transcript::{KeccakTranscript, traits::Transcript};
+
+const FIELD_LIMBS: usize = 4;
+type F = MontyField<FIELD_LIMBS>;
+
+fn bench_multipoint_eval(c: &mut Criterion, num_vars: usize, num_cols: usize) {
+    let mut rng = rng();
+    let n = 1usize << num_vars;
+    let params = format!("nvars={}/cols={}", num_vars, num_cols);
+
+    let mut transcript = KeccakTranscript::new();
+    let field_cfg =
+        transcript.get_random_field_cfg::<F, Uint<FIELD_LIMBS>, MillerRabin>();
+    let zero_inner = F::from_with_cfg(0u32, &field_cfg).into_inner();
+
+    // Build random trace MLEs.
+    let trace_mles: Vec<DenseMultilinearExtension<_>> = (0..num_cols)
+        .map(|_| {
+            let evals: Vec<_> = (0..n)
+                .map(|_| F::from_with_cfg(rng.random::<u32>(), &field_cfg).into_inner())
+                .collect();
+            DenseMultilinearExtension::from_evaluations_vec(num_vars, evals, zero_inner)
+        })
+        .collect();
+
+    // Random evaluation point.
+    let eval_point: Vec<F> = (0..num_vars)
+        .map(|_| F::from_with_cfg(rng.random::<u32>(), &field_cfg))
+        .collect();
+
+    // Compute up_evals = v_j(r').
+    let up_evals: Vec<F> = trace_mles
+        .iter()
+        .map(|mle| {
+            mle.clone()
+                .evaluate_with_config(&eval_point, &field_cfg)
+                .unwrap()
+        })
+        .collect();
+
+    // Compute down_evals = v_j^{down}(r') (shift by one position).
+    let down_evals: Vec<F> = trace_mles
+        .iter()
+        .map(|mle| {
+            let mut shifted = mle.evaluations[1..].to_vec();
+            shifted.push(zero_inner);
+            let shifted_mle =
+                DenseMultilinearExtension::from_evaluations_vec(num_vars, shifted, zero_inner);
+            shifted_mle
+                .evaluate_with_config(&eval_point, &field_cfg)
+                .unwrap()
+        })
+        .collect();
+
+    let mut group = c.benchmark_group("Multipoint eval");
+
+    // --- Bench prover ---
+    group.bench_with_input(
+        BenchmarkId::new("Prover", &params),
+        &(),
+        |bench, _| {
+            bench.iter_batched(
+                || {
+                    let mut t = KeccakTranscript::new();
+                    t.absorb_slice(b"bench");
+                    t
+                },
+                |mut t| {
+                    let _ = black_box(
+                        MultipointEval::<F>::prove_as_subprotocol(
+                            &mut t,
+                            &trace_mles,
+                            &eval_point,
+                            &up_evals,
+                            &down_evals,
+                            &field_cfg,
+                        )
+                        .expect("prover failed"),
+                    );
+                },
+                BatchSize::SmallInput,
+            );
+        },
+    );
+
+    // --- Bench verifier ---
+    // First produce a valid proof.
+    let mut prover_transcript = KeccakTranscript::new();
+    prover_transcript.absorb_slice(b"bench");
+    let (proof, prover_state) = MultipointEval::<F>::prove_as_subprotocol(
+        &mut prover_transcript,
+        &trace_mles,
+        &eval_point,
+        &up_evals,
+        &down_evals,
+        &field_cfg,
+    )
+    .expect("prover failed");
+
+    let open_evals: Vec<F> = trace_mles
+        .iter()
+        .map(|mle| {
+            mle.clone()
+                .evaluate_with_config(&prover_state.eval_point, &field_cfg)
+                .unwrap()
+        })
+        .collect();
+
+    group.bench_with_input(
+        BenchmarkId::new("Verifier", &params),
+        &(),
+        |bench, _| {
+            bench.iter_batched(
+                || {
+                    let mut t = KeccakTranscript::new();
+                    t.absorb_slice(b"bench");
+                    (t, proof.clone())
+                },
+                |(mut t, proof)| {
+                    let _ = black_box(
+                        MultipointEval::<F>::verify_as_subprotocol(
+                            &mut t,
+                            proof,
+                            &eval_point,
+                            &up_evals,
+                            &down_evals,
+                            &open_evals,
+                            num_vars,
+                            &field_cfg,
+                        )
+                        .expect("verifier failed"),
+                    );
+                },
+                BatchSize::SmallInput,
+            );
+        },
+    );
+
+    group.finish();
+}
+
+pub fn multipoint_eval_benches(c: &mut Criterion) {
+    // Vary trace size with fixed 3 columns.
+    for num_vars in [13, 14, 15, 16, 17] {
+        bench_multipoint_eval(c, num_vars, 3);
+    }
+
+    // Vary column count at fixed size — this is the key axis for the
+    // precombine optimisation: costs become constant (4 MLEs) after precombine
+    // instead of scaling with J
+    for num_cols in [1, 3, 10, 25, 50, 100] {
+        bench_multipoint_eval(c, 14, num_cols);
+    }
+}
+
+criterion_group!(benches, multipoint_eval_benches);
+criterion_main!(benches);

--- a/piop/benches/multipoint_eval.rs
+++ b/piop/benches/multipoint_eval.rs
@@ -149,7 +149,7 @@ pub fn multipoint_eval_benches(c: &mut Criterion) {
     }
 
     // Vary column count at fixed size — this is the key axis for the
-    // precombine optimisation: costs become constant (4 MLEs) after precombine
+    // precombine optimisation: costs become constant (3 MLEs) after precombine
     // instead of scaling with J
     for num_cols in [1, 3, 10, 25, 50, 100] {
         bench_multipoint_eval(c, 14, num_cols);

--- a/piop/benches/multipoint_eval.rs
+++ b/piop/benches/multipoint_eval.rs
@@ -2,11 +2,10 @@
 
 use std::hint::black_box;
 
-use criterion::{
-    BatchSize, BenchmarkId, Criterion, criterion_group,
-    criterion_main,
+use criterion::{BatchSize, BenchmarkId, Criterion, criterion_group, criterion_main};
+use crypto_primitives::{
+    FromWithConfig, crypto_bigint_monty::MontyField, crypto_bigint_uint::Uint,
 };
-use crypto_primitives::{FromWithConfig, crypto_bigint_monty::MontyField, crypto_bigint_uint::Uint};
 use rand::{Rng, rng};
 use zinc_piop::multipoint_eval::MultipointEval;
 use zinc_poly::mle::{DenseMultilinearExtension, MultilinearExtensionWithConfig};
@@ -22,8 +21,7 @@ fn bench_multipoint_eval(c: &mut Criterion, num_vars: usize, num_cols: usize) {
     let params = format!("nvars={}/cols={}", num_vars, num_cols);
 
     let mut transcript = KeccakTranscript::new();
-    let field_cfg =
-        transcript.get_random_field_cfg::<F, Uint<FIELD_LIMBS>, MillerRabin>();
+    let field_cfg = transcript.get_random_field_cfg::<F, Uint<FIELD_LIMBS>, MillerRabin>();
     let zero_inner = F::from_with_cfg(0u32, &field_cfg).into_inner();
 
     // Build random trace MLEs.
@@ -47,7 +45,7 @@ fn bench_multipoint_eval(c: &mut Criterion, num_vars: usize, num_cols: usize) {
         .map(|mle| {
             mle.clone()
                 .evaluate_with_config(&eval_point, &field_cfg)
-                .unwrap()
+                .expect("up_eval evaluation failed")
         })
         .collect();
 
@@ -61,40 +59,36 @@ fn bench_multipoint_eval(c: &mut Criterion, num_vars: usize, num_cols: usize) {
                 DenseMultilinearExtension::from_evaluations_vec(num_vars, shifted, zero_inner);
             shifted_mle
                 .evaluate_with_config(&eval_point, &field_cfg)
-                .unwrap()
+                .expect("down_eval evaluation failed")
         })
         .collect();
 
     let mut group = c.benchmark_group("Multipoint eval");
 
     // --- Bench prover ---
-    group.bench_with_input(
-        BenchmarkId::new("Prover", &params),
-        &(),
-        |bench, _| {
-            bench.iter_batched(
-                || {
-                    let mut t = KeccakTranscript::new();
-                    t.absorb_slice(b"bench");
-                    t
-                },
-                |mut t| {
-                    let _ = black_box(
-                        MultipointEval::<F>::prove_as_subprotocol(
-                            &mut t,
-                            &trace_mles,
-                            &eval_point,
-                            &up_evals,
-                            &down_evals,
-                            &field_cfg,
-                        )
-                        .expect("prover failed"),
-                    );
-                },
-                BatchSize::SmallInput,
-            );
-        },
-    );
+    group.bench_with_input(BenchmarkId::new("Prover", &params), &(), |bench, _| {
+        bench.iter_batched(
+            || {
+                let mut t = KeccakTranscript::new();
+                t.absorb_slice(b"bench");
+                t
+            },
+            |mut t| {
+                let _ = black_box(
+                    MultipointEval::<F>::prove_as_subprotocol(
+                        &mut t,
+                        &trace_mles,
+                        &eval_point,
+                        &up_evals,
+                        &down_evals,
+                        &field_cfg,
+                    )
+                    .expect("prover failed"),
+                );
+            },
+            BatchSize::SmallInput,
+        );
+    });
 
     // --- Bench verifier ---
     // First produce a valid proof.
@@ -115,39 +109,35 @@ fn bench_multipoint_eval(c: &mut Criterion, num_vars: usize, num_cols: usize) {
         .map(|mle| {
             mle.clone()
                 .evaluate_with_config(&prover_state.eval_point, &field_cfg)
-                .unwrap()
+                .expect("open_eval evaluation failed")
         })
         .collect();
 
-    group.bench_with_input(
-        BenchmarkId::new("Verifier", &params),
-        &(),
-        |bench, _| {
-            bench.iter_batched(
-                || {
-                    let mut t = KeccakTranscript::new();
-                    t.absorb_slice(b"bench");
-                    (t, proof.clone())
-                },
-                |(mut t, proof)| {
-                    let _ = black_box(
-                        MultipointEval::<F>::verify_as_subprotocol(
-                            &mut t,
-                            proof,
-                            &eval_point,
-                            &up_evals,
-                            &down_evals,
-                            &open_evals,
-                            num_vars,
-                            &field_cfg,
-                        )
-                        .expect("verifier failed"),
-                    );
-                },
-                BatchSize::SmallInput,
-            );
-        },
-    );
+    group.bench_with_input(BenchmarkId::new("Verifier", &params), &(), |bench, _| {
+        bench.iter_batched(
+            || {
+                let mut t = KeccakTranscript::new();
+                t.absorb_slice(b"bench");
+                (t, proof.clone())
+            },
+            |(mut t, proof)| {
+                let _ = black_box(
+                    MultipointEval::<F>::verify_as_subprotocol(
+                        &mut t,
+                        proof,
+                        &eval_point,
+                        &up_evals,
+                        &down_evals,
+                        &open_evals,
+                        num_vars,
+                        &field_cfg,
+                    )
+                    .expect("verifier failed"),
+                );
+            },
+            BatchSize::SmallInput,
+        );
+    });
 
     group.finish();
 }

--- a/piop/benches/multipoint_eval.rs
+++ b/piop/benches/multipoint_eval.rs
@@ -65,14 +65,14 @@ fn bench_multipoint_eval(c: &mut Criterion, num_vars: usize, num_cols: usize) {
 
     let mut group = c.benchmark_group("Multipoint eval");
 
+    // Prepare a transcript with the seed absorbed once.
+    let mut base_transcript = KeccakTranscript::new();
+    base_transcript.absorb_slice(b"bench");
+
     // --- Bench prover ---
-    group.bench_with_input(BenchmarkId::new("Prover", &params), &(), |bench, _| {
+    group.bench_function(BenchmarkId::new("Prover", &params), |bench| {
         bench.iter_batched(
-            || {
-                let mut t = KeccakTranscript::new();
-                t.absorb_slice(b"bench");
-                t
-            },
+            || base_transcript.clone(),
             |mut t| {
                 let _ = black_box(
                     MultipointEval::<F>::prove_as_subprotocol(
@@ -113,13 +113,9 @@ fn bench_multipoint_eval(c: &mut Criterion, num_vars: usize, num_cols: usize) {
         })
         .collect();
 
-    group.bench_with_input(BenchmarkId::new("Verifier", &params), &(), |bench, _| {
+    group.bench_function(BenchmarkId::new("Verifier", &params), |bench| {
         bench.iter_batched(
-            || {
-                let mut t = KeccakTranscript::new();
-                t.absorb_slice(b"bench");
-                (t, proof.clone())
-            },
+            || (base_transcript.clone(), proof.clone()),
             |(mut t, proof)| {
                 let _ = black_box(
                     MultipointEval::<F>::verify_as_subprotocol(

--- a/piop/src/multipoint_eval.rs
+++ b/piop/src/multipoint_eval.rs
@@ -5,9 +5,12 @@
 //! `v_j^{down}(r')` - to a single set of standard MLE evaluation claims
 //! `v_j(r_0)` at a new random point `r_0` via one sumcheck.
 //!
-//! The sumcheck proves:
+//! The trace column MLEs are precombined into a single MLE
+//! `precombined(b) = \sum_j \gamma_j * v_j(b)` before entering the sumcheck, so
+//! the prover works with only 3 MLEs (`eq`, `next`, `precombined`) regardless
+//! of the number of columns. The sumcheck proves:
 //! ```text
-//! \sum_b [eq(b, r') + \alpha * next(r', b)] * [\sum_j \gamma_j * v_j(b)]
+//! \sum_b [eq(b, r') + \alpha * next(r', b)] * precombined(b)
 //!   = \sum_j \gamma_j * (up_eval_j + \alpha * down_eval_j)
 //! ```
 //!
@@ -26,7 +29,6 @@ use std::marker::PhantomData;
 
 use crate::sumcheck::{MLSumcheck, SumCheckError, SumcheckProof};
 use crypto_primitives::{FromPrimitiveWithConfig, PrimeField};
-use itertools::Itertools;
 use num_traits::Zero;
 use thiserror::Error;
 use zinc_poly::{mle::DenseMultilinearExtension, utils::ArithErrors};
@@ -121,7 +123,7 @@ where
                         })
                         .into_inner()
                 })
-                .collect_vec();
+                .collect();
             DenseMultilinearExtension::from_evaluations_vec(
                 num_vars,
                 evaluations,

--- a/piop/src/multipoint_eval.rs
+++ b/piop/src/multipoint_eval.rs
@@ -107,13 +107,28 @@ where
 
         // Precombine up cols with gammas, precombined[b] = Σ_j γ_j trace[j][b]
         let precombined = {
-            let evaluations = (0..1 << num_vars).map(|b| gammas.iter().enumerate().fold(zero.clone(), |acc, (i, gamma)| {
-                let eval_f = F::new_unchecked_with_cfg(trace_mles[i].evaluations[b].clone(), field_cfg);
-                acc + gamma.clone() * eval_f
-            }).into_inner()).collect_vec();
-            DenseMultilinearExtension::from_evaluations_vec(num_vars, evaluations, zero_inner.clone())
+            let evaluations = (0..1 << num_vars)
+                .map(|b| {
+                    gammas
+                        .iter()
+                        .enumerate()
+                        .fold(zero.clone(), |acc, (i, gamma)| {
+                            let eval_f = F::new_unchecked_with_cfg(
+                                trace_mles[i].evaluations[b].clone(),
+                                field_cfg,
+                            );
+                            acc + gamma.clone() * eval_f
+                        })
+                        .into_inner()
+                })
+                .collect_vec();
+            DenseMultilinearExtension::from_evaluations_vec(
+                num_vars,
+                evaluations,
+                zero_inner.clone(),
+            )
         };
-        
+
         // Step 3: Pack MLEs: [eq_r, next_r, precombined]
         let mles = vec![eq_r, next_r, precombined];
 

--- a/piop/src/multipoint_eval.rs
+++ b/piop/src/multipoint_eval.rs
@@ -26,6 +26,7 @@ use std::marker::PhantomData;
 
 use crate::sumcheck::{MLSumcheck, SumCheckError, SumcheckProof};
 use crypto_primitives::{FromPrimitiveWithConfig, PrimeField};
+use itertools::Itertools;
 use num_traits::Zero;
 use thiserror::Error;
 use zinc_poly::{mle::DenseMultilinearExtension, utils::ArithErrors};
@@ -91,6 +92,7 @@ where
         let num_cols = trace_mles.len();
         let num_vars = eval_point.len();
         let zero = F::zero_with_cfg(field_cfg);
+        let zero_inner = zero.inner();
 
         // Step 1: Sample multi-point batching coefficient \alpha and column
         // batching coefficients \gamma_1,...,\gamma_J.
@@ -103,18 +105,22 @@ where
         let eq_r = zinc_poly::utils::build_eq_x_r_inner(eval_point, field_cfg)?;
         let next_r = zinc_poly::utils::build_next_r_mle(eval_point, field_cfg)?;
 
-        // Step 3: Pack MLEs: [eq_r, next_r, v_1, ..., v_J]
-        let mut mles: Vec<DenseMultilinearExtension<F::Inner>> = Vec::with_capacity(2 + num_cols);
-        mles.push(eq_r);
-        mles.push(next_r);
-        for col in trace_mles {
-            mles.push(col.clone());
-        }
+        // Precombine up cols with gammas, precombined[b] = Σ_j γ_j trace[j][b]
+        let precombined = {
+            let evaluations = (0..1 << num_vars).map(|b| gammas.iter().enumerate().fold(zero.clone(), |acc, (i, gamma)| {
+                let eval_f = F::new_unchecked_with_cfg(trace_mles[i].evaluations[b].clone(), field_cfg);
+                acc + gamma.clone() * eval_f
+            }).into_inner()).collect_vec();
+            DenseMultilinearExtension::from_evaluations_vec(num_vars, evaluations, zero_inner.clone())
+        };
+        
+        // Step 3: Pack MLEs: [eq_r, next_r, precombined]
+        let mles = vec![eq_r, next_r, precombined];
 
         // Step 4: Run sumcheck with degree=2.
 
-        // comb_fn([eq_r, next_r, v_1, ..., v_J]) =
-        //     (eq_r + \alpha * next_r) * \sum_j(\gamma_j * v_j)
+        // comb_fn([eq_r, next_r, precombined]) =
+        //     (eq_r + \alpha * next_r) * precombined
         let (sumcheck_proof, sumcheck_prover_state) = MLSumcheck::prove_as_subprotocol(
             transcript,
             mles,
@@ -124,11 +130,7 @@ where
                 let eq_val = &mle_values[0];
                 let next_val = &mle_values[1];
                 let selector = eq_val.clone() + alpha.clone() * next_val;
-                let batched = gammas
-                    .iter()
-                    .zip(mle_values[2..].iter())
-                    .fold(zero.clone(), |acc, (g, v)| acc + g.clone() * v);
-                selector * &batched
+                selector * &mle_values[2]
             },
             field_cfg,
         );


### PR DESCRIPTION
## Summary
- Pre-combine `J` trace column MLEs into a single `w(b) = Σ_j γ_j · v_j(b)` before entering the sumcheck, reducing the MLE count from `2 + J` to 3 (`eq`, `next`, `w`)
- The sumcheck combining closure becomes a simple `(eq + α·next) * w` instead of recomputing the linear combination each round
- Add `multipoint_eval` benchmark varying both trace size and column count

## Benchmark results

**Fixed nvars=14, varying column count:**

| cols | before | after | improvement |
|------|--------|-------|-------------|
| 1 | 7.77 ms | 6.63 ms | **14%** |
| 3 | 11.75 ms | 7.55 ms | **36%** |
| 10 | 27.15 ms | 10.68 ms | **61%** |
| 25 | 56.95 ms | 17.81 ms | **69%** |
| 50 | 113.2 ms | 32.07 ms | **72%** |
| 100 | 222.1 ms | 61.50 ms | **72%** |

**Fixed cols=3, varying trace size:**

| nvars | improvement |
|-------|-------------|
| 13 | **34%** |
| 14 | **36%** |
| 15 | **35%** |
| 16 | **33%** |
| 17 | **34%** |

Verifier times unchanged (noise).

## Test plan
- [x] All existing tests pass (`cargo test -p zinc-piop`)
- [x] Benchmarks run cleanly (`cargo bench --bench multipoint_eval`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)