### PR TITLE
Custom row length in IPRS

### DIFF
--- a/protocol/benches/e2e.rs
+++ b/protocol/benches/e2e.rs
@@ -266,12 +266,22 @@ type Pp<Zt> = (
 );
 
 /// Use row size equal to poly size, resulting in flat single-row matrices
+#[allow(clippy::unwrap_used)]
 fn setup_pp(num_vars: usize) -> Pp<BenchZincTypes> {
     let poly_size = 1 << num_vars;
     (
-        ZipPlus::setup(poly_size, IprsCode::new_with_optimal_depth(poly_size)),
-        ZipPlus::setup(poly_size, IprsCode::new_with_optimal_depth(poly_size)),
-        ZipPlus::setup(poly_size, IprsCode::new_with_optimal_depth(poly_size)),
+        ZipPlus::setup(
+            poly_size,
+            IprsCode::new_with_optimal_depth(poly_size).unwrap(),
+        ),
+        ZipPlus::setup(
+            poly_size,
+            IprsCode::new_with_optimal_depth(poly_size).unwrap(),
+        ),
+        ZipPlus::setup(
+            poly_size,
+            IprsCode::new_with_optimal_depth(poly_size).unwrap(),
+        ),
     )
 }
 

--- a/protocol/benches/e2e.rs
+++ b/protocol/benches/e2e.rs
@@ -44,6 +44,7 @@ use zip_plus::{
     pcs::structs::{ZipPlus, ZipPlusParams, ZipTypes},
     utils::eprint_proof_size,
 };
+
 //
 // Type definitions and constants
 //
@@ -53,6 +54,9 @@ const PERFORM_CHECKS: bool = if cfg!(feature = "unchecked") {
 } else {
     zinc_utils::CHECKED
 };
+
+/// Repetition factor for linear code, an inverse rate.
+const REP: usize = 4;
 
 #[allow(clippy::type_complexity)]
 #[derive(Debug, Clone, Copy)]
@@ -221,9 +225,9 @@ where
         MBSInnerProduct,
     >;
 
-    type BinaryLc = IprsCode<Self::BinaryZt, PnttConfigF65537, 4, PERFORM_CHECKS>;
-    type ArbitraryLc = IprsCode<Self::ArbitraryZt, PnttConfigF65537, 4, PERFORM_CHECKS>;
-    type IntLc = IprsCode<Self::IntZt, PnttConfigF65537, 4, PERFORM_CHECKS>;
+    type BinaryLc = IprsCode<Self::BinaryZt, PnttConfigF65537, REP, PERFORM_CHECKS>;
+    type ArbitraryLc = IprsCode<Self::ArbitraryZt, PnttConfigF65537, REP, PERFORM_CHECKS>;
+    type IntLc = IprsCode<Self::IntZt, PnttConfigF65537, REP, PERFORM_CHECKS>;
 }
 
 //

--- a/protocol/benches/e2e.rs
+++ b/protocol/benches/e2e.rs
@@ -54,11 +54,6 @@ const PERFORM_CHECKS: bool = if cfg!(feature = "unchecked") {
     zinc_utils::CHECKED
 };
 
-const IPRS_DEPTH: usize = 1;
-
-// FIXME: Use flat matrices, i.e. those having just one row
-const LEGACY_IPRS_ROW_LEN: usize = 32 * (1 << (3 * IPRS_DEPTH));
-
 #[allow(clippy::type_complexity)]
 #[derive(Debug, Clone, Copy)]
 pub struct GenericBenchZipTypes<
@@ -266,13 +261,13 @@ type Pp<Zt> = (
     >,
 );
 
+/// Use row size equal to poly size, resulting in flat single-row matrices
 fn setup_pp(num_vars: usize) -> Pp<BenchZincTypes> {
     let poly_size = 1 << num_vars;
-    // FIXME: Use flat matrices, i.e. those having just one row
     (
-        ZipPlus::setup(poly_size, IprsCode::new(LEGACY_IPRS_ROW_LEN, IPRS_DEPTH)),
-        ZipPlus::setup(poly_size, IprsCode::new(LEGACY_IPRS_ROW_LEN, IPRS_DEPTH)),
-        ZipPlus::setup(poly_size, IprsCode::new(LEGACY_IPRS_ROW_LEN, IPRS_DEPTH)),
+        ZipPlus::setup(poly_size, IprsCode::new_with_optimal_depth(poly_size)),
+        ZipPlus::setup(poly_size, IprsCode::new_with_optimal_depth(poly_size)),
+        ZipPlus::setup(poly_size, IprsCode::new_with_optimal_depth(poly_size)),
     )
 }
 

--- a/protocol/benches/e2e.rs
+++ b/protocol/benches/e2e.rs
@@ -40,7 +40,7 @@ use zinc_utils::{
     projectable_to_field::ProjectableToField,
 };
 use zip_plus::{
-    code::iprs::{IprsCode, PnttConfigF65537_32_128},
+    code::iprs::{IprsCode, PnttConfigF65537},
     pcs::structs::{ZipPlus, ZipPlusParams, ZipTypes},
     utils::eprint_proof_size,
 };
@@ -55,6 +55,9 @@ const PERFORM_CHECKS: bool = if cfg!(feature = "unchecked") {
 };
 
 const IPRS_DEPTH: usize = 1;
+
+// FIXME: Use flat matrices, i.e. those having just one row
+const LEGACY_IPRS_ROW_LEN: usize = 32 * (1 << (3 * IPRS_DEPTH));
 
 #[allow(clippy::type_complexity)]
 #[derive(Debug, Clone, Copy)]
@@ -223,10 +226,9 @@ where
         MBSInnerProduct,
     >;
 
-    type BinaryLc = IprsCode<Self::BinaryZt, PnttConfigF65537_32_128<IPRS_DEPTH>, PERFORM_CHECKS>;
-    type ArbitraryLc =
-        IprsCode<Self::ArbitraryZt, PnttConfigF65537_32_128<IPRS_DEPTH>, PERFORM_CHECKS>;
-    type IntLc = IprsCode<Self::IntZt, PnttConfigF65537_32_128<IPRS_DEPTH>, PERFORM_CHECKS>;
+    type BinaryLc = IprsCode<Self::BinaryZt, PnttConfigF65537, 4, PERFORM_CHECKS>;
+    type ArbitraryLc = IprsCode<Self::ArbitraryZt, PnttConfigF65537, 4, PERFORM_CHECKS>;
+    type IntLc = IprsCode<Self::IntZt, PnttConfigF65537, 4, PERFORM_CHECKS>;
 }
 
 //
@@ -266,10 +268,11 @@ type Pp<Zt> = (
 
 fn setup_pp(num_vars: usize) -> Pp<BenchZincTypes> {
     let poly_size = 1 << num_vars;
+    // FIXME: Use flat matrices, i.e. those having just one row
     (
-        ZipPlus::setup(poly_size, IprsCode::default()),
-        ZipPlus::setup(poly_size, IprsCode::default()),
-        ZipPlus::setup(poly_size, IprsCode::default()),
+        ZipPlus::setup(poly_size, IprsCode::new(LEGACY_IPRS_ROW_LEN, IPRS_DEPTH)),
+        ZipPlus::setup(poly_size, IprsCode::new(LEGACY_IPRS_ROW_LEN, IPRS_DEPTH)),
+        ZipPlus::setup(poly_size, IprsCode::new(LEGACY_IPRS_ROW_LEN, IPRS_DEPTH)),
     )
 }
 

--- a/protocol/src/lib.rs
+++ b/protocol/src/lib.rs
@@ -435,7 +435,8 @@ mod tests {
 
     const K: usize = INT_LIMBS * 4;
     const M: usize = INT_LIMBS * 8;
-    const IPRS_DEPTH: usize = 1;
+
+    const REP: usize = 4;
 
     type F = MontyField<FIELD_LIMBS>;
 
@@ -541,12 +542,10 @@ mod tests {
         type ArbitraryZt = ArbitraryPolyZipTypesIprs;
         type IntZt = IntZipTypes;
 
-        type BinaryLc = IprsCode<Self::BinaryZt, PnttConfigF65537, 4, CHECKED>;
-        type ArbitraryLc = IprsCode<Self::ArbitraryZt, PnttConfigF65537, 4, CHECKED>;
-        type IntLc = IprsCode<Self::IntZt, PnttConfigF65537, 4, CHECKED>;
+        type BinaryLc = IprsCode<Self::BinaryZt, PnttConfigF65537, REP, CHECKED>;
+        type ArbitraryLc = IprsCode<Self::ArbitraryZt, PnttConfigF65537, REP, CHECKED>;
+        type IntLc = IprsCode<Self::IntZt, PnttConfigF65537, REP, CHECKED>;
     }
-
-    const RAA_REP: usize = 4;
 
     #[derive(Copy, Clone)]
     struct TestRaaConfig;
@@ -569,13 +568,16 @@ mod tests {
         type ArbitraryZt = ArbitraryPolyZipTypesRaa;
         type IntZt = IntZipTypes;
 
-        type BinaryLc = RaaCode<Self::BinaryZt, TestRaaConfig, RAA_REP>;
-        type ArbitraryLc = RaaCode<Self::ArbitraryZt, TestRaaConfig, RAA_REP>;
-        type IntLc = RaaCode<Self::IntZt, TestRaaConfig, RAA_REP>;
+        type BinaryLc = RaaCode<Self::BinaryZt, TestRaaConfig, REP>;
+        type ArbitraryLc = RaaCode<Self::ArbitraryZt, TestRaaConfig, REP>;
+        type IntLc = RaaCode<Self::IntZt, TestRaaConfig, REP>;
     }
 
-    // FIXME: Use flat matrices, i.e. those having just one row
-    const LEGACY_IPRS_ROW_LEN: usize = 32 * (1 << (3 * IPRS_DEPTH));
+    /// Use row size equal to poly size, resulting in flat single-row matrices
+    fn make_iprs<Zt: ZipTypes>(num_vars: usize) -> IprsCode<Zt, PnttConfigF65537, REP, CHECKED> {
+        let poly_size = 1 << num_vars;
+        IprsCode::new_with_optimal_depth(poly_size)
+    }
 
     /// Set up Zip+ PCS parameters for a given number of MLE variables.
     #[allow(clippy::type_complexity)]
@@ -685,12 +687,13 @@ mod tests {
     /// (one constraint, no polynomial multiplication, ideal = <X - 2>).
     #[test]
     fn test_e2e_no_multiplication() {
+        let num_vars = 8;
         do_test::<TestZincTypesIprs, TestAirNoMultiplication<ZtInt>>(
-            8,
+            num_vars,
             (
-                IprsCode::new(LEGACY_IPRS_ROW_LEN, IPRS_DEPTH),
-                IprsCode::new(LEGACY_IPRS_ROW_LEN, IPRS_DEPTH),
-                IprsCode::new(LEGACY_IPRS_ROW_LEN, IPRS_DEPTH),
+                make_iprs(num_vars),
+                make_iprs(num_vars),
+                make_iprs(num_vars),
             ),
             default_project_ideal!(),
             |_| {},
@@ -731,12 +734,13 @@ mod tests {
     /// Constraints: a[i+1] = a[i] + b[i], c[i] = b[i+2].
     #[test]
     fn test_e2e_mixed_shifts() {
+        let num_vars = 8;
         do_test::<TestZincTypesIprs, TestUairMixedShifts<ZtInt>>(
-            8,
+            num_vars,
             (
-                IprsCode::new(LEGACY_IPRS_ROW_LEN, IPRS_DEPTH),
-                IprsCode::new(LEGACY_IPRS_ROW_LEN, IPRS_DEPTH),
-                IprsCode::new(LEGACY_IPRS_ROW_LEN, IPRS_DEPTH),
+                make_iprs(num_vars),
+                make_iprs(num_vars),
+                make_iprs(num_vars),
             ),
             |_ideal, _field_cfg| IdealOrZero::<DegreeOneIdeal<F>>::zero(),
             |_| {},
@@ -750,12 +754,13 @@ mod tests {
     /// UAIR constraint: binary_poly[0] - int[0] \in <X - 2>
     #[test]
     fn test_e2e_binary_decomposition() {
+        let num_vars = 8;
         do_test::<TestZincTypesIprs, BinaryDecompositionUair<ZtInt>>(
-            8,
+            num_vars,
             (
-                IprsCode::new(LEGACY_IPRS_ROW_LEN, IPRS_DEPTH),
-                IprsCode::new(LEGACY_IPRS_ROW_LEN, IPRS_DEPTH),
-                IprsCode::new(LEGACY_IPRS_ROW_LEN, IPRS_DEPTH),
+                make_iprs(num_vars),
+                make_iprs(num_vars),
+                make_iprs(num_vars),
             ),
             default_project_ideal!(),
             |_| {},
@@ -772,12 +777,13 @@ mod tests {
     ///   up.binary_poly[i] - down.binary_poly[i] = 0, for i=1..15
     #[test]
     fn test_e2e_big_linear() {
+        let num_vars = 8;
         do_test::<TestZincTypesIprs, BigLinearUair<ZtInt>>(
-            8,
+            num_vars,
             (
-                IprsCode::new(LEGACY_IPRS_ROW_LEN, IPRS_DEPTH),
-                IprsCode::new(LEGACY_IPRS_ROW_LEN, IPRS_DEPTH),
-                IprsCode::new(LEGACY_IPRS_ROW_LEN, IPRS_DEPTH),
+                make_iprs(num_vars),
+                make_iprs(num_vars),
+                make_iprs(num_vars),
             ),
             default_project_ideal!(),
             |_| {},
@@ -791,12 +797,13 @@ mod tests {
     /// public inputs.
     #[test]
     fn test_e2e_big_linear_with_public_input() {
+        let num_vars = 8;
         do_test::<TestZincTypesIprs, BigLinearUairWithPublicInput<ZtInt>>(
-            8,
+            num_vars,
             (
-                IprsCode::new(LEGACY_IPRS_ROW_LEN, IPRS_DEPTH),
-                IprsCode::new(LEGACY_IPRS_ROW_LEN, IPRS_DEPTH),
-                IprsCode::new(LEGACY_IPRS_ROW_LEN, IPRS_DEPTH),
+                make_iprs(num_vars),
+                make_iprs(num_vars),
+                make_iprs(num_vars),
             ),
             default_project_ideal!(),
             |_| {},
@@ -811,12 +818,13 @@ mod tests {
 
     #[test]
     fn test_big_linear_tamper_lifted_evals() {
+        let num_vars = 8;
         do_test::<TestZincTypesIprs, BigLinearUairWithPublicInput<ZtInt>>(
-            8,
+            num_vars,
             (
-                IprsCode::new(LEGACY_IPRS_ROW_LEN, IPRS_DEPTH),
-                IprsCode::new(LEGACY_IPRS_ROW_LEN, IPRS_DEPTH),
-                IprsCode::new(LEGACY_IPRS_ROW_LEN, IPRS_DEPTH),
+                make_iprs(num_vars),
+                make_iprs(num_vars),
+                make_iprs(num_vars),
             ),
             default_project_ideal!(),
             |proof| proof.witness_lifted_evals.swap(0, 1),
@@ -831,12 +839,13 @@ mod tests {
 
     #[test]
     fn test_big_linear_tamper_up_evals() {
+        let num_vars = 8;
         do_test::<TestZincTypesIprs, BigLinearUairWithPublicInput<ZtInt>>(
-            8,
+            num_vars,
             (
-                IprsCode::new(LEGACY_IPRS_ROW_LEN, IPRS_DEPTH),
-                IprsCode::new(LEGACY_IPRS_ROW_LEN, IPRS_DEPTH),
-                IprsCode::new(LEGACY_IPRS_ROW_LEN, IPRS_DEPTH),
+                make_iprs(num_vars),
+                make_iprs(num_vars),
+                make_iprs(num_vars),
             ),
             default_project_ideal!(),
             |proof| proof.resolver.up_evals.swap(0, 1),
@@ -853,12 +862,13 @@ mod tests {
 
     #[test]
     fn test_big_linear_tamper_down_evals() {
+        let num_vars = 8;
         do_test::<TestZincTypesIprs, BigLinearUairWithPublicInput<ZtInt>>(
-            8,
+            num_vars,
             (
-                IprsCode::new(LEGACY_IPRS_ROW_LEN, IPRS_DEPTH),
-                IprsCode::new(LEGACY_IPRS_ROW_LEN, IPRS_DEPTH),
-                IprsCode::new(LEGACY_IPRS_ROW_LEN, IPRS_DEPTH),
+                make_iprs(num_vars),
+                make_iprs(num_vars),
+                make_iprs(num_vars),
             ),
             default_project_ideal!(),
             |proof| proof.resolver.down_evals.swap(0, 1),
@@ -878,12 +888,13 @@ mod tests {
     // combined_mle_values were computed under the original transcript.
     #[test]
     fn test_big_linear_tamper_commitment() {
+        let num_vars = 8;
         do_test::<TestZincTypesIprs, BigLinearUairWithPublicInput<ZtInt>>(
-            8,
+            num_vars,
             (
-                IprsCode::new(LEGACY_IPRS_ROW_LEN, IPRS_DEPTH),
-                IprsCode::new(LEGACY_IPRS_ROW_LEN, IPRS_DEPTH),
-                IprsCode::new(LEGACY_IPRS_ROW_LEN, IPRS_DEPTH),
+                make_iprs(num_vars),
+                make_iprs(num_vars),
+                make_iprs(num_vars),
             ),
             default_project_ideal!(),
             |proof| proof.commitments.0.root = Default::default(),
@@ -895,12 +906,13 @@ mod tests {
 
     #[test]
     fn test_big_linear_tamper_ideal_check() {
+        let num_vars = 8;
         do_test::<TestZincTypesIprs, BigLinearUairWithPublicInput<ZtInt>>(
-            8,
+            num_vars,
             (
-                IprsCode::new(LEGACY_IPRS_ROW_LEN, IPRS_DEPTH),
-                IprsCode::new(LEGACY_IPRS_ROW_LEN, IPRS_DEPTH),
-                IprsCode::new(LEGACY_IPRS_ROW_LEN, IPRS_DEPTH),
+                make_iprs(num_vars),
+                make_iprs(num_vars),
+                make_iprs(num_vars),
             ),
             default_project_ideal!(),
             |proof| proof.ideal_check.combined_mle_values.swap(0, 1),

--- a/protocol/src/lib.rs
+++ b/protocol/src/lib.rs
@@ -576,7 +576,7 @@ mod tests {
     /// Use row size equal to poly size, resulting in flat single-row matrices
     fn make_iprs<Zt: ZipTypes>(num_vars: usize) -> IprsCode<Zt, PnttConfigF65537, REP, CHECKED> {
         let poly_size = 1 << num_vars;
-        IprsCode::new_with_optimal_depth(poly_size)
+        IprsCode::new_with_optimal_depth(poly_size).unwrap()
     }
 
     /// Set up Zip+ PCS parameters for a given number of MLE variables.

--- a/protocol/src/lib.rs
+++ b/protocol/src/lib.rs
@@ -420,7 +420,7 @@ mod tests {
     };
     use zip_plus::{
         code::{
-            iprs::{IprsCode, PnttConfigF65537_32_128},
+            iprs::{IprsCode, PnttConfigF65537},
             raa::{RaaCode, RaaConfig},
         },
         pcs::structs::{ZipPlus, ZipPlusParams},
@@ -541,10 +541,9 @@ mod tests {
         type ArbitraryZt = ArbitraryPolyZipTypesIprs;
         type IntZt = IntZipTypes;
 
-        type BinaryLc = IprsCode<Self::BinaryZt, PnttConfigF65537_32_128<IPRS_DEPTH>, CHECKED>;
-        type ArbitraryLc =
-            IprsCode<Self::ArbitraryZt, PnttConfigF65537_32_128<IPRS_DEPTH>, CHECKED>;
-        type IntLc = IprsCode<Self::IntZt, PnttConfigF65537_32_128<IPRS_DEPTH>, CHECKED>;
+        type BinaryLc = IprsCode<Self::BinaryZt, PnttConfigF65537, 4, CHECKED>;
+        type ArbitraryLc = IprsCode<Self::ArbitraryZt, PnttConfigF65537, 4, CHECKED>;
+        type IntLc = IprsCode<Self::IntZt, PnttConfigF65537, 4, CHECKED>;
     }
 
     const RAA_REP: usize = 4;
@@ -574,6 +573,9 @@ mod tests {
         type ArbitraryLc = RaaCode<Self::ArbitraryZt, TestRaaConfig, RAA_REP>;
         type IntLc = RaaCode<Self::IntZt, TestRaaConfig, RAA_REP>;
     }
+
+    // FIXME: Use flat matrices, i.e. those having just one row
+    const LEGACY_IPRS_ROW_LEN: usize = 32 * (1 << (3 * IPRS_DEPTH));
 
     /// Set up Zip+ PCS parameters for a given number of MLE variables.
     #[allow(clippy::type_complexity)]
@@ -685,7 +687,11 @@ mod tests {
     fn test_e2e_no_multiplication() {
         do_test::<TestZincTypesIprs, TestAirNoMultiplication<ZtInt>>(
             8,
-            Default::default(),
+            (
+                IprsCode::new(LEGACY_IPRS_ROW_LEN, IPRS_DEPTH),
+                IprsCode::new(LEGACY_IPRS_ROW_LEN, IPRS_DEPTH),
+                IprsCode::new(LEGACY_IPRS_ROW_LEN, IPRS_DEPTH),
+            ),
             default_project_ideal!(),
             |_| {},
             |res| res.unwrap(),
@@ -727,7 +733,11 @@ mod tests {
     fn test_e2e_mixed_shifts() {
         do_test::<TestZincTypesIprs, TestUairMixedShifts<ZtInt>>(
             8,
-            Default::default(),
+            (
+                IprsCode::new(LEGACY_IPRS_ROW_LEN, IPRS_DEPTH),
+                IprsCode::new(LEGACY_IPRS_ROW_LEN, IPRS_DEPTH),
+                IprsCode::new(LEGACY_IPRS_ROW_LEN, IPRS_DEPTH),
+            ),
             |_ideal, _field_cfg| IdealOrZero::<DegreeOneIdeal<F>>::zero(),
             |_| {},
             |res| res.unwrap(),
@@ -742,7 +752,11 @@ mod tests {
     fn test_e2e_binary_decomposition() {
         do_test::<TestZincTypesIprs, BinaryDecompositionUair<ZtInt>>(
             8,
-            Default::default(),
+            (
+                IprsCode::new(LEGACY_IPRS_ROW_LEN, IPRS_DEPTH),
+                IprsCode::new(LEGACY_IPRS_ROW_LEN, IPRS_DEPTH),
+                IprsCode::new(LEGACY_IPRS_ROW_LEN, IPRS_DEPTH),
+            ),
             default_project_ideal!(),
             |_| {},
             |res| res.unwrap(),
@@ -760,7 +774,11 @@ mod tests {
     fn test_e2e_big_linear() {
         do_test::<TestZincTypesIprs, BigLinearUair<ZtInt>>(
             8,
-            Default::default(),
+            (
+                IprsCode::new(LEGACY_IPRS_ROW_LEN, IPRS_DEPTH),
+                IprsCode::new(LEGACY_IPRS_ROW_LEN, IPRS_DEPTH),
+                IprsCode::new(LEGACY_IPRS_ROW_LEN, IPRS_DEPTH),
+            ),
             default_project_ideal!(),
             |_| {},
             |res| res.unwrap(),
@@ -775,7 +793,11 @@ mod tests {
     fn test_e2e_big_linear_with_public_input() {
         do_test::<TestZincTypesIprs, BigLinearUairWithPublicInput<ZtInt>>(
             8,
-            Default::default(),
+            (
+                IprsCode::new(LEGACY_IPRS_ROW_LEN, IPRS_DEPTH),
+                IprsCode::new(LEGACY_IPRS_ROW_LEN, IPRS_DEPTH),
+                IprsCode::new(LEGACY_IPRS_ROW_LEN, IPRS_DEPTH),
+            ),
             default_project_ideal!(),
             |_| {},
             |res| res.unwrap(),
@@ -791,7 +813,11 @@ mod tests {
     fn test_big_linear_tamper_lifted_evals() {
         do_test::<TestZincTypesIprs, BigLinearUairWithPublicInput<ZtInt>>(
             8,
-            Default::default(),
+            (
+                IprsCode::new(LEGACY_IPRS_ROW_LEN, IPRS_DEPTH),
+                IprsCode::new(LEGACY_IPRS_ROW_LEN, IPRS_DEPTH),
+                IprsCode::new(LEGACY_IPRS_ROW_LEN, IPRS_DEPTH),
+            ),
             default_project_ideal!(),
             |proof| proof.witness_lifted_evals.swap(0, 1),
             |res| {
@@ -807,7 +833,11 @@ mod tests {
     fn test_big_linear_tamper_up_evals() {
         do_test::<TestZincTypesIprs, BigLinearUairWithPublicInput<ZtInt>>(
             8,
-            Default::default(),
+            (
+                IprsCode::new(LEGACY_IPRS_ROW_LEN, IPRS_DEPTH),
+                IprsCode::new(LEGACY_IPRS_ROW_LEN, IPRS_DEPTH),
+                IprsCode::new(LEGACY_IPRS_ROW_LEN, IPRS_DEPTH),
+            ),
             default_project_ideal!(),
             |proof| proof.resolver.up_evals.swap(0, 1),
             |res| {
@@ -825,7 +855,11 @@ mod tests {
     fn test_big_linear_tamper_down_evals() {
         do_test::<TestZincTypesIprs, BigLinearUairWithPublicInput<ZtInt>>(
             8,
-            Default::default(),
+            (
+                IprsCode::new(LEGACY_IPRS_ROW_LEN, IPRS_DEPTH),
+                IprsCode::new(LEGACY_IPRS_ROW_LEN, IPRS_DEPTH),
+                IprsCode::new(LEGACY_IPRS_ROW_LEN, IPRS_DEPTH),
+            ),
             default_project_ideal!(),
             |proof| proof.resolver.down_evals.swap(0, 1),
             |res| {
@@ -846,7 +880,11 @@ mod tests {
     fn test_big_linear_tamper_commitment() {
         do_test::<TestZincTypesIprs, BigLinearUairWithPublicInput<ZtInt>>(
             8,
-            Default::default(),
+            (
+                IprsCode::new(LEGACY_IPRS_ROW_LEN, IPRS_DEPTH),
+                IprsCode::new(LEGACY_IPRS_ROW_LEN, IPRS_DEPTH),
+                IprsCode::new(LEGACY_IPRS_ROW_LEN, IPRS_DEPTH),
+            ),
             default_project_ideal!(),
             |proof| proof.commitments.0.root = Default::default(),
             |res| {
@@ -859,7 +897,11 @@ mod tests {
     fn test_big_linear_tamper_ideal_check() {
         do_test::<TestZincTypesIprs, BigLinearUairWithPublicInput<ZtInt>>(
             8,
-            Default::default(),
+            (
+                IprsCode::new(LEGACY_IPRS_ROW_LEN, IPRS_DEPTH),
+                IprsCode::new(LEGACY_IPRS_ROW_LEN, IPRS_DEPTH),
+                IprsCode::new(LEGACY_IPRS_ROW_LEN, IPRS_DEPTH),
+            ),
             default_project_ideal!(),
             |proof| proof.ideal_check.combined_mle_values.swap(0, 1),
             |res| {

--- a/zip-plus/benches/zip_plus_benches.rs
+++ b/zip-plus/benches/zip_plus_benches.rs
@@ -97,11 +97,11 @@ fn zip_plus_benchmarks_iprs(c: &mut Criterion) {
     // Use flat single-row Zip+ matrix
     do_bench::<BenchZipPlusTypes<i64, 32>, SomeIprsCode<i64, 32, PERFORM_CHECKS>, PERFORM_CHECKS>(
         &mut group,
-        IprsCode::new_with_optimal_depth,
+        |poly_size| IprsCode::new_with_optimal_depth(poly_size).unwrap(),
     );
     do_bench::<BenchZipPlusTypes<i64, 64>, SomeIprsCode<i64, 64, PERFORM_CHECKS>, PERFORM_CHECKS>(
         &mut group,
-        IprsCode::new_with_optimal_depth,
+        |poly_size| IprsCode::new_with_optimal_depth(poly_size).unwrap(),
     );
 
     group.finish();

--- a/zip-plus/benches/zip_plus_benches.rs
+++ b/zip-plus/benches/zip_plus_benches.rs
@@ -20,7 +20,7 @@ use zinc_transcript::traits::ConstTranscribable;
 use zinc_utils::{from_ref::FromRef, inner_product::MBSInnerProduct, named::Named};
 use zip_plus::{
     code::{
-        iprs::{IprsCode, PnttConfigF65537_32_128},
+        iprs::{IprsCode, PnttConfigF65537},
         raa::{RaaCode, RaaConfig},
     },
     pcs::structs::ZipTypes,
@@ -73,8 +73,8 @@ impl RaaConfig for BenchRaaConfig {
 type SomeRaaCode<const D_PLUS_ONE: usize> =
     RaaCode<BenchZipPlusTypes<i32, D_PLUS_ONE>, BenchRaaConfig, 4>;
 
-type SomeIprsCode<Twiddle, const DEPTH: usize, const D_PLUS_ONE: usize, const CHECK: bool> =
-    IprsCode<BenchZipPlusTypes<Twiddle, D_PLUS_ONE>, PnttConfigF65537_32_128<DEPTH>, CHECK>;
+type SomeIprsCode<Twiddle, const D_PLUS_ONE: usize, const CHECK: bool> =
+    IprsCode<BenchZipPlusTypes<Twiddle, D_PLUS_ONE>, PnttConfigF65537, 4, CHECK>;
 
 fn zip_plus_benchmarks_raa(c: &mut Criterion) {
     let mut group = c.benchmark_group("Zip+ RAA");
@@ -94,13 +94,16 @@ fn zip_plus_benchmarks_raa(c: &mut Criterion) {
 fn zip_plus_benchmarks_iprs(c: &mut Criterion) {
     let mut group = c.benchmark_group("Zip+ IPRS");
 
-    do_bench::<BenchZipPlusTypes<i64, 32>, SomeIprsCode<i64, 1, 32, PERFORM_CHECKS>, PERFORM_CHECKS>(
+    const IPRS_DEPTH: usize = 1;
+    // FIXME: Use flat matrices, i.e. those having just one row
+    const LEGACY_IPRS_ROW_LEN: usize = 32 * (1 << (3 * IPRS_DEPTH));
+    do_bench::<BenchZipPlusTypes<i64, 32>, SomeIprsCode<i64, 32, PERFORM_CHECKS>, PERFORM_CHECKS>(
         &mut group,
-        |_poly_size| IprsCode::default(),
+        |_poly_size| IprsCode::new(LEGACY_IPRS_ROW_LEN, IPRS_DEPTH),
     );
-    do_bench::<BenchZipPlusTypes<i64, 64>, SomeIprsCode<i64, 1, 64, PERFORM_CHECKS>, PERFORM_CHECKS>(
+    do_bench::<BenchZipPlusTypes<i64, 64>, SomeIprsCode<i64, 64, PERFORM_CHECKS>, PERFORM_CHECKS>(
         &mut group,
-        |_poly_size| IprsCode::default(),
+        |_poly_size| IprsCode::new(LEGACY_IPRS_ROW_LEN, IPRS_DEPTH),
     );
 
     group.finish();

--- a/zip-plus/benches/zip_plus_benches.rs
+++ b/zip-plus/benches/zip_plus_benches.rs
@@ -94,16 +94,14 @@ fn zip_plus_benchmarks_raa(c: &mut Criterion) {
 fn zip_plus_benchmarks_iprs(c: &mut Criterion) {
     let mut group = c.benchmark_group("Zip+ IPRS");
 
-    const IPRS_DEPTH: usize = 1;
-    // FIXME: Use flat matrices, i.e. those having just one row
-    const LEGACY_IPRS_ROW_LEN: usize = 32 * (1 << (3 * IPRS_DEPTH));
+    // Use flat single-row Zip+ matrix
     do_bench::<BenchZipPlusTypes<i64, 32>, SomeIprsCode<i64, 32, PERFORM_CHECKS>, PERFORM_CHECKS>(
         &mut group,
-        |_poly_size| IprsCode::new(LEGACY_IPRS_ROW_LEN, IPRS_DEPTH),
+        IprsCode::new_with_optimal_depth,
     );
     do_bench::<BenchZipPlusTypes<i64, 64>, SomeIprsCode<i64, 64, PERFORM_CHECKS>, PERFORM_CHECKS>(
         &mut group,
-        |_poly_size| IprsCode::new(LEGACY_IPRS_ROW_LEN, IPRS_DEPTH),
+        IprsCode::new_with_optimal_depth,
     );
 
     group.finish();

--- a/zip-plus/src/code/iprs.rs
+++ b/zip-plus/src/code/iprs.rs
@@ -36,6 +36,19 @@ where
         }
     }
 
+    /// Create a new IPRS code with the optimal depth heuristics trying to keep
+    /// number of columns in the base matrix small.
+    /// Currently, keeps number of columns <= 2^7 but this might be tweaked in
+    /// the future.
+    pub fn new_with_optimal_depth(row_len: usize) -> Self {
+        const MAX_BASE_COLS_LOG2: usize = 7;
+
+        let target_base_len = 1 << MAX_BASE_COLS_LOG2;
+        let depth = 1.max(((row_len / target_base_len).ilog2() as usize).div_ceil(3));
+
+        Self::new(row_len, depth)
+    }
+
     /// Encode without modular reduction, purely over the integers.
     fn encode_inner<In, Out>(&self, row: &[In]) -> Vec<Out>
     where

--- a/zip-plus/src/code/iprs.rs
+++ b/zip-plus/src/code/iprs.rs
@@ -4,18 +4,14 @@ use crate::{code::LinearCode, pcs::structs::ZipTypes};
 use crypto_primitives::{FromPrimitiveWithConfig, FromWithConfig};
 use num_traits::{CheckedAdd, CheckedMul};
 use pntt::radix8::params::Config as PnttConfig;
-pub use pntt::radix8::params::{
-    PnttConfigF65537_1_4, PnttConfigF65537_2_8, PnttConfigF65537_4_16, PnttConfigF65537_16_64,
-    PnttConfigF65537_32_64, PnttConfigF65537_32_128, PnttConfigF65537_64_256, PnttInt,
-    Radix8PnttParams,
-};
+pub use pntt::radix8::params::{PnttConfigF65537, PnttInt, Radix8PnttParams};
 use std::{
     fmt::Debug,
     iter::Sum,
     marker::PhantomData,
     ops::{Add, AddAssign},
 };
-use zinc_utils::{from_ref::FromRef, mul, mul_by_scalar::MulByScalar};
+use zinc_utils::{from_ref::FromRef, mul_by_scalar::MulByScalar};
 
 /// Pseudo Reed-Solomon encoder over the integers. Internally uses a
 /// radix-8 NTT-style recursion with a base Vandermonde matrix sized
@@ -23,16 +19,23 @@ use zinc_utils::{from_ref::FromRef, mul, mul_by_scalar::MulByScalar};
 ///
 /// To create a new instance, use [`IprsCode::default`] method.
 #[derive(Clone)]
-pub struct IprsCode<Zt: ZipTypes, Config: PnttConfig, const CHECK: bool> {
+pub struct IprsCode<Zt: ZipTypes, Config: PnttConfig, const REP: usize, const CHECK: bool> {
     pntt_params: Radix8PnttParams<Config>,
     _phantom: PhantomData<Zt>,
 }
 
-impl<Zt, Config, const CHECK: bool> IprsCode<Zt, Config, CHECK>
+impl<Zt, Config, const REP: usize, const CHECK: bool> IprsCode<Zt, Config, REP, CHECK>
 where
     Zt: ZipTypes,
     Config: PnttConfig,
 {
+    pub fn new(row_len: usize, depth: usize) -> Self {
+        Self {
+            pntt_params: Radix8PnttParams::new(row_len, depth, REP),
+            _phantom: Default::default(),
+        }
+    }
+
     /// Encode without modular reduction, purely over the integers.
     fn encode_inner<In, Out>(&self, row: &[In]) -> Vec<Out>
     where
@@ -51,10 +54,10 @@ where
     {
         assert_eq!(
             row.len(),
-            Config::INPUT_LEN,
+            self.pntt_params.row_len,
             "Input length {} does not match expected row length {}",
             row.len(),
-            Config::INPUT_LEN
+            self.pntt_params.row_len,
         );
 
         macro_rules! mul_fn {
@@ -77,10 +80,10 @@ where
     {
         assert_eq!(
             row.len(),
-            Config::INPUT_LEN,
+            self.pntt_params.row_len,
             "Input length {} does not match expected row length {}",
             row.len(),
-            Config::INPUT_LEN
+            self.pntt_params.row_len,
         );
 
         let mul_fn = |f: &F, tw: &PnttInt| f.clone() * F::from_with_cfg(*tw, f.cfg());
@@ -89,7 +92,8 @@ where
     }
 }
 
-impl<Zt: ZipTypes, Config, const CHECK: bool> LinearCode<Zt> for IprsCode<Zt, Config, CHECK>
+impl<Zt: ZipTypes, Config, const REP: usize, const CHECK: bool> LinearCode<Zt>
+    for IprsCode<Zt, Config, REP, CHECK>
 where
     Zt: ZipTypes,
     Config: PnttConfig,
@@ -97,26 +101,26 @@ where
     Zt::CombR: for<'a> MulByScalar<&'a PnttInt>,
     Zt::Cw: CheckedAdd + for<'a> MulByScalar<&'a PnttInt>,
 {
-    const REPETITION_FACTOR: usize = Config::OUTPUT_LEN / Config::INPUT_LEN;
+    const REPETITION_FACTOR: usize = REP;
 
     fn encode(&self, row: &[Zt::Eval]) -> Vec<Zt::Cw> {
         assert_eq!(
             row.len(),
-            Config::INPUT_LEN,
+            self.pntt_params.row_len,
             "Input length {} does not match expected row length {}",
             row.len(),
-            Config::INPUT_LEN
+            self.pntt_params.row_len,
         );
 
         self.encode_inner(row)
     }
 
     fn row_len(&self) -> usize {
-        Config::INPUT_LEN
+        self.pntt_params.row_len
     }
 
     fn codeword_len(&self) -> usize {
-        Config::OUTPUT_LEN
+        self.pntt_params.codeword_len
     }
 
     fn encode_wide(&self, row: &[Zt::CombR]) -> Vec<Zt::CombR> {
@@ -131,32 +135,7 @@ where
     }
 }
 
-impl<Zt, Config, const CHECK: bool> Default for IprsCode<Zt, Config, CHECK>
-where
-    Zt: ZipTypes,
-    Config: PnttConfig,
-    Zt::Eval: for<'a> MulByScalar<&'a PnttInt, Zt::Cw>,
-    Zt::CombR: for<'a> MulByScalar<&'a PnttInt>,
-    Zt::Cw: CheckedAdd + for<'a> MulByScalar<&'a PnttInt>,
-{
-    fn default() -> Self {
-        assert_eq!(
-            Config::OUTPUT_LEN,
-            mul!(Config::INPUT_LEN, Self::REPETITION_FACTOR),
-            "Codeword length {} must equal row length {} times repetition factor {}",
-            Config::OUTPUT_LEN,
-            Config::INPUT_LEN,
-            Self::REPETITION_FACTOR
-        );
-
-        Self {
-            pntt_params: Radix8PnttParams::new(),
-            _phantom: Default::default(),
-        }
-    }
-}
-
-impl<Zt, Config, const CHECK: bool> Debug for IprsCode<Zt, Config, CHECK>
+impl<Zt, Config, const REP: usize, const CHECK: bool> Debug for IprsCode<Zt, Config, REP, CHECK>
 where
     Zt: ZipTypes,
     Config: PnttConfig,
@@ -168,7 +147,7 @@ where
     }
 }
 
-impl<Zt, Config, const CHECK: bool> PartialEq for IprsCode<Zt, Config, CHECK>
+impl<Zt, Config, const REP: usize, const CHECK: bool> PartialEq for IprsCode<Zt, Config, REP, CHECK>
 where
     Config: PnttConfig,
     Zt: ZipTypes,
@@ -178,7 +157,7 @@ where
     }
 }
 
-impl<Zt, Config, const CHECK: bool> Eq for IprsCode<Zt, Config, CHECK>
+impl<Zt, Config, const REP: usize, const CHECK: bool> Eq for IprsCode<Zt, Config, REP, CHECK>
 where
     Zt: ZipTypes,
     Config: PnttConfig,

--- a/zip-plus/src/code/iprs.rs
+++ b/zip-plus/src/code/iprs.rs
@@ -1,6 +1,6 @@
 mod pntt;
 
-use crate::{code::LinearCode, pcs::structs::ZipTypes};
+use crate::{ZipError, code::LinearCode, pcs::structs::ZipTypes};
 use crypto_primitives::{FromPrimitiveWithConfig, FromWithConfig};
 use num_traits::{CheckedAdd, CheckedMul};
 use pntt::radix8::params::Config as PnttConfig;
@@ -16,8 +16,6 @@ use zinc_utils::{from_ref::FromRef, mul_by_scalar::MulByScalar};
 /// Pseudo Reed-Solomon encoder over the integers. Internally uses a
 /// radix-8 NTT-style recursion with a base Vandermonde matrix sized
 /// `base_len x base_dim` (defaults to 64x32).
-///
-/// To create a new instance, use [`IprsCode::default`] method.
 #[derive(Clone)]
 pub struct IprsCode<Zt: ZipTypes, Config: PnttConfig, const REP: usize, const CHECK: bool> {
     pntt_params: Radix8PnttParams<Config>,
@@ -29,22 +27,23 @@ where
     Zt: ZipTypes,
     Config: PnttConfig,
 {
-    pub fn new(row_len: usize, depth: usize) -> Self {
-        Self {
-            pntt_params: Radix8PnttParams::new(row_len, depth, REP),
+    pub fn new(row_len: usize, depth: usize) -> Result<Self, ZipError> {
+        Ok(Self {
+            pntt_params: Radix8PnttParams::new(row_len, depth, REP)?,
             _phantom: Default::default(),
-        }
+        })
     }
 
     /// Create a new IPRS code with the optimal depth heuristics trying to keep
     /// number of columns in the base matrix small.
     /// Currently, keeps number of columns <= 2^7 but this might be tweaked in
     /// the future.
-    pub fn new_with_optimal_depth(row_len: usize) -> Self {
+    pub fn new_with_optimal_depth(row_len: usize) -> Result<Self, ZipError> {
         const MAX_BASE_COLS_LOG2: usize = 7;
 
         let target_base_len = 1 << MAX_BASE_COLS_LOG2;
-        let depth = 1.max(((row_len / target_base_len).ilog2() as usize).div_ceil(3));
+        // We want depth to be at least 1.
+        let depth = 1.max(((1.max(row_len / target_base_len)).ilog2() as usize).div_ceil(3));
 
         Self::new(row_len, depth)
     }
@@ -175,4 +174,33 @@ where
     Zt: ZipTypes,
     Config: PnttConfig,
 {
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::pcs::test_utils::*;
+    use crypto_bigint::U64;
+    use zinc_utils::CHECKED;
+
+    const INT_LIMBS: usize = U64::LIMBS;
+    const N: usize = INT_LIMBS;
+    const K: usize = INT_LIMBS * 4;
+    const M: usize = INT_LIMBS * 8;
+    type Zt = TestZipTypes<N, K, M>;
+
+    type Code = IprsCode<Zt, PnttConfigF65537, REP_FACTOR, CHECKED>;
+
+    #[test]
+    fn new_with_different_params() {
+        assert!(Code::new(1, 0).is_ok());
+        assert!(Code::new(8, 0).is_ok());
+        assert!(Code::new(1, 1).is_err());
+        assert!(Code::new(8, 1).is_ok());
+
+        assert!(Code::new_with_optimal_depth(1).is_err());
+        assert!(Code::new_with_optimal_depth(8).is_ok());
+        assert!(Code::new_with_optimal_depth(12).is_err());
+        assert!(Code::new_with_optimal_depth(16).is_ok());
+    }
 }

--- a/zip-plus/src/code/iprs/pntt/radix8.rs
+++ b/zip-plus/src/code/iprs/pntt/radix8.rs
@@ -37,10 +37,10 @@ where
         + for<'a> Add<&'a Out, Output = Out>,
 {
     assert_eq!(
-        C::INPUT_LEN,
+        params.row_len,
         input.len(),
         "PNTT expects length = {}, got {}",
-        C::INPUT_LEN,
+        params.row_len,
         input.len()
     );
 
@@ -63,9 +63,9 @@ fn combine_stages<R, C, const CHECK: bool>(
     C: Config,
     R: CheckedAdd + CheckedMul + for<'a> Add<&'a R, Output = R> + Clone + Send + Sync + Debug,
 {
-    for k in 0..C::DEPTH {
+    for k in 0..params.depth {
         // The length of chunks in the current layer.
-        let sub_chunk_length = C::BASE_DIM * (1 << (3 * k));
+        let sub_chunk_length = params.base_dim * (1 << (3 * k));
 
         // On each step of recursive radix-8 NTT
         // we divide the length of the evaluation domain by 8.
@@ -76,8 +76,8 @@ fn combine_stages<R, C, const CHECK: bool>(
         //
         // Since we are going from bottom up we are successively
         // taking
-        //      \omega^(8 ^ (C::DEPTH - 1))
-        //      \omega^(8 ^ (C::DEPTH - 2))
+        //      \omega^(8 ^ (params.depth - 1))
+        //      \omega^(8 ^ (params.depth - 2))
         //      ...
         //      \omega^(8 ^ 0) = \omega
         // These factors are already absorbed into `layer_twiddles`.
@@ -130,18 +130,18 @@ where
         + Sync
         + for<'a> Add<&'a Out, Output = Out>,
 {
-    cfg_into_iter!(0..C::OUTPUT_LEN)
+    cfg_into_iter!(0..params.codeword_len)
         .map(|i| {
-            let chunk = i >> C::BASE_DIM_LOG2; // i / C::BASE_DIM
-            let row = i & C::BASE_DIM_MASK; // i % C::BASE_DIM
+            let chunk = i >> params.base_dim_log2; // i / BASE_DIM
+            let row = i & params.base_dim_mask; // i % BASE_DIM
 
             // If we'd done all the divide steps of the NTT recursively
             // we'd end up with chunks of original indices
-            // combined together according to their `3 * C::DEPTH`
+            // combined together according to their `3 * params.depth`
             // least significant bits. Moreover, the value of these
             // least significant bits correspond to the number of the chunk
             // in octet-reverse order.
-            let oct_rev_chunk = octet_reversal(chunk, C::DEPTH);
+            let oct_rev_chunk = octet_reversal(chunk, params.depth);
 
             // We always know that the first column of the Vandermonde matrix
             // consists of 1's.
@@ -149,7 +149,7 @@ where
                 Out::from_ref(&input[oct_rev_chunk]),
                 |acc, (col, bm_row_col)| {
                     let term = mul_by_twiddle(
-                        &input[oct_rev_chunk | ((col + 1) << (3 * C::DEPTH))],
+                        &input[oct_rev_chunk | ((col + 1) << (3 * params.depth))],
                         bm_row_col,
                     );
 
@@ -172,22 +172,22 @@ mod tests {
 
     use super::*;
 
-    fn compare_to_arkworks_ntt_base_layer_generic<C: Config>()
+    fn compare_to_arkworks_ntt_base_layer_generic<C: Config>(params: &Radix8PnttParams<C>)
     where
         C::Field: From<PnttInt>,
     {
-        let input = (0i64..(32i64 * PnttInt::from(1 << (3 * C::DEPTH)))).collect_vec();
+        let input = (0i64..(32i64 * PnttInt::from(1 << (3 * params.depth)))).collect_vec();
 
         let arkworks_res = {
-            let mut result = Vec::with_capacity(64 * (1 << (3 * C::DEPTH)));
+            let mut result = Vec::with_capacity(64 * (1 << (3 * params.depth)));
             let domain = Radix2EvaluationDomain::<C::Field>::new(64).unwrap();
 
-            for chunk in 0..(1 << (3 * C::DEPTH)) {
+            for chunk in 0..(1 << (3 * params.depth)) {
                 let mut input = input
                     .iter()
                     .enumerate()
                     .filter(|(i, _)| {
-                        i & ((1 << (3 * C::DEPTH)) - 1) == octet_reversal(chunk, C::DEPTH)
+                        i & ((1 << (3 * params.depth)) - 1) == octet_reversal(chunk, params.depth)
                     })
                     .map(|(_, x)| C::Field::from(*x))
                     .collect_vec();
@@ -201,9 +201,7 @@ mod tests {
         };
 
         let our_res = {
-            let params = Radix8PnttParams::<C>::new();
-
-            let output = base_multiply_into_output::<_, _, _, CHECKED>(&input, &params, |a, b| {
+            let output = base_multiply_into_output::<_, _, _, CHECKED>(&input, params, |a, b| {
                 a.mul_by_scalar::<CHECKED>(b).unwrap()
             });
 
@@ -215,26 +213,28 @@ mod tests {
 
     #[test]
     fn compare_to_arkworks_ntt_base_layer_multiply() {
-        compare_to_arkworks_ntt_base_layer_generic::<PnttConfigF65537_32_64<1>>();
-        compare_to_arkworks_ntt_base_layer_generic::<PnttConfigF65537_32_64<2>>();
-        compare_to_arkworks_ntt_base_layer_generic::<PnttConfigF65537_32_64<3>>();
+        for depth in 1..=3 {
+            let row_len = 32 * (1 << (3 * depth));
+            let params = Radix8PnttParams::new(row_len, depth, 2);
+            compare_to_arkworks_ntt_base_layer_generic::<PnttConfigF65537>(&params);
+        }
     }
 
-    fn pntt_against_arkworks_generic<C: Config>()
+    fn pntt_against_arkworks_generic<C: Config>(params: &Radix8PnttParams<C>)
     where
         C::Field: From<PnttInt>,
         Int<4>: From<PnttInt> + for<'a> MulByScalar<&'a PnttInt>,
     {
-        let input: Vec<PnttInt> = (0..C::INPUT_LEN)
+        let input: Vec<PnttInt> = (0..params.row_len)
             .map(|x| PnttInt::try_from(x).unwrap())
             .collect_vec();
 
         let arkworks_res = {
-            let domain = Radix2EvaluationDomain::<C::Field>::new(C::OUTPUT_LEN).unwrap();
+            let domain = Radix2EvaluationDomain::<C::Field>::new(params.codeword_len).unwrap();
 
             let mut input = input.iter().map(|i| C::Field::from(*i)).collect_vec();
 
-            input.resize(C::OUTPUT_LEN, C::Field::zero());
+            input.resize(params.codeword_len, C::Field::zero());
 
             domain.fft_in_place(&mut input);
 
@@ -244,11 +244,9 @@ mod tests {
         let our_res = {
             let input: Vec<Int<4>> = input.into_iter().map(|x| x.into()).collect_vec();
 
-            let params = Radix8PnttParams::<C>::new();
-
             let res: Vec<Int<4>> = pntt::<_, _, _, CHECKED>(
                 &input,
-                &params,
+                params,
                 |a, b| a.mul_by_scalar::<CHECKED>(b).unwrap(),
                 |a, b| a.mul_by_scalar::<CHECKED>(b).unwrap(),
             );
@@ -274,8 +272,12 @@ mod tests {
 
     #[test]
     fn pntt_against_arkworks() {
-        pntt_against_arkworks_generic::<PnttConfigF65537_32_64<1>>();
-        pntt_against_arkworks_generic::<PnttConfigF65537_32_64<2>>();
-        pntt_against_arkworks_generic::<PnttConfigF65537_32_64<3>>();
+        let base_len = 32;
+        for depth in 1..=3 {
+            let row_len = base_len * (1 << (3 * depth));
+            pntt_against_arkworks_generic::<PnttConfigF65537>(&Radix8PnttParams::new(
+                row_len, depth, 2,
+            ));
+        }
     }
 }

--- a/zip-plus/src/code/iprs/pntt/radix8.rs
+++ b/zip-plus/src/code/iprs/pntt/radix8.rs
@@ -215,7 +215,7 @@ mod tests {
     fn compare_to_arkworks_ntt_base_layer_multiply() {
         for depth in 1..=3 {
             let row_len = 32 * (1 << (3 * depth));
-            let params = Radix8PnttParams::new(row_len, depth, 2);
+            let params = Radix8PnttParams::new(row_len, depth, 2).unwrap();
             compare_to_arkworks_ntt_base_layer_generic::<PnttConfigF65537>(&params);
         }
     }
@@ -275,9 +275,9 @@ mod tests {
         let base_len = 32;
         for depth in 1..=3 {
             let row_len = base_len * (1 << (3 * depth));
-            pntt_against_arkworks_generic::<PnttConfigF65537>(&Radix8PnttParams::new(
-                row_len, depth, 2,
-            ));
+            pntt_against_arkworks_generic::<PnttConfigF65537>(
+                &Radix8PnttParams::new(row_len, depth, 2).unwrap(),
+            );
         }
     }
 }

--- a/zip-plus/src/code/iprs/pntt/radix8/params.rs
+++ b/zip-plus/src/code/iprs/pntt/radix8/params.rs
@@ -1,3 +1,4 @@
+use crate::ZipError;
 use ark_ff::{FftField, FpConfig};
 use num_traits::Euclid;
 use std::{fmt::Debug, marker::PhantomData};
@@ -55,33 +56,34 @@ pub struct Radix8PnttParams<C: Config> {
 
 impl<C: Config> Radix8PnttParams<C> {
     /// Precompute pseudo NTT parameters.
-    pub fn new(row_len: usize, depth: usize, rep_factor: usize) -> Self {
+    pub fn new(row_len: usize, depth: usize, rep_factor: usize) -> Result<Self, ZipError> {
         let codeword_len = mul!(row_len, rep_factor);
-        assert!(
-            codeword_len < C::FIELD_MODULUS as usize,
-            "Codeword length is more than the number of elements in the field"
-        );
+        if codeword_len >= C::FIELD_MODULUS as usize {
+            return Err(ZipError::InvalidPcsParam(
+                "Codeword length is more than the number of elements in the field".to_owned(),
+            ));
+        }
 
         let coeff = 1_usize << mul!(3, depth);
         let (base_len, base_len_rem) = row_len.div_rem_euclid(&coeff);
-        assert_eq!(
-            base_len_rem, 0,
-            "Row length must be a multiple of {}",
-            coeff
-        );
+        if base_len_rem != 0 {
+            return Err(ZipError::InvalidPcsParam(format!(
+                "Row length {row_len} must be a multiple of {coeff}"
+            )));
+        }
 
         let base_dim = mul!(base_len, rep_factor);
-        assert!(
-            base_dim.is_power_of_two(),
-            "Base dimension must be a power of 2, got {}",
-            base_dim
-        );
+        if !base_dim.is_power_of_two() {
+            return Err(ZipError::InvalidPcsParam(format!(
+                "Base dimension {base_dim} must be a power of 2"
+            )));
+        }
 
         let base_dim_log2: u32 = base_dim.trailing_zeros();
 
         let base_dim_mask: usize = sub!(base_dim, 1);
 
-        Self {
+        Ok(Self {
             row_len,
             codeword_len,
             depth,
@@ -96,7 +98,7 @@ impl<C: Config> Radix8PnttParams<C> {
                 depth,
             ),
             _phantom: PhantomData,
-        }
+        })
     }
 }
 

--- a/zip-plus/src/code/iprs/pntt/radix8/params.rs
+++ b/zip-plus/src/code/iprs/pntt/radix8/params.rs
@@ -1,5 +1,7 @@
 use ark_ff::{FftField, FpConfig};
+use num_traits::Euclid;
 use std::{fmt::Debug, marker::PhantomData};
+use zinc_utils::{mul, sub};
 
 /// The integer types of twiddles.
 pub type PnttInt = i64;
@@ -11,38 +13,91 @@ pub trait Config: Debug + Copy + Send + Sync {
     type Field: FftField;
     const FIELD_MODULUS: u32;
 
-    /// The number of steps where NTT is performed recursivily.
-    const DEPTH: usize;
-    /// The number of columns of the base matrix.
-    const BASE_LEN: usize;
-    /// The number of rows of the base matrix, always a power of 2.
-    const BASE_DIM: usize;
-    /// log2 of the number of rows of the base matrix.
-    const BASE_DIM_LOG2: u32 = Self::BASE_DIM.trailing_zeros();
-    /// The mask to compute `i % Self::BASE_DIM`.
-    const BASE_DIM_MASK: usize = Self::BASE_DIM - 1;
     /// The coefficients used to combine subresults.
     /// They are the 8-th roots of unity from the field `Self::Field`
     /// lifted to `Self::Int`.
     const BASE_TWIDDLES: [PnttInt; 8];
-
-    /// The length of the pseudo NTT's input.
-    const INPUT_LEN: usize = Self::BASE_LEN * (1 << (3 * Self::DEPTH));
-    /// The length of the pseudo NTT's output.
-    const OUTPUT_LEN: usize = {
-        let value = Self::BASE_DIM * (1 << (3 * Self::DEPTH));
-        assert!(
-            value < Self::FIELD_MODULUS as usize,
-            "Output length is more than the number of elements in the field"
-        );
-        value
-    };
 
     /// A helper to get an integer representation that
     /// lies in the range `[-(p - 1)/2, (p - 1)/2]` from a field element.
     // TODO(alex): If we need it somewhere else, it would make sense to make this a
     // property of the field.
     fn field_to_int_normalized(x: Self::Field) -> PnttInt;
+}
+
+// Precomputed parameters needed for
+// pseudo NTT algorithm.
+#[derive(Clone, Debug)]
+pub struct Radix8PnttParams<C: Config> {
+    /// The length of the pseudo NTT's input.
+    pub row_len: usize,
+    /// The length of the pseudo NTT's output.
+    pub codeword_len: usize,
+    /// The number of steps where NTT is performed recursively.
+    pub depth: usize,
+    /// The number of columns of the base matrix.
+    pub base_len: usize,
+    /// The number of rows of the base matrix, always a power of 2.
+    pub base_dim: usize,
+    /// log2 of the number of rows of the base matrix.
+    pub base_dim_log2: u32,
+    /// The mask to compute `i % base_dim`.
+    pub base_dim_mask: usize,
+    /// The base matrix of the pseudo NTT.
+    pub base_matrix: Vec<Vec<PnttInt>>, // TODO(Alex): Maybe use DenseRowMatrix for this?
+    /// Precomputed twiddles for every stage that already contain the relevant
+    /// root-of-unity factor. This lets the butterfly apply a single
+    /// multiplication per term instead of two.
+    pub butterfly_twiddles: Vec<Vec<[[PnttInt; 8]; 7]>>,
+
+    _phantom: PhantomData<C>,
+}
+
+impl<C: Config> Radix8PnttParams<C> {
+    /// Precompute pseudo NTT parameters.
+    pub fn new(row_len: usize, depth: usize, rep_factor: usize) -> Self {
+        let codeword_len = mul!(row_len, rep_factor);
+        assert!(
+            codeword_len < C::FIELD_MODULUS as usize,
+            "Codeword length is more than the number of elements in the field"
+        );
+
+        let coeff = 1_usize << mul!(3, depth);
+        let (base_len, base_len_rem) = row_len.div_rem_euclid(&coeff);
+        assert_eq!(
+            base_len_rem, 0,
+            "Row length must be a multiple of {}",
+            coeff
+        );
+
+        let base_dim = mul!(base_len, rep_factor);
+        assert!(
+            base_dim.is_power_of_two(),
+            "Base dimension must be a power of 2, got {}",
+            base_dim
+        );
+
+        let base_dim_log2: u32 = base_dim.trailing_zeros();
+
+        let base_dim_mask: usize = sub!(base_dim, 1);
+
+        Self {
+            row_len,
+            codeword_len,
+            depth,
+            base_len,
+            base_dim,
+            base_dim_log2,
+            base_dim_mask,
+            base_matrix: precompute::precompute_base_matrix::<C>(base_dim, base_len),
+            butterfly_twiddles: precompute::precompute_butterfly_twiddles::<C>(
+                base_dim,
+                codeword_len,
+                depth,
+            ),
+            _phantom: PhantomData,
+        }
+    }
 }
 
 mod precompute {
@@ -54,13 +109,17 @@ mod precompute {
     use zinc_utils::mul;
 
     #[allow(clippy::arithmetic_side_effects)]
-    pub(super) fn precompute_butterfly_twiddles<C: Config>() -> Vec<Vec<[[PnttInt; 8]; 7]>> {
-        let roots_of_unity = precompute_roots_of_unity::<C>(C::OUTPUT_LEN);
+    pub(super) fn precompute_butterfly_twiddles<C: Config>(
+        base_dim: usize,
+        output_len: usize,
+        depth: usize,
+    ) -> Vec<Vec<[[PnttInt; 8]; 7]>> {
+        let roots_of_unity = precompute_roots_of_unity::<C>(output_len);
 
-        (0..C::DEPTH)
+        (0..depth)
             .map(|k| {
-                let sub_chunk_length = C::BASE_DIM * (1 << (3 * k));
-                let curr_prim_root_power = 1 << (3 * (C::DEPTH - 1 - k));
+                let sub_chunk_length = base_dim * (1 << (3 * k));
+                let curr_prim_root_power = 1 << (3 * (depth - 1 - k));
 
                 (0..sub_chunk_length)
                     .map(|i| {
@@ -81,14 +140,17 @@ mod precompute {
             .collect()
     }
 
-    pub(super) fn precompute_base_matrix<C: Config>() -> Vec<Vec<PnttInt>> {
-        let domain = Radix2EvaluationDomain::<C::Field>::new(C::BASE_DIM)
-            .expect("Failed to create NTT domain");
+    pub(super) fn precompute_base_matrix<C: Config>(
+        base_dim: usize,
+        base_len: usize,
+    ) -> Vec<Vec<PnttInt>> {
+        let domain =
+            Radix2EvaluationDomain::<C::Field>::new(base_dim).expect("Failed to create NTT domain");
 
         domain
             .elements()
             .map(|root| {
-                (0..C::BASE_LEN)
+                (0..base_len)
                     .map(move |i| C::field_to_int_normalized(root.pow([i as u64])))
                     .collect_vec()
             })
@@ -131,36 +193,6 @@ mod precompute {
     }
 }
 
-// Precomputed parameters needed for
-// pseudo NTT algorithm.
-#[derive(Clone, Debug)]
-pub struct Radix8PnttParams<C: Config> {
-    /// The base matrix of the pseudo NTT.
-    pub base_matrix: Vec<Vec<PnttInt>>, // TODO(Alex): Maybe use DenseRowMatrix for this?
-    /// Precomputed twiddles for every stage that already contain the relevant
-    /// root-of-unity factor. This lets the butterfly apply a single
-    /// multiplication per term instead of two.
-    pub butterfly_twiddles: Vec<Vec<[[PnttInt; 8]; 7]>>,
-    _phantom: PhantomData<C>,
-}
-
-impl<C: Config> Default for Radix8PnttParams<C> {
-    fn default() -> Self {
-        Self::new()
-    }
-}
-
-impl<C: Config> Radix8PnttParams<C> {
-    /// Precompute pseudo NTT parameters.
-    pub fn new() -> Self {
-        Self {
-            base_matrix: precompute::precompute_base_matrix::<C>(),
-            butterfly_twiddles: precompute::precompute_butterfly_twiddles::<C>(),
-            _phantom: PhantomData,
-        }
-    }
-}
-
 mod f65537 {
     #![allow(non_local_definitions)]
     use ark_ff::{Fp64, MontBackend, MontConfig};
@@ -176,71 +208,19 @@ mod f65537 {
     pub const MODULUS: u32 = Config::MODULUS.0[0] as u32;
 }
 
-macro_rules! define_configs {
-    ($($(#[$outer:meta])* $name:ident(BASE_LEN=$base_len:literal, BASE_DIM=$base_dim:literal)),* $(,)?) => {
-        $(
-            $(#[$outer])*
-            #[derive(Debug, Clone, Copy)]
-            pub struct $name<const DEPTH: usize>;
+/// Pseudo NTT configuration for F65537 (2^16 + 1).
+#[derive(Debug, Clone, Copy)]
+pub struct PnttConfigF65537;
 
-            impl<const DEPTH: usize> Config for $name<DEPTH> {
-                type Field = f65537::Field;
-                const FIELD_MODULUS: u32 = f65537::MODULUS;
-                const BASE_LEN: usize = $base_len;
-                const BASE_DIM: usize = $base_dim;
-                const DEPTH: usize = DEPTH;
-                const BASE_TWIDDLES: [PnttInt; 8] = [1, 4096, -256, 16, -1, -4096, 256, -16];
+impl Config for PnttConfigF65537 {
+    type Field = f65537::Field;
+    const FIELD_MODULUS: u32 = f65537::MODULUS;
+    const BASE_TWIDDLES: [PnttInt; 8] = [1, 4096, -256, 16, -1, -4096, 256, -16];
 
-                fn field_to_int_normalized(x: Self::Field) -> PnttInt {
-                    let big_int = f65537::Backend::into_bigint(x);
-
-                    precompute::normalize_field_element(big_int.0[0], Self::FIELD_MODULUS)
-                }
-            }
-        )*
-    };
-}
-
-define_configs! {
-    //
-    // Rate 1/2 configurations
-    //
-
-    /// Pseudo NTT configuration for F65537 (2^16 + 1) with BASE_LEN=32, BASE_DIM=64 (rate 1/2).
-    ///
-    /// Supports `DEPTH` up to `3`.
-    PnttConfigF65537_32_64(BASE_LEN=32, BASE_DIM=64),
-
-    //
-    // Rate 1/4 configurations
-    //
-
-    /// Pseudo NTT configuration for F65537 (2^16 + 1) with BASE_LEN=1, BASE_DIM=4 (rate 1/4).
-    /// NTT domain up to 2^16. Row lengths: 8 (D=1), 64 (D=2), 512 (D=3)..
-    PnttConfigF65537_1_4(BASE_LEN=1, BASE_DIM=4),
-
-    /// Pseudo NTT configuration for F65537 (2^16 + 1) with BASE_LEN=2, BASE_DIM=8 (rate 1/4).
-    /// NTT domain up to 2^16. Row lengths: 16 (D=1), 128 (D=2), 1024 (D=3).
-    PnttConfigF65537_2_8(BASE_LEN=2, BASE_DIM=8),
-
-    /// Pseudo NTT configuration for F65537 (2^16 + 1) with BASE_LEN=4, BASE_DIM=16 (rate 1/4).
-    /// NTT domain up to 2^16. Row lengths: 32 (D=1), 256 (D=2), 2048 (D=3).
-    PnttConfigF65537_4_16(BASE_LEN=4, BASE_DIM=16),
-
-    /// Pseudo NTT configuration for F65537 (2^16 + 1) with BASE_LEN=16, BASE_DIM=64 (rate 1/4).
-    /// NTT domain up to 2^16, enabling row lengths up to 2^13.
-    /// Row lengths: 128 (D=1), 1024 (D=2), 8192 (D=3).
-    PnttConfigF65537_16_64(BASE_LEN=16, BASE_DIM=64),
-
-    /// Pseudo NTT configuration for F65537 (2^16 + 1) with BASE_LEN=32, BASE_DIM=128 (rate 1/4).
-    /// NTT domain up to 2^16, enabling row lengths up to 2^11.
-    /// Row lengths: 256 (D=1), 2048 (D=2).
-    PnttConfigF65537_32_128(BASE_LEN=32, BASE_DIM=128),
-
-    /// Pseudo NTT configuration for F65537 (2^16 + 1) with BASE_LEN=64, BASE_DIM=256 (rate 1/4).
-    /// NTT domain up to 2^16, enabling row lengths up to 2^12.
-    /// Row lengths: 512 (D=1), 4096 (D=2).
-    PnttConfigF65537_64_256(BASE_LEN=64, BASE_DIM=256),
+    fn field_to_int_normalized(x: Self::Field) -> PnttInt {
+        let big_int = f65537::Backend::into_bigint(x);
+        precompute::normalize_field_element(big_int.0[0], Self::FIELD_MODULUS)
+    }
 }
 
 #[cfg(test)]
@@ -250,24 +230,12 @@ mod tests {
     // Twiddles are indeed the 8th roots of unity.
     fn check_twiddles_generic<C: Config>() {
         let expected = precompute::precompute_roots_of_unity::<C>(8);
-
         let our = C::BASE_TWIDDLES.to_vec();
-        let ol = C::OUTPUT_LEN;
-        let field_modulus = C::FIELD_MODULUS as usize;
-        assert!(ol < field_modulus);
-
         assert_eq!(expected, our);
     }
 
     #[test]
-    fn check_twiddles_f65537() {
-        check_twiddles_generic::<PnttConfigF65537_32_64<1>>();
-        check_twiddles_generic::<PnttConfigF65537_1_4<1>>();
-        check_twiddles_generic::<PnttConfigF65537_2_8<1>>();
-        check_twiddles_generic::<PnttConfigF65537_4_16<1>>();
-        check_twiddles_generic::<PnttConfigF65537_16_64<1>>();
-        check_twiddles_generic::<PnttConfigF65537_32_128<1>>();
-        check_twiddles_generic::<PnttConfigF65537_64_256<1>>();
-        check_twiddles_generic::<PnttConfigF65537_64_256<2>>();
+    fn check_twiddles() {
+        check_twiddles_generic::<PnttConfigF65537>();
     }
 }

--- a/zip-plus/src/pcs/phase_commit.rs
+++ b/zip-plus/src/pcs/phase_commit.rs
@@ -213,12 +213,12 @@ mod tests {
     const DEGREE_PLUS_ONE: usize = 3;
 
     type Zt = TestZipTypes<N, K, M>;
-    type C = IprsCode<Zt, TestIprsConfig, CHECKED>;
-    static C: LazyLock<C> = LazyLock::new(C::default);
+    type C = IprsCode<Zt, TestIprsConfig, REP_FACTOR, CHECKED>;
+    static C: LazyLock<C> = LazyLock::new(|| C::new(IPRS_ROW_LEN, IPRS_DEPTH));
 
     type PolyZt = TestBinPolyZipTypes<K, M, DEGREE_PLUS_ONE>;
-    type PolyC = IprsCode<PolyZt, TestIprsConfig, CHECKED>;
-    static POLY_C: LazyLock<PolyC> = LazyLock::new(PolyC::default);
+    type PolyC = IprsCode<PolyZt, TestIprsConfig, REP_FACTOR, CHECKED>;
+    static POLY_C: LazyLock<PolyC> = LazyLock::new(|| PolyC::new(IPRS_ROW_LEN, IPRS_DEPTH));
 
     type TestZip = ZipPlus<Zt, C>;
     type TestPolyZip = ZipPlus<PolyZt, PolyC>;

--- a/zip-plus/src/pcs/phase_commit.rs
+++ b/zip-plus/src/pcs/phase_commit.rs
@@ -214,11 +214,12 @@ mod tests {
 
     type Zt = TestZipTypes<N, K, M>;
     type C = IprsCode<Zt, TestIprsConfig, REP_FACTOR, CHECKED>;
-    static C: LazyLock<C> = LazyLock::new(|| C::new(IPRS_ROW_LEN, IPRS_DEPTH));
+    static C: LazyLock<C> = LazyLock::new(|| C::new(IPRS_ROW_LEN, IPRS_DEPTH).unwrap());
 
     type PolyZt = TestBinPolyZipTypes<K, M, DEGREE_PLUS_ONE>;
     type PolyC = IprsCode<PolyZt, TestIprsConfig, REP_FACTOR, CHECKED>;
-    static POLY_C: LazyLock<PolyC> = LazyLock::new(|| PolyC::new(IPRS_ROW_LEN, IPRS_DEPTH));
+    static POLY_C: LazyLock<PolyC> =
+        LazyLock::new(|| PolyC::new(IPRS_ROW_LEN, IPRS_DEPTH).unwrap());
 
     type TestZip = ZipPlus<Zt, C>;
     type TestPolyZip = ZipPlus<PolyZt, PolyC>;

--- a/zip-plus/src/pcs/phase_prove.rs
+++ b/zip-plus/src/pcs/phase_prove.rs
@@ -338,10 +338,10 @@ mod tests {
     type F = BoxedMontyField;
 
     type Zt = TestZipTypes<N, K, M>;
-    type C = IprsCode<Zt, TestIprsConfig, CHECKED>;
+    type C = IprsCode<Zt, TestIprsConfig, REP_FACTOR, CHECKED>;
 
     type PolyZt = TestBinPolyZipTypes<K, M, DEGREE_PLUS_ONE>;
-    type PolyC = IprsCode<PolyZt, TestIprsConfig, CHECKED>;
+    type PolyC = IprsCode<PolyZt, TestIprsConfig, REP_FACTOR, CHECKED>;
 
     type TestZip = ZipPlus<Zt, C>;
     type TestPolyZip = ZipPlus<PolyZt, PolyC>;

--- a/zip-plus/src/pcs/phase_verify.rs
+++ b/zip-plus/src/pcs/phase_verify.rs
@@ -347,12 +347,12 @@ mod tests {
     type F = MontyField<K>;
 
     type Zt = TestZipTypes<N, K, M>;
-    type C = IprsCode<Zt, TestIprsConfig, CHECKED>;
-    static C: LazyLock<C> = LazyLock::new(C::default);
+    type C = IprsCode<Zt, TestIprsConfig, REP_FACTOR, CHECKED>;
+    static C: LazyLock<C> = LazyLock::new(|| C::new(IPRS_ROW_LEN, IPRS_DEPTH));
 
     type PolyZt = TestBinPolyZipTypes<K, M, DEGREE_PLUS_ONE>;
-    type PolyC = IprsCode<PolyZt, TestIprsConfig, CHECKED>;
-    static POLY_C: LazyLock<PolyC> = LazyLock::new(PolyC::default);
+    type PolyC = IprsCode<PolyZt, TestIprsConfig, REP_FACTOR, CHECKED>;
+    static POLY_C: LazyLock<PolyC> = LazyLock::new(|| PolyC::new(IPRS_ROW_LEN, IPRS_DEPTH));
 
     type TestZip = ZipPlus<Zt, C>;
     type TestPolyZip = ZipPlus<PolyZt, PolyC>;

--- a/zip-plus/src/pcs/phase_verify.rs
+++ b/zip-plus/src/pcs/phase_verify.rs
@@ -323,7 +323,7 @@ mod tests {
     };
     use crypto_bigint::U64;
     use crypto_primitives::{
-        Field, FromWithConfig, IntoWithConfig, PrimeField, crypto_bigint_int::Int,
+        Field, FromWithConfig, IntSemiring, IntoWithConfig, PrimeField, crypto_bigint_int::Int,
         crypto_bigint_monty::MontyField,
     };
     use itertools::Itertools;
@@ -348,11 +348,12 @@ mod tests {
 
     type Zt = TestZipTypes<N, K, M>;
     type C = IprsCode<Zt, TestIprsConfig, REP_FACTOR, CHECKED>;
-    static C: LazyLock<C> = LazyLock::new(|| C::new(IPRS_ROW_LEN, IPRS_DEPTH));
+    static C: LazyLock<C> = LazyLock::new(|| C::new(IPRS_ROW_LEN, IPRS_DEPTH).unwrap());
 
     type PolyZt = TestBinPolyZipTypes<K, M, DEGREE_PLUS_ONE>;
     type PolyC = IprsCode<PolyZt, TestIprsConfig, REP_FACTOR, CHECKED>;
-    static POLY_C: LazyLock<PolyC> = LazyLock::new(|| PolyC::new(IPRS_ROW_LEN, IPRS_DEPTH));
+    static POLY_C: LazyLock<PolyC> =
+        LazyLock::new(|| PolyC::new(IPRS_ROW_LEN, IPRS_DEPTH).unwrap());
 
     type TestZip = ZipPlus<Zt, C>;
     type TestPolyZip = ZipPlus<PolyZt, PolyC>;
@@ -1043,6 +1044,69 @@ mod tests {
         );
 
         assert!(verification_result.is_ok());
+    }
+
+    #[test]
+    fn verification_succeeds_for_code_row_length_of_1() {
+        let num_vars = 8;
+        macro_rules! make_code {
+            () => {
+                IprsCode::new(1, 0).unwrap()
+            };
+        }
+        {
+            let (pp, comm, point_f, eval_f, mut transcript) =
+                setup_full_protocol_inner::<Zt, C, F, N>(
+                    num_vars,
+                    |num_vars| {
+                        setup_test_params_inner(num_vars, make_code!(), |poly_size| {
+                            (1..=poly_size as i32).map(Int::from).collect()
+                        })
+                    },
+                    || (0..num_vars).map(|i| Int::from(i as i32 + 2)).collect(),
+                );
+            let field_cfg = get_field_cfg::<Zt, F>(&mut transcript.fs_transcript);
+
+            let result = TestZip::verify::<_, CHECKED>(
+                &mut transcript,
+                &pp,
+                &comm,
+                &field_cfg,
+                &point_f,
+                &eval_f,
+            );
+            assert!(result.is_ok(), "Verification failed: {result:?}")
+        };
+        {
+            let (pp, comm, point_f, eval_f, mut transcript) =
+                setup_full_protocol_inner::<PolyZt, PolyC, F, N>(
+                    num_vars,
+                    |num_vars| {
+                        setup_test_params_inner(num_vars, make_code!(), |poly_size| {
+                            let degree = DEGREE_PLUS_ONE - 1;
+                            let eval_coeffs: Vec<_> = (1..=(poly_size * degree) as i64)
+                                .map(|v| v.is_odd().into())
+                                .collect_vec();
+                            eval_coeffs
+                                .chunks_exact(degree)
+                                .map(BinaryPoly::new)
+                                .collect_vec()
+                        })
+                    },
+                    || (0..num_vars).map(|i| i as i128 + 2).collect(),
+                );
+            let field_cfg = get_field_cfg::<Zt, F>(&mut transcript.fs_transcript);
+
+            let result = TestPolyZip::verify::<_, CHECKED>(
+                &mut transcript,
+                &pp,
+                &comm,
+                &field_cfg,
+                &point_f,
+                &eval_f,
+            );
+            assert!(result.is_ok(), "Verification failed: {result:?}")
+        }
     }
 
     #[test]

--- a/zip-plus/src/pcs/test_utils.rs
+++ b/zip-plus/src/pcs/test_utils.rs
@@ -10,7 +10,7 @@
 use crate::{
     code::{
         LinearCode,
-        iprs::{IprsCode, PnttConfigF65537_32_128},
+        iprs::{IprsCode, PnttConfigF65537},
     },
     pcs::structs::{ZipPlus, ZipPlusCommitment, ZipPlusParams, ZipTypes},
     pcs_transcript::{PcsProverTranscript, PcsVerifierTranscript},
@@ -37,9 +37,13 @@ use zinc_utils::{
     projectable_to_field::ProjectableToField,
 };
 
-const IPRS_DEPTH: usize = 1;
+pub const IPRS_DEPTH: usize = 1;
+pub const IPRS_ROW_LEN: usize = 32 * (1 << (3 * IPRS_DEPTH)); // I.e. BASE_DIM = 32
 
-pub type TestIprsConfig = PnttConfigF65537_32_128<IPRS_DEPTH>;
+/// Linear code repetition factor (inverse rate).
+pub const REP_FACTOR: usize = 4;
+
+pub type TestIprsConfig = PnttConfigF65537;
 
 #[derive(Debug, Clone)]
 pub struct TestZipTypes<const N: usize, const K: usize, const M: usize> {}
@@ -87,12 +91,17 @@ impl<const K: usize, const M: usize, const DEGREE_PLUS_ONE: usize> ZipTypes
 pub fn setup_test_params<const N: usize, const K: usize, const M: usize>(
     num_vars: usize,
 ) -> (
-    ZipPlusParams<TestZipTypes<N, K, M>, IprsCode<TestZipTypes<N, K, M>, TestIprsConfig, CHECKED>>,
+    ZipPlusParams<
+        TestZipTypes<N, K, M>,
+        IprsCode<TestZipTypes<N, K, M>, TestIprsConfig, REP_FACTOR, CHECKED>,
+    >,
     DenseMultilinearExtension<<TestZipTypes<N, K, M> as ZipTypes>::Eval>,
 ) {
-    setup_test_params_inner(num_vars, IprsCode::default(), |poly_size| {
-        (1..=poly_size as i32).map(Int::from).collect()
-    })
+    setup_test_params_inner(
+        num_vars,
+        IprsCode::new(IPRS_ROW_LEN, IPRS_DEPTH),
+        |poly_size| (1..=poly_size as i32).map(Int::from).collect(),
+    )
 }
 
 /// Helper function to set up common parameters for tests.
@@ -101,20 +110,24 @@ pub fn setup_poly_test_params<const K: usize, const M: usize, const DEGREE_PLUS_
 ) -> (
     ZipPlusParams<
         TestBinPolyZipTypes<K, M, DEGREE_PLUS_ONE>,
-        IprsCode<TestBinPolyZipTypes<K, M, DEGREE_PLUS_ONE>, TestIprsConfig, CHECKED>,
+        IprsCode<TestBinPolyZipTypes<K, M, DEGREE_PLUS_ONE>, TestIprsConfig, REP_FACTOR, CHECKED>,
     >,
     DenseMultilinearExtension<<TestBinPolyZipTypes<K, M, DEGREE_PLUS_ONE> as ZipTypes>::Eval>,
 ) {
-    setup_test_params_inner(num_vars, IprsCode::default(), |poly_size| {
-        let degree = DEGREE_PLUS_ONE - 1;
-        let eval_coeffs: Vec<_> = (1..=(poly_size * degree) as i64)
-            .map(|v| v.is_odd().into())
-            .collect_vec();
-        eval_coeffs
-            .chunks_exact(degree)
-            .map(BinaryPoly::new)
-            .collect_vec()
-    })
+    setup_test_params_inner(
+        num_vars,
+        IprsCode::new(IPRS_ROW_LEN, IPRS_DEPTH),
+        |poly_size| {
+            let degree = DEGREE_PLUS_ONE - 1;
+            let eval_coeffs: Vec<_> = (1..=(poly_size * degree) as i64)
+                .map(|v| v.is_odd().into())
+                .collect_vec();
+            eval_coeffs
+                .chunks_exact(degree)
+                .map(BinaryPoly::new)
+                .collect_vec()
+        },
+    )
 }
 
 fn setup_test_params_inner<Zt: ZipTypes, Lc: LinearCode<Zt>>(
@@ -141,7 +154,10 @@ fn setup_test_params_inner<Zt: ZipTypes, Lc: LinearCode<Zt>>(
 pub fn setup_full_protocol<F, const N: usize, const K: usize, const M: usize>(
     num_vars: usize,
 ) -> (
-    ZipPlusParams<TestZipTypes<N, K, M>, IprsCode<TestZipTypes<N, K, M>, TestIprsConfig, CHECKED>>,
+    ZipPlusParams<
+        TestZipTypes<N, K, M>,
+        IprsCode<TestZipTypes<N, K, M>, TestIprsConfig, REP_FACTOR, CHECKED>,
+    >,
     ZipPlusCommitment,
     Vec<F>,
     F,
@@ -173,7 +189,7 @@ pub fn setup_full_protocol_poly<
 ) -> (
     ZipPlusParams<
         TestBinPolyZipTypes<K, M, DEGREE_PLUS_ONE>,
-        IprsCode<TestBinPolyZipTypes<K, M, DEGREE_PLUS_ONE>, TestIprsConfig, CHECKED>,
+        IprsCode<TestBinPolyZipTypes<K, M, DEGREE_PLUS_ONE>, TestIprsConfig, REP_FACTOR, CHECKED>,
     >,
     ZipPlusCommitment,
     Vec<F>,

--- a/zip-plus/src/pcs/test_utils.rs
+++ b/zip-plus/src/pcs/test_utils.rs
@@ -99,7 +99,7 @@ pub fn setup_test_params<const N: usize, const K: usize, const M: usize>(
 ) {
     setup_test_params_inner(
         num_vars,
-        IprsCode::new(IPRS_ROW_LEN, IPRS_DEPTH),
+        IprsCode::new(IPRS_ROW_LEN, IPRS_DEPTH).unwrap(),
         |poly_size| (1..=poly_size as i32).map(Int::from).collect(),
     )
 }
@@ -116,7 +116,7 @@ pub fn setup_poly_test_params<const K: usize, const M: usize, const DEGREE_PLUS_
 ) {
     setup_test_params_inner(
         num_vars,
-        IprsCode::new(IPRS_ROW_LEN, IPRS_DEPTH),
+        IprsCode::new(IPRS_ROW_LEN, IPRS_DEPTH).unwrap(),
         |poly_size| {
             let degree = DEGREE_PLUS_ONE - 1;
             let eval_coeffs: Vec<_> = (1..=(poly_size * degree) as i64)
@@ -130,7 +130,7 @@ pub fn setup_poly_test_params<const K: usize, const M: usize, const DEGREE_PLUS_
     )
 }
 
-fn setup_test_params_inner<Zt: ZipTypes, Lc: LinearCode<Zt>>(
+pub fn setup_test_params_inner<Zt: ZipTypes, Lc: LinearCode<Zt>>(
     num_vars: usize,
     code: Lc,
     prepare_evaluations: impl FnOnce(usize) -> Vec<Zt::Eval>,
@@ -212,7 +212,7 @@ where
     })
 }
 
-fn setup_full_protocol_inner<Zt, Lc, F, const N: usize>(
+pub fn setup_full_protocol_inner<Zt, Lc, F, const N: usize>(
     num_vars: usize,
     setup: impl FnOnce(usize) -> (ZipPlusParams<Zt, Lc>, DenseMultilinearExtension<Zt::Eval>),
     prepare_evaluation_point: impl FnOnce() -> Vec<Zt::Pt>,


### PR DESCRIPTION
Resolves #120, builds on top of #157

Reworked IPRS codes. Instead of having a bunch of constants in config, those values are now calculated at runtime to allow a configurable row length.
* A lot of values moved from constants in `Config` to fields in `Radix8PnttParams`.
* IPRS config is now specific to field only, and there's just one defined: `PnttConfigF65537`.
* Repetition factor (inverse rate) made a generic parameter on the IPRS code itself.

On top of that, the parameters themself were tweaked:
* Zip+ with IPRS now uses flat single-row matrix per polynomial in batch (i.e. before stacking said matrices for commitment).
* Added an alternative constructor for IPRS that uses a heuristics for depth: at least 1, and large enough for IPRS encoding matrix to have no more than 2^7 (128) columns.
  * This constructor is now used in all benchmarks as well as E2E tests.
* As a result, proving/verification time increased by up to 30% but proof sizes lowered drastically.