### PR TITLE
Integrate lookups with simple benches

### DIFF
--- a/piop/benches/multipoint_eval.rs
+++ b/piop/benches/multipoint_eval.rs
@@ -7,7 +7,7 @@ use crypto_primitives::{
     FromWithConfig, crypto_bigint_monty::MontyField, crypto_bigint_uint::Uint,
 };
 use rand::{Rng, rng};
-use zinc_piop::multipoint_eval::MultipointEval;
+use zinc_piop::multipoint_eval::{MultipointEval, MultipointEvalData};
 use zinc_poly::mle::{DenseMultilinearExtension, MultilinearExtensionWithConfig};
 use zinc_primality::MillerRabin;
 use zinc_transcript::{Blake3Transcript, traits::Transcript};
@@ -84,10 +84,13 @@ fn bench_multipoint_eval(c: &mut Criterion, num_vars: usize, num_cols: usize) {
                     MultipointEval::<F>::prove_as_subprotocol(
                         &mut t,
                         &trace_mles,
-                        &eval_point,
-                        &up_evals,
-                        &down_evals,
-                        &shifts,
+                        &[],
+                        MultipointEvalData {
+                            eval_point: &eval_point,
+                            up_evals: &up_evals,
+                            down_evals: &down_evals,
+                            shifts: &shifts,
+                        },
                         &field_cfg,
                     )
                     .expect("prover failed"),
@@ -104,10 +107,13 @@ fn bench_multipoint_eval(c: &mut Criterion, num_vars: usize, num_cols: usize) {
     let (proof, prover_state) = MultipointEval::<F>::prove_as_subprotocol(
         &mut prover_transcript,
         &trace_mles,
-        &eval_point,
-        &up_evals,
-        &down_evals,
-        &shifts,
+        &[],
+        MultipointEvalData {
+            eval_point: &eval_point,
+            up_evals: &up_evals,
+            down_evals: &down_evals,
+            shifts: &shifts,
+        },
         &field_cfg,
     )
     .expect("prover failed");
@@ -128,11 +134,13 @@ fn bench_multipoint_eval(c: &mut Criterion, num_vars: usize, num_cols: usize) {
                 let subclaim = MultipointEval::<F>::verify_as_subprotocol(
                     &mut t,
                     proof,
-                    &eval_point,
-                    &up_evals,
-                    &down_evals,
-                    &shifts,
-                    num_vars,
+                    &[],
+                    MultipointEvalData {
+                        eval_point: &eval_point,
+                        up_evals: &up_evals,
+                        down_evals: &down_evals,
+                        shifts: &shifts,
+                    },
                     &field_cfg,
                 )
                 .expect("verifier failed");

--- a/piop/src/lookup/logup.rs
+++ b/piop/src/lookup/logup.rs
@@ -11,7 +11,7 @@
 //! `u = 1/(β − w)` via Zip+ PCS. The table inverse `v = 1/(β − T)` is
 //! NOT committed — the verifier computes it from the public table.
 //!
-//! ## γ-Batched sumcheck groups
+//! ## Batched sumcheck groups
 //!
 //! For L witness columns sharing the same table, a random challenge γ
 //! collapses 2·L individual groups into exactly **2 groups**:
@@ -41,7 +41,7 @@ use zinc_poly::{
 };
 use zinc_transcript::traits::{ConstTranscribable, Transcript};
 use zinc_uair::LookupTableType;
-use zinc_utils::{cfg_iter, inner_transparent_field::InnerTransparentField, log2};
+use zinc_utils::{cfg_iter, div, inner_transparent_field::InnerTransparentField, log2, powers};
 
 use crate::{
     lookup::{
@@ -51,15 +51,19 @@ use crate::{
 };
 
 use super::{
-    structs::{LogupVerifierPreSumcheckData, LookupError},
-    utils::{generate_bitpoly_table, generate_word_table},
+    structs::{DecompInfo, LogupVerifierPreSumcheckData, LookupError},
+    utils::{
+        bitpoly_decomp_base, decompose_bitpoly_column, decompose_word_column,
+        generate_bitpoly_subtable, generate_bitpoly_table, generate_word_subtable,
+        generate_word_table, word_decomp_base,
+    },
 };
 
 /// LogUp sumcheck group builder and verifier finalizer.
 pub struct LogupProtocol<F: InnerTransparentField>(PhantomData<F>);
 
 impl<F: InnerTransparentField + FromPrimitiveWithConfig + Send + Sync> LogupProtocol<F> {
-    /// Build two γ-batched LogUp sumcheck groups from L columns.
+    /// Build two batched LogUp sumcheck groups from L columns.
     ///
     /// Takes L witnesses and their auxiliary vectors. Returns exactly
     /// 2 groups regardless of L: `[group_0, group_1]`
@@ -189,6 +193,103 @@ impl<F: InnerTransparentField + FromPrimitiveWithConfig + Send + Sync> LogupProt
         Ok(vec![group_0, group_1])
     }
 
+    /// Build a single batched reconstruction zerocheck group for
+    /// decomposed lookups.
+    ///
+    /// Combines L reconstruction identities into one degree-2 group:
+    /// `(Σ_l γ^l · (w_l(y) − Σ_k decomp_bases[k] · chunk_{l,k}(y))) · eq(r, y)
+    /// = 0`
+    ///
+    /// Returns a `Vec` with exactly 1 group (empty if L=0).
+    ///
+    /// MLE layout: `[eq, w_0, chunk_{0,0}, …, chunk_{0,K-1}, w_1, …]`
+    /// Total: `1 + L·(K+1)` MLEs, degree 2.
+    ///
+    /// # Arguments
+    ///
+    /// - `witnesses`: L original witness columns.
+    /// - `chunks`: `chunks[l]` is K chunk columns for witness l.
+    /// - `decomp_bases`: K positional bases `[1, base, base^2, …]`.
+    /// - `gamma`: the same γ challenge used for LogUp batching.
+    /// - `r`: random evaluation point for eq.
+    /// - `field_cfg`: field configuration.
+    #[allow(clippy::arithmetic_side_effects)]
+    pub fn build_reconstruction_group(
+        witnesses: &[&[F]],
+        chunks: &[Vec<Vec<F>>],
+        decomp_bases: &[F],
+        gamma: &F,
+        r: &[F],
+        field_cfg: &F::Config,
+    ) -> Result<Vec<MultiDegreeSumcheckGroup<F>>, LookupError>
+    where
+        F::Inner: Zero + Default + Send + Sync,
+        F: 'static,
+    {
+        let num_cols = witnesses.len();
+        if num_cols == 0 {
+            return Ok(Vec::new());
+        }
+        assert_eq!(num_cols, chunks.len());
+        let k = decomp_bases.len();
+
+        let zero = F::zero_with_cfg(field_cfg);
+        let one = F::one_with_cfg(field_cfg);
+        let inner_zero = zero.inner().clone();
+
+        let num_vars = log2(witnesses[0].len().next_power_of_two()) as usize;
+
+        let eq_r = build_eq_x_r_inner(r, field_cfg)?;
+
+        let mk_mle = |data: &[F]| -> DenseMultilinearExtension<F::Inner> {
+            DenseMultilinearExtension::from_evaluations_vec(
+                num_vars,
+                cfg_iter!(data).map(|x| x.inner().clone()).collect(),
+                inner_zero.clone(),
+            )
+        };
+
+        // MLEs: [eq, w_0, chunk_{0,0..K-1}, w_1, chunk_{1,0..K-1}, ...]
+        let mut mles = Vec::with_capacity(1 + num_cols * (k + 1));
+        mles.push(eq_r);
+        for l in 0..num_cols {
+            assert_eq!(chunks[l].len(), k);
+            mles.push(mk_mle(witnesses[l]));
+            for chunk in &chunks[l] {
+                mles.push(mk_mle(chunk));
+            }
+        }
+
+        let gamma_pows = powers(gamma.clone(), one, num_cols);
+        let bases = decomp_bases.to_vec();
+        let zero_c = zero;
+        let stride = k + 1; // w + K chunks per column
+
+        let group = MultiDegreeSumcheckGroup::new(
+            2,
+            mles,
+            Box::new(move |v: &[F]| {
+                // v[0] = eq
+                // v[1 + l*stride] = w_l
+                // v[1 + l*stride + 1 .. 1 + l*stride + K] = chunk_{l,0..K-1}
+                let eq_val = &v[0];
+                let mut sum = zero_c.clone();
+                for l in 0..gamma_pows.len() {
+                    let w_val = &v[1 + l * stride];
+                    let mut recon = zero_c.clone();
+                    for (idx, base) in bases.iter().enumerate() {
+                        recon += &(base.clone() * &v[1 + l * stride + 1 + idx]);
+                    }
+                    let diff = w_val.clone() - &recon;
+                    sum += &(gamma_pows[l].clone() * &diff);
+                }
+                sum * eq_val
+            }),
+        );
+
+        Ok(vec![group])
+    }
+
     /// Extract witness columns and the shared lookup table for a group.
     ///
     /// Returns `(witnesses, table)` where `witnesses[i]` corresponds to
@@ -221,6 +322,76 @@ impl<F: InnerTransparentField + FromPrimitiveWithConfig + Send + Sync> LogupProt
         (witnesses, table)
     }
 
+    /// Extract decomposition data for a lookup group with `chunk_width`.
+    ///
+    /// Returns `None` when the table type has no `chunk_width` set.
+    /// Otherwise returns the subtable, positional bases, and decomposed
+    /// chunk columns for all L witnesses.
+    ///
+    /// The prover uses the returned subtable (instead of the full table)
+    /// for LogUp, commits the chunk columns via PCS, and builds a
+    /// reconstruction sumcheck group from the chunks + bases.
+    pub fn extract_decomposed(
+        witnesses: &[Vec<F>],
+        group_info: &super::LookupGroup,
+        projecting_element_f: &F,
+        field_cfg: &F::Config,
+    ) -> Option<DecompInfo<F>>
+    where
+        F::Inner: ConstTranscribable,
+    {
+        let (width, chunk_width) = match &group_info.table_type {
+            LookupTableType::BitPoly {
+                width,
+                chunk_width: Some(cw),
+            } => (*width, *cw),
+            LookupTableType::Word {
+                width,
+                chunk_width: Some(cw),
+            } => (*width, *cw),
+            _ => return None,
+        };
+
+        let k = div!(width, chunk_width);
+
+        let subtable = match &group_info.table_type {
+            LookupTableType::BitPoly { .. } => {
+                generate_bitpoly_subtable(chunk_width, projecting_element_f, field_cfg)
+            }
+            LookupTableType::Word { .. } => generate_word_subtable(chunk_width, field_cfg),
+            // unreachable given the match above, but keeps the compiler happy
+        };
+
+        let base = match &group_info.table_type {
+            LookupTableType::BitPoly { .. } => {
+                bitpoly_decomp_base(chunk_width, projecting_element_f)
+            }
+            LookupTableType::Word { .. } => word_decomp_base(chunk_width, field_cfg),
+        };
+        let one = F::one_with_cfg(field_cfg);
+        let decomp_bases = powers(base, one, k);
+
+        let chunks: Vec<Vec<Vec<F>>> = witnesses
+            .iter()
+            .map(|w| match &group_info.table_type {
+                LookupTableType::BitPoly { .. } => {
+                    decompose_bitpoly_column(w, width, chunk_width, projecting_element_f, &subtable)
+                        .expect("bitpoly decomposition failed")
+                }
+                LookupTableType::Word { .. } => {
+                    decompose_word_column(w, width, chunk_width, field_cfg)
+                        .expect("word decomposition failed")
+                }
+            })
+            .collect();
+
+        Some(DecompInfo {
+            subtable,
+            decomp_bases,
+            chunks,
+        })
+    }
+
     /// Pre-sumcheck transcript sync for LogUp.
     ///
     /// Absorbs PCS commitment roots into the transcript
@@ -249,10 +420,10 @@ impl<F: InnerTransparentField + FromPrimitiveWithConfig + Send + Sync> LogupProt
         LogupVerifierPreSumcheckData { r, beta, gamma }
     }
 
-    /// Post-sumcheck finalization for the γ-batched LogUp verifier.
+    /// Post-sumcheck finalization for the batched LogUp verifier.
     ///
-    /// Given the subclaim point `x*` and two expected evaluations (one
-    /// per γ-batched group), checks:
+    /// Given the subclaim point `r*` and two expected evaluations (one
+    /// per batched group), checks:
     ///
     /// - Group 0: `Σ_l γ^l · (d_l·u_l − 1) · eq_val == expected[0]` where d_l =
     ///   (β − w_l)
@@ -292,15 +463,20 @@ impl<F: InnerTransparentField + FromPrimitiveWithConfig + Send + Sync> LogupProt
             });
         }
 
-        // Evaluate eq(x*, r)
+        // Evaluate eq(r*, r)
         let eq_val = eq_eval(subclaim_point, r, one.clone())?;
 
-        // Compute v_eval from public table
+        // Compute v_eval from the lookup table. For decomposed groups the
+        // LogUp identities operate over the subtable (size 2^chunk_width).
         let table: Vec<F> = match &group_info.table_type {
-            LookupTableType::BitPoly { width, .. } => {
-                generate_bitpoly_table(*width, projecting_element_f, field_cfg)
-            }
-            LookupTableType::Word { width, .. } => generate_word_table(*width, field_cfg),
+            LookupTableType::BitPoly { width, chunk_width } => match chunk_width {
+                Some(cw) => generate_bitpoly_subtable(*cw, projecting_element_f, field_cfg),
+                None => generate_bitpoly_table(*width, projecting_element_f, field_cfg),
+            },
+            LookupTableType::Word { width, chunk_width } => match chunk_width {
+                Some(cw) => generate_word_subtable(*cw, field_cfg),
+                None => generate_word_table(*width, field_cfg),
+            },
         };
 
         let eq_at_point = build_eq_x_r_vec(subclaim_point, field_cfg)?;
@@ -490,7 +666,7 @@ mod tests {
         }
     }
 
-    /// Full γ-batched LogUp pipeline: `setup_logup_harness` then honest
+    /// Full batched LogUp pipeline: `setup_logup_harness` then honest
     /// finalize.
     fn run_logup_roundtrip(witnesses: &[Vec<F>], table: &[F]) {
         setup_logup_harness(witnesses, table)

--- a/piop/src/lookup/structs.rs
+++ b/piop/src/lookup/structs.rs
@@ -250,6 +250,9 @@ pub enum LookupError {
     #[error("malformed proof: w_evals length ({w}) != aux_evals length ({aux})")]
     EvalLengthMismatch { w: usize, aux: usize },
 
+    #[error("malformed proof: missing chunk commitment for decomposed group")]
+    MissingChunkCommitment,
+
     #[error("arithmetic error: {0}")]
     Arith(#[from] ArithErrors),
 }

--- a/piop/src/lookup/structs.rs
+++ b/piop/src/lookup/structs.rs
@@ -133,7 +133,7 @@ pub struct LogupVerifierPreSumcheckData<F> {
 }
 
 /// Scalar MLE evaluations of lookup auxiliary columns at the subclaim
-/// point x*, obtained from PCS openings via MultipointEval.
+/// point r*, obtained from PCS openings via MultipointEval.
 ///
 /// Used by `finalize_verifier` to check the LogUp identities
 #[derive(Clone, Debug)]
@@ -145,18 +145,44 @@ pub struct LookupAuxEvals<F> {
 /// Bundle of per-group evaluation data passed to
 /// [`LogupProtocol::finalize_verifier`].
 ///
-/// Carries L columns' evaluation data for the two γ-batched groups.
+/// Carries evaluation data for the 2 batched LogUp groups.
+/// For non-decomposed lookups, `w_evals` and `aux_evals` have L entries.
+/// For decomposed lookups (K chunks per column), both have L*K entries
+///
+/// The reconstruction check for decomposed lookups is handled at the
+/// protocol level (verifier.rs), not here.
 #[derive(Clone, Debug)]
 pub struct LogupFinalizerInput<'a, F> {
-    /// The multi-degree sumcheck subclaim point (x*).
+    /// The multi-degree sumcheck subclaim point (r*).
     pub subclaim_point: &'a [F],
-    /// Expected evaluations from the sumcheck subclaim (len=2, one
-    /// per γ-batched group).
+    /// Expected evaluations from the sumcheck subclaim for the 2
+    /// batched LogUp groups.
     pub expected_evaluations: &'a [F],
-    /// Evaluations of the L witness column polynomials at x*.
+    /// Evaluations of the witness column polynomials at r*.
+    /// L entries for non-decomposed, L*K chunk evals for decomposed.
     pub w_evals: &'a [F],
-    /// Per-column auxiliary evaluations (u, m) at x*.
+    /// Per-column auxiliary evaluations (u, m) at r*.
+    /// Length L for non-decomposed, L*K for decomposed.
     pub aux_evals: &'a [LookupAuxEvals<F>],
+}
+
+// ---------------------------------------------------------------------------
+// Decomposition info
+// ---------------------------------------------------------------------------
+
+/// Bundle of decomposition data for a single lookup group with
+/// `chunk_width.is_some()`.
+///
+/// Produced by [`LogupProtocol::extract_decomposed`] and consumed by the
+/// prover to build reconstruction sumcheck groups and commit chunk columns.
+#[derive(Clone, Debug)]
+pub struct DecompInfo<F> {
+    /// The smaller subtable (2^chunk_width entries) used for LogUp.
+    pub subtable: Vec<F>,
+    /// Positional bases `[1, base, base^2, …]` of length K.
+    pub decomp_bases: Vec<F>,
+    /// Decomposed chunk columns. `chunks[l][k]` is chunk k of column l.
+    pub chunks: Vec<Vec<Vec<F>>>,
 }
 
 // ---------------------------------------------------------------------------

--- a/piop/src/lookup/utils.rs
+++ b/piop/src/lookup/utils.rs
@@ -81,6 +81,55 @@ where
         .collect()
 }
 
+/// Generate the projected `BitPoly(half_width)` sub-table for
+/// decomposition.
+///
+/// This is the same as `generate_bitpoly_table(chunk_width, …)`.
+/// Provided as a convenience for clarity.
+pub fn generate_bitpoly_subtable<F: PrimeField + FromPrimitiveWithConfig>(
+    chunk_width: usize,
+    projecting_element: &F,
+    field_cfg: &F::Config,
+) -> Vec<F> {
+    generate_bitpoly_table(chunk_width, projecting_element, field_cfg)
+}
+
+/// Generate the projected `Word(chunk_width)` sub-table for
+/// decomposition.
+///
+/// This is just `{0, 1, …, 2^{chunk_width} − 1} mod q`.
+pub fn generate_word_subtable<F: PrimeField + FromPrimitiveWithConfig>(
+    chunk_width: usize,
+    field_cfg: &F::Config,
+) -> Vec<F> {
+    generate_word_table(chunk_width, field_cfg)
+}
+
+/// Compute the decomposition base for BitPoly.
+///
+/// For `BitPoly(w)` with `chunk_width = c` projected at `a`, the base
+/// is `a^c`. The K positional bases are `[1, base, base^2, …, base^{K-1}]`
+#[allow(clippy::arithmetic_side_effects)]
+pub fn bitpoly_decomp_base<F: PrimeField>(chunk_width: usize, projecting_element: &F) -> F {
+    let mut result = F::one_with_cfg(projecting_element.cfg());
+    for _ in 0..chunk_width {
+        result *= projecting_element;
+    }
+    result
+}
+
+/// Compute the decomposition base for Word.
+///
+/// For `Word(w)` with `chunk_width = c`, the base is `2^c mod q`.
+/// The K positional bases are `[1, 2^c, 2^{2c}, …]`.
+#[allow(clippy::arithmetic_side_effects)]
+pub fn word_decomp_base<F: PrimeField + FromPrimitiveWithConfig>(
+    chunk_width: usize,
+    field_cfg: &F::Config,
+) -> F {
+    F::from_with_cfg(1u64 << chunk_width, field_cfg)
+}
+
 /// Compute batch multiplicative inverses using a two-phase Montgomery trick.
 ///
 /// Given `values = [v_0, v_1, …, v_{n-1}]`, returns
@@ -181,7 +230,6 @@ fn reduce_chunk_products<F: PrimeField>(prefixes: &[Vec<F>], one: &F) -> Vec<F> 
     accs[0] = inv_acc;
     accs
 }
-
 /// Build a reusable table index mapping each table entry's byte
 /// representation to its position.
 ///
@@ -351,6 +399,131 @@ where
     result
 }
 
+// ── Column decomposition helpers ────────────────────────────────────────────
+
+/// Decompose a BitPoly column into K chunks of `chunk_width` bits.
+///
+/// Given a column of projected field elements (each being the evaluation
+/// of a binary polynomial of degree < `total_width` at projecting element
+/// `a`), splits each entry into K sub-polynomial evaluations such that:
+///
+/// ```text
+/// witness[i] = Σ_{k=0}^{K-1} decomp_bases[k] · chunks[k][i]
+/// ```
+///
+/// where `decomp_bases[k] = a^{k·chunk_width}` and `chunks[k][i]` is
+/// the evaluation of the k-th chunk of the binary polynomial.
+///
+/// # Arguments
+///
+/// - `witness`: projected column entries (field elements).
+/// - `total_width`: the full width (e.g. 32 for `BitPoly(32)`).
+/// - `chunk_width`: the width of each sub-table (e.g. 16).
+/// - `projecting_element`: the element `a` used for projection.
+/// - `subtable`: the projected BitPoly(chunk_width) sub-table.
+///
+/// # Returns
+///
+/// A vector of K chunk vectors, where K = total_width / chunk_width.
+/// Each chunk[k][i] is the projected evaluation of the k-th sub-polynomial.
+///
+/// Returns `None` if any witness entry is not found in the full
+/// BitPoly(total_width) table.
+#[allow(clippy::arithmetic_side_effects)]
+pub fn decompose_bitpoly_column<F: PrimeField + FromPrimitiveWithConfig + Send + Sync>(
+    witness: &[F],
+    total_width: usize,
+    chunk_width: usize,
+    projecting_element: &F,
+    subtable: &[F],
+) -> Option<Vec<Vec<F>>>
+where
+    F::Config: Sync,
+    F::Inner: ConstTranscribable,
+{
+    let num_chunks = total_width / chunk_width;
+    let mask = (1usize << chunk_width) - 1;
+
+    // Build the full BitPoly table and index to map field elements → indices.
+    let full_table =
+        generate_bitpoly_table(total_width, projecting_element, projecting_element.cfg());
+    let full_index = build_table_index(&full_table);
+
+    let elem_size = std::mem::size_of::<F::Inner>();
+    let mut chunks = vec![Vec::with_capacity(witness.len()); num_chunks];
+
+    for w in witness {
+        let bytes = unsafe {
+            std::slice::from_raw_parts(w.inner() as *const F::Inner as *const u8, elem_size)
+        };
+        let &n = full_index.get(bytes)?;
+
+        for (k, chunk) in chunks.iter_mut().take(num_chunks).enumerate() {
+            let sub_idx = (n >> (k * chunk_width)) & mask;
+            chunk.push(subtable[sub_idx].clone());
+        }
+    }
+
+    Some(chunks)
+}
+
+/// Decompose a Word column into K chunks of `chunk_width` bits.
+///
+/// Given a column of projected field elements (each being an integer in
+/// [0, 2^total_width)), splits each entry into K chunks such that:
+///
+/// ```text
+/// witness[i] = Σ_{k=0}^{K-1} 2^{k·chunk_width} · chunks[k][i]
+/// ```
+///
+/// where `chunks[k][i] = (witness_int >> k*chunk_width) & (2^chunk_width - 1)`.
+///
+/// # Implementation
+///
+/// Since `PrimeField` doesn't expose a direct `to_u64()`, we reverse-look up
+/// each witness entry in the Word(total_width) full table to find its integer
+/// index, then extract chunks from that index.
+///
+/// # Returns
+///
+/// A vector of K chunk vectors. Returns `None` if any witness entry is not
+/// a valid Word(total_width) (i.e. not in [0, 2^total_width)).
+#[allow(clippy::arithmetic_side_effects)]
+pub fn decompose_word_column<F: PrimeField + FromPrimitiveWithConfig + Send + Sync>(
+    witness: &[F],
+    total_width: usize,
+    chunk_width: usize,
+    field_cfg: &F::Config,
+) -> Option<Vec<Vec<F>>>
+where
+    F::Config: Sync,
+    F::Inner: ConstTranscribable,
+{
+    let num_chunks = total_width / chunk_width;
+    let mask = (1usize << chunk_width) - 1;
+
+    // Build the full Word table and its index to map field elements → integers.
+    let full_table: Vec<F> = generate_word_table(total_width, field_cfg);
+    let full_index = build_table_index(&full_table);
+
+    let elem_size = std::mem::size_of::<F::Inner>();
+    let mut chunks = vec![Vec::with_capacity(witness.len()); num_chunks];
+
+    for w in witness {
+        let bytes = unsafe {
+            std::slice::from_raw_parts(w.inner() as *const F::Inner as *const u8, elem_size)
+        };
+        let &n = full_index.get(bytes)?;
+
+        for (k, chunk) in chunks.iter_mut().take(num_chunks).enumerate() {
+            let chunk_val = (n >> (k * chunk_width)) & mask;
+            chunk.push(F::from_with_cfg(chunk_val as u64, field_cfg));
+        }
+    }
+
+    Some(chunks)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -489,5 +662,146 @@ mod tests {
         for (v, inv) in values.iter().zip(result.iter()) {
             assert_eq!((beta - v) * inv, one);
         }
+    }
+
+    // ── Subtable / decomp_base tests ────────────────────────────────
+
+    #[test]
+    fn bitpoly_subtable_matches_table() {
+        let a = F::from(3u32);
+        let sub = generate_bitpoly_subtable(4, &a, &());
+        let full = generate_bitpoly_table(4, &a, &());
+        assert_eq!(sub, full);
+    }
+
+    #[test]
+    fn word_subtable_matches_table() {
+        let sub = generate_word_subtable::<F>(4, &());
+        let full = generate_word_table::<F>(4, &());
+        assert_eq!(sub, full);
+    }
+
+    #[test]
+    fn bitpoly_decomp_base_value() {
+        let a = F::from(3u32);
+        // chunk_width=4 → base = a^4 = 3^4 = 81
+        let base = bitpoly_decomp_base(4, &a);
+        assert_eq!(base, F::from(81u32));
+    }
+
+    #[test]
+    fn word_decomp_base_value() {
+        // chunk_width=4 → base = 2^4 = 16
+        let base = word_decomp_base::<F>(4, &());
+        assert_eq!(base, F::from(16u32));
+    }
+
+    // ── Decomposition tests ─────────────────────────────────────────
+
+    /// Verify decomposition: reconstruction matches witness, chunks in
+    /// subtable.
+    #[allow(clippy::arithmetic_side_effects)]
+    fn assert_decompose_roundtrip(witness: &[F], chunks: &[Vec<F>], bases: &[F], subtable: &[F]) {
+        assert_eq!(chunks.len(), bases.len());
+        assert!(chunks.iter().all(|c| c.len() == witness.len()));
+
+        for (i, w) in witness.iter().enumerate() {
+            let mut reconstructed = F::from(0u32);
+            for (k, base) in bases.iter().enumerate() {
+                reconstructed += &(base * chunks[k][i]);
+            }
+            assert_eq!(reconstructed, *w, "reconstruction failed at index {i}");
+        }
+        for chunk_col in chunks {
+            for entry in chunk_col {
+                assert!(subtable.contains(entry), "chunk entry not in subtable");
+            }
+        }
+    }
+
+    #[test]
+    fn decompose_bitpoly_k2() {
+        let a = F::from(3u32);
+        let subtable = generate_bitpoly_subtable(4, &a, &());
+        let full_table = generate_bitpoly_table(8, &a, &());
+        let witness = vec![
+            full_table[0],
+            full_table[5],
+            full_table[170],
+            full_table[255],
+        ];
+
+        let chunks = decompose_bitpoly_column(&witness, 8, 4, &a, &subtable)
+            .expect("decomposition should succeed");
+        let base = bitpoly_decomp_base(4, &a);
+        let bases = zinc_utils::powers(base, F::from(1u32), 2);
+        assert_decompose_roundtrip(&witness, &chunks, &bases, &subtable);
+    }
+
+    #[test]
+    fn decompose_bitpoly_k3() {
+        let a = F::from(3u32);
+        let subtable = generate_bitpoly_subtable(3, &a, &());
+        let full_table = generate_bitpoly_table(9, &a, &());
+        let witness = vec![
+            full_table[0],
+            full_table[7],
+            full_table[73],
+            full_table[256],
+            full_table[511],
+        ];
+
+        let chunks = decompose_bitpoly_column(&witness, 9, 3, &a, &subtable)
+            .expect("decomposition should succeed");
+        let base = bitpoly_decomp_base(3, &a);
+        let bases = zinc_utils::powers(base, F::from(1u32), 3);
+        assert_decompose_roundtrip(&witness, &chunks, &bases, &subtable);
+    }
+
+    #[test]
+    fn decompose_word_k2() {
+        let subtable = generate_word_subtable::<F>(4, &());
+        let witness: Vec<F> = [0u32, 1, 15, 16, 42, 170, 255]
+            .iter()
+            .map(|&v| F::from(v))
+            .collect();
+
+        let chunks =
+            decompose_word_column(&witness, 8, 4, &()).expect("decomposition should succeed");
+        let base = word_decomp_base::<F>(4, &());
+        let bases = zinc_utils::powers(base, F::from(1u32), 2);
+        assert_decompose_roundtrip(&witness, &chunks, &bases, &subtable);
+    }
+
+    #[test]
+    fn decompose_word_k4() {
+        let subtable = generate_word_subtable::<F>(2, &());
+        let witness: Vec<F> = [0u32, 1, 63, 170, 255]
+            .iter()
+            .map(|&v| F::from(v))
+            .collect();
+
+        let chunks =
+            decompose_word_column(&witness, 8, 2, &()).expect("decomposition should succeed");
+        let base = word_decomp_base::<F>(2, &());
+        let bases = zinc_utils::powers(base, F::from(1u32), 4);
+        assert_decompose_roundtrip(&witness, &chunks, &bases, &subtable);
+    }
+
+    #[test]
+    fn decompose_bitpoly_rejects_invalid() {
+        let a = F::from(3u32);
+        let subtable = generate_bitpoly_subtable(4, &a, &());
+        let full_table = generate_bitpoly_table(8, &a, &());
+        let mut bad = F::from(2u32);
+        while full_table.contains(&bad) {
+            bad += &F::from(1u32);
+        }
+        assert!(decompose_bitpoly_column(&[bad], 8, 4, &a, &subtable).is_none());
+    }
+
+    #[test]
+    fn decompose_word_rejects_invalid() {
+        assert!(decompose_word_column(&[F::from(300u32)], 8, 4, &()).is_none());
     }
 }

--- a/piop/src/multipoint_eval.rs
+++ b/piop/src/multipoint_eval.rs
@@ -38,6 +38,8 @@ use crypto_primitives::{FromPrimitiveWithConfig, PrimeField};
 use num_traits::Zero;
 use std::marker::PhantomData;
 use thiserror::Error;
+#[cfg(debug_assertions)]
+use zinc_poly::mle::MultilinearExtensionWithConfig;
 use zinc_poly::{
     mle::DenseMultilinearExtension,
     utils::{ArithErrors, build_eq_x_r_inner, build_next_c_r_mle},
@@ -96,6 +98,18 @@ pub struct Subclaim<F: PrimeField> {
     pub shifts_at_r0: Vec<F>,
 }
 
+/// Shared evaluation data for [`MultipointEval`] — common to both prover and
+/// verifier.
+///
+/// Represents the evaluation claims produced by the CPR step: the shared
+/// evaluation point, the up/down evaluations, and the shift specifications.
+pub struct MultipointEvalData<'a, F: PrimeField> {
+    pub eval_point: &'a [F],
+    pub up_evals: &'a [F],
+    pub down_evals: &'a [F],
+    pub shifts: &'a [ShiftSpec],
+}
+
 //
 // Protocol
 //
@@ -119,13 +133,18 @@ where
     pub fn prove_as_subprotocol(
         transcript: &mut impl Transcript,
         trace_mles: &[DenseMultilinearExtension<F::Inner>],
-        eval_point: &[F],
-        up_evals: &[F],
-        down_evals: &[F],
-        shifts: &[ShiftSpec],
+        lookup_aux_mles: &[DenseMultilinearExtension<F::Inner>],
+        data: MultipointEvalData<'_, F>,
         field_cfg: &F::Config,
     ) -> Result<(Proof<F>, ProverState<F>), MultipointEvalError<F>> {
+        let MultipointEvalData {
+            eval_point,
+            up_evals: _up_evals,
+            down_evals: _down_evals,
+            shifts,
+        } = data;
         let num_cols = trace_mles.len();
+        let num_lookup_cols = lookup_aux_mles.len();
         let num_down_cols = shifts.len();
         let num_vars = eval_point.len();
         let zero = F::zero_with_cfg(field_cfg);
@@ -134,7 +153,7 @@ where
         // Step 1: Sample multi-point batching coefficient \alpha and column
         // batching coefficients \gamma_1,...,\gamma_J.
         let alphas: Vec<F> = transcript.get_field_challenges(num_down_cols, field_cfg);
-        let gammas: Vec<F> = transcript.get_field_challenges(num_cols, field_cfg);
+        let gammas: Vec<F> = transcript.get_field_challenges(num_cols + num_lookup_cols, field_cfg);
 
         // Step 2: Build the two selector MLEs:
         //   eq_r(b)   = eq(b, r')
@@ -151,7 +170,7 @@ where
             .into_iter()
             .unzip();
 
-        // Precombine up cols with gammas, precombined[b] = Σ_j γ_j trace[j][b]
+        // Precombine all up cols (trace + lookup aux) with gammas
         let precombined = {
             let evaluations: Vec<_> = cfg_into_iter!(0..1 << num_vars)
                 .map(|b| {
@@ -159,10 +178,12 @@ where
                         .iter()
                         .enumerate()
                         .fold(zero.clone(), |acc, (i, gamma)| {
-                            let eval_f = F::new_unchecked_with_cfg(
-                                trace_mles[i].evaluations[b].clone(),
-                                field_cfg,
-                            );
+                            let eval_inner = if i < num_cols {
+                                trace_mles[i].evaluations[b].clone()
+                            } else {
+                                lookup_aux_mles[i - num_cols].evaluations[b].clone()
+                            };
+                            let eval_f = F::new_unchecked_with_cfg(eval_inner, field_cfg);
                             acc + gamma.clone() * eval_f
                         })
                         .into_inner()
@@ -206,11 +227,23 @@ where
             field_cfg,
         );
 
-        // Sanity check
-        debug_assert_eq!(
-            sumcheck_proof.claimed_sum,
-            compute_expected_sum(up_evals, down_evals, &gammas, &alphas, zero)
-        );
+        // Sanity check: the claimed sum needs extended up_evals (trace + lookup aux).
+        // Lookup aux evals at eval_point are computed from the MLEs.
+        #[cfg(debug_assertions)]
+        {
+            let mut all_up = _up_evals.to_vec();
+            for mle in lookup_aux_mles {
+                all_up.push(
+                    mle.clone()
+                        .evaluate_with_config(eval_point, field_cfg)
+                        .expect("MLE evaluation should succeed"),
+                );
+            }
+            debug_assert_eq!(
+                sumcheck_proof.claimed_sum,
+                compute_expected_sum(&all_up, _down_evals, &gammas, &alphas, zero)
+            );
+        }
 
         Ok((
             Proof { sumcheck_proof },
@@ -228,29 +261,39 @@ where
     /// `shifts_at_r0`. The caller finalizes via
     /// [`verify_subclaim`](Self::verify_subclaim) once `open_evals` are
     /// available.
-    #[allow(clippy::arithmetic_side_effects, clippy::too_many_arguments)]
+    #[allow(clippy::arithmetic_side_effects)]
     pub fn verify_as_subprotocol(
         transcript: &mut impl Transcript,
         proof: Proof<F>,
-        eval_point: &[F],
-        up_evals: &[F],
-        down_evals: &[F],
-        shifts: &[ShiftSpec],
-        num_vars: usize,
+        lookup_aux_evals: &[F],
+        data: MultipointEvalData<'_, F>,
         field_cfg: &F::Config,
     ) -> Result<Subclaim<F>, MultipointEvalError<F>> {
+        let MultipointEvalData {
+            eval_point,
+            up_evals,
+            down_evals,
+            shifts,
+        } = data;
+        let num_vars = eval_point.len();
         let num_cols = up_evals.len();
+        let num_lookup_cols = lookup_aux_evals.len();
         let num_down_cols = shifts.len();
         let zero = F::zero_with_cfg(field_cfg);
         let one = F::one_with_cfg(field_cfg);
 
         // Step 1: Sample \alpha_k and \gamma_j (must match prover).
         let alphas: Vec<F> = transcript.get_field_challenges(num_down_cols, field_cfg);
-        let gammas: Vec<F> = transcript.get_field_challenges(num_cols, field_cfg);
+        let gammas: Vec<F> = transcript.get_field_challenges(num_cols + num_lookup_cols, field_cfg);
 
-        // Step 2: Compute expected sum
+        // Step 2: Compute expected sum (trace up_evals + lookup_aux_evals)
+        let all_up_evals: Vec<F> = up_evals
+            .iter()
+            .chain(lookup_aux_evals.iter())
+            .cloned()
+            .collect();
         let expected_sum: F =
-            compute_expected_sum(up_evals, down_evals, &gammas, &alphas, zero.clone());
+            compute_expected_sum(&all_up_evals, down_evals, &gammas, &alphas, zero.clone());
 
         if proof.sumcheck_proof.claimed_sum != expected_sum {
             return Err(MultipointEvalError::WrongSumcheckSum {
@@ -409,7 +452,6 @@ mod tests {
         up_evals: Vec<F>,
         down_evals: Vec<F>,
         shifts: Vec<ShiftSpec>,
-        num_vars: usize,
     }
 
     /// What the prover sends to the verifier.
@@ -470,7 +512,6 @@ mod tests {
             up_evals,
             down_evals,
             shifts: shifts.to_vec(),
-            num_vars,
         };
         (trace_mles, public)
     }
@@ -484,10 +525,13 @@ mod tests {
         let (proof, prover_state) = MultipointEval::<F>::prove_as_subprotocol(
             &mut transcript,
             trace_mles,
-            &public.eval_point,
-            &public.up_evals,
-            &public.down_evals,
-            &public.shifts,
+            &[],
+            MultipointEvalData {
+                eval_point: &public.eval_point,
+                up_evals: &public.up_evals,
+                down_evals: &public.down_evals,
+                shifts: &public.shifts,
+            },
             &(),
         )
         .expect("prover should succeed");
@@ -509,11 +553,13 @@ mod tests {
         let subclaim = MultipointEval::<F>::verify_as_subprotocol(
             &mut make_transcript(),
             msg.proof.clone(),
-            &public.eval_point,
-            &public.up_evals,
-            &public.down_evals,
-            &public.shifts,
-            public.num_vars,
+            &[],
+            MultipointEvalData {
+                eval_point: &public.eval_point,
+                up_evals: &public.up_evals,
+                down_evals: &public.down_evals,
+                shifts: &public.shifts,
+            },
             &(),
         )?;
 
@@ -584,6 +630,171 @@ mod tests {
         let shifts = vec![ShiftSpec::new(0, 2), ShiftSpec::new(0, 5)];
         let (public, msg) = honest_interaction(4, 3, &shifts);
         run_verifier(&public, &msg).unwrap();
+    }
+
+    // --- Happy-path: with lookup aux columns ---
+
+    fn build_lookup_aux(
+        num_vars: usize,
+        num_aux: usize,
+    ) -> Vec<DenseMultilinearExtension<<F as crypto_primitives::Field>::Inner>> {
+        let n = 1usize << num_vars;
+        let zero_inner = F::ZERO.into_inner();
+        (0..num_aux)
+            .map(|col| {
+                let evals: Vec<_> = (0..n)
+                    .map(|i| F::from(((col + 10) * n + i + 42) as u32).into_inner())
+                    .collect();
+                DenseMultilinearExtension::from_evaluations_vec(num_vars, evals, zero_inner)
+            })
+            .collect()
+    }
+
+    fn run_prover_with_lookup(
+        trace_mles: &[DenseMultilinearExtension<<F as crypto_primitives::Field>::Inner>],
+        lookup_aux_mles: &[DenseMultilinearExtension<<F as crypto_primitives::Field>::Inner>],
+        public: &SharedSubprotocolInput,
+    ) -> ProverMessage {
+        let mut transcript = make_transcript();
+        let (proof, prover_state) = MultipointEval::<F>::prove_as_subprotocol(
+            &mut transcript,
+            trace_mles,
+            lookup_aux_mles,
+            MultipointEvalData {
+                eval_point: &public.eval_point,
+                up_evals: &public.up_evals,
+                down_evals: &public.down_evals,
+                shifts: &public.shifts,
+            },
+            &(),
+        )
+        .expect("prover should succeed");
+
+        let r_0 = &prover_state.eval_point;
+        let mut open_evals: Vec<F> = trace_mles
+            .iter()
+            .map(|mle| mle.clone().evaluate_with_config(r_0, &()).unwrap())
+            .collect();
+        for mle in lookup_aux_mles {
+            open_evals.push(mle.clone().evaluate_with_config(r_0, &()).unwrap());
+        }
+
+        ProverMessage { proof, open_evals }
+    }
+
+    fn run_verifier_with_lookup(
+        public: &SharedSubprotocolInput,
+        lookup_aux_evals: &[F],
+        msg: &ProverMessage,
+    ) -> Result<Subclaim<F>, MultipointEvalError<F>> {
+        let subclaim = MultipointEval::<F>::verify_as_subprotocol(
+            &mut make_transcript(),
+            msg.proof.clone(),
+            lookup_aux_evals,
+            MultipointEvalData {
+                eval_point: &public.eval_point,
+                up_evals: &public.up_evals,
+                down_evals: &public.down_evals,
+                shifts: &public.shifts,
+            },
+            &(),
+        )?;
+
+        MultipointEval::<F>::verify_subclaim(&subclaim, &msg.open_evals, &public.shifts, &())?;
+
+        Ok(subclaim)
+    }
+
+    #[test]
+    fn honest_prove_verify_with_lookup_aux() {
+        let num_vars = 4;
+        let num_cols = 3;
+        let shifts = all_shift_by_1(num_cols);
+        let (trace_mles, public) = build_trace(num_vars, num_cols, &shifts);
+        let lookup_aux = build_lookup_aux(num_vars, 3);
+
+        let lookup_aux_evals: Vec<F> = lookup_aux
+            .iter()
+            .map(|mle| {
+                mle.clone()
+                    .evaluate_with_config(&public.eval_point, &())
+                    .unwrap()
+            })
+            .collect();
+
+        let msg = run_prover_with_lookup(&trace_mles, &lookup_aux, &public);
+        run_verifier_with_lookup(&public, &lookup_aux_evals, &msg).unwrap();
+    }
+
+    #[test]
+    fn honest_prove_verify_with_lookup_aux_no_shifts() {
+        let num_vars = 3;
+        let (trace_mles, public) = build_trace(num_vars, 2, &[]);
+        let lookup_aux = build_lookup_aux(num_vars, 5);
+
+        let lookup_aux_evals: Vec<F> = lookup_aux
+            .iter()
+            .map(|mle| {
+                mle.clone()
+                    .evaluate_with_config(&public.eval_point, &())
+                    .unwrap()
+            })
+            .collect();
+
+        let msg = run_prover_with_lookup(&trace_mles, &lookup_aux, &public);
+        run_verifier_with_lookup(&public, &lookup_aux_evals, &msg).unwrap();
+    }
+
+    #[test]
+    fn wrong_lookup_aux_eval_rejected() {
+        let num_vars = 4;
+        let shifts = all_shift_by_1(3);
+        let (trace_mles, public) = build_trace(num_vars, 3, &shifts);
+        let lookup_aux = build_lookup_aux(num_vars, 3);
+
+        let mut lookup_aux_evals: Vec<F> = lookup_aux
+            .iter()
+            .map(|mle| {
+                mle.clone()
+                    .evaluate_with_config(&public.eval_point, &())
+                    .unwrap()
+            })
+            .collect();
+
+        let msg = run_prover_with_lookup(&trace_mles, &lookup_aux, &public);
+
+        // Corrupt one lookup aux eval
+        lookup_aux_evals[1] += F::ONE;
+        let err = run_verifier_with_lookup(&public, &lookup_aux_evals, &msg).unwrap_err();
+        assert!(
+            matches!(err, MultipointEvalError::WrongSumcheckSum { .. }),
+            "expected WrongSumcheckSum, got {err:?}",
+        );
+    }
+
+    #[test]
+    fn wrong_lookup_open_eval_rejected() {
+        let num_vars = 3;
+        let (trace_mles, public) = build_trace(num_vars, 2, &[]);
+        let lookup_aux = build_lookup_aux(num_vars, 2);
+
+        let lookup_aux_evals: Vec<F> = lookup_aux
+            .iter()
+            .map(|mle| {
+                mle.clone()
+                    .evaluate_with_config(&public.eval_point, &())
+                    .unwrap()
+            })
+            .collect();
+
+        let mut msg = run_prover_with_lookup(&trace_mles, &lookup_aux, &public);
+        // Corrupt the lookup portion of open_evals (index 2 = first lookup col)
+        msg.open_evals[2] += F::ONE;
+        let err = run_verifier_with_lookup(&public, &lookup_aux_evals, &msg).unwrap_err();
+        assert!(
+            matches!(err, MultipointEvalError::ClaimMismatch { .. }),
+            "expected ClaimMismatch, got {err:?}",
+        );
     }
 
     // --- Failure: corrupted down_evals with mixed shifts ---

--- a/protocol/benches/e2e.rs
+++ b/protocol/benches/e2e.rs
@@ -23,7 +23,7 @@ use zinc_primality::{MillerRabin, PrimalityTest};
 use zinc_protocol::{Proof, ZincPlusPiop, ZincTypes};
 use zinc_test_uair::{
     BigLinearUair, BigLinearUairWithPublicInput, BinaryDecompositionUair, GenerateRandomTrace,
-    TestAirNoMultiplication,
+    RangeCheck8Uair, SimpleLookupUair, TestAirNoMultiplication, Word8LookupUair,
 };
 use zinc_transcript::traits::ConstTranscribable;
 use zinc_uair::{
@@ -136,12 +136,13 @@ where
     type ArrCombRDotChal = ArrCombRDotChal;
 }
 
-struct GenericBenchZincTypes<Int, CwR, Chal, Pt, CombR, Fmod, PrimeTest, const D: usize>(
-    PhantomData<(Int, CwR, Chal, Pt, CombR, Fmod, PrimeTest)>,
+#[allow(clippy::type_complexity)]
+struct GenericBenchZincTypes<Int, CwR, Chal, Pt, CombR, Fmod, PrimeTest, LkEval, const D: usize>(
+    PhantomData<(Int, CwR, Chal, Pt, CombR, Fmod, PrimeTest, LkEval)>,
 );
 
-impl<Int, CwR, Chal, Pt, CombR, Fmod, PrimeTest, const D: usize> ZincTypes<D>
-    for GenericBenchZincTypes<Int, CwR, Chal, Pt, CombR, Fmod, PrimeTest, D>
+impl<Int, CwR, Chal, Pt, CombR, Fmod, PrimeTest, LkEval, const D: usize> ZincTypes<D>
+    for GenericBenchZincTypes<Int, CwR, Chal, Pt, CombR, Fmod, PrimeTest, LkEval, D>
 where
     Int: ConstIntSemiring
         + for<'a> MulByScalar<&'a i64, CwR>
@@ -164,12 +165,14 @@ where
     Chal: ConstIntRing + ConstTranscribable + Named,
     Pt: ConstIntRing,
     CombR: ConstIntRing
+        + ConstCoeffBitWidth
         + Polynomial<CombR>
         + Neg<Output = CombR>
         + for<'a> MulByScalar<&'a i64>
         + for<'a> MulByScalar<&'a Chal>
         + ConstTranscribable
         + Named
+        + Copy
         + FromRef<i64>
         + FromRef<Int>
         + FromRef<CwR>
@@ -177,6 +180,18 @@ where
         + FromRef<CombR>,
     Fmod: ConstIntSemiring + ConstTranscribable + Named,
     PrimeTest: PrimalityTest<Fmod> + Send + Sync,
+    LkEval: ConstIntSemiring
+        + ConstCoeffBitWidth
+        + ConstTranscribable
+        + Named
+        + Default
+        + Copy
+        + for<'a> MulByScalar<&'a i64, CombR>
+        + Send
+        + Sync
+        + 'static,
+    CombR: FromRef<LkEval>,
+    LkEval: FromRef<CombR>,
 {
     type Int = Int;
     type Chal = Chal;
@@ -225,9 +240,24 @@ where
         MBSInnerProduct,
     >;
 
+    type LookupZt = GenericBenchZipTypes<
+        LkEval,
+        CombR,
+        Fmod,
+        PrimeTest,
+        Chal,
+        Pt,
+        CombR,
+        CombR,
+        ScalarProduct,
+        ScalarProduct,
+        MBSInnerProduct,
+    >;
+
     type BinaryLc = IprsCode<Self::BinaryZt, PnttConfigF65537, REP, PERFORM_CHECKS>;
     type ArbitraryLc = IprsCode<Self::ArbitraryZt, PnttConfigF65537, REP, PERFORM_CHECKS>;
     type IntLc = IprsCode<Self::IntZt, PnttConfigF65537, REP, PERFORM_CHECKS>;
+    type LookupLc = IprsCode<Self::LookupZt, PnttConfigF65537, REP, PERFORM_CHECKS>;
 }
 
 //
@@ -237,6 +267,11 @@ where
 const DEGREE_PLUS_ONE: usize = 32;
 const INT_LIMBS: usize = U64::LIMBS;
 const FIELD_LIMBS: usize = U64::LIMBS * 3;
+/// Lookup evals are field-element-sized Uint→Int conversions, so we need
+/// FIELD_LIMBS+1 (the sign bit of Int<FIELD_LIMBS> can't hold a full
+/// field element). CombR is widened to Int<7> (448 bits) to accommodate:
+///   actual_lc_bits ≈ 145 + 256 = 401  ≤  448
+const LOOKUP_EVAL_LIMBS: usize = FIELD_LIMBS + 1;
 
 type F = MontyField<FIELD_LIMBS>;
 
@@ -245,9 +280,11 @@ type BenchZincTypes = GenericBenchZincTypes<
     /* CwR = */ i128,
     /* Chal = */ i128,
     /* Pt = */ i128,
-    /* CombR = */ Int<{ INT_LIMBS * 6 }>,
+    /* CombR — widened to 7 limbs (448 bits) for lookup LC budget */
+    Int<{ INT_LIMBS * 7 }>,
     /* Fmod = */ Uint<FIELD_LIMBS>,
     MillerRabin,
+    /* LkEval = */ Int<LOOKUP_EVAL_LIMBS>,
     DEGREE_PLUS_ONE,
 >;
 type Pp<Zt> = (
@@ -263,24 +300,38 @@ type Pp<Zt> = (
         <Zt as ZincTypes<DEGREE_PLUS_ONE>>::IntZt,
         <Zt as ZincTypes<DEGREE_PLUS_ONE>>::IntLc,
     >,
+    ZipPlusParams<
+        <Zt as ZincTypes<DEGREE_PLUS_ONE>>::LookupZt,
+        <Zt as ZincTypes<DEGREE_PLUS_ONE>>::LookupLc,
+    >,
 );
 
 /// Use row size equal to poly size, resulting in flat single-row matrices
 #[allow(clippy::unwrap_used)]
 fn setup_pp(num_vars: usize) -> Pp<BenchZincTypes> {
     let poly_size = 1 << num_vars;
+    macro_rules! mk {
+        ($Zt:ty, $Lc:ty) => {
+            ZipPlus::<$Zt, $Lc>::setup(poly_size, <$Lc>::new_with_optimal_depth(poly_size).unwrap())
+        };
+    }
+    type Zt = BenchZincTypes;
     (
-        ZipPlus::setup(
-            poly_size,
-            IprsCode::new_with_optimal_depth(poly_size).unwrap(),
+        mk!(
+            <Zt as ZincTypes<DEGREE_PLUS_ONE>>::BinaryZt,
+            <Zt as ZincTypes<DEGREE_PLUS_ONE>>::BinaryLc
         ),
-        ZipPlus::setup(
-            poly_size,
-            IprsCode::new_with_optimal_depth(poly_size).unwrap(),
+        mk!(
+            <Zt as ZincTypes<DEGREE_PLUS_ONE>>::ArbitraryZt,
+            <Zt as ZincTypes<DEGREE_PLUS_ONE>>::ArbitraryLc
         ),
-        ZipPlus::setup(
-            poly_size,
-            IprsCode::new_with_optimal_depth(poly_size).unwrap(),
+        mk!(
+            <Zt as ZincTypes<DEGREE_PLUS_ONE>>::IntZt,
+            <Zt as ZincTypes<DEGREE_PLUS_ONE>>::IntLc
+        ),
+        mk!(
+            <Zt as ZincTypes<DEGREE_PLUS_ONE>>::LookupZt,
+            <Zt as ZincTypes<DEGREE_PLUS_ONE>>::LookupLc
         ),
     )
 }
@@ -316,6 +367,7 @@ fn do_bench<Zt, U, IdealOverF>(
         + 'static,
     F: for<'a> FromWithConfig<&'a Zt::Int>,
     <F as Field>::Modulus: ConstTranscribable + FromRef<Zt::Fmod>,
+    <Zt::LookupZt as ZipTypes>::Eval: FromRef<<F as Field>::Inner>,
     U: Uair + 'static,
     IdealOverF: Ideal + IdealCheck<DynamicPolynomialF<F>>,
 {
@@ -428,6 +480,20 @@ fn bench_big_linear_public_input(group: &mut BenchmarkGroup<WallTime>, num_vars:
     do_bench_uair::<BigLinearUairWithPublicInput<i64>>(group, "BigLinearPI", num_vars);
 }
 
+fn bench_simple_lookup(group: &mut BenchmarkGroup<WallTime>, num_vars: usize) {
+    let mut rng = rng();
+    let trace = SimpleLookupUair::<i64>::generate_random_trace(num_vars, &mut rng);
+    do_bench::<BenchZincTypes, SimpleLookupUair<i64>, _>(
+        group,
+        "SimpleLookup",
+        num_vars,
+        setup_pp,
+        trace,
+        zinc_protocol::project_scalar_fn,
+        |_ideal, _field_cfg| IdealOrZero::<DegreeOneIdeal<F>>::zero(),
+    );
+}
+
 //
 // Criterion entry point
 //
@@ -451,6 +517,57 @@ fn e2e_benches(c: &mut Criterion) {
     bench_big_linear_public_input(&mut group, 10);
     bench_big_linear_public_input(&mut group, 12);
 
+    bench_simple_lookup(&mut group, 8);
+    bench_simple_lookup(&mut group, 10);
+    bench_simple_lookup(&mut group, 12);
+
+    group.finish();
+}
+
+/// Lookup vs constraint comparison: 8-bit range check two ways.
+fn lookup_vs_constraint(c: &mut Criterion) {
+    let mut group = c.benchmark_group("8-bit Range Check: Lookup vs Constraint");
+
+    for num_vars in [8, 10, 12] {
+        let mut rng = rng();
+        let params = format!("nvars={num_vars}");
+        let pp = setup_pp(num_vars);
+
+        macro_rules! zinc_plus {
+            ($U:ty) => {
+                ZincPlusPiop::<BenchZincTypes, $U, F, DEGREE_PLUS_ONE>
+            };
+        }
+
+        // Word(8) lookup
+        let trace_lk = Word8LookupUair::<i64>::generate_random_trace(num_vars, &mut rng);
+        group.bench_function(BenchmarkId::new("Prove (Lookup)", &params), |bench| {
+            bench.iter(|| {
+                black_box(<zinc_plus!(Word8LookupUair<i64>)>::prove::<
+                    false,
+                    PERFORM_CHECKS,
+                >(
+                    &pp, &trace_lk, num_vars, zinc_protocol::project_scalar_fn
+                ))
+                .expect("lookup prove");
+            });
+        });
+
+        // Binary decomposition (no lookup)
+        let trace_rc = RangeCheck8Uair::<i64>::generate_random_trace(num_vars, &mut rng);
+        group.bench_function(BenchmarkId::new("Prove (Constraint)", &params), |bench| {
+            bench.iter(|| {
+                black_box(<zinc_plus!(RangeCheck8Uair<i64>)>::prove::<
+                    false,
+                    PERFORM_CHECKS,
+                >(
+                    &pp, &trace_rc, num_vars, zinc_protocol::project_scalar_fn
+                ))
+                .expect("constraint prove");
+            });
+        });
+    }
+
     group.finish();
 }
 
@@ -459,4 +576,9 @@ criterion_group! {
     config = Criterion::default().sample_size(500);
     targets = e2e_benches
 }
-criterion_main!(benches);
+criterion_group! {
+    name = comparison;
+    config = Criterion::default().sample_size(10);
+    targets = lookup_vs_constraint
+}
+criterion_main!(benches, comparison);

--- a/protocol/src/lib.rs
+++ b/protocol/src/lib.rs
@@ -29,7 +29,7 @@ use thiserror::Error;
 use zinc_piop::{
     combined_poly_resolver::{CombinedPolyResolverError, Proof as CombinedPolyResolverProof},
     ideal_check::{IdealCheckError, Proof as IdealCheckProof},
-    lookup::{BatchedLookupProof, LookupError},
+    lookup::LookupError,
     multipoint_eval::{MultipointEvalError, Proof as MultipointEvalProof},
     projections::ProjectedTrace,
     sumcheck::multi_degree::MultiDegreeSumcheckProof,
@@ -57,6 +57,34 @@ use zip_plus::{
 // Data structures
 //
 
+/// Lookup-specific proof data (commitments, evaluations, lifted evals).
+///
+/// Present only when the UAIR has lookup specs (`Proof::lookup` is `Some`).
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct LookupProofData<F: PrimeField> {
+    /// Zip+ commitments for lookup auxiliary columns.
+    /// One pair `(comm_m, comm_u)` per lookup group.
+    pub commitments: Vec<(ZipPlusCommitment, ZipPlusCommitment)>,
+    /// Lookup auxiliary column evaluations at the shared sumcheck point r*.
+    /// Order: per group `[m_0..m_{L-1}, u_0..u_{L-1}]`.
+    pub aux_evals: Vec<F>,
+    /// Lookup auxiliary column lifted MLE evaluations at r_0.
+    /// Each is a `DynamicPolynomialF` (single field element).
+    /// Same ordering as `aux_evals`.
+    pub lifted_evals: Vec<DynamicPolynomialF<F>>,
+    /// Zip+ commitments for decomposed chunk columns.
+    /// One commitment per decomposed lookup group (batching L·K chunk MLEs).
+    /// Empty when no lookup group uses decomposition.
+    pub chunk_commitments: Vec<ZipPlusCommitment>,
+    /// Chunk column evaluations at the shared sumcheck point r*.
+    /// Order: per decomposed group, flattened `[chunk_{0,0}, ...,
+    /// chunk_{L-1,K-1}]`.
+    pub chunk_evals: Vec<F>,
+    /// Chunk column lifted MLE evaluations at r_0 for PCS opening.
+    /// Same ordering as `chunk_evals`.
+    pub chunk_lifted_evals: Vec<DynamicPolynomialF<F>>,
+}
+
 /// Full proof produced by the Zinc+ PIOP for UCS.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct Proof<F: PrimeField> {
@@ -80,8 +108,8 @@ pub struct Proof<F: PrimeField> {
     /// interleaves them with these, and derives scalar open_evals via
     /// \psi_a for the sumcheck consistency check and Zip+ PCS verify.
     pub witness_lifted_evals: Vec<DynamicPolynomialF<F>>,
-    /// Lookup argument proof. `None` when the UAIR has no lookup specs.
-    pub lookup_proof: Option<BatchedLookupProof<F>>,
+    /// Lookup argument proof data. `None` when the UAIR has no lookup specs.
+    pub lookup: Option<LookupProofData<F>>,
 }
 
 impl<F> GenTranscribable for Proof<F>
@@ -111,8 +139,52 @@ where
         let (witness_vec, bytes) = DynamicPolyVecF::<F>::read_transcription_bytes_subset(bytes);
         let witness_lifted_evals = witness_vec.0;
 
-        // TODO: deserialize lookup_proof once BatchedLookupProof gets
-        // Transcribable impls (lookup is not yet implemented).
+        // Lookup data: u8 flag (0 = None, 1 = Some) then fields
+        let (has_lookup, mut bytes) = u8::read_transcription_bytes_subset(bytes);
+        let lookup = if has_lookup == 0 {
+            None
+        } else {
+            let (aux_evals, rest) = Vec::<F>::read_transcription_bytes_subset(bytes);
+            let (lifted_vec, rest) = DynamicPolyVecF::<F>::read_transcription_bytes_subset(rest);
+
+            let (num_comms, rest) = u32::read_transcription_bytes_subset(rest);
+            let num_comms =
+                usize::try_from(num_comms).expect("lookup comm count must fit into usize");
+            let mut commitments = Vec::with_capacity(num_comms);
+            let mut rest = rest;
+            for _ in 0..num_comms {
+                let (c1, r) = ZipPlusCommitment::read_transcription_bytes_subset(rest);
+                let (c2, r) = ZipPlusCommitment::read_transcription_bytes_subset(r);
+                commitments.push((c1, c2));
+                rest = r;
+            }
+
+            let (num_chunk_comms, rest) = u32::read_transcription_bytes_subset(rest);
+            let num_chunk_comms =
+                usize::try_from(num_chunk_comms).expect("chunk comm count must fit into usize");
+            let mut chunk_commitments = Vec::with_capacity(num_chunk_comms);
+            let mut rest = rest;
+            for _ in 0..num_chunk_comms {
+                let (c, r) = ZipPlusCommitment::read_transcription_bytes_subset(rest);
+                chunk_commitments.push(c);
+                rest = r;
+            }
+
+            let (chunk_evals, rest) = Vec::<F>::read_transcription_bytes_subset(rest);
+            let (chunk_lifted_vec, rest) =
+                DynamicPolyVecF::<F>::read_transcription_bytes_subset(rest);
+            bytes = rest;
+
+            Some(LookupProofData {
+                commitments,
+                aux_evals,
+                lifted_evals: lifted_vec.0,
+                chunk_commitments,
+                chunk_evals,
+                chunk_lifted_evals: chunk_lifted_vec.0,
+            })
+        };
+
         assert!(bytes.is_empty(), "All bytes should be consumed");
 
         Self {
@@ -123,7 +195,7 @@ where
             combined_sumcheck,
             multipoint_eval,
             witness_lifted_evals,
-            lookup_proof: None,
+            lookup,
         }
     }
 
@@ -153,10 +225,41 @@ where
         buf = self.multipoint_eval.write_transcription_bytes_subset(buf);
 
         // witness_lifted_evals: u32 length prefix + DynamicPolyVecF encoding
-        // TODO: serialize lookup_proof once BatchedLookupProof gets
-        // Transcribable impls (lookup is not yet implemented).
-        DynamicPolyVecF::reinterpret(&self.witness_lifted_evals)
+        buf = DynamicPolyVecF::reinterpret(&self.witness_lifted_evals)
             .write_transcription_bytes_subset(buf);
+
+        // Lookup data: u8 flag + fields
+        let has_lookup: u8 = u8::from(self.lookup.is_some());
+        has_lookup.write_transcription_bytes_exact(&mut buf[..u8::NUM_BYTES]);
+        buf = &mut buf[u8::NUM_BYTES..];
+
+        if let Some(ref lk) = self.lookup {
+            buf = lk.aux_evals.write_transcription_bytes_subset(buf);
+            buf = DynamicPolyVecF::reinterpret(&lk.lifted_evals)
+                .write_transcription_bytes_subset(buf);
+
+            let num_comms = u32::try_from(lk.commitments.len()).expect("comms count fits u32");
+            num_comms.write_transcription_bytes_exact(&mut buf[..u32::NUM_BYTES]);
+            buf = &mut buf[u32::NUM_BYTES..];
+            for (c1, c2) in &lk.commitments {
+                buf = c1.write_transcription_bytes_subset(buf);
+                buf = c2.write_transcription_bytes_subset(buf);
+            }
+
+            let num_chunk_comms =
+                u32::try_from(lk.chunk_commitments.len()).expect("chunk comms count fits u32");
+            num_chunk_comms.write_transcription_bytes_exact(&mut buf[..u32::NUM_BYTES]);
+            buf = &mut buf[u32::NUM_BYTES..];
+            for c in &lk.chunk_commitments {
+                buf = c.write_transcription_bytes_subset(buf);
+            }
+
+            buf = lk.chunk_evals.write_transcription_bytes_subset(buf);
+            buf = DynamicPolyVecF::reinterpret(&lk.chunk_lifted_evals)
+                .write_transcription_bytes_subset(buf);
+        }
+
+        let _ = buf;
     }
 }
 
@@ -180,10 +283,23 @@ where
             + self.combined_sumcheck.get_num_bytes()
             + MultipointEvalProof::<F>::LENGTH_NUM_BYTES
             + self.multipoint_eval.get_num_bytes()
-            // TODO: add lookup_proof size once BatchedLookupProof gets
-            // Transcribable impls (lookup is not yet implemented).
             + DynamicPolyVecF::<F>::LENGTH_NUM_BYTES
             + witness_vec.get_num_bytes()
+            + u8::NUM_BYTES
+            + self.lookup.as_ref().map_or(0, |lk| {
+                Vec::<F>::LENGTH_NUM_BYTES
+                    + lk.aux_evals.get_num_bytes()
+                    + DynamicPolyVecF::<F>::LENGTH_NUM_BYTES
+                    + DynamicPolyVecF::reinterpret(&lk.lifted_evals).get_num_bytes()
+                    + u32::NUM_BYTES
+                    + lk.commitments.len() * 2 * ZipPlusCommitment::NUM_BYTES
+                    + u32::NUM_BYTES
+                    + lk.chunk_commitments.len() * ZipPlusCommitment::NUM_BYTES
+                    + Vec::<F>::LENGTH_NUM_BYTES
+                    + lk.chunk_evals.get_num_bytes()
+                    + DynamicPolyVecF::<F>::LENGTH_NUM_BYTES
+                    + DynamicPolyVecF::reinterpret(&lk.chunk_lifted_evals).get_num_bytes()
+            })
     }
 }
 
@@ -257,6 +373,19 @@ pub trait ZincTypes<const DEGREE_PLUS_ONE: usize> {
 
     /// Linear code used in Zip+ for the integer trace columns.
     type IntLc: LinearCode<Self::IntZt>;
+
+    /// Zip+ types for lookup auxiliary columns (m, u, v) — field-element-sized
+    /// integers.
+    type LookupZt: ZipTypes<
+            Chal = Self::Chal,
+            Pt = Self::Pt,
+            CombR = Self::CombR,
+            Fmod = Self::Fmod,
+            PrimeTest = Self::PrimeTest,
+        >;
+
+    /// Linear code for lookup auxiliary columns.
+    type LookupLc: LinearCode<Self::LookupZt>;
 }
 
 /// Main struct for the Zinc+ PIOP. The protocol is implemented as associated
@@ -429,8 +558,10 @@ mod tests {
     use zinc_poly::univariate::{binary::BinaryPolyInnerProduct, dense::DensePolyInnerProduct};
     use zinc_primality::MillerRabin;
     use zinc_test_uair::{
-        BigLinearUair, BigLinearUairWithPublicInput, BinaryDecompositionUair, GenerateRandomTrace,
-        TestAirNoMultiplication, TestUairMixedShifts, TestUairSimpleMultiplication,
+        BigLinearUair, BigLinearUairWithPublicInput, BinaryDecompositionUair, BitPolyLookupUair,
+        DecomposedBitPolyUair, DecomposedWordUair, GenerateRandomTrace, MultiColLookupUair,
+        MultiGroupLookupUair, RangeCheck8Uair, SimpleLookupUair, TestAirNoMultiplication,
+        TestUairMixedShifts, TestUairSimpleMultiplication, Word8LookupUair,
     };
     use zinc_uair::{
         degree_counter::count_max_degree, ideal::degree_one::DegreeOneIdeal,
@@ -552,6 +683,28 @@ mod tests {
         type ArrCombRDotChal = MBSInnerProduct;
     }
 
+    /// Zip+ types for lookup auxiliary columns (m, u, v).
+    /// Eval = Int<LOOKUP_EVAL_LIMBS> holds any element of F_q.
+    /// FIELD_LIMBS + 1 because Int is signed: Int<3> maxes at 2^191-1,
+    /// but field elements can be up to q-1 ≈ 2^192-1.
+    const LOOKUP_EVAL_LIMBS: usize = FIELD_LIMBS + 1;
+
+    pub struct LookupZipTypes {}
+    impl ZipTypes for LookupZipTypes {
+        const NUM_COLUMN_OPENINGS: usize = 200;
+        type Eval = Int<LOOKUP_EVAL_LIMBS>;
+        type Cw = Int<M>;
+        type Fmod = Uint<FIELD_LIMBS>;
+        type PrimeTest = MillerRabin;
+        type Chal = i128;
+        type Pt = i128;
+        type CombR = Int<M>;
+        type Comb = Self::CombR;
+        type EvalDotChal = ScalarProduct;
+        type CombDotChal = ScalarProduct;
+        type ArrCombRDotChal = MBSInnerProduct;
+    }
+
     struct TestZincTypesIprs;
 
     impl ZincTypes<DEGREE_PLUS_ONE> for TestZincTypesIprs {
@@ -565,10 +718,12 @@ mod tests {
         type BinaryZt = BinPolyZipTypes;
         type ArbitraryZt = ArbitraryPolyZipTypesIprs;
         type IntZt = IntZipTypes;
+        type LookupZt = LookupZipTypes;
 
         type BinaryLc = IprsCode<Self::BinaryZt, PnttConfigF65537, REP, CHECKED>;
         type ArbitraryLc = IprsCode<Self::ArbitraryZt, PnttConfigF65537, REP, CHECKED>;
         type IntLc = IprsCode<Self::IntZt, PnttConfigF65537, REP, CHECKED>;
+        type LookupLc = IprsCode<Self::LookupZt, PnttConfigF65537, REP, CHECKED>;
     }
 
     #[derive(Copy, Clone)]
@@ -591,10 +746,12 @@ mod tests {
         type BinaryZt = BinPolyZipTypes;
         type ArbitraryZt = ArbitraryPolyZipTypesRaa;
         type IntZt = IntZipTypes;
+        type LookupZt = LookupZipTypes;
 
         type BinaryLc = RaaCode<Self::BinaryZt, TestRaaConfig, REP>;
         type ArbitraryLc = RaaCode<Self::ArbitraryZt, TestRaaConfig, REP>;
         type IntLc = RaaCode<Self::IntZt, TestRaaConfig, REP>;
+        type LookupLc = RaaCode<Self::LookupZt, TestRaaConfig, REP>;
     }
 
     /// Use row size equal to poly size, resulting in flat single-row matrices
@@ -607,11 +764,12 @@ mod tests {
     #[allow(clippy::type_complexity)]
     fn setup_pp<Zt>(
         num_vars: usize,
-        linear_codes: (Zt::BinaryLc, Zt::ArbitraryLc, Zt::IntLc),
+        linear_codes: (Zt::BinaryLc, Zt::ArbitraryLc, Zt::IntLc, Zt::LookupLc),
     ) -> (
         ZipPlusParams<Zt::BinaryZt, Zt::BinaryLc>,
         ZipPlusParams<Zt::ArbitraryZt, Zt::ArbitraryLc>,
         ZipPlusParams<Zt::IntZt, Zt::IntLc>,
+        ZipPlusParams<Zt::LookupZt, Zt::LookupLc>,
     )
     where
         Zt: ZincTypes<DEGREE_PLUS_ONE>,
@@ -621,6 +779,7 @@ mod tests {
             ZipPlus::<Zt::BinaryZt, Zt::BinaryLc>::setup(poly_size, linear_codes.0),
             ZipPlus::<Zt::ArbitraryZt, Zt::ArbitraryLc>::setup(poly_size, linear_codes.1),
             ZipPlus::<Zt::IntZt, Zt::IntLc>::setup(poly_size, linear_codes.2),
+            ZipPlus::<Zt::LookupZt, Zt::LookupLc>::setup(poly_size, linear_codes.3),
         )
     }
 
@@ -633,7 +792,7 @@ mod tests {
     #[allow(clippy::result_large_err)]
     fn do_test<Zt, U>(
         num_vars: usize,
-        linear_codes: (Zt::BinaryLc, Zt::ArbitraryLc, Zt::IntLc),
+        linear_codes: (Zt::BinaryLc, Zt::ArbitraryLc, Zt::IntLc, Zt::LookupLc),
         project_ideal: impl Fn(
             &IdealOrZero<U::Ideal>,
             &<F as PrimeField>::Config,
@@ -656,6 +815,7 @@ mod tests {
             + for<'a> FromWithConfig<&'a Zt::Pt>,
         <F as Field>::Inner: FromRef<Zt::Fmod>,
         <F as Field>::Modulus: FromRef<Zt::Fmod>,
+        <Zt::LookupZt as ZipTypes>::Eval: FromRef<<F as Field>::Inner>,
     {
         let mut rng = rng();
         let pp = setup_pp::<Zt>(num_vars, linear_codes);
@@ -718,6 +878,7 @@ mod tests {
                 make_iprs(num_vars),
                 make_iprs(num_vars),
                 make_iprs(num_vars),
+                make_iprs(num_vars),
             ),
             default_project_ideal!(),
             |_| {},
@@ -745,6 +906,7 @@ mod tests {
                 RaaCode::new(num_vars),
                 RaaCode::new(num_vars),
                 RaaCode::new(num_vars),
+                RaaCode::new(num_vars),
             ),
             |_ideal, _field_cfg| IdealOrZero::<DegreeOneIdeal<F>>::zero(),
             |_| {},
@@ -765,6 +927,7 @@ mod tests {
                 make_iprs(num_vars),
                 make_iprs(num_vars),
                 make_iprs(num_vars),
+                make_iprs(num_vars),
             ),
             |_ideal, _field_cfg| IdealOrZero::<DegreeOneIdeal<F>>::zero(),
             |_| {},
@@ -782,6 +945,7 @@ mod tests {
         do_test::<TestZincTypesIprs, BinaryDecompositionUair<ZtInt>>(
             num_vars,
             (
+                make_iprs(num_vars),
                 make_iprs(num_vars),
                 make_iprs(num_vars),
                 make_iprs(num_vars),
@@ -808,6 +972,7 @@ mod tests {
                 make_iprs(num_vars),
                 make_iprs(num_vars),
                 make_iprs(num_vars),
+                make_iprs(num_vars),
             ),
             default_project_ideal!(),
             |_| {},
@@ -828,10 +993,335 @@ mod tests {
                 make_iprs(num_vars),
                 make_iprs(num_vars),
                 make_iprs(num_vars),
+                make_iprs(num_vars),
             ),
             default_project_ideal!(),
             |_| {},
             |res| res.unwrap(),
+        );
+    }
+
+    /// End-to-end test: SimpleLookupUair.
+    ///
+    /// 2 int cols, constraint: a - b = 0, column 0 looked up against Word(4).
+    #[test]
+    fn test_e2e_simple_lookup() {
+        let num_vars = 8;
+        do_test::<TestZincTypesIprs, SimpleLookupUair<ZtInt>>(
+            num_vars,
+            (
+                make_iprs(num_vars),
+                make_iprs(num_vars),
+                make_iprs(num_vars),
+                make_iprs(num_vars),
+            ),
+            |_ideal, _field_cfg| IdealOrZero::<DegreeOneIdeal<F>>::zero(),
+            |_| {},
+            |res| res.unwrap(),
+        );
+    }
+
+    /// End-to-end test: Word8LookupUair (Word(8) lookup, no decomp).
+    #[test]
+    fn test_e2e_word8_lookup() {
+        let num_vars = 8;
+        do_test::<TestZincTypesIprs, Word8LookupUair<ZtInt>>(
+            num_vars,
+            (
+                make_iprs(num_vars),
+                make_iprs(num_vars),
+                make_iprs(num_vars),
+                make_iprs(num_vars),
+            ),
+            |_ideal, _field_cfg| IdealOrZero::<DegreeOneIdeal<F>>::zero(),
+            |_| {},
+            |res| res.unwrap(),
+        );
+    }
+
+    /// End-to-end test: RangeCheck8Uair (8-bit binary decomp, no lookup).
+    #[test]
+    fn test_e2e_range_check_8() {
+        let num_vars = 8;
+        do_test::<TestZincTypesIprs, RangeCheck8Uair<ZtInt>>(
+            num_vars,
+            (
+                make_iprs(num_vars),
+                make_iprs(num_vars),
+                make_iprs(num_vars),
+                make_iprs(num_vars),
+            ),
+            default_project_ideal!(),
+            |_| {},
+            |res| res.unwrap(),
+        );
+    }
+
+    //
+    // Negative tests for SimpleLookupUair
+    //
+
+    #[test]
+    fn test_lookup_tamper_aux_evals() {
+        let num_vars = 8;
+        do_test::<TestZincTypesIprs, SimpleLookupUair<ZtInt>>(
+            num_vars,
+            (
+                make_iprs(num_vars),
+                make_iprs(num_vars),
+                make_iprs(num_vars),
+                make_iprs(num_vars),
+            ),
+            |_ideal, _field_cfg| IdealOrZero::<DegreeOneIdeal<F>>::zero(),
+            |proof| {
+                let lk = proof.lookup.as_mut().unwrap();
+                let cfg = *lk.aux_evals[0].cfg();
+                lk.aux_evals[0] += &F::from_with_cfg(1u64, &cfg);
+            },
+            |res| {
+                assert!(res.is_err(), "tampered lookup_aux_evals should be rejected");
+            },
+        );
+    }
+
+    #[test]
+    fn test_lookup_tamper_lifted_evals() {
+        let num_vars = 8;
+        do_test::<TestZincTypesIprs, SimpleLookupUair<ZtInt>>(
+            num_vars,
+            (
+                make_iprs(num_vars),
+                make_iprs(num_vars),
+                make_iprs(num_vars),
+                make_iprs(num_vars),
+            ),
+            |_ideal, _field_cfg| IdealOrZero::<DegreeOneIdeal<F>>::zero(),
+            |proof| {
+                let lk = proof.lookup.as_mut().unwrap();
+                if let Some(c) = lk.lifted_evals[0].coeffs.first_mut() {
+                    let one = F::from_with_cfg(1u64, &c.cfg().clone());
+                    *c += &one;
+                }
+            },
+            |res| {
+                assert!(
+                    res.is_err(),
+                    "tampered lookup_lifted_evals should be rejected"
+                );
+            },
+        );
+    }
+
+    #[test]
+    fn test_lookup_tamper_commitment() {
+        let num_vars = 8;
+        do_test::<TestZincTypesIprs, SimpleLookupUair<ZtInt>>(
+            num_vars,
+            (
+                make_iprs(num_vars),
+                make_iprs(num_vars),
+                make_iprs(num_vars),
+                make_iprs(num_vars),
+            ),
+            |_ideal, _field_cfg| IdealOrZero::<DegreeOneIdeal<F>>::zero(),
+            |proof| {
+                if let Some(ref mut lk) = proof.lookup {
+                    lk.commitments[0].0.root = Default::default();
+                }
+            },
+            |res| {
+                assert!(
+                    res.is_err(),
+                    "tampered lookup commitment should be rejected"
+                );
+            },
+        );
+    }
+
+    /// End-to-end test: MultiColLookupUair (L=2, same Word(4) table).
+    #[test]
+    fn test_e2e_multi_col_lookup() {
+        let num_vars = 8;
+        do_test::<TestZincTypesIprs, MultiColLookupUair<ZtInt>>(
+            num_vars,
+            (
+                make_iprs(num_vars),
+                make_iprs(num_vars),
+                make_iprs(num_vars),
+                make_iprs(num_vars),
+            ),
+            |_ideal, _field_cfg| IdealOrZero::<DegreeOneIdeal<F>>::zero(),
+            |_| {},
+            |res| res.unwrap(),
+        );
+    }
+
+    /// End-to-end test: MultiGroupLookupUair (Word(4) + Word(8), two groups).
+    #[test]
+    fn test_e2e_multi_group_lookup() {
+        let num_vars = 8;
+        do_test::<TestZincTypesIprs, MultiGroupLookupUair<ZtInt>>(
+            num_vars,
+            (
+                make_iprs(num_vars),
+                make_iprs(num_vars),
+                make_iprs(num_vars),
+                make_iprs(num_vars),
+            ),
+            |_ideal, _field_cfg| IdealOrZero::<DegreeOneIdeal<F>>::zero(),
+            |_| {},
+            |res| res.unwrap(),
+        );
+    }
+
+    /// End-to-end test: BitPolyLookupUair (BitPoly(8) table type).
+    #[test]
+    fn test_e2e_bitpoly_lookup() {
+        let num_vars = 8;
+        do_test::<TestZincTypesIprs, BitPolyLookupUair<ZtInt>>(
+            num_vars,
+            (
+                make_iprs(num_vars),
+                make_iprs(num_vars),
+                make_iprs(num_vars),
+                make_iprs(num_vars),
+            ),
+            default_project_ideal!(),
+            |_| {},
+            |res| res.unwrap(),
+        );
+    }
+
+    //
+    // Decomposed lookup tests
+    //
+
+    /// E2E: DecomposedWordUair — Word(8) with chunk_width=4, K=2.
+    #[test]
+    fn test_e2e_decomposed_word_lookup() {
+        let num_vars = 8;
+        do_test::<TestZincTypesIprs, DecomposedWordUair<ZtInt>>(
+            num_vars,
+            (
+                make_iprs(num_vars),
+                make_iprs(num_vars),
+                make_iprs(num_vars),
+                make_iprs(num_vars),
+            ),
+            |_ideal, _field_cfg| IdealOrZero::<DegreeOneIdeal<F>>::zero(),
+            |_| {},
+            |res| res.unwrap(),
+        );
+    }
+
+    /// E2E: DecomposedBitPolyUair — BitPoly(8) with chunk_width=4, K=2.
+    #[test]
+    fn test_e2e_decomposed_bitpoly_lookup() {
+        let num_vars = 8;
+        do_test::<TestZincTypesIprs, DecomposedBitPolyUair<ZtInt>>(
+            num_vars,
+            (
+                make_iprs(num_vars),
+                make_iprs(num_vars),
+                make_iprs(num_vars),
+                make_iprs(num_vars),
+            ),
+            default_project_ideal!(),
+            |_| {},
+            |res| res.unwrap(),
+        );
+    }
+
+    #[test]
+    fn test_decomposed_word_tamper_chunk_evals() {
+        let num_vars = 8;
+        do_test::<TestZincTypesIprs, DecomposedWordUair<ZtInt>>(
+            num_vars,
+            (
+                make_iprs(num_vars),
+                make_iprs(num_vars),
+                make_iprs(num_vars),
+                make_iprs(num_vars),
+            ),
+            |_ideal, _field_cfg| IdealOrZero::<DegreeOneIdeal<F>>::zero(),
+            |proof| {
+                let lk = proof.lookup.as_mut().unwrap();
+                let cfg = *lk.chunk_evals[0].cfg();
+                lk.chunk_evals[0] += &F::from_with_cfg(1u64, &cfg);
+            },
+            |res| {
+                assert!(res.is_err(), "tampered chunk_evals should be rejected");
+            },
+        );
+    }
+
+    #[test]
+    fn test_decomposed_word_tamper_chunk_commitment() {
+        let num_vars = 8;
+        do_test::<TestZincTypesIprs, DecomposedWordUair<ZtInt>>(
+            num_vars,
+            (
+                make_iprs(num_vars),
+                make_iprs(num_vars),
+                make_iprs(num_vars),
+                make_iprs(num_vars),
+            ),
+            |_ideal, _field_cfg| IdealOrZero::<DegreeOneIdeal<F>>::zero(),
+            |proof| {
+                if let Some(ref mut lk) = proof.lookup {
+                    lk.chunk_commitments[0].root = Default::default();
+                }
+            },
+            |res| {
+                assert!(res.is_err(), "tampered chunk commitment should be rejected");
+            },
+        );
+    }
+
+    #[test]
+    #[allow(clippy::arithmetic_side_effects)]
+    fn test_decomposed_bitpoly_tamper_chunk_evals() {
+        let num_vars = 8;
+        do_test::<TestZincTypesIprs, DecomposedBitPolyUair<ZtInt>>(
+            num_vars,
+            (
+                make_iprs(num_vars),
+                make_iprs(num_vars),
+                make_iprs(num_vars),
+                make_iprs(num_vars),
+            ),
+            default_project_ideal!(),
+            |proof| {
+                let lk = proof.lookup.as_mut().unwrap();
+                let cfg = *lk.chunk_evals[0].cfg();
+                lk.chunk_evals[0] += &F::from_with_cfg(1u64, &cfg);
+            },
+            |res| {
+                assert!(res.is_err(), "tampered chunk_evals should be rejected");
+            },
+        );
+    }
+
+    #[test]
+    fn test_decomposed_bitpoly_tamper_chunk_commitment() {
+        let num_vars = 8;
+        do_test::<TestZincTypesIprs, DecomposedBitPolyUair<ZtInt>>(
+            num_vars,
+            (
+                make_iprs(num_vars),
+                make_iprs(num_vars),
+                make_iprs(num_vars),
+                make_iprs(num_vars),
+            ),
+            default_project_ideal!(),
+            |proof| {
+                if let Some(ref mut lk) = proof.lookup {
+                    lk.chunk_commitments[0].root = Default::default();
+                }
+            },
+            |res| {
+                assert!(res.is_err(), "tampered chunk commitment should be rejected");
+            },
         );
     }
 
@@ -846,6 +1336,7 @@ mod tests {
         do_test::<TestZincTypesIprs, BigLinearUairWithPublicInput<ZtInt>>(
             num_vars,
             (
+                make_iprs(num_vars),
                 make_iprs(num_vars),
                 make_iprs(num_vars),
                 make_iprs(num_vars),
@@ -870,6 +1361,7 @@ mod tests {
                 make_iprs(num_vars),
                 make_iprs(num_vars),
                 make_iprs(num_vars),
+                make_iprs(num_vars),
             ),
             default_project_ideal!(),
             |proof| proof.resolver.up_evals.swap(0, 1),
@@ -890,6 +1382,7 @@ mod tests {
         do_test::<TestZincTypesIprs, BigLinearUairWithPublicInput<ZtInt>>(
             num_vars,
             (
+                make_iprs(num_vars),
                 make_iprs(num_vars),
                 make_iprs(num_vars),
                 make_iprs(num_vars),
@@ -919,6 +1412,7 @@ mod tests {
                 make_iprs(num_vars),
                 make_iprs(num_vars),
                 make_iprs(num_vars),
+                make_iprs(num_vars),
             ),
             default_project_ideal!(),
             |proof| proof.commitments.0.root = Default::default(),
@@ -934,6 +1428,7 @@ mod tests {
         do_test::<TestZincTypesIprs, BigLinearUairWithPublicInput<ZtInt>>(
             num_vars,
             (
+                make_iprs(num_vars),
                 make_iprs(num_vars),
                 make_iprs(num_vars),
                 make_iprs(num_vars),

--- a/protocol/src/prover.rs
+++ b/protocol/src/prover.rs
@@ -249,12 +249,14 @@ where
         let lookup_chunk_evals = eval_inner_mles(&lookup_chunk_inner_mles, r_star, &field_cfg);
 
         let mut transcription_buf: Vec<u8> = vec![0; F::Inner::NUM_BYTES];
+        let all_lookup_evals: Vec<F> = lookup_aux_evals
+            .iter()
+            .chain(lookup_chunk_evals.iter())
+            .cloned()
+            .collect();
         pcs_transcript
             .fs_transcript
-            .absorb_random_field_slice(&lookup_aux_evals, &mut transcription_buf);
-        pcs_transcript
-            .fs_transcript
-            .absorb_random_field_slice(&lookup_chunk_evals, &mut transcription_buf);
+            .absorb_random_field_slice(&all_lookup_evals, &mut transcription_buf);
 
         // === Step 5: Multi-point evaluation sumcheck ===
         // Extend trace_mles and up_evals with lookup (aux + chunks).
@@ -476,7 +478,7 @@ where
             };
 
         for group_info in &lookup_groups_info {
-            let (witnesses, _full_table) = LogupProtocol::<F>::extract_witnesses_and_table(
+            let (witnesses, full_table) = LogupProtocol::<F>::extract_witnesses_and_table(
                 projected_trace_f,
                 group_info,
                 projecting_element_f,
@@ -499,7 +501,7 @@ where
                     .flat_map(|per_col| per_col.iter().cloned())
                     .collect();
 
-                // Commit L*K chunk columns (Round LC — before β)
+                // Commit L*K chunk columns
                 let chunk_mles: Vec<_> = virtual_cols.iter().map(|c| mk_lookup_mle(c)).collect();
                 let (h_chunk, c_chunk) =
                     ZipPlus::<Zt::LookupZt, Zt::LookupLc>::commit(pp_lookup, &chunk_mles)?;
@@ -512,7 +514,7 @@ where
                 };
                 (virtual_cols, decomp.subtable.clone(), Some(chunk_pcs))
             } else {
-                (witnesses.clone(), _full_table, None)
+                (witnesses.clone(), full_table, None)
             };
 
             // Compute multiplicities against effective table, commit in one batch
@@ -586,7 +588,7 @@ where
                 )?;
                 all_groups.extend(recon_grps);
 
-                // Collect chunk F vectors for eval at r* / lifted eval / PCS
+                // Collect chunk F vectors for eval at r*
                 for per_col in &decomp.chunks {
                     for chunk in per_col {
                         all_chunk_f.push(chunk.clone());

--- a/protocol/src/prover.rs
+++ b/protocol/src/prover.rs
@@ -4,32 +4,60 @@ use num_traits::Zero;
 use zinc_piop::{
     combined_poly_resolver::CombinedPolyResolver,
     ideal_check::IdealCheckProtocol,
-    multipoint_eval::MultipointEval,
+    lookup::{
+        LogupProverAncillary, group_lookup_specs,
+        logup::LogupProtocol,
+        utils::{batch_inverse_shifted, compute_multiplicities},
+    },
+    multipoint_eval::{MultipointEval, MultipointEvalData},
     projections::{
         ProjectedTrace, evaluate_trace_to_column_mles, project_scalars, project_scalars_to_field,
         project_trace_coeffs_column_major, project_trace_coeffs_row_major,
     },
-    sumcheck::multi_degree::MultiDegreeSumcheck,
+    sumcheck::multi_degree::{MultiDegreeSumcheck, MultiDegreeSumcheckGroup},
 };
-use zinc_poly::univariate::dynamic::over_field::DynamicPolynomialF;
+use zinc_poly::{
+    mle::MultilinearExtensionWithConfig, univariate::dynamic::over_field::DynamicPolynomialF,
+};
 use zinc_transcript::traits::{ConstTranscribable, Transcript};
 use zinc_uair::{
-    Uair, UairTrace, constraint_counter::count_constraints, degree_counter::count_max_degree,
+    ColumnLayout, Uair, UairTrace, constraint_counter::count_constraints,
+    degree_counter::count_max_degree,
 };
 use zinc_utils::{
-    add, cfg_join, from_ref::FromRef, inner_transparent_field::InnerTransparentField,
+    cfg_join, from_ref::FromRef, inner_transparent_field::InnerTransparentField,
     mul_by_scalar::MulByScalar, projectable_to_field::ProjectableToField,
 };
 use zip_plus::{
-    pcs::structs::{ZipPlus, ZipPlusHint, ZipPlusParams, ZipTypes},
+    pcs::structs::{ZipPlus, ZipPlusCommitment, ZipPlusHint, ZipPlusParams, ZipTypes},
     pcs_transcript::PcsProverTranscript,
 };
+
+/// Per-group PCS data for lookup auxiliary columns, needed for
+/// Step 7 PCS opening at r_0.
+struct LookupGroupPcsData<Zt: ZipTypes> {
+    hint_m: ZipPlusHint<Zt::Cw>,
+    hint_u: ZipPlusHint<Zt::Cw>,
+    pcs_m_mles: Vec<DenseMultilinearExtension<Zt::Eval>>,
+    pcs_u_mles: Vec<DenseMultilinearExtension<Zt::Eval>>,
+    comm_m: ZipPlusCommitment,
+    comm_u: ZipPlusCommitment,
+    /// Chunk PCS data, present only for decomposed lookups.
+    chunk: Option<ChunkPcsData<Zt>>,
+}
+
+struct ChunkPcsData<Zt: ZipTypes> {
+    hint: ZipPlusHint<Zt::Cw>,
+    mles: Vec<DenseMultilinearExtension<Zt::Eval>>,
+    comm: ZipPlusCommitment,
+}
 
 impl<Zt, U, F, const D: usize> ZincPlusPiop<Zt, U, F, D>
 where
     Zt: ZincTypes<D>,
     Zt::Int: ProjectableToField<F>,
     <Zt::ArbitraryZt as ZipTypes>::Eval: ProjectableToField<F>,
+    <Zt::LookupZt as ZipTypes>::Eval: FromRef<F::Inner>,
     F: InnerTransparentField
         + FromPrimitiveWithConfig
         + for<'a> FromWithConfig<&'a Zt::Int>
@@ -73,22 +101,24 @@ where
     /// 4. **Combined CPR + Lookup multi-degree sumcheck**: batches the CPR
     ///    constraint claim (degree `max_deg+2`) with lookup groups (one per
     ///    table type) into a single sumcheck sharing one evaluation point `r*`.
-    ///    Produces `up_evals` and `down_evals` (CPR) and lookup auxiliary
-    ///    witnesses at `r*`.
-    /// 5. **Multi-point evaluation sumcheck**: single sumcheck combining
-    ///    `up_evals` and `down_evals` at `r'` into a single evaluation point
-    ///    `r_0`. Only the sumcheck proof is sent; scalar evaluations at `r_0`
-    ///    are derived from the polynomial-valued `lifted_evals` in Step 6.
+    ///    Produces `up_evals` and `down_evals` (CPR), then evaluates lookup
+    ///    auxiliary and chunk inner MLEs at `r*` and absorbs them.
+    /// 5. **Multi-point evaluation sumcheck**: batches trace MLEs and lookup
+    ///    aux + chunk inner MLEs with challenge, then reduces `up_evals` and
+    ///    `down_evals` into a single evaluation point `r_0` via one sumcheck.
+    ///    Scalar evaluations at `r_0` are derived from `lifted_evals` in Step
+    ///    6.
     /// 6. **Lift-and-project**: compute per-column polynomial MLE evaluations
     ///    at `r_0` (in `F_q[X]`, before `\psi_a`). Absorb into transcript.
-    /// 7. **PCS open**: Zip+ prove for each committed *witness* column at
-    ///    `r_0`.
-    #[allow(clippy::too_many_arguments, clippy::type_complexity)]
+    /// 7. **PCS open**: Zip+ prove for each committed column set (witness
+    ///    trace, lookup m/u, and chunk if decomposed) at `r_0`.
+    #[allow(clippy::type_complexity)]
     pub fn prove<const MLE_FIRST: bool, const CHECK_FOR_OVERFLOW: bool>(
-        (pp_bin, pp_arb, pp_int): &(
+        (pp_bin, pp_arb, pp_int, pp_lookup): &(
             ZipPlusParams<Zt::BinaryZt, Zt::BinaryLc>,
             ZipPlusParams<Zt::ArbitraryZt, Zt::ArbitraryLc>,
             ZipPlusParams<Zt::IntZt, Zt::IntLc>,
+            ZipPlusParams<Zt::LookupZt, Zt::LookupLc>,
         ),
         trace: &UairTrace<'static, Zt::Int, Zt::Int, D>,
         num_vars: usize,
@@ -170,7 +200,7 @@ where
         let max_degree = count_max_degree::<U>();
 
         // === Step 4: Sumcheck over F_q ===
-        // 4a: CPR prepare → sumcheck group
+        // 4a: CPR + Lookup prepare → sumcheck group
         let (cpr_group, cpr_ancillary) = CombinedPolyResolver::prepare_sumcheck_group::<U>(
             &mut pcs_transcript.fs_transcript,
             projected_trace_f.clone(),
@@ -182,21 +212,27 @@ where
             &field_cfg,
         )?;
 
-        // 4b: Lookup prepare — placeholder
-        let lookup_specs = U::signature();
-        let groups = vec![cpr_group];
-        // TODO: for each LookupGroup from group_lookup_specs(lookup_specs):
-        //   - call prepare_batched_lookup_group(transcript, instance, &field_cfg)
-        //   - push triple into groups, collect pending proofs + metas
-        let _ = lookup_specs; // suppress unused warning until logup is implemented
+        // Prepare Lookup groups
+        let (lookup_groups, lookup_pcs_data, lookup_aux_f, lookup_chunk_f) =
+            Self::prepare_lookup_groups(
+                &mut pcs_transcript,
+                pp_lookup,
+                &projected_trace_f,
+                num_vars,
+                &projecting_element_f,
+                &field_cfg,
+            )?;
 
-        // 4c: Multi-degree sumcheck width CPR group and lookup groups
+        // 4b: Multi-degree sumcheck with CPR group and lookup groups
+        let mut groups = vec![cpr_group];
+        groups.extend(lookup_groups);
         let (combined_sumcheck, md_states) = MultiDegreeSumcheck::prove_as_subprotocol(
             &mut pcs_transcript.fs_transcript,
             groups,
             num_vars,
             &field_cfg,
         );
+
         // 4c: Finalize up_evals, down_evals
         let (cpr_proof, cpr_prover_state) = CombinedPolyResolver::finalize_prover(
             &mut pcs_transcript.fs_transcript,
@@ -205,20 +241,41 @@ where
             &field_cfg,
         )?;
 
-        // TODO: build BatchedLookupProof from collected lookup_proofs + lookup_metas
-        let lookup_proof = None;
+        // 4d: Compute lookup aux + chunk evals at r* and absorb
+        let lookup_aux_inner_mles = to_inner_mles(&lookup_aux_f, num_vars, &field_cfg);
+        let lookup_chunk_inner_mles = to_inner_mles(&lookup_chunk_f, num_vars, &field_cfg);
+        let r_star = &cpr_prover_state.evaluation_point;
+        let lookup_aux_evals = eval_inner_mles(&lookup_aux_inner_mles, r_star, &field_cfg);
+        let lookup_chunk_evals = eval_inner_mles(&lookup_chunk_inner_mles, r_star, &field_cfg);
+
+        let mut transcription_buf: Vec<u8> = vec![0; F::Inner::NUM_BYTES];
+        pcs_transcript
+            .fs_transcript
+            .absorb_random_field_slice(&lookup_aux_evals, &mut transcription_buf);
+        pcs_transcript
+            .fs_transcript
+            .absorb_random_field_slice(&lookup_chunk_evals, &mut transcription_buf);
 
         // === Step 5: Multi-point evaluation sumcheck ===
+        // Extend trace_mles and up_evals with lookup (aux + chunks).
         // Combines up_evals and down_evals at r' into a single evaluation
         // point r_0 via one sumcheck.
         let uair_sig = U::signature();
+        let all_lookup_inner_mles: Vec<_> = lookup_aux_inner_mles
+            .iter()
+            .chain(lookup_chunk_inner_mles.iter())
+            .cloned()
+            .collect();
         let (mp_proof, mp_prover_state) = MultipointEval::prove_as_subprotocol(
             &mut pcs_transcript.fs_transcript,
             &projected_trace_f,
-            &cpr_prover_state.evaluation_point,
-            &cpr_proof.up_evals,
-            &cpr_proof.down_evals,
-            uair_sig.shifts(),
+            &all_lookup_inner_mles,
+            MultipointEvalData {
+                eval_point: &cpr_prover_state.evaluation_point,
+                up_evals: &cpr_proof.up_evals,
+                down_evals: &cpr_proof.down_evals,
+                shifts: uair_sig.shifts(),
+            },
             &field_cfg,
         )?;
 
@@ -228,70 +285,118 @@ where
         // open_evals via \psi_a for the sumcheck consistency check, and
         // supplies these to the Zip+ PCS for alpha-projection.
         let r_0 = &mp_prover_state.eval_point;
-
         let lifted_evals =
             compute_lifted_evals::<F, D>(r_0, &trace.binary_poly, &projected_trace, &field_cfg);
+        let lookup_lifted_evals = inner_mles_to_lifted(&lookup_aux_inner_mles, r_0, &field_cfg);
+        let lookup_chunk_lifted_evals =
+            inner_mles_to_lifted(&lookup_chunk_inner_mles, r_0, &field_cfg);
 
-        let mut transcription_buf: Vec<u8> = vec![0; F::Inner::NUM_BYTES];
-        for bar_u in &lifted_evals {
+        for lifted in &lifted_evals {
             pcs_transcript
                 .fs_transcript
-                .absorb_random_field_slice(&bar_u.coeffs, &mut transcription_buf);
+                .absorb_random_field_slice(&lifted.coeffs, &mut transcription_buf);
+        }
+        for lifted in lookup_lifted_evals
+            .iter()
+            .chain(lookup_chunk_lifted_evals.iter())
+        {
+            pcs_transcript
+                .fs_transcript
+                .absorb_random_field_slice(&lifted.coeffs, &mut transcription_buf);
         }
 
         // === Step 7: PCS open at r_0 (witness columns only) ===
-        if let Some(hint_bin) = &hint_bin {
-            let _ = ZipPlus::<Zt::BinaryZt, Zt::BinaryLc>::prove_f::<_, CHECK_FOR_OVERFLOW>(
-                &mut pcs_transcript,
-                pp_bin,
-                &witness_trace.binary_poly,
-                r_0,
-                hint_bin,
-                &field_cfg,
-            )?;
+        macro_rules! pcs_open {
+            ($zt:ty, $lc:ty, $pp:expr, $mles:expr, $hint:expr) => {
+                if let Some(hint) = $hint {
+                    let _ = ZipPlus::<$zt, $lc>::prove_f::<_, CHECK_FOR_OVERFLOW>(
+                        &mut pcs_transcript,
+                        $pp,
+                        $mles,
+                        r_0,
+                        hint,
+                        &field_cfg,
+                    )?;
+                }
+            };
         }
-        if let Some(hint_arb) = &hint_arb {
-            let _ = ZipPlus::<Zt::ArbitraryZt, Zt::ArbitraryLc>::prove_f::<_, CHECK_FOR_OVERFLOW>(
-                &mut pcs_transcript,
-                pp_arb,
-                &witness_trace.arbitrary_poly,
-                r_0,
-                hint_arb,
-                &field_cfg,
-            )?;
-        }
-        if let Some(hint_int) = &hint_int {
-            let _ = ZipPlus::<Zt::IntZt, Zt::IntLc>::prove_f::<_, CHECK_FOR_OVERFLOW>(
-                &mut pcs_transcript,
-                pp_int,
-                &witness_trace.int,
-                r_0,
-                hint_int,
-                &field_cfg,
-            )?;
+
+        pcs_open!(
+            Zt::BinaryZt,
+            Zt::BinaryLc,
+            pp_bin,
+            &witness_trace.binary_poly,
+            &hint_bin
+        );
+        pcs_open!(
+            Zt::ArbitraryZt,
+            Zt::ArbitraryLc,
+            pp_arb,
+            &witness_trace.arbitrary_poly,
+            &hint_arb
+        );
+        pcs_open!(Zt::IntZt, Zt::IntLc, pp_int, &witness_trace.int, &hint_int);
+
+        for data in &lookup_pcs_data {
+            pcs_open!(
+                Zt::LookupZt,
+                Zt::LookupLc,
+                pp_lookup,
+                &data.pcs_m_mles,
+                &Some(&data.hint_m)
+            );
+            pcs_open!(
+                Zt::LookupZt,
+                Zt::LookupLc,
+                pp_lookup,
+                &data.pcs_u_mles,
+                &Some(&data.hint_u)
+            );
+            if let Some(ref chunk) = data.chunk {
+                pcs_open!(
+                    Zt::LookupZt,
+                    Zt::LookupLc,
+                    pp_lookup,
+                    &chunk.mles,
+                    &Some(&chunk.hint)
+                );
+            }
         }
 
         let zip_proof = pcs_transcript.stream.into_inner();
         let commitments = (commitment_bin, commitment_arb, commitment_int);
 
-        // Extract witness-only lifted evals (public columns come first in trace).
-        let pub_cols = sig.public_cols();
-        let num_pub_bin = pub_cols.num_binary_poly_cols();
-        let num_pub_arb = pub_cols.num_arbitrary_poly_cols();
-        let num_pub_int = pub_cols.num_int_cols();
-        let total = sig.total_cols();
-        let num_total_bin = total.num_binary_poly_cols();
-        let num_total_arb = total.num_arbitrary_poly_cols();
-        let witness = sig.witness_cols();
-        let witness_arb_offset = add!(num_total_bin, num_pub_arb);
-        let witness_arb_end = add!(witness_arb_offset, witness.num_arbitrary_poly_cols());
-        let witness_int_offset = add!(add!(num_total_bin, num_total_arb), num_pub_int);
-        let witness_lifted_evals: Vec<_> = lifted_evals[num_pub_bin..num_total_bin]
+        // Extract witness-only lifted evals (public columns come first in each
+        // segment).
+        let total: &ColumnLayout = sig.total_cols().into();
+        let public: &ColumnLayout = sig.public_cols().into();
+        let [wit_bin, wit_arb, wit_int] = total.witness_ranges(public);
+        let witness_lifted_evals: Vec<_> = lifted_evals[wit_bin]
             .iter()
-            .chain(&lifted_evals[witness_arb_offset..witness_arb_end])
-            .chain(&lifted_evals[witness_int_offset..])
+            .chain(&lifted_evals[wit_arb])
+            .chain(&lifted_evals[wit_int])
             .cloned()
             .collect();
+
+        let lookup = if lookup_pcs_data.is_empty() {
+            None
+        } else {
+            let chunk_commitments: Vec<_> = lookup_pcs_data
+                .iter()
+                .filter_map(|d| d.chunk.as_ref().map(|c| c.comm.clone()))
+                .collect();
+            Some(LookupProofData {
+                commitments: lookup_pcs_data
+                    .iter()
+                    .map(|d| (d.comm_m.clone(), d.comm_u.clone()))
+                    .collect(),
+                aux_evals: lookup_aux_evals,
+                lifted_evals: lookup_lifted_evals,
+                chunk_commitments,
+                chunk_evals: lookup_chunk_evals,
+                chunk_lifted_evals: lookup_chunk_lifted_evals,
+            })
+        };
 
         Ok(Proof {
             commitments,
@@ -301,8 +406,214 @@ where
             multipoint_eval: mp_proof,
             zip: zip_proof,
             witness_lifted_evals,
-            lookup_proof,
+            lookup,
         })
+    }
+
+    /// Prepare lookup sumcheck groups for all lookup specs in the UAIR.
+    ///
+    /// For each group of L columns sharing the same table type:
+    ///
+    /// **Non-decomposed** (`chunk_width = None`):
+    /// 1. Extract witnesses + full table
+    /// 2. Commit m (L cols), squeeze β, commit u (L cols), squeeze r, γ
+    /// 3. `build_sumcheck_groups` → 2 groups
+    ///
+    /// **Decomposed** (`chunk_width = Some(c)`):
+    /// 1. Construct decomposed witnesses and subtables + L×K chunks
+    /// 2. Commit chunks (L*K), commit m (L*K), squeeze β, commit u (L*K),
+    ///    squeeze r, γ
+    /// 3. `build_sumcheck_groups` with L*K virtual cols → 2 groups
+    /// 4. `build_reconstruction_group` → 1 group
+    ///
+    /// Returns `(sumcheck_groups, pcs_data, aux_f, chunk_f)`:
+    /// - `aux_f`: per-group `[m_0..m_{N-1}, u_0..u_{N-1}]` (N = L or L*K)
+    /// - `chunk_f`: per-group flattened chunk columns (empty for
+    ///   non-decomposed)
+    #[allow(clippy::type_complexity)]
+    fn prepare_lookup_groups(
+        pcs_transcript: &mut PcsProverTranscript,
+        pp_lookup: &ZipPlusParams<Zt::LookupZt, Zt::LookupLc>,
+        projected_trace_f: &[DenseMultilinearExtension<F::Inner>],
+        num_vars: usize,
+        projecting_element_f: &F,
+        field_cfg: &F::Config,
+    ) -> Result<
+        (
+            Vec<MultiDegreeSumcheckGroup<F>>,
+            Vec<LookupGroupPcsData<Zt::LookupZt>>,
+            Vec<Vec<F>>,
+            Vec<Vec<F>>,
+        ),
+        ProtocolError<F, U::Ideal>,
+    >
+    where
+        F::Inner: ConstTranscribable + Zero + Default,
+        F::Modulus: ConstTranscribable,
+        <Zt::LookupZt as ZipTypes>::Eval: FromRef<F::Inner>,
+    {
+        // Convert field element to the canonical integer
+        let f_to_eval = |f: &F| -> <Zt::LookupZt as ZipTypes>::Eval {
+            <Zt::LookupZt as ZipTypes>::Eval::from_ref(&f.retrieve_canonical())
+        };
+
+        let sig = U::signature();
+        let lookup_groups_info = group_lookup_specs(sig.lookup_specs());
+
+        let mut all_groups = Vec::new();
+        let mut all_pcs_data = Vec::new();
+        let mut all_aux_f: Vec<Vec<F>> = Vec::new();
+        let mut all_chunk_f: Vec<Vec<F>> = Vec::new();
+
+        let eval_zero = f_to_eval(&F::zero_with_cfg(field_cfg));
+        let mk_lookup_mle =
+            |vals: &[F]| -> DenseMultilinearExtension<<Zt::LookupZt as ZipTypes>::Eval> {
+                DenseMultilinearExtension::from_evaluations_vec(
+                    num_vars,
+                    vals.iter().map(&f_to_eval).collect(),
+                    eval_zero.clone(),
+                )
+            };
+
+        for group_info in &lookup_groups_info {
+            let (witnesses, _full_table) = LogupProtocol::<F>::extract_witnesses_and_table(
+                projected_trace_f,
+                group_info,
+                projecting_element_f,
+                field_cfg,
+            );
+
+            let decomp = LogupProtocol::<F>::extract_decomposed(
+                &witnesses,
+                group_info,
+                projecting_element_f,
+                field_cfg,
+            );
+
+            // If decomposed determine columns + table for LogUp
+            let (logup_cols, logup_table, chunk_pcs) = if let Some(ref decomp) = decomp {
+                // Flatten chunks[l][k] → L*K virtual columns
+                let virtual_cols: Vec<Vec<F>> = decomp
+                    .chunks
+                    .iter()
+                    .flat_map(|per_col| per_col.iter().cloned())
+                    .collect();
+
+                // Commit L*K chunk columns (Round LC — before β)
+                let chunk_mles: Vec<_> = virtual_cols.iter().map(|c| mk_lookup_mle(c)).collect();
+                let (h_chunk, c_chunk) =
+                    ZipPlus::<Zt::LookupZt, Zt::LookupLc>::commit(pp_lookup, &chunk_mles)?;
+                pcs_transcript.fs_transcript.absorb_slice(&c_chunk.root);
+
+                let chunk_pcs = ChunkPcsData {
+                    hint: h_chunk,
+                    mles: chunk_mles,
+                    comm: c_chunk,
+                };
+                (virtual_cols, decomp.subtable.clone(), Some(chunk_pcs))
+            } else {
+                (witnesses.clone(), _full_table, None)
+            };
+
+            // Compute multiplicities against effective table, commit in one batch
+            let num_logup_cols = logup_cols.len();
+            let mut m_vecs = Vec::with_capacity(num_logup_cols);
+            let mut m_mles = Vec::with_capacity(num_logup_cols);
+            for col in &logup_cols {
+                let m = compute_multiplicities(col, &logup_table, field_cfg)
+                    .ok_or(LookupError::WitnessNotInTable)?;
+                m_mles.push(mk_lookup_mle(&m));
+                m_vecs.push(m);
+            }
+            let (hint_m, comm_m) =
+                ZipPlus::<Zt::LookupZt, Zt::LookupLc>::commit(pp_lookup, &m_mles)?;
+            pcs_transcript.fs_transcript.absorb_slice(&comm_m.root);
+
+            // Squeeze β (shared across all columns in this group)
+            let beta: F = pcs_transcript.fs_transcript.get_field_challenge(field_cfg);
+
+            // Compute inverse witnesses + shared table inverse, commit only u
+            let mut u_vecs = Vec::with_capacity(num_logup_cols);
+            let mut u_mles = Vec::with_capacity(num_logup_cols);
+            for col in &logup_cols {
+                let u = batch_inverse_shifted(&beta, col);
+                u_mles.push(mk_lookup_mle(&u));
+                u_vecs.push(u);
+            }
+            let v = batch_inverse_shifted(&beta, &logup_table);
+            let (hint_u, comm_u) =
+                ZipPlus::<Zt::LookupZt, Zt::LookupLc>::commit(pp_lookup, &u_mles)?;
+            pcs_transcript.fs_transcript.absorb_slice(&comm_u.root);
+
+            // Squeeze r then γ
+            let r: Vec<F> = pcs_transcript
+                .fs_transcript
+                .get_field_challenges(num_vars, field_cfg);
+            let gamma: F = pcs_transcript.fs_transcript.get_field_challenge(field_cfg);
+
+            // Build 2 batched LogUp sumcheck groups
+            let col_refs: Vec<&[F]> = logup_cols.iter().map(|c| c.as_slice()).collect();
+            let auxs: Vec<LogupProverAncillary<'_, F>> = m_vecs
+                .iter()
+                .zip(u_vecs.iter())
+                .map(|(m, u)| LogupProverAncillary {
+                    multiplicities: m,
+                    inverse_witness: u,
+                    inverse_table: &v,
+                })
+                .collect();
+            let grps = LogupProtocol::build_sumcheck_groups(
+                &col_refs,
+                &logup_table,
+                &auxs,
+                &beta,
+                &gamma,
+                &r,
+                field_cfg,
+            )?;
+            all_groups.extend(grps);
+
+            // Optionally build reconstruction group for decomposed lookups
+            if let Some(ref decomp) = decomp {
+                let witness_refs: Vec<&[F]> = witnesses.iter().map(|w| w.as_slice()).collect();
+                let recon_grps = LogupProtocol::build_reconstruction_group(
+                    &witness_refs,
+                    &decomp.chunks,
+                    &decomp.decomp_bases,
+                    &gamma,
+                    &r,
+                    field_cfg,
+                )?;
+                all_groups.extend(recon_grps);
+
+                // Collect chunk F vectors for eval at r* / lifted eval / PCS
+                for per_col in &decomp.chunks {
+                    for chunk in per_col {
+                        all_chunk_f.push(chunk.clone());
+                    }
+                }
+            }
+
+            // Collect aux F vectors: [m_0..m_{N-1}, u_0..u_{N-1}]
+            for m in &m_vecs {
+                all_aux_f.push(m.clone());
+            }
+            for u in &u_vecs {
+                all_aux_f.push(u.clone());
+            }
+
+            all_pcs_data.push(LookupGroupPcsData {
+                hint_m,
+                hint_u,
+                pcs_m_mles: m_mles,
+                pcs_u_mles: u_mles,
+                comm_m,
+                comm_u,
+                chunk: chunk_pcs,
+            });
+        }
+
+        Ok((all_groups, all_pcs_data, all_aux_f, all_chunk_f))
     }
 }
 
@@ -323,4 +634,55 @@ fn commit_optionally<Zt: ZipTypes, Lc: LinearCode<Zt>>(
         let (hint, commitment) = ZipPlus::commit(pp, trace)?;
         Ok((Some(hint), commitment))
     }
+}
+
+fn to_inner_mles<F: InnerTransparentField>(
+    vecs: &[Vec<F>],
+    num_vars: usize,
+    cfg: &F::Config,
+) -> Vec<DenseMultilinearExtension<F::Inner>>
+where
+    F::Inner: Clone + Default,
+{
+    let inner_zero = F::zero_with_cfg(cfg).inner().clone();
+    vecs.iter()
+        .map(|vals| {
+            DenseMultilinearExtension::from_evaluations_vec(
+                num_vars,
+                vals.iter().map(|f| f.inner().clone()).collect(),
+                inner_zero.clone(),
+            )
+        })
+        .collect()
+}
+
+fn eval_inner_mles<F: InnerTransparentField>(
+    mles: &[DenseMultilinearExtension<F::Inner>],
+    point: &[F],
+    cfg: &F::Config,
+) -> Vec<F>
+where
+    DenseMultilinearExtension<F::Inner>: MultilinearExtensionWithConfig<F>,
+{
+    mles.iter()
+        .map(|mle| {
+            mle.clone()
+                .evaluate_with_config(point, cfg)
+                .expect("MLE evaluation should succeed")
+        })
+        .collect()
+}
+
+fn inner_mles_to_lifted<F: InnerTransparentField>(
+    mles: &[DenseMultilinearExtension<F::Inner>],
+    point: &[F],
+    cfg: &F::Config,
+) -> Vec<DynamicPolynomialF<F>>
+where
+    DenseMultilinearExtension<F::Inner>: MultilinearExtensionWithConfig<F>,
+{
+    eval_inner_mles(mles, point, cfg)
+        .into_iter()
+        .map(|eval| DynamicPolynomialF::new_trimmed(vec![eval]))
+        .collect()
 }

--- a/protocol/src/verifier.rs
+++ b/protocol/src/verifier.rs
@@ -372,7 +372,9 @@ where
                 pcs_verify!(Zt::LookupZt, Zt::LookupLc, vp_lookup, comm_m, 3);
                 pcs_verify!(Zt::LookupZt, Zt::LookupLc, vp_lookup, comm_u, 4);
                 if gi.table_type.is_decomposed() {
-                    let comm_chunk = chunk_comm_iter.next().expect("chunk commitment");
+                    let comm_chunk = chunk_comm_iter
+                        .next()
+                        .ok_or(LookupError::MissingChunkCommitment)?;
                     pcs_verify!(Zt::LookupZt, Zt::LookupLc, vp_lookup, comm_chunk, 5);
                 }
             }

--- a/protocol/src/verifier.rs
+++ b/protocol/src/verifier.rs
@@ -3,13 +3,19 @@ use crypto_primitives::{ConstIntSemiring, FromPrimitiveWithConfig, FromWithConfi
 use num_traits::Zero;
 use std::io::Cursor;
 use zinc_piop::{
-    combined_poly_resolver::CombinedPolyResolver,
+    combined_poly_resolver::{CombinedPolyResolver, VerifierSubclaim},
     ideal_check::IdealCheckProtocol,
-    multipoint_eval::MultipointEval,
+    lookup::{
+        LogupFinalizerInput, LogupVerifierPreSumcheckData, LookupAuxEvals, LookupGroup,
+        group_lookup_specs,
+        logup::LogupProtocol,
+        utils::{bitpoly_decomp_base, word_decomp_base},
+    },
+    multipoint_eval::{MultipointEval, MultipointEvalData},
     projections::{
         ProjectedTrace, project_scalars, project_scalars_to_field, project_trace_coeffs_row_major,
     },
-    sumcheck::multi_degree::MultiDegreeSumcheck,
+    sumcheck::multi_degree::{MultiDegreeSubClaims, MultiDegreeSumcheck},
 };
 use zinc_poly::{EvaluatablePolynomial, univariate::dynamic::over_field::DynamicPolynomialF};
 use zinc_transcript::{
@@ -17,19 +23,25 @@ use zinc_transcript::{
     traits::{ConstTranscribable, Transcript},
 };
 use zinc_uair::{
-    Uair, UairTrace,
+    ColumnLayout, LookupTableType, Uair, UairTrace,
     constraint_counter::count_constraints,
     ideal::{Ideal, IdealCheck},
     ideal_collector::IdealOrZero,
 };
 use zinc_utils::{
-    add, from_ref::FromRef, inner_transparent_field::InnerTransparentField,
-    mul_by_scalar::MulByScalar, projectable_to_field::ProjectableToField,
+    add, from_ref::FromRef, inner_transparent_field::InnerTransparentField, mul,
+    mul_by_scalar::MulByScalar, powers, projectable_to_field::ProjectableToField,
 };
 use zip_plus::{
     pcs::structs::{ZipPlus, ZipPlusParams, ZipTypes},
     pcs_transcript::PcsVerifierTranscript,
 };
+
+/// Flat proof-provided evaluation slices for lookup verification.
+struct LookupEvalsFlat<'a, F> {
+    aux: &'a [F],
+    chunk: &'a [F],
+}
 
 impl<Zt, U, F, const D: usize> ZincPlusPiop<Zt, U, F, D>
 where
@@ -63,12 +75,13 @@ where
     /// derives scalar `open_evals` via `\psi_a`, and checks the multipoint
     /// eval consistency. A Zip+ PCS invocation (Step 7) confirms
     /// the witness `lifted_evals`.
-    #[allow(clippy::too_many_arguments, clippy::type_complexity)]
+    #[allow(clippy::type_complexity)]
     pub fn verify<IdealOverF, const CHECK_FOR_OVERFLOW: bool>(
-        (vp_bin, vp_arb, vp_int): &(
+        (vp_bin, vp_arb, vp_int, vp_lookup): &(
             ZipPlusParams<Zt::BinaryZt, Zt::BinaryLc>,
             ZipPlusParams<Zt::ArbitraryZt, Zt::ArbitraryLc>,
             ZipPlusParams<Zt::IntZt, Zt::IntLc>,
+            ZipPlusParams<Zt::LookupZt, Zt::LookupLc>,
         ),
         proof: Proof<F>,
         public_trace: &UairTrace<Zt::Int, Zt::Int, D>,
@@ -138,6 +151,47 @@ where
             &field_cfg,
         )?;
 
+        // 4a: Lookup pre-sumcheck
+        let sig = U::signature();
+        let lookup_groups_info = group_lookup_specs(sig.lookup_specs());
+        let (lookup_aux_evals, lookup_chunk_evals, lookup_lifted_evals, lookup_chunk_lifted_evals) =
+            match proof.lookup.as_ref() {
+                Some(lookup) => (
+                    &lookup.aux_evals[..],
+                    &lookup.chunk_evals[..],
+                    &lookup.lifted_evals[..],
+                    &lookup.chunk_lifted_evals[..],
+                ),
+                None => (
+                    &[][..],
+                    &[][..],
+                    &[][..] as &[DynamicPolynomialF<F>],
+                    &[][..],
+                ),
+            };
+
+        let mut lookup_verifier_pre_sumcheck_data = Vec::new();
+        if let Some(ref lookup) = proof.lookup {
+            let mut chunk_comm_idx = 0;
+            for (g, group_info) in lookup_groups_info.iter().enumerate() {
+                // For decomposed groups, absorb chunk commitment before m
+                if group_info.table_type.chunk_width().is_some() {
+                    let cc = &lookup.chunk_commitments[chunk_comm_idx];
+                    pcs_transcript.fs_transcript.absorb_slice(&cc.root);
+                    chunk_comm_idx = add!(chunk_comm_idx, 1);
+                }
+                let (comm_m, comm_uv) = &lookup.commitments[g];
+                let data = LogupProtocol::<F>::build_verifier_pre_sumcheck(
+                    &mut pcs_transcript.fs_transcript,
+                    &comm_m.root,
+                    &comm_uv.root,
+                    num_vars,
+                    &field_cfg,
+                );
+                lookup_verifier_pre_sumcheck_data.push(data);
+            }
+        }
+
         // 4b: Multi-degree sumcheck verify
         let md_subclaims = MultiDegreeSumcheck::verify_as_subprotocol(
             &mut pcs_transcript.fs_transcript,
@@ -158,23 +212,43 @@ where
             &field_cfg,
         )?;
 
-        // 4d: Lookup verify — placeholder
-        // TODO: if proof.lookup_proof.is_some():
-        //   - call verify_batched_lookup(transcript, proof.lookup_proof,
-        //     &projecting_element_f, &field_cfg)
-        //   - check md_subclaims.expected_evaluations()[1..] against lookup group evals
-        let _ = &proof.lookup_proof;
+        // 4d: Lookup finalize — verify batched LogUp + reconstruction at r*
+        Self::finalize_lookup_groups(
+            &lookup_groups_info,
+            &lookup_verifier_pre_sumcheck_data,
+            &md_subclaims,
+            &cpr_subclaim,
+            &LookupEvalsFlat {
+                aux: lookup_aux_evals,
+                chunk: lookup_chunk_evals,
+            },
+            &projecting_element_f,
+            &field_cfg,
+        )?;
+
+        // Absorb lookup aux + chunk evals into transcript
+        let mut transcription_buf: Vec<u8> = vec![0; F::Inner::NUM_BYTES];
+        let all_lookup_evals: Vec<F> = lookup_aux_evals
+            .iter()
+            .chain(lookup_chunk_evals.iter())
+            .cloned()
+            .collect();
+        pcs_transcript
+            .fs_transcript
+            .absorb_random_field_slice(&all_lookup_evals, &mut transcription_buf);
 
         // === Step 5: Multi-point evaluation sumcheck ===
         let uair_sig = U::signature();
         let mp_subclaim = MultipointEval::verify_as_subprotocol(
             &mut pcs_transcript.fs_transcript,
             proof.multipoint_eval,
-            &cpr_subclaim.evaluation_point,
-            &cpr_subclaim.up_evals,
-            &cpr_subclaim.down_evals,
-            uair_sig.shifts(),
-            num_vars,
+            &all_lookup_evals,
+            MultipointEvalData {
+                eval_point: &cpr_subclaim.evaluation_point,
+                up_evals: &cpr_subclaim.up_evals,
+                down_evals: &cpr_subclaim.down_evals,
+                shifts: uair_sig.shifts(),
+            },
             &field_cfg,
         )?;
 
@@ -187,16 +261,11 @@ where
         // then interleaves them with the witness portion to reconstruct the
         // full lifted_evals in canonical order:
         //   [pub_bin, wit_bin, pub_arb, wit_arb, pub_int, wit_int]
-        let pub_cols = uair_sig.public_cols();
-        let num_pub_bin = pub_cols.num_binary_poly_cols();
-        let num_pub_arb = pub_cols.num_arbitrary_poly_cols();
-        let num_pub_int = pub_cols.num_int_cols();
+        let total: &ColumnLayout = uair_sig.total_cols().into();
+        let public: &ColumnLayout = uair_sig.public_cols().into();
+        let [wit_bin, wit_arb, wit_int] = total.witness_ranges(public);
 
-        let wit_cols = uair_sig.witness_cols();
-        let num_wit_bin = wit_cols.num_binary_poly_cols();
-        let num_wit_arb = wit_cols.num_arbitrary_poly_cols();
-
-        let public_lifted = if add!(add!(num_pub_bin, num_pub_arb), num_pub_int) > 0 {
+        let public_lifted = if public.cols() > 0 {
             let projected_public =
                 project_trace_coeffs_row_major::<F, Zt::Int, Zt::Int, D>(public_trace, &field_cfg);
             compute_lifted_evals::<F, D>(
@@ -209,13 +278,21 @@ where
             Vec::new()
         };
 
+        let (num_pub_bin, num_pub_arb) = (
+            public.num_binary_poly_cols(),
+            public.num_arbitrary_poly_cols(),
+        );
+        let (num_wit_bin, num_wit_arb) = (wit_bin.len(), wit_arb.len());
+        let wit = &proof.witness_lifted_evals;
         let all_lifted_evals: Vec<_> = public_lifted[..num_pub_bin]
             .iter()
-            .chain(&proof.witness_lifted_evals[..num_wit_bin])
+            .chain(&wit[..num_wit_bin])
             .chain(&public_lifted[num_pub_bin..add!(num_pub_bin, num_pub_arb)])
-            .chain(&proof.witness_lifted_evals[num_wit_bin..add!(num_wit_bin, num_wit_arb)])
+            .chain(&wit[num_wit_bin..add!(num_wit_bin, num_wit_arb)])
             .chain(&public_lifted[add!(num_pub_bin, num_pub_arb)..])
-            .chain(&proof.witness_lifted_evals[add!(num_wit_bin, num_wit_arb)..])
+            .chain(&wit[add!(num_wit_bin, num_wit_arb)..])
+            .chain(lookup_lifted_evals.iter())
+            .chain(lookup_chunk_lifted_evals.iter())
             .cloned()
             .collect();
 
@@ -223,36 +300,36 @@ where
         // eval consistency check.
         let open_evals: Vec<F> = all_lifted_evals
             .iter()
-            .map(|bar_u| bar_u.evaluate_at_point(&projecting_element_f))
+            .map(|lifted| lifted.evaluate_at_point(&projecting_element_f))
             .collect::<Result<Vec<_>, _>>()
             .map_err(ProtocolError::LiftedEvalProjection)?;
 
         MultipointEval::verify_subclaim(&mp_subclaim, &open_evals, uair_sig.shifts(), &field_cfg)?;
 
         // Absorb all lifted_evals into transcript (same order as prover).
-        let mut transcription_buf: Vec<u8> = vec![0; F::Inner::NUM_BYTES];
-        for bar_u in &all_lifted_evals {
+        for lifted in &all_lifted_evals {
             pcs_transcript
                 .fs_transcript
-                .absorb_random_field_slice(&bar_u.coeffs, &mut transcription_buf);
+                .absorb_random_field_slice(&lifted.coeffs, &mut transcription_buf);
         }
 
         // === Step 7: PCS verify at r_0 (witness columns only) ===
 
-        macro_rules! verify_pcs_batch {
-            ($Zt:ty, $Lc:ty, $vp:expr, $idx:tt, [$evals_range:expr]) => {{
-                let comm = &proof.commitments.$idx;
-                if comm.batch_size > 0 {
+        let mut lifted_offset = wit_bin.start;
+        macro_rules! pcs_verify {
+            ($Zt:ty, $Lc:ty, $vp:expr, $comm:expr, $err_idx:expr) => {
+                if $comm.batch_size > 0 {
+                    let end = add!(lifted_offset, $comm.batch_size);
                     let per_poly_alphas = ZipPlus::<$Zt, $Lc>::sample_alphas(
                         &mut pcs_transcript.fs_transcript,
-                        comm.batch_size,
+                        $comm.batch_size,
                     );
                     let mut eval_f = F::zero_with_cfg(&field_cfg);
-                    for (bar_u, alphas) in all_lifted_evals[$evals_range]
+                    for (lifted, alphas) in all_lifted_evals[lifted_offset..end]
                         .iter()
                         .zip(per_poly_alphas.iter())
                     {
-                        for (coeff, alpha) in bar_u.coeffs.iter().zip(alphas.iter()) {
+                        for (coeff, alpha) in lifted.coeffs.iter().zip(alphas.iter()) {
                             let mut term = F::from_with_cfg(alpha, &field_cfg);
                             term *= coeff;
                             eval_f += &term;
@@ -261,41 +338,169 @@ where
                     ZipPlus::<$Zt, $Lc>::verify_with_alphas::<F, CHECK_FOR_OVERFLOW>(
                         &mut pcs_transcript,
                         $vp,
-                        comm,
+                        $comm,
                         &field_cfg,
                         r_0,
                         &eval_f,
                         &per_poly_alphas,
                     )
-                    .map_err(|e| ProtocolError::PcsVerification($idx, e))?;
+                    .map_err(|e| ProtocolError::PcsVerification($err_idx, e))?;
+                    #[allow(unused_assignments)]
+                    {
+                        lifted_offset = end;
+                    }
                 }
-            }};
+            };
         }
-
-        let total = uair_sig.total_cols();
-        let num_total_bin = total.num_binary_poly_cols();
-        let num_total_arb = total.num_arbitrary_poly_cols();
-        verify_pcs_batch!(
-            Zt::BinaryZt,
-            Zt::BinaryLc,
-            vp_bin,
-            0,
-            [num_pub_bin..num_total_bin]
-        );
-        verify_pcs_batch!(
+        pcs_verify!(Zt::BinaryZt, Zt::BinaryLc, vp_bin, &proof.commitments.0, 0);
+        lifted_offset = wit_arb.start;
+        pcs_verify!(
             Zt::ArbitraryZt,
             Zt::ArbitraryLc,
             vp_arb,
-            1,
-            [add!(num_total_bin, num_pub_arb)..add!(num_total_bin, num_total_arb)]
+            &proof.commitments.1,
+            1
         );
-        verify_pcs_batch!(
-            Zt::IntZt,
-            Zt::IntLc,
-            vp_int,
-            2,
-            [add!(add!(num_total_bin, num_total_arb), num_pub_int)..]
-        );
+        lifted_offset = wit_int.start;
+        pcs_verify!(Zt::IntZt, Zt::IntLc, vp_int, &proof.commitments.2, 2);
+
+        // PCS verify for lookup aux + chunks at r_0
+        lifted_offset = wit_int.end;
+        if let Some(ref lk) = proof.lookup {
+            let mut chunk_comm_iter = lk.chunk_commitments.iter();
+            for (gi, (comm_m, comm_u)) in lookup_groups_info.iter().zip(lk.commitments.iter()) {
+                pcs_verify!(Zt::LookupZt, Zt::LookupLc, vp_lookup, comm_m, 3);
+                pcs_verify!(Zt::LookupZt, Zt::LookupLc, vp_lookup, comm_u, 4);
+                if gi.table_type.is_decomposed() {
+                    let comm_chunk = chunk_comm_iter.next().expect("chunk commitment");
+                    pcs_verify!(Zt::LookupZt, Zt::LookupLc, vp_lookup, comm_chunk, 5);
+                }
+            }
+        }
+
+        Ok(())
+    }
+
+    /// Verify batched LogUp identities and reconstruction checks for each
+    /// lookup group.
+    fn finalize_lookup_groups(
+        groups: &[LookupGroup],
+        pre_sumcheck: &[LogupVerifierPreSumcheckData<F>],
+        md_subclaims: &MultiDegreeSubClaims<F>,
+        cpr_subclaim: &VerifierSubclaim<F>,
+        lookup_evals: &LookupEvalsFlat<F>,
+        projecting_element: &F,
+        field_cfg: &F::Config,
+    ) -> Result<(), LookupError> {
+        let aux_evals_flat = lookup_evals.aux;
+        let chunk_evals_flat = lookup_evals.chunk;
+        let mut md_group_idx = 1; // skip CPR group at index 0
+        let mut aux_offset = 0;
+        let mut chunk_offset = 0;
+
+        for (g, group_info) in groups.iter().enumerate() {
+            let num_lk_cols = group_info.column_indices.len();
+            let num_chunks = group_info.table_type.num_chunks();
+            let num_logup_cols = mul!(num_lk_cols, num_chunks);
+            let is_decomposed = group_info.table_type.is_decomposed();
+
+            let expected = [
+                md_subclaims.expected_evaluations()[md_group_idx].clone(),
+                md_subclaims.expected_evaluations()[add!(md_group_idx, 1)].clone(),
+            ];
+
+            // For decomposed: L*K chunk evals; non-decomposed: L trace evals
+            let decomp_w_evals: Vec<F> = if is_decomposed {
+                chunk_evals_flat[chunk_offset..add!(chunk_offset, num_logup_cols)].to_vec()
+            } else {
+                group_info
+                    .column_indices
+                    .iter()
+                    .map(|&idx| cpr_subclaim.up_evals[idx].clone())
+                    .collect()
+            };
+
+            let aux_evals: Vec<LookupAuxEvals<F>> = (0..num_logup_cols)
+                .map(|j| {
+                    let m_idx = add!(aux_offset, j);
+                    let u_idx = add!(add!(aux_offset, num_logup_cols), j);
+                    LookupAuxEvals {
+                        m_eval: aux_evals_flat[m_idx].clone(),
+                        u_eval: aux_evals_flat[u_idx].clone(),
+                    }
+                })
+                .collect();
+
+            LogupProtocol::<F>::finalize_verifier(
+                &pre_sumcheck[g],
+                LogupFinalizerInput {
+                    subclaim_point: md_subclaims.point(),
+                    expected_evaluations: &expected,
+                    w_evals: &decomp_w_evals,
+                    aux_evals: &aux_evals,
+                },
+                group_info,
+                projecting_element,
+                field_cfg,
+            )?;
+
+            // Reconstruction check
+            if is_decomposed {
+                let reconstruction_expected =
+                    &md_subclaims.expected_evaluations()[add!(md_group_idx, 2)];
+
+                let trace_evals: Vec<F> = group_info
+                    .column_indices
+                    .iter()
+                    .map(|&idx| cpr_subclaim.up_evals[idx].clone())
+                    .collect();
+
+                let one = F::one_with_cfg(field_cfg);
+                let eq_val = zinc_poly::utils::eq_eval(
+                    md_subclaims.point(),
+                    &pre_sumcheck[g].r,
+                    one.clone(),
+                )?;
+
+                let decomp_base: F = match &group_info.table_type {
+                    LookupTableType::BitPoly {
+                        chunk_width: Some(c),
+                        ..
+                    } => bitpoly_decomp_base(*c, projecting_element),
+                    LookupTableType::Word {
+                        chunk_width: Some(c),
+                        ..
+                    } => word_decomp_base(*c, field_cfg),
+                    _ => unreachable!("is_decomposed guard"),
+                };
+                let bases = powers(decomp_base, one.clone(), num_chunks);
+                let gamma = &pre_sumcheck[g].gamma;
+                let gamma_pows = powers(gamma.clone(), one, num_lk_cols);
+
+                let mut computed = F::zero_with_cfg(field_cfg);
+                for (col_l, witness_eval) in trace_evals.iter().enumerate() {
+                    let chunk_start = add!(chunk_offset, mul!(col_l, num_chunks));
+                    let chunk_end = add!(chunk_start, num_chunks);
+                    let chunk_slice = &chunk_evals_flat[chunk_start..chunk_end];
+                    let mut reconstructed = F::zero_with_cfg(field_cfg);
+                    for (idx, base) in bases.iter().enumerate() {
+                        reconstructed += &(base.clone() * &chunk_slice[idx]);
+                    }
+                    let diff = witness_eval.clone() - &reconstructed;
+                    computed += &(gamma_pows[col_l].clone() * &diff);
+                }
+                computed *= &eq_val;
+                if computed != *reconstruction_expected {
+                    return Err(LookupError::DecompositionInconsistent);
+                }
+            }
+
+            md_group_idx = add!(md_group_idx, if is_decomposed { 3 } else { 2 });
+            aux_offset = add!(aux_offset, mul!(2, num_logup_cols));
+            if is_decomposed {
+                chunk_offset = add!(chunk_offset, num_logup_cols);
+            }
+        }
 
         Ok(())
     }

--- a/test-uair/src/lib.rs
+++ b/test-uair/src/lib.rs
@@ -885,6 +885,188 @@ macro_rules! impl_bitpoly_int_trace {
 
 impl_bitpoly_int_trace!(BitPolyLookupUair, 256);
 
+/// Decomposed Word lookup: Word(8) with chunk_width=4, K=2.
+/// 2 int columns: a looked up (decomposed), b = a (trivial constraint).
+pub struct DecomposedWordUair<R>(PhantomData<R>);
+
+impl<R> Uair for DecomposedWordUair<R>
+where
+    R: ConstSemiring + From<u32> + 'static,
+{
+    type Ideal = ImpossibleIdeal;
+    type Scalar = DensePolynomial<R, 32>;
+
+    fn signature() -> UairSignature {
+        UairSignature::new(
+            TotalColumnLayout::new(0, 0, 2),
+            PublicColumnLayout::default(),
+            vec![],
+            vec![LookupColumnSpec {
+                column_index: 0,
+                table_type: LookupTableType::Word {
+                    width: 8,
+                    chunk_width: Some(4),
+                },
+            }],
+        )
+    }
+
+    fn constrain_general<B, FromR, MulByScalar, IFromR>(
+        b: &mut B,
+        up: TraceRow<B::Expr>,
+        _down: TraceRow<B::Expr>,
+        _from_ref: FromR,
+        _mbs: MulByScalar,
+        _ideal_from_ref: IFromR,
+    ) where
+        B: ConstraintBuilder,
+        IFromR: Fn(&Self::Ideal) -> B::Ideal,
+    {
+        b.assert_zero(up.int[0].clone() - &up.int[1]);
+    }
+}
+
+impl_int_copy_trace!(DecomposedWordUair, 256);
+
+/// Decomposed BitPoly lookup: BitPoly(8) with chunk_width=4, K=2.
+/// 1 binary_poly column looked up (decomposed) + 1 int column.
+/// Constraint: binary_poly[0] - int[0] ∈ <X-2>.
+pub struct DecomposedBitPolyUair<R>(PhantomData<R>);
+
+impl<R> Uair for DecomposedBitPolyUair<R>
+where
+    R: ConstSemiring + From<u32> + 'static,
+{
+    type Ideal = DegreeOneIdeal<R>;
+    type Scalar = DensePolynomial<R, 32>;
+
+    fn signature() -> UairSignature {
+        UairSignature::new(
+            TotalColumnLayout::new(1, 0, 1),
+            PublicColumnLayout::default(),
+            vec![],
+            vec![LookupColumnSpec {
+                column_index: 0,
+                table_type: LookupTableType::BitPoly {
+                    width: 8,
+                    chunk_width: Some(4),
+                },
+            }],
+        )
+    }
+
+    fn constrain_general<B, FromR, MulByScalar, IFromR>(
+        b: &mut B,
+        up: TraceRow<B::Expr>,
+        _down: TraceRow<B::Expr>,
+        _from_ref: FromR,
+        _mbs: MulByScalar,
+        ideal_from_ref: IFromR,
+    ) where
+        B: ConstraintBuilder,
+        FromR: Fn(&Self::Scalar) -> B::Expr,
+        MulByScalar: Fn(&B::Expr, &Self::Scalar) -> Option<B::Expr>,
+        IFromR: Fn(&Self::Ideal) -> B::Ideal,
+    {
+        b.assert_in_ideal(
+            up.binary_poly[0].clone() - &up.int[0],
+            &ideal_from_ref(&DegreeOneIdeal::new(R::from(2))),
+        );
+    }
+}
+
+impl_bitpoly_int_trace!(DecomposedBitPolyUair, 256);
+
+// ---------------------------------------------------------------------------
+// Comparison UAIRs: lookup vs pure-constraint for the same 8-bit range check
+// ---------------------------------------------------------------------------
+
+/// 8-bit range check via lookup: Word(8), 2 int columns, a=b.
+/// Compare against `RangeCheck8Uair` to measure lookup vs constraint cost.
+pub struct Word8LookupUair<R>(PhantomData<R>);
+
+impl<R> Uair for Word8LookupUair<R>
+where
+    R: ConstSemiring + From<u32> + 'static,
+{
+    type Ideal = ImpossibleIdeal;
+    type Scalar = DensePolynomial<R, 32>;
+
+    fn signature() -> UairSignature {
+        UairSignature::new(
+            TotalColumnLayout::new(0, 0, 2),
+            PublicColumnLayout::default(),
+            vec![],
+            vec![LookupColumnSpec {
+                column_index: 0,
+                table_type: LookupTableType::Word {
+                    width: 8,
+                    chunk_width: None,
+                },
+            }],
+        )
+    }
+
+    fn constrain_general<B, FromR, MulByScalar, IFromR>(
+        b: &mut B,
+        up: TraceRow<B::Expr>,
+        _down: TraceRow<B::Expr>,
+        _from_ref: FromR,
+        _mbs: MulByScalar,
+        _ideal_from_ref: IFromR,
+    ) where
+        B: ConstraintBuilder,
+        IFromR: Fn(&Self::Ideal) -> B::Ideal,
+    {
+        b.assert_zero(up.int[0].clone() - &up.int[1]);
+    }
+}
+
+impl_int_copy_trace!(Word8LookupUair, 256);
+
+/// 8-bit range check via binary decomposition (no lookup):
+/// 1 binary_poly column (8-bit values) + 1 int column, constraint mod 2.
+/// Compare against `Word8LookupUair` to measure constraint vs lookup cost.
+pub struct RangeCheck8Uair<R>(PhantomData<R>);
+
+impl<R> Uair for RangeCheck8Uair<R>
+where
+    R: ConstSemiring + From<u32> + 'static,
+{
+    type Ideal = DegreeOneIdeal<R>;
+    type Scalar = DensePolynomial<R, 32>;
+
+    fn signature() -> UairSignature {
+        UairSignature::new(
+            TotalColumnLayout::new(1, 0, 1),
+            PublicColumnLayout::default(),
+            vec![],
+            vec![],
+        )
+    }
+
+    fn constrain_general<B, FromR, MulByScalar, IFromR>(
+        b: &mut B,
+        up: TraceRow<B::Expr>,
+        _down: TraceRow<B::Expr>,
+        _from_ref: FromR,
+        _mbs: MulByScalar,
+        ideal_from_ref: IFromR,
+    ) where
+        B: ConstraintBuilder,
+        FromR: Fn(&Self::Scalar) -> B::Expr,
+        MulByScalar: Fn(&B::Expr, &Self::Scalar) -> Option<B::Expr>,
+        IFromR: Fn(&Self::Ideal) -> B::Ideal,
+    {
+        b.assert_in_ideal(
+            up.binary_poly[0].clone() - &up.int[0],
+            &ideal_from_ref(&DegreeOneIdeal::new(R::from(2))),
+        );
+    }
+}
+
+impl_bitpoly_int_trace!(RangeCheck8Uair, 256);
+
 #[cfg(test)]
 mod tests {
     use crypto_primitives::crypto_bigint_int::Int;
@@ -919,6 +1101,10 @@ mod tests {
         assert_uair_shape::<MultiColLookupUair<u32>>(&[1]);
         assert_uair_shape::<MultiGroupLookupUair<u32>>(&[1]);
         assert_uair_shape::<BitPolyLookupUair<u32>>(&[1]);
+        assert_uair_shape::<DecomposedWordUair<u32>>(&[1]);
+        assert_uair_shape::<DecomposedBitPolyUair<u32>>(&[1]);
+        assert_uair_shape::<Word8LookupUair<u32>>(&[1]);
+        assert_uair_shape::<RangeCheck8Uair<u32>>(&[1]);
     }
 
     #[test]

--- a/uair/src/lib.rs
+++ b/uair/src/lib.rs
@@ -10,7 +10,7 @@ pub mod ideal_collector;
 pub mod lookup_types;
 
 use crypto_primitives::Semiring;
-use std::borrow::Cow;
+use std::{borrow::Cow, ops::Range};
 use zinc_poly::{
     mle::DenseMultilinearExtension,
     univariate::{binary::BinaryPoly, dense::DensePolynomial},
@@ -127,9 +127,25 @@ impl ColumnLayout {
     }
 
     /// The sum of the numbers of columns across all types.
-    #[allow(clippy::arithmetic_side_effects)]
     pub fn cols(&self) -> usize {
-        self.num_binary_poly_cols + self.num_arbitrary_poly_cols + self.num_int_cols
+        add!(
+            add!(self.num_binary_poly_cols, self.num_arbitrary_poly_cols),
+            self.num_int_cols
+        )
+    }
+
+    /// Returns the three (bin, arb, int) witness ranges within a flat
+    /// `[all_bin | all_arb | all_int]` array, given the public prefix counts.
+    pub fn witness_ranges(&self, public: &ColumnLayout) -> [Range<usize>; 3] {
+        let total_bin = self.num_binary_poly_cols;
+        let total_arb = self.num_arbitrary_poly_cols;
+        let arb_offset = add!(total_bin, public.num_arbitrary_poly_cols);
+        let int_offset = add!(add!(total_bin, total_arb), public.num_int_cols);
+        [
+            public.num_binary_poly_cols..total_bin,
+            arb_offset..add!(arb_offset, sub!(total_arb, public.num_arbitrary_poly_cols)),
+            int_offset..add!(int_offset, sub!(self.num_int_cols, public.num_int_cols)),
+        ]
     }
 }
 
@@ -150,6 +166,14 @@ macro_rules! column_layout_wrapper {
             pub fn max_cols(&self) -> usize { self.0.max_cols() }
             pub fn cols(&self) -> usize { self.0.cols() }
             pub fn as_column_layout(&self) -> &ColumnLayout { &self.0 }
+        }
+
+        impl From<$name> for ColumnLayout {
+            fn from(w: $name) -> Self { w.0 }
+        }
+
+        impl<'a> From<&'a $name> for &'a ColumnLayout {
+            fn from(w: &'a $name) -> Self { &w.0 }
         }
     };
 }

--- a/uair/src/lookup_types.rs
+++ b/uair/src/lookup_types.rs
@@ -6,6 +6,8 @@
 //! of [`UairSignature`] via `UairSignature::new(..., lookup_specs)`, the
 //! same way shifts are declared.
 
+use zinc_utils::div;
+
 /// Describes the type of lookup table a column should be checked against.
 /// Full table size = `2^width` for each type; decomposed into chunks of
 /// `chunk_width`
@@ -22,6 +24,32 @@ pub enum LookupTableType {
         width: usize,
         chunk_width: Option<usize>,
     },
+}
+
+impl LookupTableType {
+    pub fn width(&self) -> usize {
+        match self {
+            Self::BitPoly { width, .. } | Self::Word { width, .. } => *width,
+        }
+    }
+
+    pub fn chunk_width(&self) -> Option<usize> {
+        match self {
+            Self::BitPoly { chunk_width, .. } | Self::Word { chunk_width, .. } => *chunk_width,
+        }
+    }
+
+    pub fn is_decomposed(&self) -> bool {
+        self.chunk_width().is_some()
+    }
+
+    /// Number of chunks per column. Returns 1 for non-decomposed.
+    pub fn num_chunks(&self) -> usize {
+        match self.chunk_width() {
+            Some(cw) => div!(self.width(), cw),
+            None => 1,
+        }
+    }
 }
 
 /// Specifies that a trace column should be looked up against a prescribed

--- a/utils/src/field/const_monty.rs
+++ b/utils/src/field/const_monty.rs
@@ -63,6 +63,10 @@ impl<Mod: ConstMontyParams<LIMBS>, const LIMBS: usize, const LIMBS2: usize>
 impl<Mod: ConstMontyParams<LIMBS>, const LIMBS: usize> InnerTransparentField
     for ConstMontyField<Mod, LIMBS>
 {
+    fn retrieve_canonical(&self) -> Self::Inner {
+        self.retrieve()
+    }
+
     fn add_inner(lhs: &Self::Inner, rhs: &Self::Inner, _config: &Self::Config) -> Self::Inner {
         Uint::new(
             lhs.inner()

--- a/utils/src/field/monty.rs
+++ b/utils/src/field/monty.rs
@@ -36,6 +36,10 @@ where
 }
 
 impl<const LIMBS: usize> InnerTransparentField for MontyField<LIMBS> {
+    fn retrieve_canonical(&self) -> Self::Inner {
+        self.retrieve()
+    }
+
     fn add_inner(lhs: &Self::Inner, rhs: &Self::Inner, config: &Self::Config) -> Self::Inner {
         Uint::new(
             lhs.inner()

--- a/utils/src/from_ref.rs
+++ b/utils/src/from_ref.rs
@@ -66,3 +66,10 @@ impl<const LIMBS: usize, const LIMBS2: usize> FromRef<Uint<LIMBS2>> for Uint<LIM
         Self::try_from(value.inner()).expect("Destination Uint type is too small")
     }
 }
+
+impl<const LIMBS: usize, const LIMBS2: usize> FromRef<Uint<LIMBS2>> for Int<LIMBS> {
+    #[inline]
+    fn from_ref(value: &Uint<LIMBS2>) -> Self {
+        Self::try_from(value.inner()).expect("value doesn't fit in destination Int type")
+    }
+}

--- a/utils/src/inner_transparent_field.rs
+++ b/utils/src/inner_transparent_field.rs
@@ -3,6 +3,9 @@ use crypto_primitives::PrimeField;
 /// A trait for fields that allow to perform operations
 /// on inner Montgomery representations of field elements.
 pub trait InnerTransparentField: PrimeField {
+    /// Retrieve the canonical integer representative of this field element.
+    fn retrieve_canonical(&self) -> Self::Inner;
+
     /// Add inner Montgomery representations using a config.
     fn add_inner(lhs: &Self::Inner, rhs: &Self::Inner, config: &Self::Config) -> Self::Inner;
 

--- a/utils/src/mul_by_scalar.rs
+++ b/utils/src/mul_by_scalar.rs
@@ -63,7 +63,20 @@ macro_rules! impl_mul_int_by_primitive_scalar {
     };
 }
 
-impl_mul_int_by_primitive_scalar!(i8, i16, i32, i64, i128);
+impl_mul_int_by_primitive_scalar!(i8, i16, i32, i128);
+
+impl<const LIMBS: usize, const LIMBS_OUT: usize> MulByScalar<&i64, Int<LIMBS_OUT>> for Int<LIMBS> {
+    #[allow(clippy::arithmetic_side_effects)] // By design
+    fn mul_by_scalar<const CHECK: bool>(&self, rhs: &i64) -> Option<Int<LIMBS_OUT>> {
+        let wide_self: Int<LIMBS_OUT> = self.resize();
+        let wide_rhs: Int<LIMBS_OUT> = Int::from(*rhs);
+        if CHECK {
+            wide_self.checked_mul(&wide_rhs)
+        } else {
+            Some(wide_self * wide_rhs)
+        }
+    }
+}
 
 impl<T> MulByScalar<&Boolean> for T
 where


### PR DESCRIPTION
Closes https://github.com/NethermindEth/zinc-plus/issues/107 — Phase 4 decomposed lookups + full protocol wiring.

## Summary

**Decomposed lookups (`piop/src/lookup/`):**

- `logup.rs`: `build_reconstruction_group` (single γ-batched degree-2 group for L reconstruction identities), `extract_decomposed` for chunk extraction, `finalize_verifier` updated with subtable-aware identity checks for decomposed groups
- `utils.rs`: subtable generators (`generate_bitpoly_subtable`/`generate_word_subtable`), decomp bases (`bitpoly_decomp_base`/`word_decomp_base`), `decompose_bitpoly_column`/`decompose_word_column` - mostly copied from @albert-garreta agentic branch.
- `structs.rs`: `DecompInfo` (subtable + decomp_bases + chunks), `LookupGroupPcsData` with optional `ChunkPcsData`, `LookupEvalsFlat`

**Protocol wiring (`protocol/src/`):**

- `lib.rs`: `Proof` struct extended with `lookup_chunk_commitments`, `lookup_chunk_evals`, `lookup_chunk_lifted_evals`
- `prover.rs`: `prepare_lookup_groups` branches on `chunk_width` — non-decomposed commits m/u against full table, decomposed decomposes into L*K virtual columns, commits chunks + m/u against subtable, appends reconstruction group; `pcs_open!` macro for consolidated PCS openings
- `verifier.rs`: `finalize_lookup_groups` method handles both paths — inline reconstruction check for decomposed groups, `md_group_idx` advances by 3 (2 LogUp + 1 reconstruction); `pcs_verify!` macro for PCS batch verification

**Test UAIRs (`test-uair/src/lib.rs`):**

- `DecomposedWordUair` (Word(8), chunk_width=4, K=2), `DecomposedBitPolyUair` (BitPoly(8), chunk_width=4, K=2)
- `Word8LookupUair`, `RangeCheck8Uair` — comparison pair for lookup vs constraint benchmarking
- `impl_int_copy_trace!`, `impl_bitpoly_int_trace!`, `impl_sum_pair_trace!` macros for trace generation boilerplate

**Benchmarks (`protocol/benches/e2e.rs`):**

- `SimpleLookupUair` in main E2E group (nvars 8/10/12)
- `lookup_vs_constraint` comparison group: `Word8LookupUair` (Word(8) lookup) vs `RangeCheck8Uair` (binary decomposition) side-by-side
- `BenchZincTypes` extended with `LookupZt`/`LookupLc`, `CombR` widened to 448 bits for LC bit budget with `Int<4>` lookup evals

### Optimizations

- **Decomposed batching**: L columns × K chunks → still only 2 LogUp groups + 1 reconstruction group check for decomposed chunks
- **Chunks committed via PCS** — reduces proof size instead of sending in the clear

### Benchmark: 8-bit range check — Lookup vs Constraint

| `num_vars` | Lookup (Word(8)) | Constraint (BinaryPoly) | Ratio |
|:----------:|:----------------:|:-----------------------:|:-----:|
| 8          | 3.80 ms          | 1.81 ms                 | 2.1×  |
| 10         | 33.3 ms          | 9.78 ms                 | 3.4×  |
| 12         | 83.7 ms          | 31.3 ms                 | 2.7×  |

**Why lookups are slower here:**

1. **Extra PCS commitments** — LogUp requires committing auxiliary columns (m, u) per lookup group. PCS commits dominate proving cost in Zinc+.
2. **Widened `CombR`** — to fit `Int<4>` (256-bit) lookup evals in the PCS linear-combination bit budget, `CombR` was widened from 6 limbs (384 bits) to 7 limbs (448 bits). This slows every PCS operation across the entire proof, not just the lookup portion.

**To improve lookup performance, we should consider using GKR verison of LogUp** 

### Test plan

- [x] 23 utils unit tests: subtable/decomp-base values, decomposition roundtrips (BitPoly K=2/3, Word K=2/4), invalid witness rejection
- [x] 7 E2E lookup roundtrips: Simple, MultiCol, MultiGroup, BitPoly, DecomposedWord, DecomposedBitPoly, Word8
- [x] 3 non-decomposed negative tests: tamper aux evals, tamper lifted evals, tamper commitment
- [x] 4 decomposed negative tests: tamper chunk evals (Word + BitPoly), tamper chunk commitment (Word + BitPoly)