### PR TITLE
Better benchmarking for IPRS

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,32 @@
 
 WIP implementation and playground on Nethermind's improvement to Zinc SNARK .
 
+## Benchmarks
+
+Available benchmarks:
+
+| Benchmark          | What it measures                                                                                                                       |
+|--------------------|----------------------------------------------------------------------------------------------------------------------------------------|
+| `zip_benches`      | PCS-level operations (encode, Merkle tree, commit, prove, verify) using **scalar** evaluations with IPRS codes. Uses `i32` evaluations |
+| `zip_plus_benches` | Same PCS-level operations using **polynomial** evaluations (degree 32 & 64) with both RAA and IPRS codes. Uses `{0,1}^D` evaluations.  |
+| `e2e`              | Full Zinc+ SNARK prove & verify on several test AIRs (NoMult, BinaryDecomposition, BigLinear, BigLinearPI) at varying sizes.           |
+
+To run benchmarks, use
+```bash
+RUSTFLAGS="-C target-cpu=native" cargo bench \
+  --features "simd parallel unchecked" \
+  --bench BENCH_NAME
+```
+
+### Flags & features
+
+| Flag / Feature         | What it does                                                                                                                                                     |
+|------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `-C target-cpu=native` | Lets the compiler emit platform-specific instructions (NEON, AVX-512, etc.). Required for `simd`.                                                                |
+| `simd`                 | Bit-packs binary polynomials into `u64`s and uses hand-written NEON / AVX-512 intrinsics for key operations (widening, inner products).                          |
+| `parallel`             | Enables [rayon](https://docs.rs/rayon)-based multi-threaded execution across the whole stack (sumcheck, encoding, commitment, etc.).                             |
+| `unchecked`            | Replaces `checked_add` / `checked_mul` with plain arithmetic, removing overflow guards. Only affects integer-typed computations; field arithmetic is unaffected. |
+
 ## License
 
 Apache 2.0

--- a/utils/src/mul_by_scalar.rs
+++ b/utils/src/mul_by_scalar.rs
@@ -78,6 +78,19 @@ where
     }
 }
 
+impl MulByScalar<&i64, i64> for i32 {
+    #[inline(always)]
+    #[allow(clippy::arithmetic_side_effects)] // By design
+    fn mul_by_scalar<const CHECK: bool>(&self, rhs: &i64) -> Option<i64> {
+        let lhs = i64::from(*self);
+        if CHECK {
+            lhs.checked_mul(*rhs)
+        } else {
+            Some(lhs * rhs)
+        }
+    }
+}
+
 impl MulByScalar<&i64> for i128 {
     #[inline(always)]
     #[allow(clippy::arithmetic_side_effects)] // By design

--- a/utils/src/mul_by_scalar.rs
+++ b/utils/src/mul_by_scalar.rs
@@ -78,16 +78,11 @@ where
     }
 }
 
-impl MulByScalar<&i64, i64> for i32 {
+impl MulByScalar<&i64, i128> for i32 {
     #[inline(always)]
-    #[allow(clippy::arithmetic_side_effects)] // By design
-    fn mul_by_scalar<const CHECK: bool>(&self, rhs: &i64) -> Option<i64> {
-        let lhs = i64::from(*self);
-        if CHECK {
-            lhs.checked_mul(*rhs)
-        } else {
-            Some(lhs * rhs)
-        }
+    #[allow(clippy::arithmetic_side_effects)] // Not possible to overflow since we are widening the result to i128
+    fn mul_by_scalar<const CHECK: bool>(&self, rhs: &i64) -> Option<i128> {
+        Some(i128::from(*self) * i128::from(*rhs))
     }
 }
 

--- a/zip-plus/benches/zip_benches.rs
+++ b/zip-plus/benches/zip_benches.rs
@@ -26,7 +26,7 @@ struct BenchZipTypes {}
 impl ZipTypes for BenchZipTypes {
     const NUM_COLUMN_OPENINGS: usize = 147;
     type Eval = i32;
-    type Cw = i64;
+    type Cw = i128;
     type Fmod = Uint<{ INT_LIMBS * 4 }>;
     type PrimeTest = MillerRabin;
     type Chal = i128;

--- a/zip-plus/benches/zip_benches.rs
+++ b/zip-plus/benches/zip_benches.rs
@@ -3,15 +3,14 @@
 
 mod zip_common;
 
-use zinc_primality::MillerRabin;
-use zinc_utils::inner_product::{MBSInnerProduct, ScalarProduct};
-use zip_common::*;
-
 use criterion::{Criterion, criterion_group, criterion_main};
 use crypto_bigint::U64;
 use crypto_primitives::{crypto_bigint_int::Int, crypto_bigint_uint::Uint};
+use zinc_primality::MillerRabin;
+use zinc_utils::inner_product::{MBSInnerProduct, ScalarProduct};
+use zip_common::*;
 use zip_plus::{
-    code::raa::{RaaCode, RaaConfig},
+    code::iprs::{IprsCode, PnttConfigF65537},
     pcs::structs::ZipTypes,
 };
 
@@ -39,19 +38,12 @@ impl ZipTypes for BenchZipTypes {
     type ArrCombRDotChal = MBSInnerProduct;
 }
 
-#[derive(Clone, Copy)]
-struct BenchRaaConfig;
-impl RaaConfig for BenchRaaConfig {
-    const PERMUTE_IN_PLACE: bool = false;
-    const CHECK_FOR_OVERFLOWS: bool = PERFORM_CHECKS;
-}
-
-type Code = RaaCode<BenchZipTypes, BenchRaaConfig, 4>;
+type BenchIprsCode = IprsCode<BenchZipTypes, PnttConfigF65537, 4, PERFORM_CHECKS>;
 
 fn zip_benchmarks(c: &mut Criterion) {
-    let mut group = c.benchmark_group("Zip+");
-    do_bench::<BenchZipTypes, Code, PERFORM_CHECKS>(&mut group, |poly_size| {
-        RaaCode::new(poly_size.isqrt().next_power_of_two())
+    let mut group = c.benchmark_group("Zip+ IPRS");
+    do_bench::<BenchZipTypes, _, PERFORM_CHECKS>(&mut group, |poly_size| {
+        BenchIprsCode::new_with_optimal_depth(poly_size).unwrap()
     });
     group.finish();
 }

--- a/zip-plus/benches/zip_benches.rs
+++ b/zip-plus/benches/zip_benches.rs
@@ -43,10 +43,14 @@ type BenchIprsCode = IprsCode<BenchZipTypes, PnttConfigF65537, 4, PERFORM_CHECKS
 fn zip_benchmarks(c: &mut Criterion) {
     let mut group = c.benchmark_group("Zip+ IPRS");
     do_bench::<BenchZipTypes, _, PERFORM_CHECKS>(&mut group, |poly_size| {
-        BenchIprsCode::new_with_optimal_depth(poly_size).unwrap()
+        BenchIprsCode::new_with_optimal_depth(poly_size).ok()
     });
     group.finish();
 }
 
-criterion_group!(benches, zip_benchmarks);
+criterion_group! {
+    name = benches;
+    config = Criterion::default().sample_size(500);
+    targets = zip_benchmarks
+}
 criterion_main!(benches);

--- a/zip-plus/benches/zip_common.rs
+++ b/zip-plus/benches/zip_common.rs
@@ -36,7 +36,7 @@ type F = MontyField<{ INT_LIMBS * 4 }>;
 
 pub fn do_bench<Zt: ZipTypes, Lc: LinearCode<Zt>, const CHECK_FOR_OVERFLOWS: bool>(
     group: &mut BenchmarkGroup<WallTime>,
-    make_linear_code: impl Fn(/* poly_size: */ usize) -> Lc + Copy,
+    make_linear_code: impl Fn(/* poly_size: */ usize) -> Option<Lc> + Copy,
 ) where
     StandardUniform: Distribution<Zt::Eval> + Distribution<Zt::Cw>,
     F: FromPrimitiveWithConfig
@@ -56,8 +56,8 @@ pub fn do_bench<Zt: ZipTypes, Lc: LinearCode<Zt>, const CHECK_FOR_OVERFLOWS: boo
 
     // Using row len > 2^14 exceeds the NTT domain for IPRS codes with F65547 and
     // rate 1/4 that we currently use
-    for lc in (8..=14)
-        .map(|row_len_ilog2| {
+    for lc in (8..=16)
+        .filter_map(|row_len_ilog2| {
             let row_len = 1 << row_len_ilog2;
             make_linear_code(row_len)
         })
@@ -109,10 +109,21 @@ pub fn do_bench<Zt: ZipTypes, Lc: LinearCode<Zt>, const CHECK_FOR_OVERFLOWS: boo
 
 pub fn encode_rows<Zt: ZipTypes, Lc: LinearCode<Zt>, const P: usize>(
     group: &mut BenchmarkGroup<WallTime>,
-    make_linear_code: impl Fn(usize) -> Lc,
+    make_linear_code: impl Fn(usize) -> Option<Lc>,
 ) where
     StandardUniform: Distribution<Zt::Eval>,
 {
+    let mut rng = ThreadRng::default();
+    let poly_size: usize = 1 << P;
+    let Some(linear_code) = make_linear_code(poly_size) else {
+        eprintln!(
+            "Skipping EncodeRows for poly_size=2^{P} as no suitable linear code could be constructed"
+        );
+        return;
+    };
+    let params = ZipPlus::setup(poly_size, linear_code);
+    let poly = DenseMultilinearExtension::<<Zt as ZipTypes>::Eval>::rand(P, &mut rng);
+
     group.bench_function(
         format!(
             "EncodeRows: {} -> {}, poly_size = 2^{P}",
@@ -120,11 +131,6 @@ pub fn encode_rows<Zt: ZipTypes, Lc: LinearCode<Zt>, const P: usize>(
             Zt::Cw::type_name()
         ),
         |b| {
-            let mut rng = ThreadRng::default();
-            let poly_size: usize = 1 << P;
-            let linear_code = make_linear_code(poly_size);
-            let params = ZipPlus::setup(poly_size, linear_code);
-            let poly = DenseMultilinearExtension::<<Zt as ZipTypes>::Eval>::rand(P, &mut rng);
             b.iter(|| {
                 let cw = ZipPlus::encode_rows(&params, &poly);
                 black_box(cw)
@@ -184,13 +190,18 @@ where
 
 pub fn commit<Zt: ZipTypes, Lc: LinearCode<Zt>, const P: usize, const BATCH: usize>(
     group: &mut BenchmarkGroup<WallTime>,
-    make_linear_code: impl Fn(usize) -> Lc,
+    make_linear_code: impl Fn(usize) -> Option<Lc>,
 ) where
     StandardUniform: Distribution<Zt::Eval>,
 {
     let mut rng = ThreadRng::default();
     let poly_size: usize = 1 << P;
-    let linear_code = make_linear_code(poly_size);
+    let Some(linear_code) = make_linear_code(poly_size) else {
+        eprintln!(
+            "Skipping Commit for poly_size=2^{P} as no suitable linear code could be constructed"
+        );
+        return;
+    };
     let params = ZipPlus::setup(poly_size, linear_code);
 
     group.bench_function(
@@ -226,7 +237,7 @@ pub fn prove<
     const BATCH: usize,
 >(
     group: &mut BenchmarkGroup<WallTime>,
-    make_linear_code: impl Fn(usize) -> Lc,
+    make_linear_code: impl Fn(usize) -> Option<Lc>,
 ) where
     StandardUniform: Distribution<Zt::Eval>,
     F: for<'a> FromWithConfig<&'a Zt::CombR>
@@ -239,7 +250,12 @@ pub fn prove<
     let mut rng = ThreadRng::default();
 
     let poly_size: usize = 1 << P;
-    let linear_code = make_linear_code(poly_size);
+    let Some(linear_code) = make_linear_code(poly_size) else {
+        eprintln!(
+            "Skipping Prove for poly_size=2^{P} as no suitable linear code could be constructed"
+        );
+        return;
+    };
     let params = ZipPlus::setup(poly_size, linear_code);
 
     let polys: Vec<_> = (0..BATCH)
@@ -307,7 +323,7 @@ pub fn verify<
     const BATCH: usize,
 >(
     group: &mut BenchmarkGroup<WallTime>,
-    make_linear_code: impl Fn(usize) -> Lc,
+    make_linear_code: impl Fn(usize) -> Option<Lc>,
 ) where
     StandardUniform: Distribution<Zt::Eval>,
     F: FromPrimitiveWithConfig
@@ -321,7 +337,12 @@ pub fn verify<
 {
     let mut rng = ThreadRng::default();
     let poly_size: usize = 1 << P;
-    let linear_code = make_linear_code(poly_size);
+    let Some(linear_code) = make_linear_code(poly_size) else {
+        eprintln!(
+            "Skipping Verify for poly_size=2^{P} as no suitable linear code could be constructed"
+        );
+        return;
+    };
     let params = ZipPlus::setup(poly_size, linear_code);
 
     let polys: Vec<_> = (0..BATCH)

--- a/zip-plus/benches/zip_common.rs
+++ b/zip-plus/benches/zip_common.rs
@@ -142,9 +142,10 @@ pub fn encode_single_row<Zt: ZipTypes, Lc: LinearCode<Zt>>(
     let mut rng = ThreadRng::default();
     let row_len = linear_code.row_len();
     let message: Vec<<Zt as ZipTypes>::Eval> = (0..row_len).map(|_i| rng.random()).collect();
+    let params = linear_code.params_string();
     group.bench_function(
         format!(
-            "EncodeMessage: {} -> {}, row_len = {row_len}",
+            "EncodeMessage: {} -> {}, {params}",
             Zt::Eval::type_name(),
             Zt::Cw::type_name()
         ),

--- a/zip-plus/benches/zip_common.rs
+++ b/zip-plus/benches/zip_common.rs
@@ -54,9 +54,13 @@ pub fn do_bench<Zt: ZipTypes, Lc: LinearCode<Zt>, const CHECK_FOR_OVERFLOWS: boo
     encode_rows::<Zt, Lc, 15>(group, make_linear_code);
     encode_rows::<Zt, Lc, 16>(group, make_linear_code);
 
-    for lc in [128, 256, 512, 1024]
-        .map(make_linear_code)
-        .into_iter()
+    // Using row len > 2^14 exceeds the NTT domain for IPRS codes with F65547 and
+    // rate 1/4 that we currently use
+    for lc in (8..=14)
+        .map(|row_len_ilog2| {
+            let row_len = 1 << row_len_ilog2;
+            make_linear_code(row_len)
+        })
         // These might be duplicate depending on linear code construction logic
         .dedup()
     {
@@ -137,6 +141,7 @@ pub fn encode_single_row<Zt: ZipTypes, Lc: LinearCode<Zt>>(
 {
     let mut rng = ThreadRng::default();
     let row_len = linear_code.row_len();
+    let message: Vec<<Zt as ZipTypes>::Eval> = (0..row_len).map(|_i| rng.random()).collect();
     group.bench_function(
         format!(
             "EncodeMessage: {} -> {}, row_len = {row_len}",
@@ -144,8 +149,6 @@ pub fn encode_single_row<Zt: ZipTypes, Lc: LinearCode<Zt>>(
             Zt::Cw::type_name()
         ),
         |b| {
-            let message: Vec<<Zt as ZipTypes>::Eval> =
-                (0..row_len).map(|_i| rng.random()).collect();
             b.iter(|| {
                 let encoded_row: Vec<<Zt as ZipTypes>::Cw> = linear_code.encode(&message);
                 black_box(encoded_row);

--- a/zip-plus/benches/zip_plus_benches.rs
+++ b/zip-plus/benches/zip_plus_benches.rs
@@ -70,23 +70,21 @@ impl RaaConfig for BenchRaaConfig {
     const CHECK_FOR_OVERFLOWS: bool = PERFORM_CHECKS;
 }
 
-type SomeRaaCode<const D_PLUS_ONE: usize> =
+type BenchRaaCode<const D_PLUS_ONE: usize> =
     RaaCode<BenchZipPlusTypes<i32, D_PLUS_ONE>, BenchRaaConfig, 4>;
 
-type SomeIprsCode<Twiddle, const D_PLUS_ONE: usize, const CHECK: bool> =
-    IprsCode<BenchZipPlusTypes<Twiddle, D_PLUS_ONE>, PnttConfigF65537, 4, CHECK>;
+type BenchIprsCode<Twiddle, const D_PLUS_ONE: usize> =
+    IprsCode<BenchZipPlusTypes<Twiddle, D_PLUS_ONE>, PnttConfigF65537, 4, PERFORM_CHECKS>;
 
 fn zip_plus_benchmarks_raa(c: &mut Criterion) {
     let mut group = c.benchmark_group("Zip+ RAA");
 
-    do_bench::<BenchZipPlusTypes<i32, 32>, SomeRaaCode<_>, PERFORM_CHECKS>(
-        &mut group,
-        |poly_size| RaaCode::new(poly_size.isqrt().next_power_of_two()),
-    );
-    do_bench::<BenchZipPlusTypes<i32, 64>, SomeRaaCode<_>, PERFORM_CHECKS>(
-        &mut group,
-        |poly_size| RaaCode::new(poly_size.isqrt().next_power_of_two()),
-    );
+    do_bench::<BenchZipPlusTypes<i32, 32>, _, PERFORM_CHECKS>(&mut group, |poly_size| {
+        BenchRaaCode::new(poly_size.isqrt().next_power_of_two())
+    });
+    do_bench::<BenchZipPlusTypes<i32, 64>, _, PERFORM_CHECKS>(&mut group, |poly_size| {
+        BenchRaaCode::new(poly_size.isqrt().next_power_of_two())
+    });
 
     group.finish();
 }
@@ -95,14 +93,12 @@ fn zip_plus_benchmarks_iprs(c: &mut Criterion) {
     let mut group = c.benchmark_group("Zip+ IPRS");
 
     // Use flat single-row Zip+ matrix
-    do_bench::<BenchZipPlusTypes<i64, 32>, SomeIprsCode<i64, 32, PERFORM_CHECKS>, PERFORM_CHECKS>(
-        &mut group,
-        |poly_size| IprsCode::new_with_optimal_depth(poly_size).unwrap(),
-    );
-    do_bench::<BenchZipPlusTypes<i64, 64>, SomeIprsCode<i64, 64, PERFORM_CHECKS>, PERFORM_CHECKS>(
-        &mut group,
-        |poly_size| IprsCode::new_with_optimal_depth(poly_size).unwrap(),
-    );
+    do_bench::<BenchZipPlusTypes<i64, 32>, _, PERFORM_CHECKS>(&mut group, |poly_size| {
+        BenchIprsCode::new_with_optimal_depth(poly_size).unwrap()
+    });
+    do_bench::<BenchZipPlusTypes<i64, 64>, _, PERFORM_CHECKS>(&mut group, |poly_size| {
+        BenchIprsCode::new_with_optimal_depth(poly_size).unwrap()
+    });
 
     group.finish();
 }

--- a/zip-plus/benches/zip_plus_benches.rs
+++ b/zip-plus/benches/zip_plus_benches.rs
@@ -80,10 +80,10 @@ fn zip_plus_benchmarks_raa(c: &mut Criterion) {
     let mut group = c.benchmark_group("Zip+ RAA");
 
     do_bench::<BenchZipPlusTypes<i32, 32>, _, PERFORM_CHECKS>(&mut group, |poly_size| {
-        BenchRaaCode::new(poly_size.isqrt().next_power_of_two())
+        Some(BenchRaaCode::new(poly_size.isqrt().next_power_of_two()))
     });
     do_bench::<BenchZipPlusTypes<i32, 64>, _, PERFORM_CHECKS>(&mut group, |poly_size| {
-        BenchRaaCode::new(poly_size.isqrt().next_power_of_two())
+        Some(BenchRaaCode::new(poly_size.isqrt().next_power_of_two()))
     });
 
     group.finish();
@@ -94,14 +94,18 @@ fn zip_plus_benchmarks_iprs(c: &mut Criterion) {
 
     // Use flat single-row Zip+ matrix
     do_bench::<BenchZipPlusTypes<i64, 32>, _, PERFORM_CHECKS>(&mut group, |poly_size| {
-        BenchIprsCode::new_with_optimal_depth(poly_size).unwrap()
+        BenchIprsCode::new_with_optimal_depth(poly_size).ok()
     });
     do_bench::<BenchZipPlusTypes<i64, 64>, _, PERFORM_CHECKS>(&mut group, |poly_size| {
-        BenchIprsCode::new_with_optimal_depth(poly_size).unwrap()
+        BenchIprsCode::new_with_optimal_depth(poly_size).ok()
     });
 
     group.finish();
 }
 
-criterion_group!(benches, zip_plus_benchmarks_raa, zip_plus_benchmarks_iprs);
+criterion_group! {
+    name = benches;
+    config = Criterion::default().sample_size(500);
+    targets = zip_plus_benchmarks_raa, zip_plus_benchmarks_iprs
+}
 criterion_main!(benches);

--- a/zip-plus/src/code.rs
+++ b/zip-plus/src/code.rs
@@ -22,6 +22,10 @@ pub trait LinearCode<Zt: ZipTypes>: Debug + Eq + Sync + Send {
     /// Length of each encoded codeword (output length after encoding)
     fn codeword_len(&self) -> usize;
 
+    /// String representation of the parameters of this linear code, used for
+    /// benchmarks. Should start with "row_len=X".
+    fn params_string(&self) -> String;
+
     /// Encodes a row of cryptographic integers using this linear encoding
     /// scheme.
     ///

--- a/zip-plus/src/code/iprs.rs
+++ b/zip-plus/src/code/iprs.rs
@@ -28,6 +28,8 @@ where
     Config: PnttConfig,
 {
     pub fn new(row_len: usize, depth: usize) -> Result<Self, ZipError> {
+        // TODO(alex): Calculate max expected Zt::Cw::COEFF_BIT_WIDTH to ensure in
+        //             advance that the encoding will not overflow
         Ok(Self {
             pntt_params: Radix8PnttParams::new(row_len, depth, REP)?,
             _phantom: Default::default(),

--- a/zip-plus/src/code/iprs.rs
+++ b/zip-plus/src/code/iprs.rs
@@ -36,10 +36,10 @@ where
 
     /// Create a new IPRS code with the optimal depth heuristics trying to keep
     /// number of columns in the base matrix small.
-    /// Currently, keeps number of columns <= 2^7 but this might be tweaked in
+    /// Currently, keeps number of columns <= 2^8 but this might be tweaked in
     /// the future.
     pub fn new_with_optimal_depth(row_len: usize) -> Result<Self, ZipError> {
-        const MAX_BASE_COLS_LOG2: usize = 7;
+        const MAX_BASE_COLS_LOG2: usize = 8;
 
         let target_base_len = 1 << MAX_BASE_COLS_LOG2;
         // We want depth to be at least 1.
@@ -187,9 +187,29 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::pcs::test_utils::*;
+    use crate::pcs::{structs::ZipPlus, test_utils::*};
     use crypto_bigint::U64;
-    use zinc_utils::CHECKED;
+    use crypto_primitives::{
+        FixedSemiring, boolean::Boolean, crypto_bigint_int::Int, crypto_bigint_uint::Uint,
+    };
+    use rand::{
+        distr::{Distribution, StandardUniform},
+        prelude::ThreadRng,
+    };
+    use zinc_poly::{
+        mle::{DenseMultilinearExtension, MultilinearExtensionRand},
+        univariate::{
+            binary::{BinaryPoly, BinaryPolyInnerProduct},
+            dense::{DensePolyInnerProduct, DensePolynomial},
+        },
+    };
+    use zinc_primality::MillerRabin;
+    use zinc_transcript::traits::ConstTranscribable;
+    use zinc_utils::{
+        CHECKED,
+        inner_product::{MBSInnerProduct, ScalarProduct},
+        named::Named,
+    };
 
     const INT_LIMBS: usize = U64::LIMBS;
     const N: usize = INT_LIMBS;
@@ -210,5 +230,87 @@ mod tests {
         assert!(Code::new_with_optimal_depth(8).is_ok());
         assert!(Code::new_with_optimal_depth(12).is_err());
         assert!(Code::new_with_optimal_depth(16).is_ok());
+    }
+
+    fn do_encode<Zt, const REP: usize>(num_vars: usize)
+    where
+        Zt: ZipTypes,
+        Zt::Eval: for<'a> MulByScalar<&'a PnttInt, Zt::Cw>,
+        Zt::CombR: for<'a> MulByScalar<&'a PnttInt>,
+        Zt::Cw: CheckedAdd + for<'a> MulByScalar<&'a PnttInt>,
+        StandardUniform: Distribution<Zt::Eval>,
+    {
+        let mut rng = ThreadRng::default();
+        let poly_size: usize = 1 << num_vars;
+        let mle = DenseMultilinearExtension::rand(num_vars, &mut rng);
+
+        let code = IprsCode::<Zt, PnttConfigF65537, 4, CHECKED>::new_with_optimal_depth(poly_size)
+            .unwrap();
+        let pp = ZipPlus::setup(poly_size, code);
+        ZipPlus::<Zt, _>::encode_rows(&pp, &mle.evaluations);
+    }
+
+    /// Test the widest integer encoding used in benchmarks
+    #[test]
+    fn encode_bench_int() {
+        struct BenchZipTypes {}
+        impl ZipTypes for BenchZipTypes {
+            const NUM_COLUMN_OPENINGS: usize = 147;
+            type Eval = i32;
+            type Cw = i128;
+            type Fmod = Uint<{ INT_LIMBS * 4 }>;
+            type PrimeTest = MillerRabin;
+            type Chal = i128;
+            type Pt = i128;
+            type CombR = Int<{ INT_LIMBS * 3 }>;
+            type Comb = Self::CombR;
+            type EvalDotChal = ScalarProduct;
+            type CombDotChal = ScalarProduct;
+            type ArrCombRDotChal = MBSInnerProduct;
+        }
+
+        do_encode::<BenchZipTypes, 4>(14);
+    }
+
+    /// Test the widest binary polynomial encoding used in benchmarks
+    #[test]
+    fn encode_bench_poly() {
+        const D_PLUS_ONE: usize = 32;
+
+        struct BenchZipPlusTypes<CwCoeff>(PhantomData<CwCoeff>);
+
+        impl<CwCoeff> ZipTypes for BenchZipPlusTypes<CwCoeff>
+        where
+            CwCoeff: ConstTranscribable
+                + Copy
+                + Default
+                + FromRef<Boolean>
+                + Named
+                + FixedSemiring
+                + Send
+                + Sync,
+            Int<5>: FromRef<CwCoeff>,
+        {
+            const NUM_COLUMN_OPENINGS: usize = 147;
+            type Eval = BinaryPoly<D_PLUS_ONE>;
+            type Cw = DensePolynomial<CwCoeff, D_PLUS_ONE>;
+            type Fmod = Uint<{ INT_LIMBS * 4 }>;
+            type PrimeTest = MillerRabin;
+            type Chal = i128;
+            type Pt = i128;
+            type CombR = Int<{ INT_LIMBS * 5 }>;
+            type Comb = DensePolynomial<Self::CombR, D_PLUS_ONE>;
+            type EvalDotChal = BinaryPolyInnerProduct<Self::Chal, D_PLUS_ONE>;
+            type CombDotChal = DensePolyInnerProduct<
+                Self::CombR,
+                Self::Chal,
+                Self::CombR,
+                MBSInnerProduct,
+                D_PLUS_ONE,
+            >;
+            type ArrCombRDotChal = MBSInnerProduct;
+        }
+
+        do_encode::<BenchZipPlusTypes<i64>, 4>(14);
     }
 }

--- a/zip-plus/src/code/iprs.rs
+++ b/zip-plus/src/code/iprs.rs
@@ -135,6 +135,14 @@ where
         self.pntt_params.codeword_len
     }
 
+    fn params_string(&self) -> String {
+        format!(
+            "row_len={}, rate=1/{REP}, depth={}",
+            self.row_len(),
+            self.pntt_params.depth
+        )
+    }
+
     fn encode_wide(&self, row: &[Zt::CombR]) -> Vec<Zt::CombR> {
         self.encode_inner(row)
     }
@@ -164,8 +172,8 @@ where
     Config: PnttConfig,
     Zt: ZipTypes,
 {
-    fn eq(&self, _other: &Self) -> bool {
-        true // All IPRS codes with the same config are identical.
+    fn eq(&self, other: &Self) -> bool {
+        self.pntt_params == other.pntt_params
     }
 }
 

--- a/zip-plus/src/code/iprs/pntt/radix8/params.rs
+++ b/zip-plus/src/code/iprs/pntt/radix8/params.rs
@@ -8,7 +8,7 @@ use zinc_utils::{mul, sub};
 pub type PnttInt = i64;
 
 /// Configuration of radix-8 pseudo NTT.
-pub trait Config: Debug + Copy + Send + Sync {
+pub trait Config: Debug + Copy + PartialEq + Send + Sync {
     /// The field used to generate the twiddle factors
     /// and the base matrix for this pseudo NTT.
     type Field: FftField;
@@ -28,7 +28,7 @@ pub trait Config: Debug + Copy + Send + Sync {
 
 // Precomputed parameters needed for
 // pseudo NTT algorithm.
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct Radix8PnttParams<C: Config> {
     /// The length of the pseudo NTT's input.
     pub row_len: usize,
@@ -211,7 +211,7 @@ mod f65537 {
 }
 
 /// Pseudo NTT configuration for F65537 (2^16 + 1).
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct PnttConfigF65537;
 
 impl Config for PnttConfigF65537 {

--- a/zip-plus/src/code/raa.rs
+++ b/zip-plus/src/code/raa.rs
@@ -140,6 +140,10 @@ impl<Zt: ZipTypes, Config: RaaConfig, const REP: usize> LinearCode<Zt>
         self.row_len * REP
     }
 
+    fn params_string(&self) -> String {
+        format!("row_len={}, rate=1/{REP}", self.row_len())
+    }
+
     fn encode(&self, row: &[Zt::Eval]) -> Vec<Zt::Cw> {
         self.encode_inner(row)
     }

--- a/zip-plus/src/code/raa_sign_flip.rs
+++ b/zip-plus/src/code/raa_sign_flip.rs
@@ -86,6 +86,10 @@ where
         self.raa.codeword_len()
     }
 
+    fn params_string(&self) -> String {
+        self.raa.params_string()
+    }
+
     fn encode(&self, row: &[Zt::Eval]) -> Vec<Zt::Cw> {
         self.encode_inner(row)
     }


### PR DESCRIPTION
* Changed Zip (integer variant of Zip+) bechnamrks to use IPRS instead of RAA.
  * Widened codeword from `i64` to `i128` for that to work.
* In Zip+ common benches for encoding, use message sizes from 2^8 to 2^16 (was 2^7 to 2^10)
* Changed Zip+ benching code to skip a benchmark if linear code cannot be constructed for the given parameters.
  * This happens for IPRS since we can't construct it with more that 2^16 elements for the current F65537 config - meaning with rate 1/4, max message size is 2^14
* To avoid overflowing when encoding binary polynomials to `Z_{64}[X]`, changed IPRS depth heuristics from keeping encoding matrix columns <= 128 to <= 256. Note that this does slow down code chosen for some row lengths significantly due to lower depth being used, but this is okay for now
  * In the future, we'd like to have a check at the IPRS creation time, not at runtime
```
Zip+ IPRS/EncodeMessage: i32 -> i128, row_len=2048, rate=1/4, depth=2
                        time:   [319.00 µs 320.60 µs 322.43 µs]
Zip+ IPRS/EncodeMessage: i32 -> i128, row_len=2048, rate=1/4, depth=1
                        time:   [1.7413 ms 1.7529 ms 1.7675 ms]

Zip+ IPRS/EncodeMessage: i32 -> i128, row_len=16384, rate=1/4, depth=3
                        time:   [3.1971 ms 3.2233 ms 3.2516 ms]
Zip+ IPRS/EncodeMessage: i32 -> i128, row_len=16384, rate=1/4, depth=2
                        time:   [15.254 ms 15.441 ms 15.647 ms]
```
* Added `params_string()` to linear codes to report config parameters as string for benchmarking
* Added README section explaining how run benchmarks