### PR TITLE
Arbitrary matrix sizes for linear code

### DIFF
--- a/protocol/benches/e2e.rs
+++ b/protocol/benches/e2e.rs
@@ -40,10 +40,7 @@ use zinc_utils::{
     projectable_to_field::ProjectableToField,
 };
 use zip_plus::{
-    code::{
-        LinearCode,
-        iprs::{IprsCode, PnttConfigF65537_32_128},
-    },
+    code::iprs::{IprsCode, PnttConfigF65537_32_128},
     pcs::structs::{ZipPlus, ZipPlusParams, ZipTypes},
 };
 
@@ -270,18 +267,9 @@ type Pp<Zt> = (
 fn setup_pp(num_vars: usize) -> Pp<BenchZincTypes> {
     let poly_size = 1 << num_vars;
     (
-        ZipPlus::setup(
-            poly_size,
-            <BenchZincTypes as ZincTypes<DEGREE_PLUS_ONE>>::BinaryLc::new(poly_size),
-        ),
-        ZipPlus::setup(
-            poly_size,
-            <BenchZincTypes as ZincTypes<DEGREE_PLUS_ONE>>::ArbitraryLc::new(poly_size),
-        ),
-        ZipPlus::setup(
-            poly_size,
-            <BenchZincTypes as ZincTypes<DEGREE_PLUS_ONE>>::IntLc::new(poly_size),
-        ),
+        ZipPlus::setup(poly_size, IprsCode::default()),
+        ZipPlus::setup(poly_size, IprsCode::default()),
+        ZipPlus::setup(poly_size, IprsCode::default()),
     )
 }
 
@@ -290,7 +278,7 @@ fn setup_pp(num_vars: usize) -> Pp<BenchZincTypes> {
 //
 
 #[allow(clippy::too_many_arguments)]
-fn bench_prove_verify<Zt, U, IdealOverF>(
+fn do_bench<Zt, U, IdealOverF>(
     group: &mut BenchmarkGroup<WallTime>,
     label: &str,
     num_vars: usize,
@@ -399,7 +387,7 @@ where
         ideal.map(|i| DegreeOneIdeal::from_with_cfg(i, field_cfg))
     };
 
-    bench_prove_verify::<BenchZincTypes, U, _>(
+    do_bench::<BenchZincTypes, U, _>(
         group,
         label,
         num_vars,

--- a/protocol/src/lib.rs
+++ b/protocol/src/lib.rs
@@ -626,6 +626,7 @@ mod tests {
     fn test_e2e_mixed_shifts() {
         do_test::<TestZincTypesIprs, TestUairMixedShifts<ZtInt>>(
             8,
+            Default::default(),
             |_ideal, _field_cfg| IdealOrZero::<DegreeOneIdeal<F>>::zero(),
             |_| {},
             |res| res.unwrap(),

--- a/protocol/src/lib.rs
+++ b/protocol/src/lib.rs
@@ -484,6 +484,7 @@ mod tests {
     #[allow(clippy::type_complexity)]
     fn setup_pp<Zt>(
         num_vars: usize,
+        linear_codes: (Zt::BinaryLc, Zt::ArbitraryLc, Zt::IntLc),
     ) -> (
         ZipPlusParams<Zt::BinaryZt, Zt::BinaryLc>,
         ZipPlusParams<Zt::ArbitraryZt, Zt::ArbitraryLc>,
@@ -494,12 +495,9 @@ mod tests {
     {
         let poly_size = 1 << num_vars;
         (
-            ZipPlus::<Zt::BinaryZt, Zt::BinaryLc>::setup(poly_size, Zt::BinaryLc::new(poly_size)),
-            ZipPlus::<Zt::ArbitraryZt, Zt::ArbitraryLc>::setup(
-                poly_size,
-                Zt::ArbitraryLc::new(poly_size),
-            ),
-            ZipPlus::<Zt::IntZt, Zt::IntLc>::setup(poly_size, Zt::IntLc::new(poly_size)),
+            ZipPlus::<Zt::BinaryZt, Zt::BinaryLc>::setup(poly_size, linear_codes.0),
+            ZipPlus::<Zt::ArbitraryZt, Zt::ArbitraryLc>::setup(poly_size, linear_codes.1),
+            ZipPlus::<Zt::IntZt, Zt::IntLc>::setup(poly_size, linear_codes.2),
         )
     }
 
@@ -512,6 +510,7 @@ mod tests {
     #[allow(clippy::result_large_err)]
     fn do_test<Zt, U>(
         num_vars: usize,
+        linear_codes: (Zt::BinaryLc, Zt::ArbitraryLc, Zt::IntLc),
         project_ideal: impl Fn(
             &IdealOrZero<U::Ideal>,
             &<F as PrimeField>::Config,
@@ -536,7 +535,7 @@ mod tests {
         <F as Field>::Modulus: FromRef<Zt::Fmod>,
     {
         let mut rng = rng();
-        let pp = setup_pp::<Zt>(num_vars);
+        let pp = setup_pp::<Zt>(num_vars, linear_codes);
 
         let trace = U::generate_random_trace(num_vars, &mut rng);
 
@@ -582,6 +581,7 @@ mod tests {
     fn test_e2e_no_multiplication() {
         do_test::<TestZincTypesIprs, TestAirNoMultiplication<ZtInt>>(
             8,
+            Default::default(),
             default_project_ideal!(),
             |_| {},
             |res| res.unwrap(),
@@ -601,8 +601,14 @@ mod tests {
     /// ~= 127^8 ~= 2^56, which fits in i64.
     #[test]
     fn test_e2e_simple_multiplication() {
+        let num_vars = 2;
         do_test::<TestZincTypesRaa, TestUairSimpleMultiplication<ZtInt>>(
-            2,
+            num_vars,
+            (
+                RaaCode::new(num_vars),
+                RaaCode::new(num_vars),
+                RaaCode::new(num_vars),
+            ),
             |_ideal, _field_cfg| IdealOrZero::<DegreeOneIdeal<F>>::zero(),
             |_| {},
             |res| res.unwrap(),
@@ -617,6 +623,7 @@ mod tests {
     fn test_e2e_binary_decomposition() {
         do_test::<TestZincTypesIprs, BinaryDecompositionUair<ZtInt>>(
             8,
+            Default::default(),
             default_project_ideal!(),
             |_| {},
             |res| res.unwrap(),
@@ -634,6 +641,7 @@ mod tests {
     fn test_e2e_big_linear() {
         do_test::<TestZincTypesIprs, BigLinearUair<ZtInt>>(
             8,
+            Default::default(),
             default_project_ideal!(),
             |_| {},
             |res| res.unwrap(),
@@ -648,6 +656,7 @@ mod tests {
     fn test_e2e_big_linear_with_public_input() {
         do_test::<TestZincTypesIprs, BigLinearUairWithPublicInput<ZtInt>>(
             8,
+            Default::default(),
             default_project_ideal!(),
             |_| {},
             |res| res.unwrap(),
@@ -662,6 +671,7 @@ mod tests {
     fn test_big_linear_tamper_lifted_evals() {
         do_test::<TestZincTypesIprs, BigLinearUairWithPublicInput<ZtInt>>(
             8,
+            Default::default(),
             default_project_ideal!(),
             |proof| proof.witness_lifted_evals.swap(0, 1),
             |res| {
@@ -674,6 +684,7 @@ mod tests {
     fn test_big_linear_tamper_up_evals() {
         do_test::<TestZincTypesIprs, BigLinearUairWithPublicInput<ZtInt>>(
             8,
+            Default::default(),
             default_project_ideal!(),
             |proof| proof.resolver.up_evals.swap(0, 1),
             |res| {
@@ -686,6 +697,7 @@ mod tests {
     fn test_big_linear_tamper_down_evals() {
         do_test::<TestZincTypesIprs, BigLinearUairWithPublicInput<ZtInt>>(
             8,
+            Default::default(),
             default_project_ideal!(),
             |proof| proof.resolver.down_evals.swap(0, 1),
             |res| {
@@ -698,6 +710,7 @@ mod tests {
     fn test_big_linear_tamper_commitment() {
         do_test::<TestZincTypesIprs, BigLinearUairWithPublicInput<ZtInt>>(
             8,
+            Default::default(),
             default_project_ideal!(),
             |proof| proof.commitments.0.root = Default::default(),
             |res| {
@@ -710,6 +723,7 @@ mod tests {
     fn test_big_linear_tamper_ideal_check() {
         do_test::<TestZincTypesIprs, BigLinearUairWithPublicInput<ZtInt>>(
             8,
+            Default::default(),
             default_project_ideal!(),
             |proof| proof.ideal_check.combined_mle_values.swap(0, 1),
             |res| {

--- a/utils/src/mul_by_scalar.rs
+++ b/utils/src/mul_by_scalar.rs
@@ -48,8 +48,8 @@ macro_rules! impl_mul_int_by_primitive_scalar {
             impl<const LIMBS: usize, const LIMBS2: usize> MulByScalar<&$t, Int<LIMBS2>> for Int<LIMBS> {
                 #[allow(clippy::arithmetic_side_effects)] // By design
                 fn mul_by_scalar<const CHECK: bool>(&self, rhs: &$t) -> Option<Int<LIMBS2>> {
-                    if LIMBS2 < LIMBS {
-                        return None; // Cannot multiply if the left operand has fewer limbs than the output
+                    const {
+                        assert!(LIMBS <= LIMBS2, "Cannot multiply if the left operand has more limbs than the output");
                     }
                     let rhs: Int<LIMBS2> = Int::from_ref(rhs);
                     if CHECK {

--- a/utils/src/mul_by_scalar.rs
+++ b/utils/src/mul_by_scalar.rs
@@ -45,14 +45,17 @@ impl<const LIMBS: usize, const LIMBS2: usize> MulByScalar<&Int<LIMBS2>> for Int<
 macro_rules! impl_mul_int_by_primitive_scalar {
     ($($t:ty),*) => {
         $(
-            impl<const LIMBS: usize> MulByScalar<&$t> for Int<LIMBS> {
+            impl<const LIMBS: usize, const LIMBS2: usize> MulByScalar<&$t, Int<LIMBS2>> for Int<LIMBS> {
                 #[allow(clippy::arithmetic_side_effects)] // By design
-                fn mul_by_scalar<const CHECK: bool>(&self, rhs: &$t) -> Option<Self> {
-                    let rhs = Self::from_ref(rhs);
+                fn mul_by_scalar<const CHECK: bool>(&self, rhs: &$t) -> Option<Int<LIMBS2>> {
+                    if LIMBS2 < LIMBS {
+                        return None; // Cannot multiply if the left operand has fewer limbs than the output
+                    }
+                    let rhs: Int<LIMBS2> = Int::from_ref(rhs);
                     if CHECK {
-                        self.checked_mul(&rhs)
+                        rhs.checked_mul(&self.resize())
                     } else {
-                        Some(*self * rhs)
+                        Some(rhs * self.resize())
                     }
                 }
             }

--- a/zip-plus/benches/zip_benches.rs
+++ b/zip-plus/benches/zip_benches.rs
@@ -11,7 +11,10 @@ use criterion::{Criterion, criterion_group, criterion_main};
 use crypto_bigint::U64;
 use crypto_primitives::{crypto_bigint_int::Int, crypto_bigint_uint::Uint};
 use zip_plus::{
-    code::raa::{RaaCode, RaaConfig},
+    code::{
+        LinearCode,
+        raa::{RaaCode, RaaConfig},
+    },
     pcs::structs::ZipTypes,
 };
 
@@ -50,7 +53,9 @@ type Code = RaaCode<BenchZipTypes, BenchRaaConfig, 4>;
 
 fn zip_benchmarks(c: &mut Criterion) {
     let mut group = c.benchmark_group("Zip+");
-    do_bench::<BenchZipTypes, Code, PERFORM_CHECKS>(&mut group);
+    do_bench::<BenchZipTypes, Code, PERFORM_CHECKS>(&mut group, |poly_size| {
+        RaaCode::new(poly_size.isqrt().next_power_of_two())
+    });
     group.finish();
 }
 

--- a/zip-plus/benches/zip_benches.rs
+++ b/zip-plus/benches/zip_benches.rs
@@ -11,10 +11,7 @@ use criterion::{Criterion, criterion_group, criterion_main};
 use crypto_bigint::U64;
 use crypto_primitives::{crypto_bigint_int::Int, crypto_bigint_uint::Uint};
 use zip_plus::{
-    code::{
-        LinearCode,
-        raa::{RaaCode, RaaConfig},
-    },
+    code::raa::{RaaCode, RaaConfig},
     pcs::structs::ZipTypes,
 };
 

--- a/zip-plus/benches/zip_common.rs
+++ b/zip-plus/benches/zip_common.rs
@@ -35,7 +35,7 @@ type F = MontyField<{ INT_LIMBS * 4 }>;
 
 pub fn do_bench<Zt: ZipTypes, Lc: LinearCode<Zt>, const CHECK_FOR_OVERFLOWS: bool>(
     group: &mut BenchmarkGroup<WallTime>,
-    make_linear_code: impl Fn(usize) -> Lc + Copy,
+    make_linear_code: impl Fn(/* poly_size: */ usize) -> Lc + Copy,
 ) where
     StandardUniform: Distribution<Zt::Eval> + Distribution<Zt::Cw>,
     F: FromPrimitiveWithConfig
@@ -53,10 +53,13 @@ pub fn do_bench<Zt: ZipTypes, Lc: LinearCode<Zt>, const CHECK_FOR_OVERFLOWS: boo
     encode_rows::<Zt, Lc, 15>(group, make_linear_code);
     encode_rows::<Zt, Lc, 16>(group, make_linear_code);
 
-    encode_single_row::<Zt, Lc>(group, make_linear_code(128));
-    encode_single_row::<Zt, Lc>(group, make_linear_code(256));
-    encode_single_row::<Zt, Lc>(group, make_linear_code(512));
-    encode_single_row::<Zt, Lc>(group, make_linear_code(1024));
+    for lc in [128, 256, 512, 1024]
+        .map(make_linear_code)
+        .into_iter()
+        .dedup()
+    {
+        encode_single_row::<Zt, Lc>(group, lc)
+    }
 
     merkle_root::<Zt, 12>(group);
     merkle_root::<Zt, 13>(group);

--- a/zip-plus/benches/zip_common.rs
+++ b/zip-plus/benches/zip_common.rs
@@ -110,8 +110,9 @@ pub fn encode_rows<Zt: ZipTypes, Lc: LinearCode<Zt>, const P: usize>(
         ),
         |b| {
             let mut rng = ThreadRng::default();
-            let poly_size = 1 << P;
-            let linear_code = Lc::new(poly_size);
+            let poly_size: usize = 1 << P;
+            let row_len = poly_size.isqrt().next_power_of_two();
+            let linear_code = Lc::new(row_len);
             let params = ZipPlus::setup(poly_size, linear_code);
             let row_len = params.linear_code.row_len();
             let poly = DenseMultilinearExtension::<<Zt as ZipTypes>::Eval>::rand(P, &mut rng);
@@ -129,8 +130,8 @@ pub fn encode_single_row<Zt: ZipTypes, Lc: LinearCode<Zt>, const ROW_LEN: usize>
     StandardUniform: Distribution<Zt::Eval>,
 {
     let mut rng = ThreadRng::default();
-    let poly_size = ROW_LEN * ROW_LEN;
-    let linear_code = Lc::new(poly_size);
+    let _poly_size = ROW_LEN * ROW_LEN;
+    let linear_code = Lc::new(ROW_LEN);
     if linear_code.row_len() != ROW_LEN {
         // TODO(Ilia): Since IPRS codes require
         //             the input size to be known at compile time
@@ -190,8 +191,9 @@ pub fn commit<Zt: ZipTypes, Lc: LinearCode<Zt>, const P: usize, const BATCH: usi
     StandardUniform: Distribution<Zt::Eval>,
 {
     let mut rng = ThreadRng::default();
-    let poly_size = 1 << P;
-    let linear_code = Lc::new(poly_size);
+    let poly_size: usize = 1 << P;
+    let row_len = poly_size.isqrt().next_power_of_two();
+    let linear_code = Lc::new(row_len);
     let params = ZipPlus::setup(poly_size, linear_code);
 
     group.bench_function(
@@ -238,8 +240,9 @@ pub fn prove<
 {
     let mut rng = ThreadRng::default();
 
-    let poly_size = 1 << P;
-    let linear_code = Lc::new(poly_size);
+    let poly_size: usize = 1 << P;
+    let row_len = poly_size.isqrt().next_power_of_two();
+    let linear_code = Lc::new(row_len);
     let params = ZipPlus::setup(poly_size, linear_code);
 
     let polys: Vec<_> = (0..BATCH)
@@ -306,8 +309,9 @@ pub fn verify<
     Zt::Eval: ProjectableToField<F>,
 {
     let mut rng = ThreadRng::default();
-    let poly_size = 1 << P;
-    let linear_code = Lc::new(poly_size);
+    let poly_size: usize = 1 << P;
+    let row_len = poly_size.isqrt().next_power_of_two();
+    let linear_code = Lc::new(row_len);
     let params = ZipPlus::setup(poly_size, linear_code);
 
     let polys: Vec<_> = (0..BATCH)

--- a/zip-plus/benches/zip_common.rs
+++ b/zip-plus/benches/zip_common.rs
@@ -35,6 +35,7 @@ type F = MontyField<{ INT_LIMBS * 4 }>;
 
 pub fn do_bench<Zt: ZipTypes, Lc: LinearCode<Zt>, const CHECK_FOR_OVERFLOWS: bool>(
     group: &mut BenchmarkGroup<WallTime>,
+    make_linear_code: impl Fn(usize) -> Lc + Copy,
 ) where
     StandardUniform: Distribution<Zt::Eval> + Distribution<Zt::Cw>,
     F: FromPrimitiveWithConfig
@@ -46,16 +47,16 @@ pub fn do_bench<Zt: ZipTypes, Lc: LinearCode<Zt>, const CHECK_FOR_OVERFLOWS: boo
     <F as Field>::Inner: FromRef<Zt::Fmod> + Transcribable,
     Zt::Eval: ProjectableToField<F>,
 {
-    encode_rows::<Zt, Lc, 12>(group);
-    encode_rows::<Zt, Lc, 13>(group);
-    encode_rows::<Zt, Lc, 14>(group);
-    encode_rows::<Zt, Lc, 15>(group);
-    encode_rows::<Zt, Lc, 16>(group);
+    encode_rows::<Zt, Lc, 12>(group, make_linear_code);
+    encode_rows::<Zt, Lc, 13>(group, make_linear_code);
+    encode_rows::<Zt, Lc, 14>(group, make_linear_code);
+    encode_rows::<Zt, Lc, 15>(group, make_linear_code);
+    encode_rows::<Zt, Lc, 16>(group, make_linear_code);
 
-    encode_single_row::<Zt, Lc, 128>(group);
-    encode_single_row::<Zt, Lc, 256>(group);
-    encode_single_row::<Zt, Lc, 512>(group);
-    encode_single_row::<Zt, Lc, 1024>(group);
+    encode_single_row::<Zt, Lc>(group, make_linear_code(128));
+    encode_single_row::<Zt, Lc>(group, make_linear_code(256));
+    encode_single_row::<Zt, Lc>(group, make_linear_code(512));
+    encode_single_row::<Zt, Lc>(group, make_linear_code(1024));
 
     merkle_root::<Zt, 12>(group);
     merkle_root::<Zt, 13>(group);
@@ -63,42 +64,43 @@ pub fn do_bench<Zt: ZipTypes, Lc: LinearCode<Zt>, const CHECK_FOR_OVERFLOWS: boo
     merkle_root::<Zt, 15>(group);
     merkle_root::<Zt, 16>(group);
 
-    commit::<Zt, Lc, 12, 1>(group);
-    commit::<Zt, Lc, 13, 1>(group);
-    commit::<Zt, Lc, 14, 1>(group);
-    commit::<Zt, Lc, 15, 1>(group);
-    commit::<Zt, Lc, 16, 1>(group);
+    commit::<Zt, Lc, 12, 1>(group, make_linear_code);
+    commit::<Zt, Lc, 13, 1>(group, make_linear_code);
+    commit::<Zt, Lc, 14, 1>(group, make_linear_code);
+    commit::<Zt, Lc, 15, 1>(group, make_linear_code);
+    commit::<Zt, Lc, 16, 1>(group, make_linear_code);
 
-    commit::<Zt, Lc, 14, 2>(group);
-    commit::<Zt, Lc, 14, 5>(group);
-    commit::<Zt, Lc, 16, 2>(group);
-    commit::<Zt, Lc, 16, 5>(group);
+    commit::<Zt, Lc, 14, 2>(group, make_linear_code);
+    commit::<Zt, Lc, 14, 5>(group, make_linear_code);
+    commit::<Zt, Lc, 16, 2>(group, make_linear_code);
+    commit::<Zt, Lc, 16, 5>(group, make_linear_code);
 
-    prove::<Zt, Lc, CHECK_FOR_OVERFLOWS, 12, 1>(group);
-    prove::<Zt, Lc, CHECK_FOR_OVERFLOWS, 13, 1>(group);
-    prove::<Zt, Lc, CHECK_FOR_OVERFLOWS, 14, 1>(group);
-    prove::<Zt, Lc, CHECK_FOR_OVERFLOWS, 15, 1>(group);
-    prove::<Zt, Lc, CHECK_FOR_OVERFLOWS, 16, 1>(group);
+    prove::<Zt, Lc, CHECK_FOR_OVERFLOWS, 12, 1>(group, make_linear_code);
+    prove::<Zt, Lc, CHECK_FOR_OVERFLOWS, 13, 1>(group, make_linear_code);
+    prove::<Zt, Lc, CHECK_FOR_OVERFLOWS, 14, 1>(group, make_linear_code);
+    prove::<Zt, Lc, CHECK_FOR_OVERFLOWS, 15, 1>(group, make_linear_code);
+    prove::<Zt, Lc, CHECK_FOR_OVERFLOWS, 16, 1>(group, make_linear_code);
 
-    prove::<Zt, Lc, CHECK_FOR_OVERFLOWS, 14, 2>(group);
-    prove::<Zt, Lc, CHECK_FOR_OVERFLOWS, 14, 5>(group);
-    prove::<Zt, Lc, CHECK_FOR_OVERFLOWS, 16, 2>(group);
-    prove::<Zt, Lc, CHECK_FOR_OVERFLOWS, 16, 5>(group);
+    prove::<Zt, Lc, CHECK_FOR_OVERFLOWS, 14, 2>(group, make_linear_code);
+    prove::<Zt, Lc, CHECK_FOR_OVERFLOWS, 14, 5>(group, make_linear_code);
+    prove::<Zt, Lc, CHECK_FOR_OVERFLOWS, 16, 2>(group, make_linear_code);
+    prove::<Zt, Lc, CHECK_FOR_OVERFLOWS, 16, 5>(group, make_linear_code);
 
-    verify::<Zt, Lc, CHECK_FOR_OVERFLOWS, 12, 1>(group);
-    verify::<Zt, Lc, CHECK_FOR_OVERFLOWS, 13, 1>(group);
-    verify::<Zt, Lc, CHECK_FOR_OVERFLOWS, 14, 1>(group);
-    verify::<Zt, Lc, CHECK_FOR_OVERFLOWS, 15, 1>(group);
-    verify::<Zt, Lc, CHECK_FOR_OVERFLOWS, 16, 1>(group);
+    verify::<Zt, Lc, CHECK_FOR_OVERFLOWS, 12, 1>(group, make_linear_code);
+    verify::<Zt, Lc, CHECK_FOR_OVERFLOWS, 13, 1>(group, make_linear_code);
+    verify::<Zt, Lc, CHECK_FOR_OVERFLOWS, 14, 1>(group, make_linear_code);
+    verify::<Zt, Lc, CHECK_FOR_OVERFLOWS, 15, 1>(group, make_linear_code);
+    verify::<Zt, Lc, CHECK_FOR_OVERFLOWS, 16, 1>(group, make_linear_code);
 
-    verify::<Zt, Lc, CHECK_FOR_OVERFLOWS, 14, 2>(group);
-    verify::<Zt, Lc, CHECK_FOR_OVERFLOWS, 14, 5>(group);
-    verify::<Zt, Lc, CHECK_FOR_OVERFLOWS, 16, 2>(group);
-    verify::<Zt, Lc, CHECK_FOR_OVERFLOWS, 16, 5>(group);
+    verify::<Zt, Lc, CHECK_FOR_OVERFLOWS, 14, 2>(group, make_linear_code);
+    verify::<Zt, Lc, CHECK_FOR_OVERFLOWS, 14, 5>(group, make_linear_code);
+    verify::<Zt, Lc, CHECK_FOR_OVERFLOWS, 16, 2>(group, make_linear_code);
+    verify::<Zt, Lc, CHECK_FOR_OVERFLOWS, 16, 5>(group, make_linear_code);
 }
 
 pub fn encode_rows<Zt: ZipTypes, Lc: LinearCode<Zt>, const P: usize>(
     group: &mut BenchmarkGroup<WallTime>,
+    make_linear_code: impl Fn(usize) -> Lc,
 ) where
     StandardUniform: Distribution<Zt::Eval>,
 {
@@ -111,48 +113,34 @@ pub fn encode_rows<Zt: ZipTypes, Lc: LinearCode<Zt>, const P: usize>(
         |b| {
             let mut rng = ThreadRng::default();
             let poly_size: usize = 1 << P;
-            let row_len = poly_size.isqrt().next_power_of_two();
-            let linear_code = Lc::new(row_len);
+            let linear_code = make_linear_code(poly_size);
             let params = ZipPlus::setup(poly_size, linear_code);
-            let row_len = params.linear_code.row_len();
             let poly = DenseMultilinearExtension::<<Zt as ZipTypes>::Eval>::rand(P, &mut rng);
             b.iter(|| {
-                let cw = ZipPlus::encode_rows(&params, row_len, &poly);
+                let cw = ZipPlus::encode_rows(&params, &poly);
                 black_box(cw)
             })
         },
     );
 }
 
-pub fn encode_single_row<Zt: ZipTypes, Lc: LinearCode<Zt>, const ROW_LEN: usize>(
+pub fn encode_single_row<Zt: ZipTypes, Lc: LinearCode<Zt>>(
     group: &mut BenchmarkGroup<WallTime>,
+    linear_code: Lc,
 ) where
     StandardUniform: Distribution<Zt::Eval>,
 {
     let mut rng = ThreadRng::default();
-    let _poly_size = ROW_LEN * ROW_LEN;
-    let linear_code = Lc::new(ROW_LEN);
-    if linear_code.row_len() != ROW_LEN {
-        // TODO(Ilia): Since IPRS codes require
-        //             the input size to be known at compile time
-        //             this detects IPRS benches.
-        //             Ofc, it's a lame way to handle this and
-        //             one can come up with a more elegant type safe way
-        //             but for the sake of a fast solution it's good enough.
-        //             Once we have time address this pls.
-
-        return;
-    }
-
+    let row_len = linear_code.row_len();
     group.bench_function(
         format!(
-            "EncodeMessage: {} -> {}, row_len = {ROW_LEN}",
+            "EncodeMessage: {} -> {}, row_len = {row_len}",
             Zt::Eval::type_name(),
             Zt::Cw::type_name()
         ),
         |b| {
             let message: Vec<<Zt as ZipTypes>::Eval> =
-                (0..ROW_LEN).map(|_i| rng.random()).collect();
+                (0..row_len).map(|_i| rng.random()).collect();
             b.iter(|| {
                 let encoded_row: Vec<<Zt as ZipTypes>::Cw> = linear_code.encode(&message);
                 black_box(encoded_row);
@@ -187,13 +175,13 @@ where
 
 pub fn commit<Zt: ZipTypes, Lc: LinearCode<Zt>, const P: usize, const BATCH: usize>(
     group: &mut BenchmarkGroup<WallTime>,
+    make_linear_code: impl Fn(usize) -> Lc,
 ) where
     StandardUniform: Distribution<Zt::Eval>,
 {
     let mut rng = ThreadRng::default();
     let poly_size: usize = 1 << P;
-    let row_len = poly_size.isqrt().next_power_of_two();
-    let linear_code = Lc::new(row_len);
+    let linear_code = make_linear_code(poly_size);
     let params = ZipPlus::setup(poly_size, linear_code);
 
     group.bench_function(
@@ -229,6 +217,7 @@ pub fn prove<
     const BATCH: usize,
 >(
     group: &mut BenchmarkGroup<WallTime>,
+    make_linear_code: impl Fn(usize) -> Lc,
 ) where
     StandardUniform: Distribution<Zt::Eval>,
     F: for<'a> FromWithConfig<&'a Zt::CombR>
@@ -241,8 +230,7 @@ pub fn prove<
     let mut rng = ThreadRng::default();
 
     let poly_size: usize = 1 << P;
-    let row_len = poly_size.isqrt().next_power_of_two();
-    let linear_code = Lc::new(row_len);
+    let linear_code = make_linear_code(poly_size);
     let params = ZipPlus::setup(poly_size, linear_code);
 
     let polys: Vec<_> = (0..BATCH)
@@ -297,6 +285,7 @@ pub fn verify<
     const BATCH: usize,
 >(
     group: &mut BenchmarkGroup<WallTime>,
+    make_linear_code: impl Fn(usize) -> Lc,
 ) where
     StandardUniform: Distribution<Zt::Eval>,
     F: FromPrimitiveWithConfig
@@ -310,8 +299,7 @@ pub fn verify<
 {
     let mut rng = ThreadRng::default();
     let poly_size: usize = 1 << P;
-    let row_len = poly_size.isqrt().next_power_of_two();
-    let linear_code = Lc::new(row_len);
+    let linear_code = make_linear_code(poly_size);
     let params = ZipPlus::setup(poly_size, linear_code);
 
     let polys: Vec<_> = (0..BATCH)

--- a/zip-plus/benches/zip_common.rs
+++ b/zip-plus/benches/zip_common.rs
@@ -56,6 +56,7 @@ pub fn do_bench<Zt: ZipTypes, Lc: LinearCode<Zt>, const CHECK_FOR_OVERFLOWS: boo
     for lc in [128, 256, 512, 1024]
         .map(make_linear_code)
         .into_iter()
+        // These might be duplicate depending on linear code construction logic
         .dedup()
     {
         encode_single_row::<Zt, Lc>(group, lc)

--- a/zip-plus/benches/zip_plus_benches.rs
+++ b/zip-plus/benches/zip_plus_benches.rs
@@ -3,15 +3,6 @@
 
 mod zip_common;
 
-use std::marker::PhantomData;
-
-use zinc_poly::univariate::{
-    binary::{BinaryPoly, BinaryPolyInnerProduct},
-    dense::{DensePolyInnerProduct, DensePolynomial},
-};
-use zinc_primality::MillerRabin;
-use zinc_transcript::traits::ConstTranscribable;
-use zinc_utils::{UNCHECKED, from_ref::FromRef, inner_product::MBSInnerProduct, named::Named};
 use zip_common::*;
 
 use criterion::{Criterion, criterion_group, criterion_main};
@@ -19,8 +10,17 @@ use crypto_bigint::U64;
 use crypto_primitives::{
     FixedSemiring, boolean::Boolean, crypto_bigint_int::Int, crypto_bigint_uint::Uint,
 };
+use std::marker::PhantomData;
+use zinc_poly::univariate::{
+    binary::{BinaryPoly, BinaryPolyInnerProduct},
+    dense::{DensePolyInnerProduct, DensePolynomial},
+};
+use zinc_primality::MillerRabin;
+use zinc_transcript::traits::ConstTranscribable;
+use zinc_utils::{UNCHECKED, from_ref::FromRef, inner_product::MBSInnerProduct, named::Named};
 use zip_plus::{
     code::{
+        LinearCode,
         iprs::{IprsCode, PnttConfigF65537_32_128},
         raa::{RaaCode, RaaConfig},
     },
@@ -74,8 +74,12 @@ type SomeIprsCode<Twiddle, const DEPTH: usize, const D_PLUS_ONE: usize, const CH
 fn zip_plus_benchmarks_raa(c: &mut Criterion) {
     let mut group = c.benchmark_group("Zip+ RAA");
 
-    do_bench::<BenchZipPlusTypes<i32, 32>, SomeRaaCode<_>, UNCHECKED>(&mut group);
-    do_bench::<BenchZipPlusTypes<i32, 64>, SomeRaaCode<_>, UNCHECKED>(&mut group);
+    do_bench::<BenchZipPlusTypes<i32, 32>, SomeRaaCode<_>, UNCHECKED>(&mut group, |poly_size| {
+        RaaCode::new(poly_size.isqrt().next_power_of_two())
+    });
+    do_bench::<BenchZipPlusTypes<i32, 64>, SomeRaaCode<_>, UNCHECKED>(&mut group, |poly_size| {
+        RaaCode::new(poly_size.isqrt().next_power_of_two())
+    });
 
     group.finish();
 }
@@ -85,9 +89,11 @@ fn zip_plus_benchmarks_iprs(c: &mut Criterion) {
 
     do_bench::<BenchZipPlusTypes<i64, 32>, SomeIprsCode<i64, 1, 32, UNCHECKED>, UNCHECKED>(
         &mut group,
+        |_poly_size| IprsCode::create(),
     );
     do_bench::<BenchZipPlusTypes<i64, 64>, SomeIprsCode<i64, 1, 64, UNCHECKED>, UNCHECKED>(
         &mut group,
+        |_poly_size| IprsCode::create(),
     );
 
     group.finish();

--- a/zip-plus/benches/zip_plus_benches.rs
+++ b/zip-plus/benches/zip_plus_benches.rs
@@ -17,14 +17,19 @@ use zinc_poly::univariate::{
 };
 use zinc_primality::MillerRabin;
 use zinc_transcript::traits::ConstTranscribable;
-use zinc_utils::{UNCHECKED, from_ref::FromRef, inner_product::MBSInnerProduct, named::Named};
+use zinc_utils::{from_ref::FromRef, inner_product::MBSInnerProduct, named::Named};
 use zip_plus::{
     code::{
-        LinearCode,
         iprs::{IprsCode, PnttConfigF65537_32_128},
         raa::{RaaCode, RaaConfig},
     },
     pcs::structs::ZipTypes,
+};
+
+const PERFORM_CHECKS: bool = if cfg!(feature = "unchecked") {
+    zinc_utils::UNCHECKED
+} else {
+    zinc_utils::CHECKED
 };
 
 const INT_LIMBS: usize = U64::LIMBS;
@@ -62,7 +67,7 @@ where
 struct BenchRaaConfig;
 impl RaaConfig for BenchRaaConfig {
     const PERMUTE_IN_PLACE: bool = true;
-    const CHECK_FOR_OVERFLOWS: bool = UNCHECKED;
+    const CHECK_FOR_OVERFLOWS: bool = PERFORM_CHECKS;
 }
 
 type SomeRaaCode<const D_PLUS_ONE: usize> =
@@ -74,12 +79,14 @@ type SomeIprsCode<Twiddle, const DEPTH: usize, const D_PLUS_ONE: usize, const CH
 fn zip_plus_benchmarks_raa(c: &mut Criterion) {
     let mut group = c.benchmark_group("Zip+ RAA");
 
-    do_bench::<BenchZipPlusTypes<i32, 32>, SomeRaaCode<_>, UNCHECKED>(&mut group, |poly_size| {
-        RaaCode::new(poly_size.isqrt().next_power_of_two())
-    });
-    do_bench::<BenchZipPlusTypes<i32, 64>, SomeRaaCode<_>, UNCHECKED>(&mut group, |poly_size| {
-        RaaCode::new(poly_size.isqrt().next_power_of_two())
-    });
+    do_bench::<BenchZipPlusTypes<i32, 32>, SomeRaaCode<_>, PERFORM_CHECKS>(
+        &mut group,
+        |poly_size| RaaCode::new(poly_size.isqrt().next_power_of_two()),
+    );
+    do_bench::<BenchZipPlusTypes<i32, 64>, SomeRaaCode<_>, PERFORM_CHECKS>(
+        &mut group,
+        |poly_size| RaaCode::new(poly_size.isqrt().next_power_of_two()),
+    );
 
     group.finish();
 }
@@ -87,13 +94,13 @@ fn zip_plus_benchmarks_raa(c: &mut Criterion) {
 fn zip_plus_benchmarks_iprs(c: &mut Criterion) {
     let mut group = c.benchmark_group("Zip+ IPRS");
 
-    do_bench::<BenchZipPlusTypes<i64, 32>, SomeIprsCode<i64, 1, 32, UNCHECKED>, UNCHECKED>(
+    do_bench::<BenchZipPlusTypes<i64, 32>, SomeIprsCode<i64, 1, 32, PERFORM_CHECKS>, PERFORM_CHECKS>(
         &mut group,
-        |_poly_size| IprsCode::create(),
+        |_poly_size| IprsCode::default(),
     );
-    do_bench::<BenchZipPlusTypes<i64, 64>, SomeIprsCode<i64, 1, 64, UNCHECKED>, UNCHECKED>(
+    do_bench::<BenchZipPlusTypes<i64, 64>, SomeIprsCode<i64, 1, 64, PERFORM_CHECKS>, PERFORM_CHECKS>(
         &mut group,
-        |_poly_size| IprsCode::create(),
+        |_poly_size| IprsCode::default(),
     );
 
     group.finish();

--- a/zip-plus/src/code.rs
+++ b/zip-plus/src/code.rs
@@ -4,9 +4,10 @@ pub mod raa_sign_flip;
 
 use crate::pcs::structs::ZipTypes;
 use crypto_primitives::FromPrimitiveWithConfig;
+use std::fmt::Debug;
 use zinc_utils::from_ref::FromRef;
 
-pub trait LinearCode<Zt: ZipTypes>: Sync + Send {
+pub trait LinearCode<Zt: ZipTypes>: Debug + Eq + Sync + Send {
     /// Repetition factor, a.k.a. inverse rate, the ratio of codeword length to
     /// input row length. Has to be at a power of 2.
     ///

--- a/zip-plus/src/code.rs
+++ b/zip-plus/src/code.rs
@@ -16,8 +16,6 @@ pub trait LinearCode<Zt: ZipTypes>: Debug + Eq + Sync + Send {
     /// makes using it too much of a hassle.
     const REPETITION_FACTOR: usize;
 
-    fn new(row_len: usize) -> Self;
-
     /// Length of each input row before encoding
     fn row_len(&self) -> usize;
 

--- a/zip-plus/src/code.rs
+++ b/zip-plus/src/code.rs
@@ -15,7 +15,7 @@ pub trait LinearCode<Zt: ZipTypes>: Sync + Send {
     /// makes using it too much of a hassle.
     const REPETITION_FACTOR: usize;
 
-    fn new(poly_size: usize) -> Self;
+    fn new(row_len: usize) -> Self;
 
     /// Length of each input row before encoding
     fn row_len(&self) -> usize;

--- a/zip-plus/src/code/iprs.rs
+++ b/zip-plus/src/code/iprs.rs
@@ -100,12 +100,12 @@ where
     const REPETITION_FACTOR: usize = Config::OUTPUT_LEN / Config::INPUT_LEN;
 
     #[allow(clippy::arithmetic_side_effects)]
-    fn new(poly_size: usize) -> Self {
+    fn new(row_len: usize) -> Self {
         assert_eq!(
-            poly_size % Config::INPUT_LEN,
-            0,
-            "Polynomial size {} is not a multiple of row length {}",
-            poly_size,
+            row_len,
+            Config::INPUT_LEN,
+            "Row length {} does not match expected row length {}",
+            row_len,
             Config::INPUT_LEN
         );
 

--- a/zip-plus/src/code/iprs.rs
+++ b/zip-plus/src/code/iprs.rs
@@ -1,15 +1,12 @@
 mod pntt;
 
-use crate::{
-    code::{LinearCode, iprs::pntt::radix8::params::Config as PnttConfig},
-    pcs::structs::ZipTypes,
-};
+use crate::{code::LinearCode, pcs::structs::ZipTypes};
 use crypto_primitives::{FromPrimitiveWithConfig, FromWithConfig};
 use num_traits::{CheckedAdd, CheckedMul};
 pub use pntt::radix8::params::{
-    PnttConfigF65537_1_4, PnttConfigF65537_2_8, PnttConfigF65537_4_16, PnttConfigF65537_16_64,
-    PnttConfigF65537_32_64, PnttConfigF65537_32_128, PnttConfigF65537_64_256, PnttInt,
-    Radix8PnttParams,
+    Config as PnttConfig, PnttConfigF65537_1_4, PnttConfigF65537_2_8, PnttConfigF65537_4_16,
+    PnttConfigF65537_16_64, PnttConfigF65537_32_64, PnttConfigF65537_32_128,
+    PnttConfigF65537_64_256, PnttInt, Radix8PnttParams,
 };
 use std::{
     fmt::Debug,
@@ -32,7 +29,28 @@ impl<Zt, Config, const CHECK: bool> IprsCode<Zt, Config, CHECK>
 where
     Zt: ZipTypes,
     Config: PnttConfig,
+    Zt::Eval: for<'a> MulByScalar<&'a PnttInt, Zt::Cw>,
+    Zt::CombR: for<'a> MulByScalar<&'a PnttInt>,
+    Zt::Cw: CheckedAdd + for<'a> MulByScalar<&'a PnttInt>,
 {
+    /// Named differently to distinguish from the [`LinearCode::new`]
+    #[allow(clippy::arithmetic_side_effects)]
+    pub fn create() -> Self {
+        assert_eq!(
+            Config::OUTPUT_LEN,
+            Config::INPUT_LEN * Self::REPETITION_FACTOR,
+            "Codeword length {} must equal row length {} times repetition factor {}",
+            Config::OUTPUT_LEN,
+            Config::INPUT_LEN,
+            Self::REPETITION_FACTOR
+        );
+
+        Self {
+            pntt_params: Radix8PnttParams::new(),
+            _phantom: Default::default(),
+        }
+    }
+
     /// Encode without modular reduction, purely over the integers.
     fn encode_inner<In, Out>(&self, row: &[In]) -> Vec<Out>
     where
@@ -109,19 +127,7 @@ where
             Config::INPUT_LEN
         );
 
-        assert_eq!(
-            Config::OUTPUT_LEN,
-            Config::INPUT_LEN * Self::REPETITION_FACTOR,
-            "Codeword length {} must equal row length {} times repetition factor {}",
-            Config::OUTPUT_LEN,
-            Config::INPUT_LEN,
-            Self::REPETITION_FACTOR
-        );
-
-        Self {
-            pntt_params: Radix8PnttParams::new(),
-            _phantom: Default::default(),
-        }
+        Self::create()
     }
 
     fn encode(&self, row: &[Zt::Eval]) -> Vec<Zt::Cw> {

--- a/zip-plus/src/code/iprs.rs
+++ b/zip-plus/src/code/iprs.rs
@@ -19,6 +19,8 @@ use zinc_utils::{from_ref::FromRef, mul_by_scalar::MulByScalar};
 /// Pseudo Reed-Solomon encoder over the integers. Internally uses a
 /// radix-8 NTT-style recursion with a base Vandermonde matrix sized
 /// `base_len x base_dim` (defaults to 64x32).
+///
+/// To create a new instance, use [`IprsCode::default`] method.
 #[derive(Clone)]
 pub struct IprsCode<Zt: ZipTypes, Config: PnttConfig, const CHECK: bool> {
     pntt_params: Radix8PnttParams<Config>,
@@ -33,24 +35,6 @@ where
     Zt::CombR: for<'a> MulByScalar<&'a PnttInt>,
     Zt::Cw: CheckedAdd + for<'a> MulByScalar<&'a PnttInt>,
 {
-    /// Named differently to distinguish from the [`LinearCode::new`]
-    #[allow(clippy::arithmetic_side_effects)]
-    pub fn create() -> Self {
-        assert_eq!(
-            Config::OUTPUT_LEN,
-            Config::INPUT_LEN * Self::REPETITION_FACTOR,
-            "Codeword length {} must equal row length {} times repetition factor {}",
-            Config::OUTPUT_LEN,
-            Config::INPUT_LEN,
-            Self::REPETITION_FACTOR
-        );
-
-        Self {
-            pntt_params: Radix8PnttParams::new(),
-            _phantom: Default::default(),
-        }
-    }
-
     /// Encode without modular reduction, purely over the integers.
     fn encode_inner<In, Out>(&self, row: &[In]) -> Vec<Out>
     where
@@ -117,19 +101,6 @@ where
 {
     const REPETITION_FACTOR: usize = Config::OUTPUT_LEN / Config::INPUT_LEN;
 
-    #[allow(clippy::arithmetic_side_effects)]
-    fn new(row_len: usize) -> Self {
-        assert_eq!(
-            row_len,
-            Config::INPUT_LEN,
-            "Row length {} does not match expected row length {}",
-            row_len,
-            Config::INPUT_LEN
-        );
-
-        Self::create()
-    }
-
     fn encode(&self, row: &[Zt::Eval]) -> Vec<Zt::Cw> {
         assert_eq!(
             row.len(),
@@ -159,6 +130,32 @@ where
         F: FromPrimitiveWithConfig + FromRef<F>,
     {
         self.encode_inner_f(row)
+    }
+}
+
+impl<Zt, Config, const CHECK: bool> Default for IprsCode<Zt, Config, CHECK>
+where
+    Zt: ZipTypes,
+    Config: PnttConfig,
+    Zt::Eval: for<'a> MulByScalar<&'a PnttInt, Zt::Cw>,
+    Zt::CombR: for<'a> MulByScalar<&'a PnttInt>,
+    Zt::Cw: CheckedAdd + for<'a> MulByScalar<&'a PnttInt>,
+{
+    #[allow(clippy::arithmetic_side_effects)]
+    fn default() -> Self {
+        assert_eq!(
+            Config::OUTPUT_LEN,
+            Config::INPUT_LEN * Self::REPETITION_FACTOR,
+            "Codeword length {} must equal row length {} times repetition factor {}",
+            Config::OUTPUT_LEN,
+            Config::INPUT_LEN,
+            Self::REPETITION_FACTOR
+        );
+
+        Self {
+            pntt_params: Radix8PnttParams::new(),
+            _phantom: Default::default(),
+        }
     }
 }
 

--- a/zip-plus/src/code/iprs.rs
+++ b/zip-plus/src/code/iprs.rs
@@ -3,10 +3,11 @@ mod pntt;
 use crate::{code::LinearCode, pcs::structs::ZipTypes};
 use crypto_primitives::{FromPrimitiveWithConfig, FromWithConfig};
 use num_traits::{CheckedAdd, CheckedMul};
+use pntt::radix8::params::Config as PnttConfig;
 pub use pntt::radix8::params::{
-    Config as PnttConfig, PnttConfigF65537_1_4, PnttConfigF65537_2_8, PnttConfigF65537_4_16,
-    PnttConfigF65537_16_64, PnttConfigF65537_32_64, PnttConfigF65537_32_128,
-    PnttConfigF65537_64_256, PnttInt, Radix8PnttParams,
+    PnttConfigF65537_1_4, PnttConfigF65537_2_8, PnttConfigF65537_4_16, PnttConfigF65537_16_64,
+    PnttConfigF65537_32_64, PnttConfigF65537_32_128, PnttConfigF65537_64_256, PnttInt,
+    Radix8PnttParams,
 };
 use std::{
     fmt::Debug,
@@ -14,7 +15,7 @@ use std::{
     marker::PhantomData,
     ops::{Add, AddAssign},
 };
-use zinc_utils::{from_ref::FromRef, mul_by_scalar::MulByScalar};
+use zinc_utils::{from_ref::FromRef, mul, mul_by_scalar::MulByScalar};
 
 /// Pseudo Reed-Solomon encoder over the integers. Internally uses a
 /// radix-8 NTT-style recursion with a base Vandermonde matrix sized
@@ -31,9 +32,6 @@ impl<Zt, Config, const CHECK: bool> IprsCode<Zt, Config, CHECK>
 where
     Zt: ZipTypes,
     Config: PnttConfig,
-    Zt::Eval: for<'a> MulByScalar<&'a PnttInt, Zt::Cw>,
-    Zt::CombR: for<'a> MulByScalar<&'a PnttInt>,
-    Zt::Cw: CheckedAdd + for<'a> MulByScalar<&'a PnttInt>,
 {
     /// Encode without modular reduction, purely over the integers.
     fn encode_inner<In, Out>(&self, row: &[In]) -> Vec<Out>
@@ -141,11 +139,10 @@ where
     Zt::CombR: for<'a> MulByScalar<&'a PnttInt>,
     Zt::Cw: CheckedAdd + for<'a> MulByScalar<&'a PnttInt>,
 {
-    #[allow(clippy::arithmetic_side_effects)]
     fn default() -> Self {
         assert_eq!(
             Config::OUTPUT_LEN,
-            Config::INPUT_LEN * Self::REPETITION_FACTOR,
+            mul!(Config::INPUT_LEN, Self::REPETITION_FACTOR),
             "Codeword length {} must equal row length {} times repetition factor {}",
             Config::OUTPUT_LEN,
             Config::INPUT_LEN,
@@ -171,7 +168,7 @@ where
     }
 }
 
-impl<Zt, Config, const CHECK: bool> PartialEq<Self> for IprsCode<Zt, Config, CHECK>
+impl<Zt, Config, const CHECK: bool> PartialEq for IprsCode<Zt, Config, CHECK>
 where
     Config: PnttConfig,
     Zt: ZipTypes,

--- a/zip-plus/src/code/iprs.rs
+++ b/zip-plus/src/code/iprs.rs
@@ -19,7 +19,7 @@ use zinc_utils::{from_ref::FromRef, mul_by_scalar::MulByScalar};
 /// Pseudo Reed-Solomon encoder over the integers. Internally uses a
 /// radix-8 NTT-style recursion with a base Vandermonde matrix sized
 /// `base_len x base_dim` (defaults to 64x32).
-#[derive(Debug, Clone)]
+#[derive(Clone)]
 pub struct IprsCode<Zt: ZipTypes, Config: PnttConfig, const CHECK: bool> {
     pntt_params: Radix8PnttParams<Config>,
     _phantom: PhantomData<Zt>,
@@ -160,4 +160,33 @@ where
     {
         self.encode_inner_f(row)
     }
+}
+
+impl<Zt, Config, const CHECK: bool> Debug for IprsCode<Zt, Config, CHECK>
+where
+    Zt: ZipTypes,
+    Config: PnttConfig,
+{
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("IprsCode")
+            .field("pntt_params", &self.pntt_params)
+            .finish()
+    }
+}
+
+impl<Zt, Config, const CHECK: bool> PartialEq<Self> for IprsCode<Zt, Config, CHECK>
+where
+    Config: PnttConfig,
+    Zt: ZipTypes,
+{
+    fn eq(&self, _other: &Self) -> bool {
+        true // All IPRS codes with the same config are identical.
+    }
+}
+
+impl<Zt, Config, const CHECK: bool> Eq for IprsCode<Zt, Config, CHECK>
+where
+    Zt: ZipTypes,
+    Config: PnttConfig,
+{
 }

--- a/zip-plus/src/code/iprs/pntt/radix8/octet_reversal.rs
+++ b/zip-plus/src/code/iprs/pntt/radix8/octet_reversal.rs
@@ -4,7 +4,10 @@
 /// `num_octets`.
 #[allow(clippy::arithmetic_side_effects)]
 pub(crate) fn octet_reversal(x: usize, num_octets: usize) -> usize {
-    assert_ne!(num_octets, 0, "The number of octets cannot be zero");
+    if num_octets == 0 {
+        assert_eq!(x, 0, "With zero octets, the only valid input is 0, got {x}");
+        return 0;
+    }
 
     let mut result = 0;
 
@@ -38,9 +41,14 @@ mod tests {
 
     #[test]
     fn octet_reversal_self_inverse() {
-        for num_octets in 1..8 {
+        for num_octets in 0..8 {
             check_octet_reversal_self_inverse(num_octets);
         }
+    }
+
+    #[test]
+    fn octet_reversal_zero_octets() {
+        assert_eq!(octet_reversal(0, 0), 0);
     }
 
     #[test]

--- a/zip-plus/src/code/iprs/pntt/radix8/params.rs
+++ b/zip-plus/src/code/iprs/pntt/radix8/params.rs
@@ -11,8 +11,7 @@ pub trait Config: Debug + Copy + Send + Sync {
     type Field: FftField;
     const FIELD_MODULUS: u32;
 
-    /// The number of steps where NTT is performed
-    /// recursivily.
+    /// The number of steps where NTT is performed recursivily.
     const DEPTH: usize;
     /// The number of columns of the base matrix.
     const BASE_LEN: usize;

--- a/zip-plus/src/code/iprs/pntt/radix8/params.rs
+++ b/zip-plus/src/code/iprs/pntt/radix8/params.rs
@@ -1,11 +1,11 @@
 use ark_ff::{FftField, FpConfig};
-use std::marker::PhantomData;
+use std::{fmt::Debug, marker::PhantomData};
 
 /// The integer types of twiddles.
 pub type PnttInt = i64;
 
 /// Configuration of radix-8 pseudo NTT.
-pub trait Config: Copy + Send + Sync {
+pub trait Config: Debug + Copy + Send + Sync {
     /// The field used to generate the twiddle factors
     /// and the base matrix for this pseudo NTT.
     type Field: FftField;
@@ -181,7 +181,7 @@ macro_rules! define_configs {
     ($($(#[$outer:meta])* $name:ident(BASE_LEN=$base_len:literal, BASE_DIM=$base_dim:literal)),* $(,)?) => {
         $(
             $(#[$outer])*
-            #[derive(Clone, Copy)]
+            #[derive(Debug, Clone, Copy)]
             pub struct $name<const DEPTH: usize>;
 
             impl<const DEPTH: usize> Config for $name<DEPTH> {

--- a/zip-plus/src/code/raa.rs
+++ b/zip-plus/src/code/raa.rs
@@ -1,7 +1,7 @@
 use crate::{code::LinearCode, pcs::structs::ZipTypes, utils::shuffle_seeded};
 use crypto_primitives::PrimeField;
 use num_traits::CheckedAdd;
-use std::{marker::PhantomData, ops::AddAssign};
+use std::{fmt::Debug, marker::PhantomData, ops::AddAssign};
 use zinc_poly::ConstCoeffBitWidth;
 use zinc_utils::{add, from_ref::FromRef, mul};
 
@@ -16,7 +16,7 @@ pub trait RaaConfig: Copy + Send + Sync {
 
 /// Implementation of a repeat-accumulate-accumulate (RAA) codes over the binary
 /// field, as defined by the Blaze paper (https://eprint.iacr.org/2024/1609)
-#[derive(Debug, Clone)]
+#[derive(Clone)]
 pub struct RaaCode<Zt: ZipTypes, Config: RaaConfig, const REP: usize> {
     pub(crate) row_len: usize,
     /// Randomness seed for the first permutation
@@ -155,6 +155,26 @@ impl<Zt: ZipTypes, Config: RaaConfig, const REP: usize> LinearCode<Zt>
         self.encode_inner(row)
     }
 }
+
+impl<Zt: ZipTypes, Config: RaaConfig, const REP: usize> Debug for RaaCode<Zt, Config, REP> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("RaaCode")
+            .field("row_len", &self.row_len)
+            .field("perm_1_seed", &self.perm_1_seed)
+            .field("perm_2_seed", &self.perm_2_seed)
+            .finish()
+    }
+}
+
+impl<Zt: ZipTypes, Config: RaaConfig, const REP: usize> PartialEq for RaaCode<Zt, Config, REP> {
+    fn eq(&self, other: &Self) -> bool {
+        self.row_len == other.row_len
+            && self.perm_1_seed == other.perm_1_seed
+            && self.perm_2_seed == other.perm_2_seed
+    }
+}
+
+impl<Zt: ZipTypes, Config: RaaConfig, const REP: usize> Eq for RaaCode<Zt, Config, REP> {}
 
 /// Repeat the given slice N times, e.g `[1,2,3] => [1,2,3,1,2,3]`
 #[allow(clippy::arithmetic_side_effects)]

--- a/zip-plus/src/code/raa.rs
+++ b/zip-plus/src/code/raa.rs
@@ -77,35 +77,30 @@ impl<Zt: ZipTypes, Config: RaaConfig, const REP: usize> LinearCode<Zt>
 {
     const REPETITION_FACTOR: usize = REP;
 
-    fn new(poly_size: usize) -> Self {
+    fn new(row_len: usize) -> Self {
         assert!(
             REP.is_power_of_two(),
             "Repetition factor must be a power of two"
         );
-
-        // Taken from original Zip codes
-        let num_vars = poly_size.ilog2();
-        let two_pow_num_vars = 1_usize
-            .checked_shl(num_vars)
-            .expect("2 ** num_vars overflows");
-        let row_len: usize = two_pow_num_vars
-            .isqrt()
-            .checked_next_power_of_two()
-            .expect("row_len overflow");
+        assert!(
+            row_len.is_power_of_two(),
+            "Row length must be a power of two"
+        );
 
         // Width of each entry in codeword vector, in bits.
-        // For RAA it's initial_bits + 2*log(repetition_factor) + num_variables
+        // For RAA it's initial_bits + 2*log2(codeword_len),
+        // where codeword_len = row_len * REP and the factor of 2
+        // comes from the two accumulation steps.
         let codeword_width_bits = {
             let initial_bits =
                 u32::try_from(Zt::Eval::COEFF_BIT_WIDTH).expect("Size of EvalR type is too large");
 
+            let row_len_log = row_len.ilog2();
             let rep_factor_log = REP.ilog2();
-            let num_vars_even = if num_vars.is_multiple_of(2) {
-                num_vars
-            } else {
-                add!(num_vars, 1)
-            };
-            add!(initial_bits, add!(num_vars_even, mul!(rep_factor_log, 2)))
+            add!(
+                initial_bits,
+                add!(mul!(row_len_log, 2), mul!(rep_factor_log, 2))
+            )
         };
         let codeword_type_bits =
             u32::try_from(Zt::Cw::COEFF_BIT_WIDTH).expect("Size of CwR type is too large");
@@ -253,16 +248,16 @@ mod tests {
     }
 
     macro_rules! test_raa {
-        ($zt:ty, $poly_size:expr, $f:expr) => {
-            test_raa!($zt, $poly_size, $f, RaaConfigGeneric<false, false>);
-            test_raa!($zt, $poly_size, $f, RaaConfigGeneric<false, true>);
-            test_raa!($zt, $poly_size, $f, RaaConfigGeneric<true, false>);
-            test_raa!($zt, $poly_size, $f, RaaConfigGeneric<true, true>);
+        ($zt:ty, $row_len:expr, $f:expr) => {
+            test_raa!($zt, $row_len, $f, RaaConfigGeneric<false, false>);
+            test_raa!($zt, $row_len, $f, RaaConfigGeneric<false, true>);
+            test_raa!($zt, $row_len, $f, RaaConfigGeneric<true, false>);
+            test_raa!($zt, $row_len, $f, RaaConfigGeneric<true, true>);
         };
 
-        ($zt:ty, $poly_size:expr, $f:expr, $config:ty) => {
+        ($zt:ty, $row_len:expr, $f:expr, $config:ty) => {
             {
-                let code = RaaCode::<$zt, $config, REPETITION_FACTOR>::new($poly_size);
+                let code = RaaCode::<$zt, $config, REPETITION_FACTOR>::new($row_len);
                 $f(&code)
             }
         };
@@ -355,7 +350,7 @@ mod tests {
     #[test]
     #[allow(clippy::arithmetic_side_effects)] // False alert
     fn encoding_preserves_linearity() {
-        test_raa!(TestZipTypes<N, K, M>, 16, |code: &RaaCode<_, _, _>| {
+        test_raa!(TestZipTypes<N, K, M>, 4, |code: &RaaCode<_, _, _>| {
             let a: Vec<Int<N>> = (1..=4).map(Int::<N>::from).collect();
             let b: Vec<Int<N>> = (5..=8).map(Int::<N>::from).collect();
             let sum_ab: Vec<Int<N>> = a.iter().zip(b.iter()).map(|(x, y)| *x + y).collect();
@@ -380,7 +375,7 @@ mod tests {
     fn encoding_produces_predictable_results() {
         let a: Vec<Int<N>> = (1..=4).map(Int::<N>::from).collect();
 
-        test_raa!(TestZipTypes<N, K, M>, 16, |code: &RaaCode<_, _, _>| {
+        test_raa!(TestZipTypes<N, K, M>, 4, |code: &RaaCode<_, _, _>| {
             let encode_a: Vec<Int<K>> = code.encode(&a);
             assert_eq!(
                 encode_a,
@@ -395,7 +390,7 @@ mod tests {
 
     #[test]
     fn encoding_zero_vector_results_in_zero_codeword() {
-        test_raa!(TestZipTypes<N, K, M>, 16, |code: &RaaCode<_, _, _>| {
+        test_raa!(TestZipTypes<N, K, M>, 4, |code: &RaaCode<_, _, _>| {
             let zero_vector: Vec<_> = vec![Int::<N>::zero(); code.row_len()];
             let encoded_vector: Vec<Int<K>> = code.encode(&zero_vector);
 
@@ -411,13 +406,13 @@ mod tests {
     #[test]
     fn in_place_permutation_should_not_affect_order() {
         let data: Vec<Int<N>> = (1..=1024).map(Int::<N>::from).collect();
-        let poly_size = data.len() * data.len();
+        let row_len = data.len();
         let codeword_1: Vec<Int<K>> = {
             let code_in_place = RaaCode::<
                 TestZipTypes<N, K, M>,
                 RaaConfigGeneric<true, true>,
                 REPETITION_FACTOR,
-            >::new(poly_size);
+            >::new(row_len);
             code_in_place.encode(&data)
         };
 
@@ -426,7 +421,7 @@ mod tests {
                 TestZipTypes<N, K, M>,
                 RaaConfigGeneric<false, true>,
                 REPETITION_FACTOR,
-            >::new(poly_size);
+            >::new(row_len);
             code_cloning.encode(&data)
         };
         assert_eq!(
@@ -445,14 +440,14 @@ mod tests {
             TestZipTypes<N, K, N>,
             RaaConfigGeneric<false, true>,
             REPETITION_FACTOR,
-        >::new(1 << 30);
+        >::new(1 << 15);
     }
 
     #[test]
     #[should_panic(expected = "Row length must match the code's row length")]
     #[cfg(debug_assertions)]
     fn encode_panics_on_mismatched_row_length() {
-        test_raa!(TestZipTypes<N, K, M>, 16, |code: &RaaCode<_, _, _>| {
+        test_raa!(TestZipTypes<N, K, M>, 4, |code: &RaaCode<_, _, _>| {
             let incorrect_row = vec![Int::<N>::from(1), Int::<N>::from(2), Int::<N>::from(3)];
             let _: Vec<Int<K>> = code.encode(&incorrect_row);
         });

--- a/zip-plus/src/code/raa.rs
+++ b/zip-plus/src/code/raa.rs
@@ -35,49 +35,7 @@ pub struct RaaCode<Zt: ZipTypes, Config: RaaConfig, const REP: usize> {
 }
 
 impl<Zt: ZipTypes, Config: RaaConfig, const REP: usize> RaaCode<Zt, Config, REP> {
-    /// Do the actual encoding, as per RAA spec
-    fn encode_inner<In, Out>(&self, row: &[In]) -> Vec<Out>
-    where
-        Out: CheckedAdd + for<'a> AddAssign<&'a Out> + FromRef<In> + Clone,
-    {
-        debug_assert_eq!(
-            row.len(),
-            self.row_len,
-            "Row length must match the code's row length"
-        );
-
-        let mut result: Vec<Out> = repeat(row, REP);
-        if Config::PERMUTE_IN_PLACE {
-            shuffle_seeded(&mut result, self.perm_1_seed);
-        } else {
-            result = clone_shuffled(&result, &self.perm_1);
-        }
-        if Config::CHECK_FOR_OVERFLOWS {
-            accumulate(&mut result);
-        } else {
-            accumulate_unchecked(&mut result);
-        }
-        if Config::PERMUTE_IN_PLACE {
-            shuffle_seeded(&mut result, self.perm_2_seed);
-        } else {
-            result = clone_shuffled(&result, &self.perm_2);
-        }
-        if Config::CHECK_FOR_OVERFLOWS {
-            accumulate(&mut result);
-        } else {
-            accumulate_unchecked(&mut result);
-        }
-        debug_assert_eq!(result.len(), self.codeword_len());
-        result
-    }
-}
-
-impl<Zt: ZipTypes, Config: RaaConfig, const REP: usize> LinearCode<Zt>
-    for RaaCode<Zt, Config, REP>
-{
-    const REPETITION_FACTOR: usize = REP;
-
-    fn new(row_len: usize) -> Self {
+    pub fn new(row_len: usize) -> Self {
         assert!(
             REP.is_power_of_two(),
             "Repetition factor must be a power of two"
@@ -130,6 +88,48 @@ impl<Zt: ZipTypes, Config: RaaConfig, const REP: usize> LinearCode<Zt>
             phantom: PhantomData,
         }
     }
+
+    /// Do the actual encoding, as per RAA spec
+    fn encode_inner<In, Out>(&self, row: &[In]) -> Vec<Out>
+    where
+        Out: CheckedAdd + for<'a> AddAssign<&'a Out> + FromRef<In> + Clone,
+    {
+        debug_assert_eq!(
+            row.len(),
+            self.row_len,
+            "Row length must match the code's row length"
+        );
+
+        let mut result: Vec<Out> = repeat(row, REP);
+        if Config::PERMUTE_IN_PLACE {
+            shuffle_seeded(&mut result, self.perm_1_seed);
+        } else {
+            result = clone_shuffled(&result, &self.perm_1);
+        }
+        if Config::CHECK_FOR_OVERFLOWS {
+            accumulate(&mut result);
+        } else {
+            accumulate_unchecked(&mut result);
+        }
+        if Config::PERMUTE_IN_PLACE {
+            shuffle_seeded(&mut result, self.perm_2_seed);
+        } else {
+            result = clone_shuffled(&result, &self.perm_2);
+        }
+        if Config::CHECK_FOR_OVERFLOWS {
+            accumulate(&mut result);
+        } else {
+            accumulate_unchecked(&mut result);
+        }
+        debug_assert_eq!(result.len(), self.codeword_len());
+        result
+    }
+}
+
+impl<Zt: ZipTypes, Config: RaaConfig, const REP: usize> LinearCode<Zt>
+    for RaaCode<Zt, Config, REP>
+{
+    const REPETITION_FACTOR: usize = REP;
 
     fn row_len(&self) -> usize {
         self.row_len

--- a/zip-plus/src/code/raa_sign_flip.rs
+++ b/zip-plus/src/code/raa_sign_flip.rs
@@ -2,17 +2,17 @@ use super::raa::*;
 use crate::{code::LinearCode, pcs::structs::ZipTypes, utils::shuffle_seeded};
 use crypto_primitives::{PrimeField, Ring};
 use num_traits::{CheckedAdd, CheckedNeg};
-use std::ops::{AddAssign, Neg};
+use std::{
+    fmt::Debug,
+    ops::{AddAssign, Neg},
+};
 use zinc_utils::{from_ref::FromRef, neg};
 
 /// Implementation of a repeat-accumulate-accumulate (RAA) codes.
 /// Flips signs of every second entry in the codeword, starting from the second
 /// one.
-#[derive(Debug, Clone)]
-pub struct RaaSignFlippingCode<Zt: ZipTypes, Config: RaaConfig, const REP: usize>
-where
-    Zt::Cw: Ring,
-{
+#[derive(Clone)]
+pub struct RaaSignFlippingCode<Zt: ZipTypes, Config: RaaConfig, const REP: usize> {
     raa: RaaCode<Zt, Config, REP>,
 }
 
@@ -100,6 +100,31 @@ where
     {
         self.encode_inner(row)
     }
+}
+
+impl<Zt: ZipTypes, Config: RaaConfig, const REP: usize> Debug
+    for RaaSignFlippingCode<Zt, Config, REP>
+{
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("SignFlipping")
+            .field("row_len", &self.raa.row_len)
+            .field("perm_1_seed", &self.raa.perm_1_seed)
+            .field("perm_2_seed", &self.raa.perm_2_seed)
+            .finish()
+    }
+}
+
+impl<Zt: ZipTypes, Config: RaaConfig, const REP: usize> PartialEq
+    for RaaSignFlippingCode<Zt, Config, REP>
+{
+    fn eq(&self, other: &Self) -> bool {
+        self.raa == other.raa
+    }
+}
+
+impl<Zt: ZipTypes, Config: RaaConfig, const REP: usize> Eq
+    for RaaSignFlippingCode<Zt, Config, REP>
+{
 }
 
 /// Flip every other entry in the codeword, starting from the second one.

--- a/zip-plus/src/code/raa_sign_flip.rs
+++ b/zip-plus/src/code/raa_sign_flip.rs
@@ -71,9 +71,9 @@ where
 {
     const REPETITION_FACTOR: usize = REP;
 
-    fn new(poly_size: usize) -> Self {
+    fn new(row_len: usize) -> Self {
         Self {
-            raa: RaaCode::new(poly_size),
+            raa: RaaCode::new(row_len),
         }
     }
 

--- a/zip-plus/src/code/raa_sign_flip.rs
+++ b/zip-plus/src/code/raa_sign_flip.rs
@@ -20,6 +20,12 @@ impl<Zt: ZipTypes, Config: RaaConfig, const REP: usize> RaaSignFlippingCode<Zt, 
 where
     Zt::Cw: Ring,
 {
+    pub fn new(row_len: usize) -> Self {
+        Self {
+            raa: RaaCode::new(row_len),
+        }
+    }
+
     /// Do the actual encoding, as per RAA spec
     fn encode_inner<In, Out>(&self, row: &[In]) -> Vec<Out>
     where
@@ -70,12 +76,6 @@ where
     Zt::Cw: Ring,
 {
     const REPETITION_FACTOR: usize = REP;
-
-    fn new(row_len: usize) -> Self {
-        Self {
-            raa: RaaCode::new(row_len),
-        }
-    }
 
     fn row_len(&self) -> usize {
         self.raa.row_len()

--- a/zip-plus/src/pcs/phase_commit.rs
+++ b/zip-plus/src/pcs/phase_commit.rs
@@ -68,7 +68,14 @@ impl<Zt: ZipTypes, Lc: LinearCode<Zt>> ZipPlus<Zt, Lc> {
         );
         let batch_size = polys.len();
         let row_len = pp.linear_code.row_len();
-        validate_input::<Zt, Lc, bool>("commit", pp.num_vars, batch_size, polys, &[])?;
+        validate_input::<Zt, Lc, bool>(
+            "commit",
+            pp.num_vars,
+            pp.linear_code.row_len(),
+            batch_size,
+            polys,
+            &[],
+        )?;
 
         let expected_num_evals = pp.num_rows * row_len;
         let cw_matrices: Vec<DenseRowMatrix<Zt::Cw>> = cfg_iter!(polys).map(|poly| {
@@ -113,7 +120,14 @@ impl<Zt: ZipTypes, Lc: LinearCode<Zt>> ZipPlus<Zt, Lc> {
         pp: &ZipPlusParams<Zt, Lc>,
         poly: &DenseMultilinearExtension<Zt::Eval>,
     ) -> Result<DenseRowMatrix<Zt::Cw>, ZipError> {
-        validate_input::<Zt, Lc, bool>("commit", pp.num_vars, 1, from_ref(poly), &[])?;
+        validate_input::<Zt, Lc, bool>(
+            "commit",
+            pp.num_vars,
+            pp.linear_code.row_len(),
+            1,
+            from_ref(poly),
+            &[],
+        )?;
 
         let row_len = pp.linear_code.row_len();
 
@@ -251,7 +265,7 @@ mod tests {
 
     #[test]
     fn commit_succeeds_for_small_polynomial() {
-        let code = C::new(16);
+        let code = C::new(4);
         let pp = ZipPlusParams::new(4, 4, code);
 
         let evaluations = vec![Int::from(42); 16];
@@ -263,7 +277,7 @@ mod tests {
 
     #[test]
     fn commit_succeeds_for_two_variables() {
-        let code = C::new(4);
+        let code = C::new(2);
         let pp = ZipPlusParams::new(2, 2, code);
 
         let evaluations = vec![Int::from(1), Int::from(2), Int::from(3), Int::from(4)];
@@ -420,8 +434,9 @@ mod tests {
         let results: Vec<Vec<Vec<Int<4>>>> = (0..10)
             .into_par_iter()
             .map(|_| {
-                let code = C::new(poly_size);
-                let pp = ZipPlusParams::new(num_vars, 8, code);
+                let row_len = 1usize << (num_vars / 2);
+                let code = C::new(row_len);
+                let pp = ZipPlusParams::new(num_vars, poly_size / row_len, code);
 
                 let rows = TestZip::encode_rows(&pp, pp.linear_code.row_len(), &poly.evaluations);
                 let rows: Vec<Vec<_>> = rows
@@ -705,8 +720,9 @@ mod tests {
 
         let mut rng = rng();
         let num_vars = 4;
-        let poly_size = 1 << num_vars;
-        let linear_code = C::new(poly_size);
+        let poly_size: usize = 1 << num_vars;
+        let row_len = poly_size.isqrt().next_power_of_two();
+        let linear_code = C::new(row_len);
         let param = TestZip::setup(poly_size, linear_code);
         let evaluations: Vec<_> = (0..poly_size)
             .map(|_| <Zt as ZipTypes>::Eval::from(rng.random::<i8>()))

--- a/zip-plus/src/pcs/phase_commit.rs
+++ b/zip-plus/src/pcs/phase_commit.rs
@@ -185,7 +185,7 @@ impl<Zt: ZipTypes, Lc: LinearCode<Zt>> ZipPlus<Zt, Lc> {
 )]
 mod tests {
     use crate::{
-        code::{LinearCode, raa::RaaCode, raa_sign_flip::RaaSignFlippingCode},
+        code::{LinearCode, iprs::IprsCode},
         merkle::{MerkleTree, MtHash},
         pcs::{
             structs::{ZipPlus, ZipPlusParams, ZipTypes},
@@ -201,6 +201,7 @@ mod tests {
     use itertools::Itertools;
     use num_traits::Zero;
     use rand::{Rng, rng};
+    use std::sync::LazyLock;
     use zinc_poly::{mle::DenseMultilinearExtension, univariate::binary::BinaryPoly};
     use zinc_utils::CHECKED;
 
@@ -212,20 +213,24 @@ mod tests {
     const DEGREE_PLUS_ONE: usize = 3;
 
     type Zt = TestZipTypes<N, K, M>;
-    type C = RaaSignFlippingCode<Zt, TestRaaConfig, 4>;
+    type C = IprsCode<Zt, TestIprsConfig, CHECKED>;
+    static C: LazyLock<C> = LazyLock::new(C::create);
 
     type PolyZt = TestBinPolyZipTypes<K, M, DEGREE_PLUS_ONE>;
-    type PolyC = RaaCode<PolyZt, TestRaaConfig, 4>;
+    type PolyC = IprsCode<PolyZt, TestIprsConfig, CHECKED>;
+    static POLY_C: LazyLock<PolyC> = LazyLock::new(PolyC::create);
 
     type TestZip = ZipPlus<Zt, C>;
     type TestPolyZip = ZipPlus<PolyZt, PolyC>;
 
     #[test]
     fn commit_rejects_too_many_variables() {
-        let (pp, _) = setup_test_params(3); // Setup for 3 variables
+        let num_vars = 10;
+        let (pp, _) = setup_test_params(num_vars);
 
-        // Create polynomial with 4 variables (which is > 3)
-        let poly: DenseMultilinearExtension<_> = (1..=16).map(Int::from).collect();
+        // Create MLE with a larger number of variables
+        let poly: DenseMultilinearExtension<_> =
+            (1..=(1 << (num_vars + 1))).map(Int::from).collect();
 
         let result = TestZip::commit_single(&pp, &poly);
         assert!(result.is_err());
@@ -233,7 +238,8 @@ mod tests {
 
     #[test]
     fn commit_is_deterministic() {
-        let (pp, poly) = setup_test_params(3);
+        let num_vars = 10;
+        let (pp, poly) = setup_test_params(num_vars);
 
         let result1 = TestZip::commit_single(&pp, &poly).unwrap();
         let result2 = TestZip::commit_single(&pp, &poly).unwrap();
@@ -243,12 +249,20 @@ mod tests {
 
     #[test]
     fn different_polynomials_produce_different_commitments() {
-        let (pp, _) = setup_test_params(3);
+        let num_vars = 10;
+        let (pp, _) = setup_test_params(num_vars);
+        let poly_size = 1 << num_vars;
 
-        let poly1 =
-            DenseMultilinearExtension::from_evaluations_vec(3, vec![Int::from(1); 8], Zero::zero());
-        let poly2 =
-            DenseMultilinearExtension::from_evaluations_vec(3, vec![Int::from(2); 8], Zero::zero());
+        let poly1 = DenseMultilinearExtension::from_evaluations_vec(
+            num_vars,
+            vec![Int::from(1); poly_size],
+            Zero::zero(),
+        );
+        let poly2 = DenseMultilinearExtension::from_evaluations_vec(
+            num_vars,
+            vec![Int::from(2); poly_size],
+            Zero::zero(),
+        );
 
         let (_, commitment1) = TestZip::commit_single(&pp, &poly1).unwrap();
         let (_, commitment2) = TestZip::commit_single(&pp, &poly2).unwrap();
@@ -258,11 +272,16 @@ mod tests {
 
     #[test]
     fn commit_succeeds_for_small_polynomial() {
-        let code = C::new(4);
-        let pp = ZipPlusParams::new(4, 4, code);
+        let num_vars = 4;
+        let num_rows = (1usize << num_vars).div_ceil(C.row_len());
+        let pp = ZipPlusParams::new(num_vars, num_rows, C.clone());
 
-        let evaluations = vec![Int::from(42); 16];
-        let poly = DenseMultilinearExtension::from_evaluations_vec(4, evaluations, Zero::zero());
+        let evaluations = vec![Int::from(42); 1 << num_vars];
+        let mut poly =
+            DenseMultilinearExtension::from_evaluations_vec(num_vars, evaluations, Zero::zero());
+        // Zero-pad MLE to match the expected number of evaluations
+        poly.evaluations
+            .resize(pp.num_rows * pp.linear_code.row_len(), Zero::zero());
 
         let result = TestZip::commit_single(&pp, &poly);
         assert!(result.is_ok());
@@ -270,11 +289,17 @@ mod tests {
 
     #[test]
     fn commit_succeeds_for_two_variables() {
-        let code = C::new(2);
-        let pp = ZipPlusParams::new(2, 2, code);
+        let num_vars = 2;
+        let num_rows = (1usize << num_vars).div_ceil(C.row_len());
+        let pp = ZipPlusParams::new(num_vars, num_rows, C.clone());
 
-        let evaluations = vec![Int::from(1), Int::from(2), Int::from(3), Int::from(4)];
-        let poly = DenseMultilinearExtension::from_evaluations_vec(2, evaluations, Zero::zero());
+        let poly_size = 1 << num_vars;
+        let evaluations: Vec<_> = (1..=poly_size).map(Int::from).collect();
+        let mut poly =
+            DenseMultilinearExtension::from_evaluations_vec(num_vars, evaluations, Zero::zero());
+        // Zero-pad MLE to match the expected number of evaluations
+        poly.evaluations
+            .resize(pp.num_rows * pp.linear_code.row_len(), Zero::zero());
 
         let result = TestZip::commit_single(&pp, &poly);
         assert!(result.is_ok());
@@ -282,11 +307,13 @@ mod tests {
 
     #[test]
     fn batch_commit_produces_different_root_than_individual_commits() {
-        let num_vars = 4;
+        let num_vars = 10;
         let (pp, _) = setup_test_params(num_vars);
+        let poly_size = 1 << num_vars;
 
-        let poly1: DenseMultilinearExtension<_> = (1..=16).map(Int::from).collect();
-        let poly2: DenseMultilinearExtension<_> = (17..=32).map(Int::from).collect();
+        let poly1: DenseMultilinearExtension<_> = (1..=poly_size).map(Int::from).collect();
+        let poly2: DenseMultilinearExtension<_> =
+            (poly_size + 1..=2 * poly_size).map(Int::from).collect();
 
         let (_, batched_comm) = TestZip::commit(&pp, &[poly1.clone(), poly2.clone()]).unwrap();
         let (_, comm1) = TestZip::commit_single(&pp, &poly1).unwrap();
@@ -298,11 +325,13 @@ mod tests {
 
     #[test]
     fn batch_commit_is_deterministic() {
-        let num_vars = 4;
+        let num_vars = 10;
         let (pp, _) = setup_test_params(num_vars);
+        let poly_size = 1 << num_vars;
 
-        let poly1: DenseMultilinearExtension<_> = (1..=16).map(Int::from).collect();
-        let poly2: DenseMultilinearExtension<_> = (17..=32).map(Int::from).collect();
+        let poly1: DenseMultilinearExtension<_> = (1..=poly_size).map(Int::from).collect();
+        let poly2: DenseMultilinearExtension<_> =
+            (poly_size + 1..=2 * poly_size).map(Int::from).collect();
 
         let (_, comm_a) = TestZip::commit(&pp, &[poly1.clone(), poly2.clone()]).unwrap();
         let (_, comm_b) = TestZip::commit(&pp, &[poly1, poly2]).unwrap();
@@ -312,13 +341,14 @@ mod tests {
 
     #[test]
     fn batch_commit_batch_size_is_correct() {
-        let num_vars = 4;
+        let num_vars = 10;
         let (pp, _) = setup_test_params(num_vars);
+        let poly_size = 1 << num_vars;
 
         let polys: Vec<DenseMultilinearExtension<_>> = (0..5)
             .map(|offset| {
-                let start = offset * 16 + 1;
-                (start..start + 16).map(Int::from).collect()
+                let start = offset * poly_size + 1;
+                (start..start + poly_size).map(Int::from).collect()
             })
             .collect();
 
@@ -329,7 +359,8 @@ mod tests {
 
     #[test]
     fn encode_rows_produces_correct_size() {
-        let (pp, poly) = setup_test_params(3);
+        let num_vars = 10;
+        let (pp, poly) = setup_test_params(num_vars);
         let encoded = TestZip::encode_rows(&pp, &poly);
 
         assert_eq!(encoded.num_rows, pp.num_rows);
@@ -340,7 +371,8 @@ mod tests {
     /// comparing it to a direct, row-by-row encoding.
     #[test]
     fn encoded_rows_match_linear_code_definition() {
-        let (pp, poly) = setup_test_params(3);
+        let num_vars = 10;
+        let (pp, poly) = setup_test_params(num_vars);
         let encoded = TestZip::encode_rows(&pp, &poly);
 
         for (i, row_chunk) in encoded.as_rows().enumerate() {
@@ -360,7 +392,8 @@ mod tests {
     /// different Merkle root.
     #[test]
     fn corrupted_encoding_changes_merkle_root() {
-        let (pp, poly) = setup_test_params(3);
+        let num_vars = 10;
+        let (pp, poly) = setup_test_params(num_vars);
         let (data, commitment) = TestZip::commit_single(&pp, &poly).unwrap();
 
         assert!(!data.cw_matrices[0].is_empty());
@@ -377,7 +410,8 @@ mod tests {
 
     #[test]
     fn batch_commit_single_poly_matches_single_commit() {
-        let (pp, poly) = setup_test_params(3);
+        let num_vars = 10;
+        let (pp, poly) = setup_test_params(num_vars);
 
         let polys = std::slice::from_ref(&poly);
         let (batched_hint, batched_comm) = TestZip::commit(&pp, polys).unwrap();
@@ -390,23 +424,21 @@ mod tests {
 
     #[test]
     fn encoded_rows_are_nonzero_for_nonzero_input() {
-        let (pp, poly) = setup_test_params(3);
+        let num_vars = 10;
+        let (pp, poly) = setup_test_params(num_vars);
         let encoded = TestZip::encode_rows(&pp, &poly.evaluations);
 
         assert_eq!(encoded.num_rows, pp.num_rows);
         assert_eq!(encoded.num_cols, pp.linear_code.codeword_len());
 
-        let non_zero_count = encoded
-            .as_rows()
-            .flatten()
-            .filter(|&&x| x != Int::from(0))
-            .count();
+        let non_zero_count = encoded.as_rows().flatten().filter(|x| !x.is_zero()).count();
         assert!(non_zero_count > 0);
     }
 
     #[test]
     fn commit_produces_correct_merkle_tree_count() {
-        let (pp, poly) = setup_test_params(3);
+        let num_vars = 10;
+        let (pp, poly) = setup_test_params(num_vars);
         let (hint, _) = TestZip::commit_single(&pp, &poly).unwrap();
 
         assert_eq!(hint.cw_matrices[0].num_rows, pp.num_rows);
@@ -418,7 +450,7 @@ mod tests {
     fn encoding_is_consistent_across_threads() {
         use rayon::prelude::*;
 
-        let num_vars = 6;
+        let num_vars = 10;
         let poly_size = 1 << num_vars;
         let evaluations = (1..=poly_size).map(|v| Int::from(v as i32)).collect();
         let poly =
@@ -428,8 +460,7 @@ mod tests {
             .into_par_iter()
             .map(|_| {
                 let row_len = 1usize << (num_vars / 2);
-                let code = C::new(row_len);
-                let pp = ZipPlusParams::new(num_vars, poly_size / row_len, code);
+                let pp = ZipPlusParams::new(num_vars, poly_size / row_len, C.clone());
 
                 let rows = TestZip::encode_rows(&pp, &poly.evaluations);
                 let rows: Vec<Vec<_>> = rows
@@ -449,20 +480,28 @@ mod tests {
 
     #[test]
     fn commit_succeeds_for_zero_polynomial() {
-        let (pp, _) = setup_test_params(3);
-        let zero_poly =
-            DenseMultilinearExtension::from_evaluations_vec(3, vec![Int::from(0); 8], Zero::zero());
+        let num_vars = 10;
+        let (pp, _) = setup_test_params(num_vars);
+        let poly_size = 1 << num_vars;
+        let zero_poly = DenseMultilinearExtension::from_evaluations_vec(
+            num_vars,
+            vec![Zero::zero(); poly_size],
+            Zero::zero(),
+        );
         let result = TestZip::commit_single(&pp, &zero_poly);
         assert!(result.is_ok());
     }
 
     #[test]
     fn commit_succeeds_for_alternating_values() {
-        let (pp, _) = setup_test_params(3);
-        let alternating = (0..8)
+        let num_vars = 10;
+        let (pp, _) = setup_test_params(num_vars);
+        let poly_size = 1 << num_vars;
+        let alternating = (0..poly_size)
             .map(|i| Int::from(if i % 2 == 0 { 1 } else { -1 }))
             .collect();
-        let poly = DenseMultilinearExtension::from_evaluations_vec(3, alternating, Zero::zero());
+        let poly =
+            DenseMultilinearExtension::from_evaluations_vec(num_vars, alternating, Zero::zero());
         let result = TestZip::commit_single(&pp, &poly);
         assert!(result.is_ok());
     }
@@ -470,19 +509,22 @@ mod tests {
     #[test]
     #[should_panic(expected = "Batch must contain at least one polynomial")]
     fn batch_commit_on_empty_slice_panics() {
-        let (pp, _) = setup_test_params(3);
+        let num_vars = 10;
+        let (pp, _) = setup_test_params(num_vars);
         let empty_polys: Vec<DenseMultilinearExtension<Int<INT_LIMBS>>> = vec![];
         let _ = TestZip::commit(&pp, &empty_polys);
     }
 
     #[test]
     fn encode_rows_succeeds_for_single_row() {
-        let code = C::new(4);
-        let pp = ZipPlusParams::new(2, 1, code);
+        let num_vars = 10;
+        let poly_size = 1 << num_vars;
+        let pp = ZipPlusParams::new(num_vars, 1, C.clone());
 
         // Create a polynomial with 2 variables and 4 evaluations
-        let evaluations = vec![Int::from(5); 4];
-        let poly = DenseMultilinearExtension::from_evaluations_vec(2, evaluations, Zero::zero());
+        let evaluations = vec![Int::from(5); poly_size];
+        let poly =
+            DenseMultilinearExtension::from_evaluations_vec(num_vars, evaluations, Zero::zero());
         let encoded = TestZip::encode_rows(&pp, &poly.evaluations);
         assert_eq!(encoded.num_rows, 1);
         assert_eq!(encoded.num_cols, pp.linear_code.codeword_len());
@@ -490,8 +532,8 @@ mod tests {
 
     #[test]
     fn encode_rows_succeeds_for_single_poly_row() {
-        let code = PolyC::new(4);
-        let pp = ZipPlusParams::new(2, 1, code);
+        let num_vars = 10;
+        let pp = ZipPlusParams::new(num_vars, 1, POLY_C.clone());
 
         // Create a polynomial with 2 variables and 4 evaluations
         let evaluations = vec![
@@ -499,7 +541,8 @@ mod tests {
             BinaryPoly::new(vec![Boolean::FALSE, Boolean::TRUE]),
             BinaryPoly::new(vec![Boolean::TRUE, Boolean::FALSE]),
         ];
-        let poly = DenseMultilinearExtension::from_evaluations_vec(2, evaluations, Zero::zero());
+        let poly =
+            DenseMultilinearExtension::from_evaluations_vec(num_vars, evaluations, Zero::zero());
         let encoded = TestPolyZip::encode_rows(&pp, &poly.evaluations);
         assert_eq!(encoded.num_rows, 1);
         assert_eq!(encoded.num_cols, pp.linear_code.codeword_len());
@@ -507,10 +550,8 @@ mod tests {
 
     #[test]
     fn matrix_dimensions_are_invariant() {
-        let test_cases = vec![(2, 2), (4, 4), (6, 8)];
+        let test_cases = vec![(8, 1), (10, 4), (12, 16)];
         for (num_vars, expected_rows) in test_cases {
-            assert_eq!(1 << (num_vars / 2), expected_rows);
-
             let (pp, poly) = setup_test_params(num_vars);
             assert_eq!(pp.num_rows, expected_rows);
             let result = TestZip::commit_single(&pp, &poly);
@@ -521,14 +562,16 @@ mod tests {
     #[test]
     #[should_panic]
     fn reject_incompatible_dimensions() {
-        let (pp, poly) = setup_test_params(3);
-        let incompatible_pp = ZipPlusParams::new(3, 3, pp.linear_code);
-        let _ = TestZip::commit_single(&incompatible_pp, &poly);
+        let num_vars = 10;
+        let (pp, poly) = setup_test_params(num_vars);
+        let incompatible_pp = ZipPlusParams::new(8, 8, pp.linear_code);
+        TestZip::commit_single(&incompatible_pp, &poly).unwrap();
     }
 
     #[test]
     fn linear_code_preserves_linearity() {
-        let (pp, poly) = setup_test_params(4);
+        let num_vars = 10;
+        let (pp, poly) = setup_test_params(num_vars);
         let encoded = TestZip::encode_rows(&pp, &poly.evaluations);
         let row_len = pp.linear_code.row_len();
         let codeword_len = pp.linear_code.codeword_len();
@@ -552,7 +595,8 @@ mod tests {
     #[test]
     #[should_panic]
     fn commit_panics_if_evaluations_not_multiple_of_row_len() {
-        let (pp, mut poly) = setup_test_params(4);
+        let num_vars = 10;
+        let (pp, mut poly) = setup_test_params(num_vars);
         poly.evaluations.truncate(15);
         assert_eq!(poly.evaluations.len(), 15);
         let _ = TestZip::commit_single(&pp, &poly);
@@ -569,19 +613,26 @@ mod tests {
 
     #[test]
     fn commit_with_smallest_matrix_arrangement() {
-        let (pp, poly) = setup_test_params(2);
-        assert_eq!(pp.num_rows, 2);
-        assert_eq!(pp.linear_code.row_len(), 2);
+        let num_vars = 8;
+        let (pp, poly) = setup_test_params(num_vars);
+        let poly_size = 1 << num_vars;
+        assert_eq!(pp.num_rows, 1);
+        assert_eq!(pp.linear_code.row_len(), poly_size);
         let result = TestZip::commit_single(&pp, &poly);
         assert!(result.is_ok());
     }
 
     #[test]
     fn encode_rows_handles_large_integer_values() {
-        let (pp, _) = setup_test_params(3);
+        let num_vars = 10;
+        let (pp, _) = setup_test_params(num_vars);
+        let poly_size = 1 << num_vars;
         let max_val = Int::<INT_LIMBS>::from(i64::MAX);
-        let poly =
-            DenseMultilinearExtension::from_evaluations_vec(3, vec![max_val; 8], Zero::zero());
+        let poly = DenseMultilinearExtension::from_evaluations_vec(
+            num_vars,
+            vec![max_val; poly_size],
+            Zero::zero(),
+        );
         let encoded_rows = TestZip::encode_rows(&pp, &poly.evaluations);
         assert_eq!(encoded_rows.num_rows, pp.num_rows);
         assert_eq!(encoded_rows.num_cols, pp.linear_code.codeword_len());
@@ -613,7 +664,7 @@ mod tests {
 
     #[test]
     fn batch_commit_poly_succeeds() {
-        let num_vars = 4;
+        let num_vars = 8;
         let (pp, _) = setup_poly_test_params::<K, M, DEGREE_PLUS_ONE>(num_vars);
         let polys = make_poly_batch(num_vars, 3);
 
@@ -624,7 +675,7 @@ mod tests {
 
     #[test]
     fn batch_commit_poly_is_deterministic() {
-        let num_vars = 4;
+        let num_vars = 8;
         let (pp, _) = setup_poly_test_params::<K, M, DEGREE_PLUS_ONE>(num_vars);
         let polys = make_poly_batch(num_vars, 2);
 
@@ -635,11 +686,12 @@ mod tests {
 
     #[test]
     fn batch_commit_poly_single_matches_commit_single() {
-        let (pp, poly) = setup_poly_test_params::<K, M, DEGREE_PLUS_ONE>(4);
+        let num_vars = 10;
+        let (pp, poly) = setup_poly_test_params::<K, M, DEGREE_PLUS_ONE>(num_vars);
 
         let polys = std::slice::from_ref(&poly);
-        let (batched_hint, batched_comm) = TestPolyZip::commit(&pp, polys).unwrap();
         let (single_hint, single_comm) = TestPolyZip::commit_single(&pp, &poly).unwrap();
+        let (batched_hint, batched_comm) = TestPolyZip::commit(&pp, polys).unwrap();
 
         assert_eq!(batched_comm.root, single_comm.root);
         assert_eq!(batched_hint.cw_matrices.len(), 1);
@@ -648,7 +700,7 @@ mod tests {
 
     #[test]
     fn batch_commit_poly_different_polys_produce_different_roots() {
-        let num_vars = 4;
+        let num_vars = 10;
         let (pp, _) = setup_poly_test_params::<K, M, DEGREE_PLUS_ONE>(num_vars);
         let polys = make_poly_batch(num_vars, 2);
 
@@ -662,11 +714,12 @@ mod tests {
 
     #[test]
     fn batch_commit_cw_matrices_are_distinct_per_poly() {
-        let num_vars = 4;
+        let num_vars = 10;
         let (pp, _) = setup_test_params(num_vars);
+        let poly_size = 1 << num_vars;
         let polys: Vec<DenseMultilinearExtension<_>> = vec![
-            (1..=16).map(Int::from).collect(),
-            (17..=32).map(Int::from).collect(),
+            (1..=poly_size).map(Int::from).collect(),
+            (poly_size + 1..=poly_size * 2).map(Int::from).collect(),
         ];
 
         let (hint, _) = TestZip::commit(&pp, &polys).unwrap();
@@ -712,11 +765,9 @@ mod tests {
         type F = BoxedMontyField;
 
         let mut rng = rng();
-        let num_vars = 4;
+        let num_vars = 10;
         let poly_size: usize = 1 << num_vars;
-        let row_len = poly_size.isqrt().next_power_of_two();
-        let linear_code = C::new(row_len);
-        let param = TestZip::setup(poly_size, linear_code);
+        let param = TestZip::setup(poly_size, C.clone());
         let evaluations: Vec<_> = (0..poly_size)
             .map(|_| <Zt as ZipTypes>::Eval::from(rng.random::<i8>()))
             .collect();

--- a/zip-plus/src/pcs/phase_commit.rs
+++ b/zip-plus/src/pcs/phase_commit.rs
@@ -214,11 +214,11 @@ mod tests {
 
     type Zt = TestZipTypes<N, K, M>;
     type C = IprsCode<Zt, TestIprsConfig, CHECKED>;
-    static C: LazyLock<C> = LazyLock::new(C::create);
+    static C: LazyLock<C> = LazyLock::new(C::default);
 
     type PolyZt = TestBinPolyZipTypes<K, M, DEGREE_PLUS_ONE>;
     type PolyC = IprsCode<PolyZt, TestIprsConfig, CHECKED>;
-    static POLY_C: LazyLock<PolyC> = LazyLock::new(PolyC::create);
+    static POLY_C: LazyLock<PolyC> = LazyLock::new(PolyC::default);
 
     type TestZip = ZipPlus<Zt, C>;
     type TestPolyZip = ZipPlus<PolyZt, PolyC>;

--- a/zip-plus/src/pcs/phase_commit.rs
+++ b/zip-plus/src/pcs/phase_commit.rs
@@ -273,7 +273,7 @@ mod tests {
     #[test]
     fn commit_succeeds_for_small_polynomial() {
         let num_vars = 4;
-        let num_rows = (1usize << num_vars).div_ceil(C.row_len());
+        let num_rows = (1_usize << num_vars).div_ceil(C.row_len());
         let pp = ZipPlusParams::new(num_vars, num_rows, C.clone());
 
         let evaluations = vec![Int::from(42); 1 << num_vars];
@@ -290,7 +290,7 @@ mod tests {
     #[test]
     fn commit_succeeds_for_two_variables() {
         let num_vars = 2;
-        let num_rows = (1usize << num_vars).div_ceil(C.row_len());
+        let num_rows = (1_usize << num_vars).div_ceil(C.row_len());
         let pp = ZipPlusParams::new(num_vars, num_rows, C.clone());
 
         let poly_size = 1 << num_vars;
@@ -459,7 +459,7 @@ mod tests {
         let results: Vec<Vec<Vec<Int<4>>>> = (0..10)
             .into_par_iter()
             .map(|_| {
-                let row_len = 1usize << (num_vars / 2);
+                let row_len = 1 << (num_vars / 2);
                 let pp = ZipPlusParams::new(num_vars, poly_size / row_len, C.clone());
 
                 let rows = TestZip::encode_rows(&pp, &poly.evaluations);

--- a/zip-plus/src/pcs/phase_commit.rs
+++ b/zip-plus/src/pcs/phase_commit.rs
@@ -87,7 +87,7 @@ impl<Zt: ZipTypes, Lc: LinearCode<Zt>> ZipPlus<Zt, Lc> {
                 expected_num_evals
             );
 
-            Self::encode_rows(pp, row_len, poly)
+            Self::encode_rows(pp, poly)
         }).collect();
 
         let all_rows: Vec<&[Zt::Cw]> = cw_matrices.iter().flat_map(|m| m.as_rows()).collect();
@@ -129,10 +129,7 @@ impl<Zt: ZipTypes, Lc: LinearCode<Zt>> ZipPlus<Zt, Lc> {
             &[],
         )?;
 
-        let row_len = pp.linear_code.row_len();
-
-        let rows = Self::encode_rows(pp, row_len, poly);
-        Ok(rows)
+        Ok(Self::encode_rows(pp, poly))
     }
 
     pub fn commit_single(
@@ -154,17 +151,13 @@ impl<Zt: ZipTypes, Lc: LinearCode<Zt>> ZipPlus<Zt, Lc> {
     /// - `pp`: Public parameters containing matrix dimensions and the linear
     ///   code.
     /// - `codeword_len`: The length of an encoded row.
-    /// - `row_len`: The length of a row before encoding.
     /// - `poly`: The polynomial whose evaluations are to be encoded.
     ///
     /// # Returns
     /// A `Vec<Int<K>>` containing all the encoded rows concatenated together.
     #[allow(clippy::arithmetic_side_effects)]
-    pub fn encode_rows(
-        pp: &ZipPlusParams<Zt, Lc>,
-        row_len: usize,
-        evals: &[Zt::Eval],
-    ) -> DenseRowMatrix<Zt::Cw> {
+    pub fn encode_rows(pp: &ZipPlusParams<Zt, Lc>, evals: &[Zt::Eval]) -> DenseRowMatrix<Zt::Cw> {
+        let row_len = pp.linear_code.row_len();
         let codeword_len = pp.linear_code.codeword_len();
 
         // Performance: Using DenseRowMatrix's linearized row in an uninit form
@@ -337,7 +330,7 @@ mod tests {
     #[test]
     fn encode_rows_produces_correct_size() {
         let (pp, poly) = setup_test_params(3);
-        let encoded = TestZip::encode_rows(&pp, pp.linear_code.row_len(), &poly);
+        let encoded = TestZip::encode_rows(&pp, &poly);
 
         assert_eq!(encoded.num_rows, pp.num_rows);
         assert_eq!(encoded.num_cols, pp.linear_code.codeword_len());
@@ -348,7 +341,7 @@ mod tests {
     #[test]
     fn encoded_rows_match_linear_code_definition() {
         let (pp, poly) = setup_test_params(3);
-        let encoded = TestZip::encode_rows(&pp, pp.linear_code.row_len(), &poly);
+        let encoded = TestZip::encode_rows(&pp, &poly);
 
         for (i, row_chunk) in encoded.as_rows().enumerate() {
             let start = i * pp.linear_code.row_len();
@@ -398,7 +391,7 @@ mod tests {
     #[test]
     fn encoded_rows_are_nonzero_for_nonzero_input() {
         let (pp, poly) = setup_test_params(3);
-        let encoded = TestZip::encode_rows(&pp, pp.linear_code.row_len(), &poly.evaluations);
+        let encoded = TestZip::encode_rows(&pp, &poly.evaluations);
 
         assert_eq!(encoded.num_rows, pp.num_rows);
         assert_eq!(encoded.num_cols, pp.linear_code.codeword_len());
@@ -438,7 +431,7 @@ mod tests {
                 let code = C::new(row_len);
                 let pp = ZipPlusParams::new(num_vars, poly_size / row_len, code);
 
-                let rows = TestZip::encode_rows(&pp, pp.linear_code.row_len(), &poly.evaluations);
+                let rows = TestZip::encode_rows(&pp, &poly.evaluations);
                 let rows: Vec<Vec<_>> = rows
                     .data
                     .chunks_exact(pp.linear_code.codeword_len())
@@ -490,7 +483,7 @@ mod tests {
         // Create a polynomial with 2 variables and 4 evaluations
         let evaluations = vec![Int::from(5); 4];
         let poly = DenseMultilinearExtension::from_evaluations_vec(2, evaluations, Zero::zero());
-        let encoded = TestZip::encode_rows(&pp, pp.linear_code.row_len(), &poly.evaluations);
+        let encoded = TestZip::encode_rows(&pp, &poly.evaluations);
         assert_eq!(encoded.num_rows, 1);
         assert_eq!(encoded.num_cols, pp.linear_code.codeword_len());
     }
@@ -507,7 +500,7 @@ mod tests {
             BinaryPoly::new(vec![Boolean::TRUE, Boolean::FALSE]),
         ];
         let poly = DenseMultilinearExtension::from_evaluations_vec(2, evaluations, Zero::zero());
-        let encoded = TestPolyZip::encode_rows(&pp, pp.linear_code.row_len(), &poly.evaluations);
+        let encoded = TestPolyZip::encode_rows(&pp, &poly.evaluations);
         assert_eq!(encoded.num_rows, 1);
         assert_eq!(encoded.num_cols, pp.linear_code.codeword_len());
     }
@@ -536,7 +529,7 @@ mod tests {
     #[test]
     fn linear_code_preserves_linearity() {
         let (pp, poly) = setup_test_params(4);
-        let encoded = TestZip::encode_rows(&pp, pp.linear_code.row_len(), &poly.evaluations);
+        let encoded = TestZip::encode_rows(&pp, &poly.evaluations);
         let row_len = pp.linear_code.row_len();
         let codeword_len = pp.linear_code.codeword_len();
         let row1_evals = &poly.evaluations[0..row_len];
@@ -589,7 +582,7 @@ mod tests {
         let max_val = Int::<INT_LIMBS>::from(i64::MAX);
         let poly =
             DenseMultilinearExtension::from_evaluations_vec(3, vec![max_val; 8], Zero::zero());
-        let encoded_rows = TestZip::encode_rows(&pp, pp.linear_code.row_len(), &poly.evaluations);
+        let encoded_rows = TestZip::encode_rows(&pp, &poly.evaluations);
         assert_eq!(encoded_rows.num_rows, pp.num_rows);
         assert_eq!(encoded_rows.num_cols, pp.linear_code.codeword_len());
     }

--- a/zip-plus/src/pcs/phase_prove.rs
+++ b/zip-plus/src/pcs/phase_prove.rs
@@ -312,7 +312,7 @@ impl<Zt: ZipTypes, Lc: LinearCode<Zt>> ZipPlus<Zt, Lc> {
 )]
 mod tests {
     use crate::{
-        code::{raa::RaaCode, raa_sign_flip::RaaSignFlippingCode},
+        code::iprs::IprsCode,
         merkle::MerkleTree,
         pcs::{
             structs::{ZipPlus, ZipPlusHint},
@@ -338,10 +338,10 @@ mod tests {
     type F = BoxedMontyField;
 
     type Zt = TestZipTypes<N, K, M>;
-    type C = RaaSignFlippingCode<Zt, TestRaaConfig, 4>;
+    type C = IprsCode<Zt, TestIprsConfig, CHECKED>;
 
     type PolyZt = TestBinPolyZipTypes<K, M, DEGREE_PLUS_ONE>;
-    type PolyC = RaaCode<PolyZt, TestRaaConfig, 4>;
+    type PolyC = IprsCode<PolyZt, TestIprsConfig, CHECKED>;
 
     type TestZip = ZipPlus<Zt, C>;
     type TestPolyZip = ZipPlus<PolyZt, PolyC>;
@@ -352,7 +352,7 @@ mod tests {
 
     #[test]
     fn prove_succeeds_for_single_poly() {
-        let num_vars = 4;
+        let num_vars = 10;
         let (pp, poly) = setup_test_params(num_vars);
         let (hint, comm) = TestZip::commit_single(&pp, &poly).unwrap();
         let point = test_point(num_vars);
@@ -373,7 +373,7 @@ mod tests {
 
     #[test]
     fn prove_succeeds_for_poly_type() {
-        let num_vars = 4;
+        let num_vars = 10;
         let (pp, poly) = setup_poly_test_params(num_vars);
         let (hint, comm) = TestPolyZip::commit_single(&pp, &poly).unwrap();
         let point: Vec<i128> = (0..num_vars).map(|i| i as i128 + 2).collect();
@@ -394,7 +394,7 @@ mod tests {
 
     #[test]
     fn prove_succeeds_with_corrupted_codeword() {
-        let num_vars = 4;
+        let num_vars = 10;
         let (pp, poly) = setup_test_params(num_vars);
         let (mut hint, comm) = TestZip::commit_single(&pp, &poly).unwrap();
 
@@ -428,7 +428,7 @@ mod tests {
 
     #[test]
     fn prove_rejects_oversized_polynomial() {
-        let num_vars = 4;
+        let num_vars = 10;
         let (pp, _) = setup_test_params(num_vars);
         let oversized_poly: DenseMultilinearExtension<_> = (0..1 << 5).map(Int::from).collect();
 
@@ -455,7 +455,7 @@ mod tests {
     /// equals poly(point) lifted to F.
     #[test]
     fn prove_returns_correct_evaluation() {
-        let num_vars = 4;
+        let num_vars = 10;
         let (pp, poly) = setup_test_params(num_vars);
         let (hint, comm) = TestZip::commit_single(&pp, &poly).unwrap();
         let point = test_point(num_vars);
@@ -498,7 +498,7 @@ mod tests {
 
     #[test]
     fn prove_succeeds_for_batch() {
-        let num_vars = 4;
+        let num_vars = 10;
         let (pp, _) = setup_test_params(num_vars);
         let polys = make_batch_polys(num_vars, 2);
 
@@ -515,7 +515,7 @@ mod tests {
 
     #[test]
     fn prove_succeeds_for_batch_5() {
-        let num_vars = 4;
+        let num_vars = 10;
         let (pp, _) = setup_test_params(num_vars);
         let polys = make_batch_polys(num_vars, 5);
 
@@ -532,7 +532,7 @@ mod tests {
 
     #[test]
     fn prove_with_corrupted_codeword_for_batch() {
-        let num_vars = 4;
+        let num_vars = 10;
         let (pp, _) = setup_test_params(num_vars);
         let polys = make_batch_polys(num_vars, 2);
 
@@ -564,7 +564,7 @@ mod tests {
 
     #[test]
     fn prove_rejects_oversized_polynomial_in_batch() {
-        let num_vars = 4;
+        let num_vars = 10;
         let (pp, _) = setup_test_params(num_vars);
         let oversized: DenseMultilinearExtension<_> = (0..1 << 5).map(Int::from).collect();
         let normal: DenseMultilinearExtension<_> = (1..=16).map(Int::from).collect();

--- a/zip-plus/src/pcs/phase_prove.rs
+++ b/zip-plus/src/pcs/phase_prove.rs
@@ -133,7 +133,14 @@ impl<Zt: ZipTypes, Lc: LinearCode<Zt>> ZipPlus<Zt, Lc> {
         F::Modulus: Transcribable,
     {
         let batch_size = polys.len();
-        validate_input::<Zt, Lc, _>("prove", pp.num_vars, batch_size, polys, &[point])?;
+        validate_input::<Zt, Lc, _>(
+            "prove",
+            pp.num_vars,
+            pp.linear_code.row_len(),
+            batch_size,
+            polys,
+            &[point],
+        )?;
 
         let num_rows = pp.num_rows;
         let row_len = pp.linear_code.row_len();

--- a/zip-plus/src/pcs/phase_prove.rs
+++ b/zip-plus/src/pcs/phase_prove.rs
@@ -430,7 +430,8 @@ mod tests {
     fn prove_rejects_oversized_polynomial() {
         let num_vars = 10;
         let (pp, _) = setup_test_params(num_vars);
-        let oversized_poly: DenseMultilinearExtension<_> = (0..1 << 5).map(Int::from).collect();
+        let oversized_poly: DenseMultilinearExtension<_> =
+            (0..1 << (num_vars + 1)).map(Int::from).collect();
 
         let (hint, comm) =
             TestZip::commit_single(&pp, &setup_test_params::<N, K, M>(num_vars).1).unwrap();

--- a/zip-plus/src/pcs/phase_verify.rs
+++ b/zip-plus/src/pcs/phase_verify.rs
@@ -348,11 +348,11 @@ mod tests {
 
     type Zt = TestZipTypes<N, K, M>;
     type C = IprsCode<Zt, TestIprsConfig, CHECKED>;
-    static C: LazyLock<C> = LazyLock::new(C::create);
+    static C: LazyLock<C> = LazyLock::new(C::default);
 
     type PolyZt = TestBinPolyZipTypes<K, M, DEGREE_PLUS_ONE>;
     type PolyC = IprsCode<PolyZt, TestIprsConfig, CHECKED>;
-    static POLY_C: LazyLock<PolyC> = LazyLock::new(PolyC::create);
+    static POLY_C: LazyLock<PolyC> = LazyLock::new(PolyC::default);
 
     type TestZip = ZipPlus<Zt, C>;
     type TestPolyZip = ZipPlus<PolyZt, PolyC>;

--- a/zip-plus/src/pcs/phase_verify.rs
+++ b/zip-plus/src/pcs/phase_verify.rs
@@ -313,7 +313,7 @@ impl<Zt: ZipTypes, Lc: LinearCode<Zt>> ZipPlus<Zt, Lc> {
 mod tests {
     use crate::{
         ZipError,
-        code::{LinearCode, raa::RaaCode, raa_sign_flip::RaaSignFlippingCode},
+        code::{LinearCode, iprs::IprsCode},
         merkle::MerkleTree,
         pcs::{
             structs::{ZipPlus, ZipPlusHint, ZipTypes},
@@ -329,7 +329,7 @@ mod tests {
     use itertools::Itertools;
     use num_traits::{ConstOne, ConstZero, Zero};
     use rand::prelude::*;
-    use std::mem::size_of;
+    use std::{mem::size_of, sync::LazyLock};
     use zinc_poly::{
         mle::{DenseMultilinearExtension, MultilinearExtensionRand},
         univariate::binary::BinaryPoly,
@@ -347,17 +347,19 @@ mod tests {
     type F = MontyField<K>;
 
     type Zt = TestZipTypes<N, K, M>;
-    type C = RaaSignFlippingCode<Zt, TestRaaConfig, 4>;
+    type C = IprsCode<Zt, TestIprsConfig, CHECKED>;
+    static C: LazyLock<C> = LazyLock::new(C::create);
 
     type PolyZt = TestBinPolyZipTypes<K, M, DEGREE_PLUS_ONE>;
-    type PolyC = RaaCode<PolyZt, TestRaaConfig, 4>;
+    type PolyC = IprsCode<PolyZt, TestIprsConfig, CHECKED>;
+    static POLY_C: LazyLock<PolyC> = LazyLock::new(PolyC::create);
 
     type TestZip = ZipPlus<Zt, C>;
     type TestPolyZip = ZipPlus<PolyZt, PolyC>;
 
     #[test]
     fn successful_verification_of_valid_proof() {
-        let num_vars = 4;
+        let num_vars = 10;
         {
             let (pp, comm, point_f, eval_f, mut transcript) =
                 setup_full_protocol::<F, N, K, M>(num_vars);
@@ -393,7 +395,7 @@ mod tests {
 
     #[test]
     fn verification_fails_with_incorrect_evaluation() {
-        let num_vars = 4;
+        let num_vars = 10;
 
         {
             let (pp, comm, point_f, eval_f, mut transcript) =
@@ -449,7 +451,7 @@ mod tests {
 
             proof
         }
-        let num_vars = 4;
+        let num_vars = 10;
 
         {
             let (pp, comm, point_f, eval_f, proof) = setup_full_protocol::<F, N, K, M>(num_vars);
@@ -485,7 +487,7 @@ mod tests {
 
     #[test]
     fn verification_fails_with_wrong_commitment() {
-        let num_vars = 4;
+        let num_vars = 10;
         {
             let (pp, _comm_poly1, point_f, eval_f, mut transcript) =
                 setup_full_protocol::<F, N, K, M>(num_vars);
@@ -514,8 +516,7 @@ mod tests {
             let field_cfg = get_field_cfg::<PolyZt, F>(&mut transcript.fs_transcript);
 
             let different_evals = {
-                let different_eval_coeffs: Vec<_> = (1..=((1 << num_vars)
-                    * (DEGREE_PLUS_ONE - 1) as i8))
+                let different_eval_coeffs: Vec<_> = (1..=((1 << num_vars) * (DEGREE_PLUS_ONE - 1)))
                     .map(|x| (x % 3 == 0).into())
                     .collect_vec();
                 different_eval_coeffs
@@ -546,7 +547,7 @@ mod tests {
 
     #[test]
     fn verification_fails_with_invalid_point_size() {
-        let num_vars = 4;
+        let num_vars = 10;
 
         let make_invalid_point = |cfg: &<F as PrimeField>::Config| {
             let mut invalid_point = vec![];
@@ -595,12 +596,13 @@ mod tests {
 
     #[test]
     fn verification_fails_due_to_incorrect_polynomial() {
-        let num_vars = 4;
+        let num_vars = 10;
         let (pp, mle1) = setup_test_params(num_vars);
+        let poly_size = 1 << num_vars;
 
         let (hint, comm) = TestZip::commit_single(&pp, &mle1).unwrap();
 
-        let mle2: DenseMultilinearExtension<_> = (20..=35).map(Int::from).collect();
+        let mle2: DenseMultilinearExtension<_> = (20..20 + poly_size).map(Int::from).collect();
 
         let point: Vec<<Zt as ZipTypes>::Pt> =
             (0..num_vars).map(|i| Int::from(i as i32 + 2)).collect();
@@ -642,7 +644,7 @@ mod tests {
 
     #[test]
     fn verification_fails_due_to_a_hint_that_is_not_close() {
-        let num_vars = 4;
+        let num_vars = 10;
         let (pp, mle) = setup_test_params(num_vars);
 
         let (original_hint, comm) = TestZip::commit_single(&pp, &mle).unwrap();
@@ -696,7 +698,7 @@ mod tests {
 
     #[test]
     fn verification_fails_due_to_incorrect_evaluation() {
-        let num_vars = 4;
+        let num_vars = 10;
         let (pp, mle) = setup_test_params(num_vars);
 
         let (hint, comm) = TestZip::commit_single(&pp, &mle).unwrap();
@@ -738,11 +740,10 @@ mod tests {
 
     #[test]
     fn verification_fails_if_proximity_check_is_invalid() {
-        let poly_size: usize = 8; // row_len=4, num_rows=2 -> proximity checks are active
+        let num_vars = 10;
+        let poly_size: usize = 1 << num_vars;
 
-        let row_len = poly_size.isqrt().next_power_of_two();
-        let linear_code = C::new(row_len);
-        let pp = TestZip::setup(poly_size, linear_code);
+        let pp = TestZip::setup(poly_size, C.clone());
 
         let mle: DenseMultilinearExtension<_> = (0..poly_size as i32)
             .map(<Zt as ZipTypes>::Eval::from)
@@ -750,10 +751,7 @@ mod tests {
 
         let (hint, comm) = TestZip::commit_single(&pp, &mle).expect("commit should succeed");
 
-        let point = [0, 0, 0]
-            .into_iter()
-            .map(Int::<1>::from)
-            .collect::<Vec<_>>();
+        let point = vec![ConstOne::ONE; num_vars];
 
         let mut prover_transcript = PcsProverTranscript::new_from_commitment(&comm);
         let field_cfg = get_field_cfg::<Zt, F>(&mut prover_transcript.fs_transcript);
@@ -813,17 +811,16 @@ mod tests {
 
     #[test]
     fn verification_fails_if_evaluation_consistency_check_is_invalid() {
-        let poly_size: usize = 8;
-        let row_len = poly_size.isqrt().next_power_of_two();
-        let linear_code = C::new(row_len);
-        let pp = TestZip::setup(poly_size, linear_code);
+        let num_vars = 10;
+        let poly_size: usize = 1 << num_vars;
+        let pp = TestZip::setup(poly_size, C.clone());
 
         let mle: DenseMultilinearExtension<_> =
             (0..poly_size as i32).map(Int::<INT_LIMBS>::from).collect();
 
         let (hint, comm) = TestZip::commit_single(&pp, &mle).expect("commit should succeed");
 
-        let point: Vec<<Zt as ZipTypes>::Pt> = [0, 0, 0].into_iter().map(Int::from).collect_vec();
+        let point: Vec<<Zt as ZipTypes>::Pt> = vec![Zero::zero(); num_vars];
 
         let mut prover_transcript = PcsProverTranscript::new_from_commitment(&comm);
         let field_cfg = get_field_cfg::<Zt, F>(&mut prover_transcript.fs_transcript);
@@ -876,16 +873,15 @@ mod tests {
 
     #[test]
     fn verification_succeeds_for_zero_polynomial() {
-        let poly_size: usize = 8;
-        let row_len = poly_size.isqrt().next_power_of_two();
-        let linear_code = C::new(row_len);
-        let pp = TestZip::setup(poly_size, linear_code);
+        let num_vars = 10;
+        let poly_size: usize = 1 << num_vars;
+        let pp = TestZip::setup(poly_size, C.clone());
 
-        let mle: DenseMultilinearExtension<_> = (0..poly_size).map(|_| Int::ZERO).collect();
+        let mle: DenseMultilinearExtension<_> = vec![Zero::zero(); poly_size].into_iter().collect();
 
         let (hint, comm) = TestZip::commit_single(&pp, &mle).expect("commit should succeed");
 
-        let point: Vec<<Zt as ZipTypes>::Pt> = [0, 0, 0].into_iter().map(Int::from).collect_vec();
+        let point: Vec<<Zt as ZipTypes>::Pt> = vec![Zero::zero(); num_vars];
 
         let mut prover_transcript = PcsProverTranscript::new_from_commitment(&comm);
         let field_cfg = get_field_cfg::<Zt, F>(&mut prover_transcript.fs_transcript);
@@ -919,18 +915,16 @@ mod tests {
 
     #[test]
     fn verification_succeeds_at_zero_point() {
-        let num_vars = 3;
+        let num_vars = 10;
         let poly_size: usize = 1 << num_vars;
-        let row_len = poly_size.isqrt().next_power_of_two();
-        let linear_code = C::new(row_len);
-        let pp = TestZip::setup(poly_size, linear_code);
+        let pp = TestZip::setup(poly_size, C.clone());
 
         let mle: DenseMultilinearExtension<_> =
             (1..=poly_size as i32).map(Int::<INT_LIMBS>::from).collect();
 
         let (hint, comm) = TestZip::commit_single(&pp, &mle).expect("commit should succeed");
 
-        let point: Vec<<Zt as ZipTypes>::Pt> = vec![Int::ZERO; num_vars];
+        let point: Vec<<Zt as ZipTypes>::Pt> = vec![Zero::zero(); num_vars];
 
         let mut prover_transcript = PcsProverTranscript::new_from_commitment(&comm);
         let field_cfg = get_field_cfg::<Zt, F>(&mut prover_transcript.fs_transcript);
@@ -964,7 +958,7 @@ mod tests {
 
     #[test]
     fn verification_succeeds_when_polynomial_coefficients_are_max_bit_size() {
-        let num_vars = 4;
+        let num_vars = 10;
         let (pp, _) = setup_test_params(num_vars);
 
         let mut evals: Vec<<Zt as ZipTypes>::Eval> =
@@ -1012,13 +1006,13 @@ mod tests {
     }
 
     #[test]
-    fn verification_succeeds_with_minimal_polynomial_size_mu_is_2() {
-        let num_vars = 2;
+    fn verification_succeeds_with_minimal_polynomial_size_mu_is_8() {
+        let num_vars = 10;
         let (pp, poly) = setup_test_params(num_vars);
 
         let (hint, comm) = TestZip::commit_single(&pp, &poly).unwrap();
 
-        let point: Vec<<Zt as ZipTypes>::Pt> = vec![Int::from(1), Int::from(2)];
+        let point: Vec<<Zt as ZipTypes>::Pt> = (1..=num_vars as i32).map(Int::from).collect_vec();
 
         let mut prover_transcript = PcsProverTranscript::new_from_commitment(&comm);
         let field_cfg = get_field_cfg::<Zt, F>(&mut prover_transcript.fs_transcript);
@@ -1053,17 +1047,15 @@ mod tests {
 
     #[test]
     fn verification_fails_at_proximity_link_check_if_combined_row_is_corrupted() {
-        let poly_size: usize = 8;
-        let row_len = poly_size.isqrt().next_power_of_two();
-        let linear_code = C::new(row_len);
-        let pp = TestZip::setup(poly_size, linear_code);
+        let num_vars = 10;
+        let poly_size: usize = 1 << num_vars;
+        let pp = TestZip::setup(poly_size, C.clone());
 
-        let mle: DenseMultilinearExtension<_> =
-            (1..=poly_size as i32).map(Int::<INT_LIMBS>::from).collect();
+        let mle: DenseMultilinearExtension<_> = (1..=poly_size as i32).map(Int::from).collect();
 
         let (hint, comm) = TestZip::commit_single(&pp, &mle).expect("commit should succeed");
 
-        let point: Vec<<Zt as ZipTypes>::Pt> = [0, 0, 0].into_iter().map(Int::from).collect_vec();
+        let point: Vec<<Zt as ZipTypes>::Pt> = vec![Zero::zero(); num_vars];
 
         let mut prover_transcript = PcsProverTranscript::new_from_commitment(&comm);
         let field_cfg = get_field_cfg::<Zt, F>(&mut prover_transcript.fs_transcript);
@@ -1118,9 +1110,7 @@ mod tests {
             let mut rng = ThreadRng::default();
             // Match the benchmark's transcript usage for linear code construction
             let poly_size: usize = 1 << P;
-            let row_len = poly_size.isqrt().next_power_of_two();
-            let linear_code = C::new(row_len);
-            let pp = TestZip::setup(poly_size, linear_code);
+            let pp = TestZip::setup(poly_size, C.clone());
 
             let mle = DenseMultilinearExtension::rand(P, &mut rng);
             let (hint, commitment) = TestZip::commit_single(&pp, &mle).expect("commit");
@@ -1178,9 +1168,7 @@ mod tests {
             let mut rng = ThreadRng::default();
             // Match the benchmark's transcript usage for linear code construction
             let poly_size: usize = 1 << P;
-            let row_len = poly_size.isqrt().next_power_of_two();
-            let linear_code = PolyC::new(row_len);
-            let pp = TestPolyZip::setup(poly_size, linear_code);
+            let pp = TestPolyZip::setup(poly_size, POLY_C.clone());
 
             let mle = DenseMultilinearExtension::rand(P, &mut rng);
             let (hint, comm) = TestPolyZip::commit_single(&pp, &mle).expect("commit");
@@ -1223,8 +1211,7 @@ mod tests {
 
     fn batched_prove_verify_inner<const BATCH: usize>(num_vars: usize) {
         let poly_size = 1 << num_vars;
-        let linear_code = C::new(poly_size);
-        let pp = TestZip::setup(poly_size, linear_code);
+        let pp = TestZip::setup(poly_size, C.clone());
 
         let polys: Vec<DenseMultilinearExtension<_>> = (0..BATCH)
             .map(|b| {
@@ -1274,25 +1261,24 @@ mod tests {
 
     #[test]
     fn batched_prove_verify_batch_2() {
-        batched_prove_verify_inner::<2>(4);
+        batched_prove_verify_inner::<2>(10);
     }
 
     #[test]
     fn batched_prove_verify_batch_5() {
-        batched_prove_verify_inner::<5>(4);
+        batched_prove_verify_inner::<5>(10);
     }
 
     #[test]
     fn batched_prove_verify_batch_1_roundtrip() {
-        batched_prove_verify_inner::<1>(4);
+        batched_prove_verify_inner::<1>(10);
     }
 
     #[test]
     fn batched_verify_fails_with_tampered_eval() {
-        let num_vars = 4;
+        let num_vars = 10;
         let poly_size = 1 << num_vars;
-        let linear_code = C::new(poly_size);
-        let pp = TestZip::setup(poly_size, linear_code);
+        let pp = TestZip::setup(poly_size, C.clone());
 
         let polys: Vec<DenseMultilinearExtension<_>> = vec![
             (1..=poly_size as i32).map(Int::from).collect(),

--- a/zip-plus/src/pcs/phase_verify.rs
+++ b/zip-plus/src/pcs/phase_verify.rs
@@ -153,7 +153,14 @@ impl<Zt: ZipTypes, Lc: LinearCode<Zt>> ZipPlus<Zt, Lc> {
         F::Modulus: FromRef<Zt::Fmod> + Transcribable,
     {
         let batch_size = comm.batch_size;
-        validate_input::<Zt, Lc, _>("verify", vp.num_vars, batch_size, &[], &[point_f])?;
+        validate_input::<Zt, Lc, _>(
+            "verify",
+            vp.num_vars,
+            vp.linear_code.row_len(),
+            batch_size,
+            &[],
+            &[point_f],
+        )?;
 
         let num_rows = vp.num_rows;
         let row_len = vp.linear_code.row_len();
@@ -731,9 +738,10 @@ mod tests {
 
     #[test]
     fn verification_fails_if_proximity_check_is_invalid() {
-        let poly_size = 8;
+        let poly_size: usize = 8; // row_len=4, num_rows=2 -> proximity checks are active
 
-        let linear_code = C::new(poly_size);
+        let row_len = poly_size.isqrt().next_power_of_two();
+        let linear_code = C::new(row_len);
         let pp = TestZip::setup(poly_size, linear_code);
 
         let mle: DenseMultilinearExtension<_> = (0..poly_size as i32)
@@ -805,8 +813,9 @@ mod tests {
 
     #[test]
     fn verification_fails_if_evaluation_consistency_check_is_invalid() {
-        let poly_size = 8;
-        let linear_code = C::new(poly_size);
+        let poly_size: usize = 8;
+        let row_len = poly_size.isqrt().next_power_of_two();
+        let linear_code = C::new(row_len);
         let pp = TestZip::setup(poly_size, linear_code);
 
         let mle: DenseMultilinearExtension<_> =
@@ -867,8 +876,9 @@ mod tests {
 
     #[test]
     fn verification_succeeds_for_zero_polynomial() {
-        let poly_size = 8;
-        let linear_code = C::new(poly_size);
+        let poly_size: usize = 8;
+        let row_len = poly_size.isqrt().next_power_of_two();
+        let linear_code = C::new(row_len);
         let pp = TestZip::setup(poly_size, linear_code);
 
         let mle: DenseMultilinearExtension<_> = (0..poly_size).map(|_| Int::ZERO).collect();
@@ -910,8 +920,9 @@ mod tests {
     #[test]
     fn verification_succeeds_at_zero_point() {
         let num_vars = 3;
-        let poly_size = 1 << num_vars;
-        let linear_code = C::new(poly_size);
+        let poly_size: usize = 1 << num_vars;
+        let row_len = poly_size.isqrt().next_power_of_two();
+        let linear_code = C::new(row_len);
         let pp = TestZip::setup(poly_size, linear_code);
 
         let mle: DenseMultilinearExtension<_> =
@@ -1042,8 +1053,9 @@ mod tests {
 
     #[test]
     fn verification_fails_at_proximity_link_check_if_combined_row_is_corrupted() {
-        let poly_size = 8;
-        let linear_code = C::new(poly_size);
+        let poly_size: usize = 8;
+        let row_len = poly_size.isqrt().next_power_of_two();
+        let linear_code = C::new(row_len);
         let pp = TestZip::setup(poly_size, linear_code);
 
         let mle: DenseMultilinearExtension<_> =
@@ -1105,8 +1117,9 @@ mod tests {
         fn inner<const P: usize>() {
             let mut rng = ThreadRng::default();
             // Match the benchmark's transcript usage for linear code construction
-            let poly_size = 1 << P;
-            let linear_code = C::new(poly_size);
+            let poly_size: usize = 1 << P;
+            let row_len = poly_size.isqrt().next_power_of_two();
+            let linear_code = C::new(row_len);
             let pp = TestZip::setup(poly_size, linear_code);
 
             let mle = DenseMultilinearExtension::rand(P, &mut rng);
@@ -1164,8 +1177,9 @@ mod tests {
         fn inner<const P: usize>() {
             let mut rng = ThreadRng::default();
             // Match the benchmark's transcript usage for linear code construction
-            let poly_size = 1 << P;
-            let linear_code = PolyC::new(poly_size);
+            let poly_size: usize = 1 << P;
+            let row_len = poly_size.isqrt().next_power_of_two();
+            let linear_code = PolyC::new(row_len);
             let pp = TestPolyZip::setup(poly_size, linear_code);
 
             let mle = DenseMultilinearExtension::rand(P, &mut rng);

--- a/zip-plus/src/pcs/structs.rs
+++ b/zip-plus/src/pcs/structs.rs
@@ -75,7 +75,7 @@ where
         let num_vars = poly_size.ilog2() as usize;
         let row_len = linear_code.row_len();
         assert!(
-            row_len > 0 && poly_size % row_len == 0,
+            row_len > 0 && poly_size.is_multiple_of(row_len),
             "poly_size ({poly_size}) must be divisible by row_len ({row_len})"
         );
         let num_rows = poly_size / row_len;

--- a/zip-plus/src/pcs/structs.rs
+++ b/zip-plus/src/pcs/structs.rs
@@ -73,7 +73,16 @@ where
     pub fn setup(poly_size: usize, linear_code: Lc) -> ZipPlusParams<Zt, Lc> {
         assert!(poly_size.is_power_of_two());
         let num_vars = poly_size.ilog2() as usize;
-        let num_rows = ((1 << num_vars) / linear_code.row_len()).next_power_of_two();
+        let row_len = linear_code.row_len();
+        assert!(
+            row_len > 0 && poly_size % row_len == 0,
+            "poly_size ({poly_size}) must be divisible by row_len ({row_len})"
+        );
+        let num_rows = poly_size / row_len;
+        assert!(
+            num_rows.is_power_of_two(),
+            "num_rows ({num_rows}) must be a power of two"
+        );
         ZipPlusParams::new(num_vars, num_rows, linear_code)
     }
 }

--- a/zip-plus/src/pcs/test_utils.rs
+++ b/zip-plus/src/pcs/test_utils.rs
@@ -129,9 +129,10 @@ fn setup_test_params_inner<Zt: ZipTypes, Lc: LinearCode<Zt>>(
     prepare_evaluations: impl FnOnce(usize) -> Vec<Zt::Eval>,
 ) -> (ZipPlusParams<Zt, Lc>, DenseMultilinearExtension<Zt::Eval>) {
     let poly_size = 1 << num_vars;
-    let num_rows = 1 << num_vars.div_ceil(2);
+    let row_len = 1usize << (num_vars / 2);
+    let num_rows = poly_size / row_len;
 
-    let code = Lc::new(poly_size);
+    let code = Lc::new(row_len);
     let pp = ZipPlusParams::new(num_vars, num_rows, code);
 
     let evaluations = prepare_evaluations(poly_size);

--- a/zip-plus/src/pcs/test_utils.rs
+++ b/zip-plus/src/pcs/test_utils.rs
@@ -90,7 +90,7 @@ pub fn setup_test_params<const N: usize, const K: usize, const M: usize>(
     ZipPlusParams<TestZipTypes<N, K, M>, IprsCode<TestZipTypes<N, K, M>, TestIprsConfig, CHECKED>>,
     DenseMultilinearExtension<<TestZipTypes<N, K, M> as ZipTypes>::Eval>,
 ) {
-    setup_test_params_inner(num_vars, IprsCode::create(), |poly_size| {
+    setup_test_params_inner(num_vars, IprsCode::default(), |poly_size| {
         (1..=poly_size as i32).map(Int::from).collect()
     })
 }
@@ -105,7 +105,7 @@ pub fn setup_poly_test_params<const K: usize, const M: usize, const DEGREE_PLUS_
     >,
     DenseMultilinearExtension<<TestBinPolyZipTypes<K, M, DEGREE_PLUS_ONE> as ZipTypes>::Eval>,
 ) {
-    setup_test_params_inner(num_vars, IprsCode::create(), |poly_size| {
+    setup_test_params_inner(num_vars, IprsCode::default(), |poly_size| {
         let degree = DEGREE_PLUS_ONE - 1;
         let eval_coeffs: Vec<_> = (1..=(poly_size * degree) as i64)
             .map(|v| v.is_odd().into())

--- a/zip-plus/src/pcs/test_utils.rs
+++ b/zip-plus/src/pcs/test_utils.rs
@@ -10,8 +10,7 @@
 use crate::{
     code::{
         LinearCode,
-        raa::{RaaCode, RaaConfig},
-        raa_sign_flip::RaaSignFlippingCode,
+        iprs::{IprsCode, PnttConfigF65537_32_128},
     },
     pcs::structs::{ZipPlus, ZipPlusCommitment, ZipPlusParams, ZipTypes},
     pcs_transcript::{PcsProverTranscript, PcsVerifierTranscript},
@@ -38,16 +37,11 @@ use zinc_utils::{
     projectable_to_field::ProjectableToField,
 };
 
-const REPETITION_FACTOR: usize = 4;
+const IPRS_DEPTH: usize = 1;
 
-#[derive(Clone, Copy)]
-pub struct TestRaaConfig;
+pub type TestIprsConfig = PnttConfigF65537_32_128<IPRS_DEPTH>;
 
-impl RaaConfig for TestRaaConfig {
-    const PERMUTE_IN_PLACE: bool = false;
-    const CHECK_FOR_OVERFLOWS: bool = true;
-}
-
+#[derive(Debug, Clone)]
 pub struct TestZipTypes<const N: usize, const K: usize, const M: usize> {}
 impl<const N: usize, const K: usize, const M: usize> ZipTypes for TestZipTypes<N, K, M> {
     const NUM_COLUMN_OPENINGS: usize = 200;
@@ -64,13 +58,14 @@ impl<const N: usize, const K: usize, const M: usize> ZipTypes for TestZipTypes<N
     type ArrCombRDotChal = MBSInnerProduct;
 }
 
+#[derive(Debug, Clone)]
 pub struct TestBinPolyZipTypes<const K: usize, const M: usize, const DEGREE_PLUS_ONE: usize> {}
 impl<const K: usize, const M: usize, const DEGREE_PLUS_ONE: usize> ZipTypes
     for TestBinPolyZipTypes<K, M, DEGREE_PLUS_ONE>
 {
     const NUM_COLUMN_OPENINGS: usize = 200;
     type Eval = BinaryPoly<DEGREE_PLUS_ONE>;
-    type Cw = DensePolynomial<i32, DEGREE_PLUS_ONE>;
+    type Cw = DensePolynomial<i64, DEGREE_PLUS_ONE>;
     type Fmod = Uint<K>;
     type PrimeTest = MillerRabin;
     type Chal = i128;
@@ -92,13 +87,10 @@ impl<const K: usize, const M: usize, const DEGREE_PLUS_ONE: usize> ZipTypes
 pub fn setup_test_params<const N: usize, const K: usize, const M: usize>(
     num_vars: usize,
 ) -> (
-    ZipPlusParams<
-        TestZipTypes<N, K, M>,
-        RaaSignFlippingCode<TestZipTypes<N, K, M>, TestRaaConfig, REPETITION_FACTOR>,
-    >,
+    ZipPlusParams<TestZipTypes<N, K, M>, IprsCode<TestZipTypes<N, K, M>, TestIprsConfig, CHECKED>>,
     DenseMultilinearExtension<<TestZipTypes<N, K, M> as ZipTypes>::Eval>,
 ) {
-    setup_test_params_inner(num_vars, |poly_size| {
+    setup_test_params_inner(num_vars, IprsCode::create(), |poly_size| {
         (1..=poly_size as i32).map(Int::from).collect()
     })
 }
@@ -109,16 +101,17 @@ pub fn setup_poly_test_params<const K: usize, const M: usize, const DEGREE_PLUS_
 ) -> (
     ZipPlusParams<
         TestBinPolyZipTypes<K, M, DEGREE_PLUS_ONE>,
-        RaaCode<TestBinPolyZipTypes<K, M, DEGREE_PLUS_ONE>, TestRaaConfig, REPETITION_FACTOR>,
+        IprsCode<TestBinPolyZipTypes<K, M, DEGREE_PLUS_ONE>, TestIprsConfig, CHECKED>,
     >,
     DenseMultilinearExtension<<TestBinPolyZipTypes<K, M, DEGREE_PLUS_ONE> as ZipTypes>::Eval>,
 ) {
-    setup_test_params_inner(num_vars, |poly_size| {
-        let eval_coeffs: Vec<_> = (1..=(poly_size * (DEGREE_PLUS_ONE - 1)) as i8)
+    setup_test_params_inner(num_vars, IprsCode::create(), |poly_size| {
+        let degree = DEGREE_PLUS_ONE - 1;
+        let eval_coeffs: Vec<_> = (1..=(poly_size * degree) as i64)
             .map(|v| v.is_odd().into())
             .collect_vec();
         eval_coeffs
-            .chunks_exact(DEGREE_PLUS_ONE - 1)
+            .chunks_exact(degree)
             .map(BinaryPoly::new)
             .collect_vec()
     })
@@ -126,13 +119,13 @@ pub fn setup_poly_test_params<const K: usize, const M: usize, const DEGREE_PLUS_
 
 fn setup_test_params_inner<Zt: ZipTypes, Lc: LinearCode<Zt>>(
     num_vars: usize,
+    code: Lc,
     prepare_evaluations: impl FnOnce(usize) -> Vec<Zt::Eval>,
 ) -> (ZipPlusParams<Zt, Lc>, DenseMultilinearExtension<Zt::Eval>) {
-    let poly_size = 1 << num_vars;
-    let row_len = 1usize << (num_vars / 2);
-    let num_rows = poly_size / row_len;
+    let poly_size: usize = 1 << num_vars;
+    let row_len = code.row_len();
+    let num_rows = poly_size.div_ceil(row_len);
 
-    let code = Lc::new(row_len);
     let pp = ZipPlusParams::new(num_vars, num_rows, code);
 
     let evaluations = prepare_evaluations(poly_size);
@@ -148,10 +141,7 @@ fn setup_test_params_inner<Zt: ZipTypes, Lc: LinearCode<Zt>>(
 pub fn setup_full_protocol<F, const N: usize, const K: usize, const M: usize>(
     num_vars: usize,
 ) -> (
-    ZipPlusParams<
-        TestZipTypes<N, K, M>,
-        RaaSignFlippingCode<TestZipTypes<N, K, M>, TestRaaConfig, REPETITION_FACTOR>,
-    >,
+    ZipPlusParams<TestZipTypes<N, K, M>, IprsCode<TestZipTypes<N, K, M>, TestIprsConfig, CHECKED>>,
     ZipPlusCommitment,
     Vec<F>,
     F,
@@ -183,7 +173,7 @@ pub fn setup_full_protocol_poly<
 ) -> (
     ZipPlusParams<
         TestBinPolyZipTypes<K, M, DEGREE_PLUS_ONE>,
-        RaaCode<TestBinPolyZipTypes<K, M, DEGREE_PLUS_ONE>, TestRaaConfig, REPETITION_FACTOR>,
+        IprsCode<TestBinPolyZipTypes<K, M, DEGREE_PLUS_ONE>, TestIprsConfig, CHECKED>,
     >,
     ZipPlusCommitment,
     Vec<F>,

--- a/zip-plus/src/pcs/utils.rs
+++ b/zip-plus/src/pcs/utils.rs
@@ -26,6 +26,8 @@ pub(super) fn validate_input<Zt: ZipTypes, Lc: LinearCode<Zt>, Pt>(
         // Inner ring should be at most 2*log_2(\rho^{-1}*d) + \log_2(d) +
         // challenge_bits + eval_elem_bits - 1, where d is the log of the size
         // of the messages being encoded (i.e. log2(row_len)).
+        // Note that the formula is tweaked a bit to handle a code with row length 1
+        // (i.e. d = 0).
         let d = row_len.ilog2() as usize;
         let codeword_bits = ilog_round_up!(mul!(Lc::REPETITION_FACTOR, d).max(1), usize);
         let mut challenge_bits = Zt::Chal::NUM_BITS;

--- a/zip-plus/src/pcs/utils.rs
+++ b/zip-plus/src/pcs/utils.rs
@@ -4,7 +4,7 @@ use zinc_poly::{
     ConstCoeffBitWidth, Polynomial, mle::DenseMultilinearExtension, utils::build_eq_x_r,
 };
 use zinc_transcript::traits::ConstTranscribable;
-use zinc_utils::{add, div, ilog_round_up, mul, sub};
+use zinc_utils::{add, ilog_round_up, mul, sub};
 
 fn err_too_many_variates(function: &str, upto: usize, got: usize) -> ZipError {
     ZipError::InvalidPcsParam(format!(
@@ -16,16 +16,17 @@ fn err_too_many_variates(function: &str, upto: usize, got: usize) -> ZipError {
 pub(super) fn validate_input<Zt: ZipTypes, Lc: LinearCode<Zt>, Pt>(
     function: &str,
     param_num_vars: usize,
+    row_len: usize,
     batch_size: usize,
     polys: &[DenseMultilinearExtension<Zt::Eval>],
     points: &[&[Pt]],
 ) -> Result<(), ZipError> {
     // Check bit-width of the linear combinations
     {
-        // Inner ring should be at most+ 2*log_2(\rho^{-1}*d) + \log_2(d) +
-        // challenge_bits + eval_elem_bits - 1, where d is the size of the messages
-        // being encoded - so num_vars / 2
-        let d = div!(param_num_vars, 2);
+        // Inner ring should be at most 2*log_2(\rho^{-1}*d) + \log_2(d) +
+        // challenge_bits + eval_elem_bits - 1, where d is the log of the size
+        // of the messages being encoded (i.e. log2(row_len)).
+        let d = row_len.ilog2() as usize;
         let codeword_bits = ilog_round_up!(mul!(Lc::REPETITION_FACTOR, d), usize);
         let mut challenge_bits = Zt::Chal::NUM_BITS;
         if Zt::Comb::DEGREE_BOUND > 0 {

--- a/zip-plus/src/pcs/utils.rs
+++ b/zip-plus/src/pcs/utils.rs
@@ -27,7 +27,7 @@ pub(super) fn validate_input<Zt: ZipTypes, Lc: LinearCode<Zt>, Pt>(
         // challenge_bits + eval_elem_bits - 1, where d is the log of the size
         // of the messages being encoded (i.e. log2(row_len)).
         let d = row_len.ilog2() as usize;
-        let codeword_bits = ilog_round_up!(mul!(Lc::REPETITION_FACTOR, d), usize);
+        let codeword_bits = ilog_round_up!(mul!(Lc::REPETITION_FACTOR, d).max(1), usize);
         let mut challenge_bits = Zt::Chal::NUM_BITS;
         if Zt::Comb::DEGREE_BOUND > 0 {
             // This means we also draft alphas (multiplied with coeffs), which
@@ -37,7 +37,7 @@ pub(super) fn validate_input<Zt: ZipTypes, Lc: LinearCode<Zt>, Pt>(
         let max_lc_bits = Zt::CombR::NUM_BITS;
         let actual_lc_bits: usize = add!(
             add!(
-                add!(mul!(codeword_bits, 2), ilog_round_up!(d, usize)),
+                add!(mul!(codeword_bits, 2), ilog_round_up!(d.max(1), usize)),
                 challenge_bits
             ),
             add!(


### PR DESCRIPTION
Goes towards #120

Based on #116, this PR allow specifying linear code row length directly. For IPRS code specifically, the row length is predefined by the config, but this is made explicit now.

Summary of changes:
* Removed universal `LinearCode::new(poly_size)` method - instead, RAA code has its own `new(poly_size)` while IPRS is simply created via `default`.
* Linear codes now universally implement `Debug` and `Eq`.
* Tweaked Zip+ type widths validation formula to accommodate non-square matrices
* Changed benchmarks to take in linear code instances instead of creating them in-place.
  * RAA codes are created with square matrices as before, so behaviour is unchanged.
* Tweaked tests to use IPRS codes instead of RAA, with the same 32/128 config we use in benches.
  * This requires us to increase number of variables (we need at least 8, but we use 10 in most places for good measure in order to have multiple rows)
  * Also requires widening`PolyZt::Cw` from `i32` to `i64`
* Fixed IPRS codes being unable to handle DEPTH == 0
* Fixed leftover: Zip+ benchmark still used `UNCHECKED` code instead of parameter being configurable via feature.