### PR TITLE
Replace Keccak256 transcript with Blake3

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ publish = false
 [workspace.dependencies]
 crypto-primitives = { git = "https://github.com/NethermindEth/crypto-primitives.git", branch = "main", features = ["std", "crypto_bigint", "rand"] }
 
+blake3 = "1.8"
 crypto-bigint = { version = "= 0.7.0-rc.9", features = ["zeroize"] }
 criterion = "0.7.0"
 derive_more = { version = "2.1.1", features = ["full"] }

--- a/piop/benches/combined_poly_resolver.rs
+++ b/piop/benches/combined_poly_resolver.rs
@@ -22,7 +22,7 @@ use zinc_poly::univariate::dense::DensePolynomial;
 use zinc_primality::{MillerRabin, PrimalityTest};
 use zinc_test_uair::{GenerateRandomTrace, TestAirNoMultiplication, TestUairSimpleMultiplication};
 use zinc_transcript::{
-    KeccakTranscript,
+    Blake3Transcript,
     traits::{ConstTranscribable, Transcript},
 };
 use zinc_uair::{
@@ -57,7 +57,7 @@ fn bench_no_mult<const INT_LIMBS: usize, const FIELD_LIMBS: usize>(
 
     let prove_cpr = |field_cfg: &<F<FIELD_LIMBS> as PrimeField>::Config,
                      trace: &UairTrace<_, _, DEGREE_PLUS_ONE>,
-                     transcript: &mut KeccakTranscript| {
+                     transcript: &mut Blake3Transcript| {
         let projected_trace = project_trace_coeffs_row_major(trace, field_cfg);
 
         let projected_scalars =
@@ -127,7 +127,7 @@ fn bench_no_mult<const INT_LIMBS: usize, const FIELD_LIMBS: usize>(
     };
 
     group.bench_function(BenchmarkId::new("CPR Prover", &params), |bench| {
-        let mut transcript = KeccakTranscript::new();
+        let mut transcript = Blake3Transcript::new();
         let field_cfg = transcript.get_random_field_cfg::<F<FIELD_LIMBS>, _, MillerRabin>();
         bench.iter_batched(
             || transcript.clone(),
@@ -139,7 +139,7 @@ fn bench_no_mult<const INT_LIMBS: usize, const FIELD_LIMBS: usize>(
     });
 
     group.bench_function(BenchmarkId::new("CPR Verifier", &params), |bench| {
-        let mut prover_transcript = KeccakTranscript::new();
+        let mut prover_transcript = Blake3Transcript::new();
         let mut verifier_transcript = prover_transcript.clone();
         let field_cfg = prover_transcript.get_random_field_cfg::<F<FIELD_LIMBS>, _, MillerRabin>();
         let _ = verifier_transcript.get_random_field_cfg::<F<FIELD_LIMBS>, _, MillerRabin>();
@@ -236,7 +236,7 @@ fn bench_simple_mult<const INT_LIMBS: usize, const FIELD_LIMBS: usize>(
 
     let prove_cpr = |field_cfg: &<F<FIELD_LIMBS> as PrimeField>::Config,
                      trace: &UairTrace<_, _, DEGREE_PLUS_ONE>,
-                     transcript: &mut KeccakTranscript| {
+                     transcript: &mut Blake3Transcript| {
         let projected_trace = project_trace_coeffs_row_major(trace, field_cfg);
 
         let projected_scalars = project_scalars::<
@@ -309,7 +309,7 @@ fn bench_simple_mult<const INT_LIMBS: usize, const FIELD_LIMBS: usize>(
     };
 
     group.bench_function(BenchmarkId::new("CPR Prover", &params), |bench| {
-        let mut transcript = KeccakTranscript::new();
+        let mut transcript = Blake3Transcript::new();
         let field_cfg = transcript.get_random_field_cfg::<F<FIELD_LIMBS>, _, MillerRabin>();
         bench.iter_batched(
             || transcript.clone(),
@@ -323,7 +323,7 @@ fn bench_simple_mult<const INT_LIMBS: usize, const FIELD_LIMBS: usize>(
     group.bench_function(
         BenchmarkId::new("CPR Verifier", &params),
         |bench| {
-            let mut prover_transcript = KeccakTranscript::new();
+            let mut prover_transcript = Blake3Transcript::new();
             let mut verifier_transcript = prover_transcript.clone();
             let field_cfg =
                 prover_transcript.get_random_field_cfg::<F<FIELD_LIMBS>, _, MillerRabin>();

--- a/piop/benches/ideal_check.rs
+++ b/piop/benches/ideal_check.rs
@@ -22,7 +22,7 @@ use zinc_test_uair::{
     TestUairSimpleMultiplication,
 };
 use zinc_transcript::{
-    KeccakTranscript,
+    Blake3Transcript,
     traits::{ConstTranscribable, Transcript},
 };
 use zinc_uair::{
@@ -56,7 +56,7 @@ fn bench_no_mult<const INT_LIMBS: usize, const FIELD_LIMBS: usize>(
 
     let prove = |field_cfg: &<F<FIELD_LIMBS> as PrimeField>::Config,
                  trace: &UairTrace<_, _, DEGREE_PLUS_ONE>,
-                 transcript: &mut KeccakTranscript|
+                 transcript: &mut Blake3Transcript|
      -> Proof<F<FIELD_LIMBS>> {
         let trace = project_trace_coeffs_row_major(trace, field_cfg);
 
@@ -83,7 +83,7 @@ fn bench_no_mult<const INT_LIMBS: usize, const FIELD_LIMBS: usize>(
     };
 
     group.bench_function(BenchmarkId::new("Ideal Check Prover", &params), |bench| {
-        let mut transcript = KeccakTranscript::new();
+        let mut transcript = Blake3Transcript::new();
         let field_cfg = transcript.get_random_field_cfg::<F<FIELD_LIMBS>, _, MillerRabin>();
         bench.iter_batched(
             || transcript.clone(),
@@ -95,7 +95,7 @@ fn bench_no_mult<const INT_LIMBS: usize, const FIELD_LIMBS: usize>(
     });
 
     group.bench_function(BenchmarkId::new("Ideal Check Verifier", &params), |bench| {
-        let mut transcript = KeccakTranscript::new();
+        let mut transcript = Blake3Transcript::new();
         let field_cfg = transcript.get_random_field_cfg::<F<FIELD_LIMBS>, _, MillerRabin>();
         let proof = prove(&field_cfg, &trace, &mut transcript);
 
@@ -148,7 +148,7 @@ fn bench_simple_mult<const INT_LIMBS: usize, const FIELD_LIMBS: usize>(
 
     let prove = |field_cfg: &<F<FIELD_LIMBS> as PrimeField>::Config,
                  trace: &UairTrace<_, _, DEGREE_PLUS_ONE>,
-                 transcript: &mut KeccakTranscript|
+                 transcript: &mut Blake3Transcript|
      -> Proof<F<FIELD_LIMBS>> {
         let trace = project_trace_coeffs_row_major(trace, field_cfg);
 
@@ -175,7 +175,7 @@ fn bench_simple_mult<const INT_LIMBS: usize, const FIELD_LIMBS: usize>(
     };
 
     group.bench_function(BenchmarkId::new("Ideal Check Prover", &params), |bench| {
-        let mut transcript = KeccakTranscript::new();
+        let mut transcript = Blake3Transcript::new();
         let field_cfg = transcript.get_random_field_cfg::<F<FIELD_LIMBS>, _, MillerRabin>();
         bench.iter_batched(
             || transcript.clone(),
@@ -190,7 +190,7 @@ fn bench_simple_mult<const INT_LIMBS: usize, const FIELD_LIMBS: usize>(
         BenchmarkId::new("Ideal Check Verifier", &params),
         &trace,
         |bench, trace| {
-            let mut transcript = KeccakTranscript::new();
+            let mut transcript = Blake3Transcript::new();
             let field_cfg = transcript.get_random_field_cfg::<F<FIELD_LIMBS>, _, MillerRabin>();
             let proof = prove(&field_cfg, trace, &mut transcript);
 
@@ -242,7 +242,7 @@ fn bench_binary_decomposition<const FIELD_LIMBS: usize>(
 
     let prove = |field_cfg: &<F<FIELD_LIMBS> as PrimeField>::Config,
                  trace: &UairTrace<_, _, DEGREE_PLUS_ONE>,
-                 transcript: &mut KeccakTranscript|
+                 transcript: &mut Blake3Transcript|
      -> Proof<F<FIELD_LIMBS>> {
         let trace = project_trace_coeffs_row_major(trace, field_cfg);
 
@@ -267,7 +267,7 @@ fn bench_binary_decomposition<const FIELD_LIMBS: usize>(
     };
 
     group.bench_function(BenchmarkId::new("Ideal Check Prover", &params), |bench| {
-        let mut transcript = KeccakTranscript::new();
+        let mut transcript = Blake3Transcript::new();
         let field_cfg = transcript.get_random_field_cfg::<F<FIELD_LIMBS>, _, MillerRabin>();
         bench.iter_batched(
             || transcript.clone(),
@@ -279,7 +279,7 @@ fn bench_binary_decomposition<const FIELD_LIMBS: usize>(
     });
 
     group.bench_function(BenchmarkId::new("Ideal Check Verifier", &params), |bench| {
-        let mut transcript = KeccakTranscript::new();
+        let mut transcript = Blake3Transcript::new();
         let field_cfg = transcript.get_random_field_cfg::<F<FIELD_LIMBS>, _, MillerRabin>();
         let proof = prove(&field_cfg, &trace, &mut transcript);
 
@@ -349,7 +349,7 @@ fn bench_big_linear_uair<const FIELD_LIMBS: usize>(
     group.bench_function(
         BenchmarkId::new("Ideal Check Prover (MLE-first)", &params),
         |bench| {
-            let mut transcript = KeccakTranscript::new();
+            let mut transcript = Blake3Transcript::new();
             let field_cfg = transcript.get_random_field_cfg::<F<FIELD_LIMBS>, _, MillerRabin>();
             bench.iter_batched(
                 || (&field_cfg, transcript.clone()),
@@ -370,7 +370,7 @@ fn bench_big_linear_uair<const FIELD_LIMBS: usize>(
     group.bench_function(
         BenchmarkId::new("Ideal Check Prover (Combined)", &params),
         |bench| {
-            let mut transcript = KeccakTranscript::new();
+            let mut transcript = Blake3Transcript::new();
             let field_cfg = transcript.get_random_field_cfg::<F<FIELD_LIMBS>, _, MillerRabin>();
             bench.iter_batched(
                 || (&field_cfg, transcript.clone()),
@@ -388,7 +388,7 @@ fn bench_big_linear_uair<const FIELD_LIMBS: usize>(
         },
     );
 
-    let mut transcript = KeccakTranscript::new();
+    let mut transcript = Blake3Transcript::new();
     let field_cfg = transcript.get_random_field_cfg::<F<FIELD_LIMBS>, _, MillerRabin>();
     let proof = prove!(
         &mut transcript,

--- a/piop/benches/multipoint_eval.rs
+++ b/piop/benches/multipoint_eval.rs
@@ -10,7 +10,7 @@ use rand::{Rng, rng};
 use zinc_piop::multipoint_eval::MultipointEval;
 use zinc_poly::mle::{DenseMultilinearExtension, MultilinearExtensionWithConfig};
 use zinc_primality::MillerRabin;
-use zinc_transcript::{KeccakTranscript, traits::Transcript};
+use zinc_transcript::{Blake3Transcript, traits::Transcript};
 use zinc_uair::ShiftSpec;
 
 const FIELD_LIMBS: usize = 4;
@@ -21,7 +21,7 @@ fn bench_multipoint_eval(c: &mut Criterion, num_vars: usize, num_cols: usize) {
     let n = 1usize << num_vars;
     let params = format!("nvars={}/cols={}", num_vars, num_cols);
 
-    let mut transcript = KeccakTranscript::new();
+    let mut transcript = Blake3Transcript::new();
     let field_cfg = transcript.get_random_field_cfg::<F, Uint<FIELD_LIMBS>, MillerRabin>();
     let zero_inner = F::from_with_cfg(0u32, &field_cfg).into_inner();
 
@@ -72,7 +72,7 @@ fn bench_multipoint_eval(c: &mut Criterion, num_vars: usize, num_cols: usize) {
     let mut group = c.benchmark_group("Multipoint eval");
 
     // Prepare a transcript with the seed absorbed once.
-    let mut base_transcript = KeccakTranscript::new();
+    let mut base_transcript = Blake3Transcript::new();
     base_transcript.absorb_slice(b"bench");
 
     // --- Bench prover ---
@@ -99,7 +99,7 @@ fn bench_multipoint_eval(c: &mut Criterion, num_vars: usize, num_cols: usize) {
 
     // --- Bench verifier ---
     // First produce a valid proof.
-    let mut prover_transcript = KeccakTranscript::new();
+    let mut prover_transcript = Blake3Transcript::new();
     prover_transcript.absorb_slice(b"bench");
     let (proof, prover_state) = MultipointEval::<F>::prove_as_subprotocol(
         &mut prover_transcript,

--- a/piop/benches/sumcheck.rs
+++ b/piop/benches/sumcheck.rs
@@ -18,7 +18,7 @@ use zinc_poly::{
 };
 use zinc_primality::{MillerRabin, PrimalityTest};
 use zinc_transcript::{
-    KeccakTranscript,
+    Blake3Transcript,
     traits::{ConstTranscribable, Transcript},
 };
 use zinc_utils::{from_ref::FromRef, inner_transparent_field::InnerTransparentField};
@@ -64,9 +64,9 @@ pub fn bench_simple_product<F, const LIMBS: usize>(
             BinaryPoly::zero(),
         );
 
-    let transcript = KeccakTranscript::new();
+    let transcript = Blake3Transcript::new();
 
-    let prove = |(a, b, c, mut transcript):(_,_,_,KeccakTranscript)| -> RFSumcheckProof<F, BinaryPoly<32>> {
+    let prove = |(a, b, c, mut transcript): (_, _, _, Blake3Transcript)| -> RFSumcheckProof<F, BinaryPoly<32>> {
         let field_cfg = transcript.get_random_field_cfg::<F, <F as Field>::Modulus, MillerRabin>();
 
         let eq_r = build_eq_x_r_inner(&vec![F::from_with_cfg(2u32, &field_cfg); nvars], &field_cfg)

--- a/piop/src/combined_poly_resolver.rs
+++ b/piop/src/combined_poly_resolver.rs
@@ -474,7 +474,7 @@ mod tests {
     use zinc_test_uair::{
         GenerateRandomTrace, TestAirNoMultiplication, TestUairSimpleMultiplication,
     };
-    use zinc_transcript::KeccakTranscript;
+    use zinc_transcript::Blake3Transcript;
     use zinc_uair::{
         constraint_counter::count_constraints,
         degree_counter::count_max_degree,
@@ -503,7 +503,7 @@ mod tests {
     {
         let mut rng = rng();
 
-        let mut prover_transcript = KeccakTranscript::new();
+        let mut prover_transcript = Blake3Transcript::new();
         let mut verifier_transcript = prover_transcript.clone();
 
         let trace = U::generate_random_trace(num_vars, &mut rng);

--- a/piop/src/ideal_check.rs
+++ b/piop/src/ideal_check.rs
@@ -316,7 +316,7 @@ mod tests {
     use zinc_test_uair::{
         GenerateRandomTrace, TestAirNoMultiplication, TestUairSimpleMultiplication,
     };
-    use zinc_transcript::KeccakTranscript;
+    use zinc_transcript::Blake3Transcript;
     use zinc_uair::{
         constraint_counter::count_constraints,
         ideal::{Ideal, IdealCheck, degree_one::DegreeOneIdeal},
@@ -348,7 +348,7 @@ mod tests {
         IdealOverFFromRef: Fn(&IdealOrZero<U::Ideal>) -> IdealOverF,
     {
         let mut rng = rng();
-        let transcript = KeccakTranscript::new();
+        let transcript = Blake3Transcript::new();
 
         let (proof, prover_state, ..) = run_ideal_check_prover_linear::<U, DEGREE_PLUS_ONE>(
             num_vars,
@@ -390,7 +390,7 @@ mod tests {
         IdealOverFFromRef: Fn(&IdealOrZero<U::Ideal>) -> IdealOverF,
     {
         let mut rng = rng();
-        let transcript = KeccakTranscript::new();
+        let transcript = Blake3Transcript::new();
 
         let (proof, prover_state, ..) = run_ideal_check_prover_combined::<U, DEGREE_PLUS_ONE>(
             num_vars,

--- a/piop/src/multipoint_eval.rs
+++ b/piop/src/multipoint_eval.rs
@@ -396,7 +396,7 @@ mod tests {
     use crypto_primitives::crypto_bigint_const_monty::ConstMontyField;
     use num_traits::{ConstOne, ConstZero};
     use zinc_poly::mle::{DenseMultilinearExtension, MultilinearExtensionWithConfig};
-    use zinc_transcript::KeccakTranscript;
+    use zinc_transcript::Blake3Transcript;
 
     const N: usize = 2;
     const_monty_params!(Params, U128, "00000000b933426489189cb5b47d567f");
@@ -419,8 +419,8 @@ mod tests {
         open_evals: Vec<F>,
     }
 
-    fn make_transcript() -> KeccakTranscript {
-        let mut t = KeccakTranscript::default();
+    fn make_transcript() -> Blake3Transcript {
+        let mut t = Blake3Transcript::default();
         t.absorb_slice(b"Lorem ipsum");
         t
     }

--- a/piop/src/random_field_sumcheck.rs
+++ b/piop/src/random_field_sumcheck.rs
@@ -152,7 +152,7 @@ mod tests {
         mle::DenseMultilinearExtension, univariate::binary::BinaryPoly, utils::build_eq_x_r_inner,
     };
     use zinc_primality::MillerRabin;
-    use zinc_transcript::{KeccakTranscript, traits::Transcript};
+    use zinc_transcript::{Blake3Transcript, traits::Transcript};
 
     use crate::random_field_sumcheck::RFSumcheck;
 
@@ -191,7 +191,7 @@ mod tests {
                 BinaryPoly::zero(),
             );
 
-        let mut transcript = KeccakTranscript::new();
+        let mut transcript = Blake3Transcript::new();
 
         let field_cfg = transcript.get_random_field_cfg::<F, <F as Field>::Inner, MillerRabin>();
 

--- a/piop/src/sumcheck/multi_degree.rs
+++ b/piop/src/sumcheck/multi_degree.rs
@@ -483,7 +483,7 @@ mod tests {
     use crypto_bigint::{U128, const_monty_params};
     use crypto_primitives::crypto_bigint_const_monty::ConstMontyField;
     use zinc_poly::{mle::MultilinearExtensionWithConfig, utils::build_eq_x_r_inner};
-    use zinc_transcript::KeccakTranscript;
+    use zinc_transcript::Blake3Transcript;
 
     const N: usize = 2;
     const_monty_params!(TestParams, U128, "00000000b933426489189cb5b47d567f");
@@ -531,12 +531,12 @@ mod tests {
         );
 
         // Prove
-        let mut pt = KeccakTranscript::new();
+        let mut pt = Blake3Transcript::new();
         let (proof, _states) =
             MultiDegreeSumcheck::<F>::prove_as_subprotocol(&mut pt, vec![g0, g1], num_vars, cfg);
 
         // Verify
-        let mut vt = KeccakTranscript::new();
+        let mut vt = Blake3Transcript::new();
         let subclaims =
             MultiDegreeSumcheck::<F>::verify_as_subprotocol(&mut vt, num_vars, &proof, cfg)
                 .expect("verification should succeed");
@@ -579,11 +579,11 @@ mod tests {
             Box::new(|v: &[F]| v[0] * v[1]),
         );
 
-        let mut pt = KeccakTranscript::new();
+        let mut pt = Blake3Transcript::new();
         let (proof, _) =
             MultiDegreeSumcheck::<F>::prove_as_subprotocol(&mut pt, vec![g], num_vars, cfg);
 
-        let mut vt = KeccakTranscript::new();
+        let mut vt = Blake3Transcript::new();
         let subclaims =
             MultiDegreeSumcheck::<F>::verify_as_subprotocol(&mut vt, num_vars, &proof, cfg)
                 .expect("verification should succeed");

--- a/piop/src/sumcheck/tests.rs
+++ b/piop/src/sumcheck/tests.rs
@@ -5,7 +5,7 @@ use crypto_primitives::{Field, crypto_bigint_const_monty::ConstMontyField};
 use num_traits::{ConstOne, ConstZero, Zero};
 use rand::RngCore;
 use zinc_poly::mle::{DenseMultilinearExtension, MultilinearExtensionWithConfig};
-use zinc_transcript::{KeccakTranscript, traits::Transcript};
+use zinc_transcript::{Blake3Transcript, traits::Transcript};
 use zinc_utils::inner_transparent_field::InnerTransparentField;
 
 use crate::sumcheck::{
@@ -25,7 +25,7 @@ fn generate_sumcheck_proof<Rn: RngCore>(
     num_vars: usize,
     mut rng: &mut Rn,
 ) -> (usize, SumcheckProof<F>) {
-    let mut transcript = KeccakTranscript::default();
+    let mut transcript = Blake3Transcript::default();
 
     let ((poly_mles, poly_degree), products, _) =
         rand_poly(num_vars, 2..5, 7, &mut rng, &()).unwrap();
@@ -51,7 +51,7 @@ fn full_sumcheck_protocol_works_correctly() {
     for _ in 0..20 {
         let (poly_degree, proof) = generate_sumcheck_proof(num_vars, &mut rng);
 
-        let mut transcript = KeccakTranscript::default();
+        let mut transcript = Blake3Transcript::default();
         let res =
             MLSumcheck::verify_as_subprotocol(&mut transcript, num_vars, poly_degree, &proof, &());
         assert!(res.is_ok())
@@ -73,7 +73,7 @@ fn subclaim_differs_with_incorrect_claimed_sum() {
     let mut rng = rand::rng();
     let num_vars = 3;
 
-    let mut transcript = KeccakTranscript::default();
+    let mut transcript = Blake3Transcript::default();
     let ((poly_mles, poly_degree), products, _) =
         rand_poly(num_vars, 2..5, 7, &mut rng, &()).unwrap();
 
@@ -91,7 +91,7 @@ fn subclaim_differs_with_incorrect_claimed_sum() {
     let one = F::from(1u32);
     let incorrect_sum = proof.claimed_sum + one;
 
-    let mut clean_verifier_transcript = KeccakTranscript::default();
+    let mut clean_verifier_transcript = Blake3Transcript::default();
     let clean_subclaim = MLSumcheck::verify_as_subprotocol(
         &mut clean_verifier_transcript,
         num_vars,
@@ -103,7 +103,7 @@ fn subclaim_differs_with_incorrect_claimed_sum() {
 
     proof.claimed_sum = incorrect_sum;
 
-    let mut verifier_transcript = KeccakTranscript::default();
+    let mut verifier_transcript = Blake3Transcript::default();
     let res = MLSumcheck::verify_as_subprotocol(
         &mut verifier_transcript,
         num_vars,
@@ -122,7 +122,7 @@ fn subclaim_changes_when_prover_message_is_tampered() {
     let mut rng = rand::rng();
     let num_vars = 3;
 
-    let mut transcript = KeccakTranscript::default();
+    let mut transcript = Blake3Transcript::default();
     let ((poly_mles, poly_degree), products, _) =
         rand_poly(num_vars, 2..5, 7, &mut rng, &()).unwrap();
 
@@ -137,7 +137,7 @@ fn subclaim_changes_when_prover_message_is_tampered() {
         &(),
     );
 
-    let mut clean_verifier_transcript = KeccakTranscript::default();
+    let mut clean_verifier_transcript = Blake3Transcript::default();
     let clean_subclaim = MLSumcheck::verify_as_subprotocol(
         &mut clean_verifier_transcript,
         num_vars,
@@ -151,7 +151,7 @@ fn subclaim_changes_when_prover_message_is_tampered() {
     let one: F = F::from(1u32);
     tampered_proof.messages[0].0[0] += one;
 
-    let mut verifier_transcript = KeccakTranscript::default();
+    let mut verifier_transcript = Blake3Transcript::default();
     let res = MLSumcheck::verify_as_subprotocol(
         &mut verifier_transcript,
         num_vars,
@@ -170,7 +170,7 @@ fn verifier_rejects_proof_with_wrong_degree() {
     let mut rng = rand::rng();
     let num_vars = 3;
 
-    let mut transcript = KeccakTranscript::default();
+    let mut transcript = Blake3Transcript::default();
     let ((poly_mles, poly_degree), products, _) =
         rand_poly(num_vars, 2..5, 7, &mut rng, &()).unwrap();
 
@@ -187,7 +187,7 @@ fn verifier_rejects_proof_with_wrong_degree() {
 
     let incorrect_degree = poly_degree - 1;
 
-    let mut verifier_transcript = KeccakTranscript::default();
+    let mut verifier_transcript = Blake3Transcript::default();
     let res = MLSumcheck::verify_as_subprotocol(
         &mut verifier_transcript,
         num_vars,
@@ -209,7 +209,7 @@ fn protocol_is_deterministic_with_same_transcript() {
 
     let comb_fn = move |vals: &[F]| -> F { rand_poly_comb_fn(vals, &products, ()) };
 
-    let mut transcript1 = KeccakTranscript::default();
+    let mut transcript1 = Blake3Transcript::default();
     let (proof1, _) = MLSumcheck::prove_as_subprotocol(
         &mut transcript1,
         poly_mles.clone(),
@@ -219,7 +219,7 @@ fn protocol_is_deterministic_with_same_transcript() {
         &(),
     );
 
-    let mut transcript2 = KeccakTranscript::default();
+    let mut transcript2 = Blake3Transcript::default();
     let (proof2, _) = MLSumcheck::prove_as_subprotocol(
         &mut transcript2,
         poly_mles,
@@ -245,7 +245,7 @@ fn different_polynomials_produce_different_proofs() {
         move |vals: &[F]| -> F { rand_poly_comb_fn(vals, &products, ()) }
     };
 
-    let mut transcript1 = KeccakTranscript::default();
+    let mut transcript1 = Blake3Transcript::default();
     let (proof1, _) = MLSumcheck::prove_as_subprotocol(
         &mut transcript1,
         poly_mles1.clone(),
@@ -261,7 +261,7 @@ fn different_polynomials_produce_different_proofs() {
 
     let comb_fn2 = move |vals: &[F]| -> F { rand_poly_comb_fn(vals, &products1, ()) };
 
-    let mut transcript2 = KeccakTranscript::default();
+    let mut transcript2 = Blake3Transcript::default();
     let (proof2, _) = MLSumcheck::prove_as_subprotocol(
         &mut transcript2,
         poly_mles2,
@@ -293,7 +293,7 @@ fn sumcheck_with_zero_polynomial() {
 
     let comb_fn = |vals: &[F]| -> F { vals.iter().product() };
 
-    let mut transcript = KeccakTranscript::default();
+    let mut transcript = Blake3Transcript::default();
     let (proof, _) = MLSumcheck::prove_as_subprotocol(
         &mut transcript,
         poly_mles,
@@ -307,7 +307,7 @@ fn sumcheck_with_zero_polynomial() {
 
     assert!(proof.claimed_sum.is_zero());
 
-    let mut verifier_transcript = KeccakTranscript::default();
+    let mut verifier_transcript = Blake3Transcript::default();
     let res = MLSumcheck::verify_as_subprotocol(
         &mut verifier_transcript,
         num_vars,
@@ -342,7 +342,7 @@ fn sumcheck_with_constant_polynomial() {
 
     let comb_fn = |vals: &[F]| -> F { vals.iter().product() };
 
-    let mut transcript = KeccakTranscript::default();
+    let mut transcript = Blake3Transcript::default();
     let (proof, _) = MLSumcheck::prove_as_subprotocol(
         &mut transcript,
         poly_mles,
@@ -354,7 +354,7 @@ fn sumcheck_with_constant_polynomial() {
 
     assert_eq!(proof.claimed_sum, sum);
 
-    let mut verifier_transcript = KeccakTranscript::default();
+    let mut verifier_transcript = Blake3Transcript::default();
     let res = MLSumcheck::verify_as_subprotocol(
         &mut verifier_transcript,
         num_vars,
@@ -371,7 +371,7 @@ fn sumcheck_with_single_variable() {
     let mut rng = rand::rng();
     let num_vars = 1;
 
-    let mut transcript = KeccakTranscript::default();
+    let mut transcript = Blake3Transcript::default();
     let ((poly_mles, poly_degree), products, _) =
         rand_poly(num_vars, 2..5, 7, &mut rng, &()).unwrap();
 
@@ -386,7 +386,7 @@ fn sumcheck_with_single_variable() {
         &(),
     );
 
-    let mut verifier_transcript = KeccakTranscript::default();
+    let mut verifier_transcript = Blake3Transcript::default();
     let res = MLSumcheck::verify_as_subprotocol(
         &mut verifier_transcript,
         num_vars,
@@ -403,7 +403,7 @@ fn subclaim_changes_if_transcript_is_tampered() {
     let mut rng = rand::rng();
     let num_vars = 3;
 
-    let mut prover_transcript = KeccakTranscript::default();
+    let mut prover_transcript = Blake3Transcript::default();
     let ((poly_mles, poly_degree), products, _) =
         rand_poly(num_vars, 2..5, 7, &mut rng, &()).unwrap();
 
@@ -418,7 +418,7 @@ fn subclaim_changes_if_transcript_is_tampered() {
         &(),
     );
 
-    let mut clean_transcript = KeccakTranscript::default();
+    let mut clean_transcript = Blake3Transcript::default();
     let clean_res = MLSumcheck::verify_as_subprotocol(
         &mut clean_transcript,
         num_vars,
@@ -428,7 +428,7 @@ fn subclaim_changes_if_transcript_is_tampered() {
     )
     .unwrap();
 
-    let mut tampered_transcript = KeccakTranscript::default();
+    let mut tampered_transcript = Blake3Transcript::default();
     tampered_transcript.absorb_slice(b"tampering the transcript");
     let tampered_res = MLSumcheck::verify_as_subprotocol(
         &mut tampered_transcript,
@@ -472,7 +472,7 @@ fn verifier_errors_on_incomplete_proof() {
     let mut rng = rand::rng();
     let num_vars = 3;
 
-    let mut transcript = KeccakTranscript::default();
+    let mut transcript = Blake3Transcript::default();
     let ((poly_mles, poly_degree), products, _) =
         rand_poly(num_vars, 2..5, 7, &mut rng, &()).unwrap();
 
@@ -490,7 +490,7 @@ fn verifier_errors_on_incomplete_proof() {
     let mut incomplete_proof = proof.clone();
     incomplete_proof.messages.pop(); // Remove last prover message
 
-    let mut verifier_transcript = KeccakTranscript::default();
+    let mut verifier_transcript = Blake3Transcript::default();
 
     let res = MLSumcheck::verify_as_subprotocol(
         &mut verifier_transcript,
@@ -515,7 +515,7 @@ fn prover_handles_empty_mle_list() {
 
     let comb_fn = |_vals: &[F]| -> F { F::ZERO };
 
-    let mut transcript = KeccakTranscript::default();
+    let mut transcript = Blake3Transcript::default();
     let (proof, _) = MLSumcheck::prove_as_subprotocol(
         &mut transcript,
         poly_mles,
@@ -525,7 +525,7 @@ fn prover_handles_empty_mle_list() {
         &(),
     );
 
-    let mut verifier_transcript = KeccakTranscript::default();
+    let mut verifier_transcript = Blake3Transcript::default();
     let res = MLSumcheck::verify_as_subprotocol(
         &mut verifier_transcript,
         num_vars,
@@ -545,7 +545,7 @@ fn verifier_errors_on_mismatched_nvars() {
 
     let (poly_degree, proof) = generate_sumcheck_proof(nvars_prover, &mut rng);
 
-    let mut transcript = KeccakTranscript::default();
+    let mut transcript = Blake3Transcript::default();
     let res = MLSumcheck::verify_as_subprotocol(
         &mut transcript,
         nvars_verifier, // verifier expects more rounds than the proof contains
@@ -566,7 +566,7 @@ fn verifier_produces_correct_subclaim() {
     let mut rng = rand::rng();
     let nvars = 3;
 
-    let mut prover_transcript = KeccakTranscript::default();
+    let mut prover_transcript = Blake3Transcript::default();
     let ((poly_mles, poly_degree), products, _) = rand_poly(nvars, 2..5, 7, &mut rng, &()).unwrap();
 
     let original_mles = poly_mles.clone();
@@ -583,7 +583,7 @@ fn verifier_produces_correct_subclaim() {
         &(),
     );
 
-    let mut verifier_transcript = KeccakTranscript::default();
+    let mut verifier_transcript = Blake3Transcript::default();
     let subclaim = MLSumcheck::verify_as_subprotocol(
         &mut verifier_transcript,
         nvars,
@@ -618,7 +618,7 @@ fn zero_variable_case_returns_correct_subclaim() {
         claimed_sum,
     };
 
-    let mut transcript = KeccakTranscript::default();
+    let mut transcript = Blake3Transcript::default();
     let _subclaim =
         MLSumcheck::verify_as_subprotocol(&mut transcript, num_vars, degree, &proof, &());
 }

--- a/protocol/src/verifier.rs
+++ b/protocol/src/verifier.rs
@@ -13,7 +13,7 @@ use zinc_piop::{
 };
 use zinc_poly::{EvaluatablePolynomial, univariate::dynamic::over_field::DynamicPolynomialF};
 use zinc_transcript::{
-    KeccakTranscript,
+    Blake3Transcript,
     traits::{ConstTranscribable, Transcript},
 };
 use zinc_uair::{
@@ -81,7 +81,7 @@ where
     {
         // === Step 0: Reconstruct transcript from commitments + public data ===
         let mut pcs_transcript = PcsVerifierTranscript {
-            fs_transcript: KeccakTranscript::default(),
+            fs_transcript: Blake3Transcript::default(),
             stream: Cursor::new(proof.zip),
         };
         for comm in [

--- a/transcript/Cargo.toml
+++ b/transcript/Cargo.toml
@@ -16,12 +16,9 @@ zinc-utils = { workspace = true }
 
 itertools = { workspace = true }
 crypto-bigint = { workspace = true }
-sha3 = "0.10"
+blake3 = { workspace = true }
 num-traits = { workspace = true }
 
 [lints]
 workspace = true
-
-[features]
-asm = ["sha3/asm"]
 

--- a/transcript/src/lib.rs
+++ b/transcript/src/lib.rs
@@ -2,29 +2,28 @@ pub mod traits;
 
 use crate::traits::{ConstTranscribable, GenTranscribable, Transcript};
 use crypto_primitives::{ConstIntSemiring, PrimeField};
-use sha3::{Digest, Keccak256};
 use zinc_primality::PrimalityTest;
 use zinc_utils::add;
 
-/// A cryptographic transcript implementation using the Keccak-256 hash
+/// A cryptographic transcript implementation using the BLAKE3 hash
 /// function. Used for Fiat-Shamir transformations in zero-knowledge proof
 /// systems.
 #[derive(Debug, Clone)]
-pub struct KeccakTranscript {
-    /// The underlying Keccak-256 hasher that maintains the transcript state.
-    hasher: Keccak256,
+pub struct Blake3Transcript {
+    /// The underlying BLAKE3 hasher that maintains the transcript state.
+    hasher: blake3::Hasher,
 }
 
-impl Default for KeccakTranscript {
+impl Default for Blake3Transcript {
     fn default() -> Self {
         Self::new()
     }
 }
 
-impl KeccakTranscript {
+impl Blake3Transcript {
     pub fn new() -> Self {
         Self {
-            hasher: Keccak256::new(),
+            hasher: blake3::Hasher::new(),
         }
     }
 
@@ -35,19 +34,7 @@ impl KeccakTranscript {
     /// Note that this does NOT update the internal state of the hasher
     #[allow(clippy::arithmetic_side_effects)]
     fn fill_with_random_bytes(&mut self, buf: &mut [u8]) {
-        let mut counter = 0;
-        let mut filled_length = 0;
-        while filled_length < buf.len() {
-            let mut temp_hasher = self.hasher.clone();
-            temp_hasher.update(i32::to_le_bytes(counter));
-            let hash = temp_hasher.finalize();
-            let start = filled_length;
-            let end = (filled_length + hash.len()).min(buf.len());
-            buf[start..end].copy_from_slice(&hash[0..(end - start)]);
-
-            filled_length += hash.len();
-            counter += 1;
-        }
+        self.hasher.finalize_xof().fill(buf);
     }
 
     fn gen_random<R: ConstTranscribable>(&mut self, buf: &mut [u8]) -> R {
@@ -57,13 +44,13 @@ impl KeccakTranscript {
     }
 }
 
-impl Transcript for KeccakTranscript {
+impl Transcript for Blake3Transcript {
     fn get_challenge<T: ConstTranscribable>(&mut self) -> T {
         let mut buf = vec![0u8; T::NUM_BYTES];
         self.fill_with_random_bytes(&mut buf);
-        self.hasher.update([0x12]);
-        self.hasher.update(&mut buf);
-        self.hasher.update([0x34]);
+        self.hasher.update(&[0x12]);
+        self.hasher.update(&buf);
+        self.hasher.update(&[0x34]);
         T::read_transcription_bytes_exact(&buf)
     }
 

--- a/zip-plus/Cargo.toml
+++ b/zip-plus/Cargo.toml
@@ -26,7 +26,7 @@ num-traits = { workspace = true }
 rand = { workspace = true }
 rand_core = { workspace = true }
 rayon = { workspace = true, optional = true }
-blake3 = "1.8.2"
+blake3 = { workspace = true }
 uninit = "0.6.2"
 
 # Compression libraries, used only to estimate compressed proof sizes
@@ -41,7 +41,6 @@ workspace = true
 
 [features]
 parallel = ["dep:rayon", "zinc-utils/parallel", "zinc-poly/parallel", "ark-ff/parallel", "ark-poly/parallel"]
-asm = ["zinc-transcript/asm"]
 simd = ["zinc-poly/simd"]
 unchecked = []
 

--- a/zip-plus/src/code/iprs/pntt/radix8/params.rs
+++ b/zip-plus/src/code/iprs/pntt/radix8/params.rs
@@ -16,7 +16,7 @@ pub trait Config: Debug + Copy + Send + Sync {
 
     /// The coefficients used to combine subresults.
     /// They are the 8-th roots of unity from the field `Self::Field`
-    /// lifted to `Self::Int`.
+    /// lifted to `PnttInt`.
     const BASE_TWIDDLES: [PnttInt; 8];
 
     /// A helper to get an integer representation that

--- a/zip-plus/src/pcs/phase_verify.rs
+++ b/zip-plus/src/pcs/phase_verify.rs
@@ -14,7 +14,7 @@ use num_traits::{ConstOne, ConstZero, Zero};
 use rayon::prelude::*;
 use zinc_poly::Polynomial;
 use zinc_transcript::{
-    KeccakTranscript,
+    Blake3Transcript,
     traits::{Transcribable, Transcript},
 };
 use zinc_utils::{
@@ -245,7 +245,7 @@ impl<Zt: ZipTypes, Lc: LinearCode<Zt>> ZipPlus<Zt, Lc> {
     /// alphas, perform alpha-projection externally, and then call
     /// [`Self::verify_with_alphas`].
     pub fn sample_alphas(
-        transcript: &mut KeccakTranscript,
+        transcript: &mut Blake3Transcript,
         batch_size: usize,
     ) -> Vec<Vec<Zt::Chal>> {
         let degree_bound = Zt::Comb::DEGREE_BOUND;

--- a/zip-plus/src/pcs_transcript.rs
+++ b/zip-plus/src/pcs_transcript.rs
@@ -3,7 +3,7 @@ use crypto_primitives::PrimeField;
 use itertools::Itertools;
 use std::io::{Cursor, ErrorKind, Read, Write};
 use zinc_transcript::{
-    KeccakTranscript,
+    Blake3Transcript,
     traits::{ConstTranscribable, GenTranscribable, Transcribable, Transcript},
 };
 use zinc_utils::{add, mul, rem};
@@ -45,7 +45,7 @@ pub struct PcsProverTranscript {
     /// Handles Fiat-Shamir transformations for non-interactive zero-knowledge
     /// proofs. Used to absorb field elements and generate cryptographic
     /// challenges.
-    pub fs_transcript: KeccakTranscript,
+    pub fs_transcript: Blake3Transcript,
 
     /// Manages serialization and deserialization of proof data as a byte
     /// stream.
@@ -61,7 +61,7 @@ impl PcsProverTranscript {
 
     pub fn new_from_commitments<'a>(comms: impl Iterator<Item = &'a ZipPlusCommitment>) -> Self {
         let mut result = Self {
-            fs_transcript: KeccakTranscript::default(),
+            fs_transcript: Blake3Transcript::default(),
             stream: Cursor::default(),
         };
 
@@ -82,7 +82,7 @@ impl PcsProverTranscript {
     /// this allows us more flexibility in how we use the transcript.
     pub fn into_verification_transcript(self) -> PcsVerifierTranscript {
         let mut result = PcsVerifierTranscript {
-            fs_transcript: KeccakTranscript::default(),
+            fs_transcript: Blake3Transcript::default(),
             stream: self.stream,
         };
         result.stream.set_position(0);
@@ -227,7 +227,7 @@ pub struct PcsVerifierTranscript {
     /// Handles Fiat-Shamir transformations for non-interactive zero-knowledge
     /// proofs. Used to absorb field elements and generate cryptographic
     /// challenges.
-    pub fs_transcript: KeccakTranscript,
+    pub fs_transcript: Blake3Transcript,
 
     /// Manages serialization and deserialization of proof data as a byte
     /// stream.


### PR DESCRIPTION
Supersedes #133.

While all-feature performance stays the same, it allows us to get rid of `sha3` dependency as well as `asm` feature flag, also giving us a nicer code for `fill_with_random_bytes`.