### PR TITLE
E2E optimizations and tweaks

### DIFF
--- a/piop/benches/ideal_check.rs
+++ b/piop/benches/ideal_check.rs
@@ -358,7 +358,7 @@ fn bench_big_linear_uair<const FIELD_LIMBS: usize>(
                         &mut transcript,
                         field_cfg,
                         project_trace_coeffs_column_major,
-                        prove_linear
+                        prove_mle_first
                     );
                     black_box(proof);
                 },
@@ -394,7 +394,7 @@ fn bench_big_linear_uair<const FIELD_LIMBS: usize>(
         &mut transcript,
         &field_cfg,
         project_trace_coeffs_column_major,
-        prove_linear
+        prove_mle_first
     );
 
     group.bench_function(BenchmarkId::new("Ideal Check Verifier", &params), |bench| {

--- a/piop/src/ideal_check.rs
+++ b/piop/src/ideal_check.rs
@@ -149,15 +149,20 @@ where
     {
         let evaluation_point = transcript.get_field_challenges(num_vars, field_cfg);
 
-        // Evaluate combined polynomials using MLE-first approach:
-        // evaluate trace columns at the point, then apply constraints.
-        let combined_mle_values = combined_poly_builder::evaluate_combined_polynomials::<_, U>(
-            trace_matrix,
-            projected_scalars,
-            num_constraints,
-            &evaluation_point,
-            field_cfg,
-        )?;
+        let ideal_collector = collect_ideals::<U>(num_constraints);
+
+        let all_zero = ideal_collector.ideals.iter().all(|i| i.is_zero_ideal());
+        let combined_mle_values = if all_zero {
+            vec![DynamicPolynomialF::ZERO; num_constraints]
+        } else {
+            combined_poly_builder::evaluate_combined_polynomials::<_, U>(
+                trace_matrix,
+                projected_scalars,
+                num_constraints,
+                &evaluation_point,
+                field_cfg,
+            )?
+        };
 
         let mut transcription_buf: Vec<u8> = vec![0; F::Inner::NUM_BYTES];
 
@@ -199,39 +204,41 @@ where
 
         let evaluation_point = transcript.get_field_challenges(num_vars, field_cfg);
 
-        // Build combined polynomial MLEs row-by-row and evaluate them.
-        let combined_mles = combined_poly_builder::compute_combined_polynomials::<_, U>(
-            trace_matrix,
-            projected_scalars,
-            num_constraints,
-            field_cfg,
-            &is_zero_ideal,
-        );
+        let combined_mle_values = if is_zero_ideal.iter().all(|&z| z) {
+            vec![DynamicPolynomialF::ZERO; num_constraints]
+        } else {
+            let combined_mles = combined_poly_builder::compute_combined_polynomials::<_, U>(
+                trace_matrix,
+                projected_scalars,
+                num_constraints,
+                field_cfg,
+                &is_zero_ideal,
+            );
 
-        let eq_table = build_eq_x_r_vec(&evaluation_point, field_cfg)?;
+            let eq_table = build_eq_x_r_vec(&evaluation_point, field_cfg)?;
 
-        // Evaluate coefficient MLEs at the evaluation point.
-        let combined_mle_values: Vec<DynamicPolynomialF<F>> = cfg_into_iter!(combined_mles)
-            .enumerate()
-            .map(|(i, coeff_mles)| {
-                // Skip zero-ideal constraints: their combined polynomial
-                // is zero for an honest prover.
-                if is_zero_ideal[i] {
-                    return DynamicPolynomialF::ZERO;
-                }
-                let coeffs = coeff_mles
-                    .into_iter()
-                    .map(|coeff_mle| {
-                        zinc_poly::utils::mle_eval_with_eq_table(
-                            &coeff_mle.evaluations,
-                            &eq_table,
-                            field_cfg,
-                        )
-                    })
-                    .collect::<Vec<_>>();
-                DynamicPolynomialF::new_trimmed(coeffs)
-            })
-            .collect::<Vec<_>>();
+            cfg_into_iter!(combined_mles)
+                .enumerate()
+                .map(|(i, coeff_mles)| {
+                    // Skip zero-ideal constraints: their combined polynomial
+                    // is zero for an honest prover.
+                    if is_zero_ideal[i] {
+                        return DynamicPolynomialF::ZERO;
+                    }
+                    let coeffs = coeff_mles
+                        .into_iter()
+                        .map(|coeff_mle| {
+                            zinc_poly::utils::mle_eval_with_eq_table(
+                                &coeff_mle.evaluations,
+                                &eq_table,
+                                field_cfg,
+                            )
+                        })
+                        .collect::<Vec<_>>();
+                    DynamicPolynomialF::new_trimmed(coeffs)
+                })
+                .collect::<Vec<_>>()
+        };
 
         let mut transcription_buf: Vec<u8> = vec![0; F::Inner::NUM_BYTES];
 

--- a/piop/src/ideal_check.rs
+++ b/piop/src/ideal_check.rs
@@ -42,7 +42,7 @@ pub trait IdealCheckProtocol: Uair {
     /// - `field_cfg`: random field configuration sampled on the previous steps
     ///   of the overall protocol.
     #[allow(clippy::type_complexity)]
-    fn prove_linear<F>(
+    fn prove_mle_first<F>(
         transcript: &mut impl Transcript,
         trace_matrix: &ColumnMajorTrace<F>,
         projected_scalars: &HashMap<Self::Scalar, DynamicPolynomialF<F>>,
@@ -130,7 +130,7 @@ where
     U: Uair,
 {
     #[allow(clippy::type_complexity)]
-    fn prove_linear<F>(
+    fn prove_mle_first<F>(
         transcript: &mut impl Transcript,
         trace_matrix: &ColumnMajorTrace<F>,
         projected_scalars: &HashMap<U::Scalar, DynamicPolynomialF<F>>,

--- a/piop/src/ideal_check.rs
+++ b/piop/src/ideal_check.rs
@@ -5,9 +5,6 @@ mod structs;
 
 pub use structs::*;
 
-#[cfg(feature = "parallel")]
-use rayon::prelude::*;
-
 use crate::projections::{ColumnMajorTrace, RowMajorTrace};
 use batched_ideal_check::*;
 use crypto_primitives::PrimeField;
@@ -15,9 +12,8 @@ use num_traits::ConstZero;
 use std::collections::HashMap;
 use thiserror::Error;
 use zinc_poly::{
-    EvaluationError,
-    univariate::dynamic::over_field::DynamicPolynomialF,
-    utils::{ArithErrors as PolyArithErrors, build_eq_x_r_vec},
+    EvaluationError, univariate::dynamic::over_field::DynamicPolynomialF,
+    utils::ArithErrors as PolyArithErrors,
 };
 use zinc_transcript::traits::{ConstTranscribable, Transcript};
 use zinc_uair::{
@@ -25,7 +21,7 @@ use zinc_uair::{
     ideal::{Ideal, IdealCheck},
     ideal_collector::{IdealOrZero, collect_ideals},
 };
-use zinc_utils::{cfg_into_iter, inner_transparent_field::InnerTransparentField};
+use zinc_utils::inner_transparent_field::InnerTransparentField;
 
 /// Ideal-check subprotocol.
 pub trait IdealCheckProtocol: Uair {
@@ -196,48 +192,30 @@ where
         // Collect ideals to identify assert_zero constraints whose
         // combined polynomial is zero by construction (for honest provers).
         let ideal_collector = collect_ideals::<U>(num_constraints);
-        let is_zero_ideal: Vec<bool> = ideal_collector
+        let non_zero_indices: Vec<usize> = ideal_collector
             .ideals
             .iter()
-            .map(|i| i.is_zero_ideal())
+            .enumerate()
+            .filter(|(_, i)| !i.is_zero_ideal())
+            .map(|(idx, _)| idx)
             .collect();
 
         let evaluation_point = transcript.get_field_challenges(num_vars, field_cfg);
 
-        let combined_mle_values = if is_zero_ideal.iter().all(|&z| z) {
-            vec![DynamicPolynomialF::ZERO; num_constraints]
-        } else {
-            let combined_mles = combined_poly_builder::compute_combined_polynomials::<_, U>(
+        let mut combined_mle_values = vec![DynamicPolynomialF::ZERO; num_constraints];
+        if !non_zero_indices.is_empty() {
+            let computed = combined_poly_builder::evaluate_for_constraints::<_, U>(
                 trace_matrix,
                 projected_scalars,
                 num_constraints,
                 field_cfg,
-                &is_zero_ideal,
-            );
+                &non_zero_indices,
+                &evaluation_point,
+            )?;
 
-            let eq_table = build_eq_x_r_vec(&evaluation_point, field_cfg)?;
-
-            cfg_into_iter!(combined_mles)
-                .enumerate()
-                .map(|(i, coeff_mles)| {
-                    // Skip zero-ideal constraints: their combined polynomial
-                    // is zero for an honest prover.
-                    if is_zero_ideal[i] {
-                        return DynamicPolynomialF::ZERO;
-                    }
-                    let coeffs = coeff_mles
-                        .into_iter()
-                        .map(|coeff_mle| {
-                            zinc_poly::utils::mle_eval_with_eq_table(
-                                &coeff_mle.evaluations,
-                                &eq_table,
-                                field_cfg,
-                            )
-                        })
-                        .collect::<Vec<_>>();
-                    DynamicPolynomialF::new_trimmed(coeffs)
-                })
-                .collect::<Vec<_>>()
+            for (&ci, val) in non_zero_indices.iter().zip(computed) {
+                combined_mle_values[ci] = val;
+            }
         };
 
         let mut transcription_buf: Vec<u8> = vec![0; F::Inner::NUM_BYTES];

--- a/piop/src/ideal_check.rs
+++ b/piop/src/ideal_check.rs
@@ -164,13 +164,11 @@ where
         let degrees = count_constraint_degrees::<U>();
 
         let mut has_linear_nonzero: bool = false;
-        let mut nonlinear_nonzero: Vec<usize> = Vec::new();
         let mut nonlinear_zero: Vec<usize> = Vec::new();
+        let mut nonlinear_nonzero: Vec<usize> = Vec::new();
         for (idx, ideal) in ideal_collector.ideals.iter().enumerate() {
             if degrees[idx] <= 1 {
-                if !has_linear_nonzero && !ideal.is_zero_ideal() {
-                    has_linear_nonzero = true;
-                }
+                has_linear_nonzero |= !ideal.is_zero_ideal();
             } else if ideal.is_zero_ideal() {
                 nonlinear_zero.push(idx);
             } else {
@@ -183,18 +181,29 @@ where
         // out correct.
         // Non-linear entries are garbage and get replaced below.
         let mut combined_mle_values: Vec<DynamicPolynomialF<F>> = if has_linear_nonzero {
-            combined_poly_builder::evaluate_combined_polynomials::<_, U>(
+            let mut res = combined_poly_builder::evaluate_combined_polynomials::<_, U>(
                 trace_matrix,
                 projected_scalars,
                 num_constraints,
                 &evaluation_point,
                 field_cfg,
-            )?
+            )?;
+
+            // Scrub garbage left by `evaluate_combined_polynomials` at non-linear
+            // zero-ideal indices.
+            for &i in &nonlinear_zero {
+                res[i] = DynamicPolynomialF::ZERO;
+            }
+
+            res
         } else {
             vec![DynamicPolynomialF::ZERO; num_constraints]
         };
 
         if !nonlinear_nonzero.is_empty() {
+            // `evaluate_for_constraints` works with row-major traces, so we have to
+            // transpose here.
+            // TODO(alex): Can/should we avoid the transposition?
             let row_major = column_major_to_row_major(trace_matrix);
             let values = combined_poly_builder::evaluate_for_constraints::<_, U>(
                 &row_major,
@@ -206,15 +215,6 @@ where
             )?;
             for (&i, v) in nonlinear_nonzero.iter().zip(values) {
                 combined_mle_values[i] = v;
-            }
-        }
-
-        // Scrub garbage left by `evaluate_combined_polynomials` at non-linear
-        // zero-ideal indices. Skipped when the initializer already produced
-        // an all-zeros vector.
-        if !nonlinear_zero.is_empty() && has_linear_nonzero {
-            for &i in &nonlinear_zero {
-                combined_mle_values[i] = DynamicPolynomialF::ZERO;
             }
         }
 

--- a/piop/src/ideal_check.rs
+++ b/piop/src/ideal_check.rs
@@ -375,12 +375,7 @@ mod tests {
     //             Once we have time we need to create a comprehensive test suite
     //             akin to the one we have for the PCS or the sumcheck.
 
-    fn test_successful_verification_linear<
-        U,
-        IdealOverF,
-        IdealOverFFromRef,
-        const DEGREE_PLUS_ONE: usize,
-    >(
+    fn do_test<U, IdealOverF, IdealOverFFromRef, const DEGREE_PLUS_ONE: usize>(
         num_vars: usize,
         ideal_over_f_from_ref: IdealOverFFromRef,
     ) where
@@ -388,75 +383,63 @@ mod tests {
             + GenerateRandomTrace<DEGREE_PLUS_ONE, PolyCoeff = Int<5>, Int = Int<5>>
             + IdealCheckProtocol,
         IdealOverF: Ideal + IdealCheck<DynamicPolynomialF<MontyField<LIMBS>>>,
-        IdealOverFFromRef: Fn(&IdealOrZero<U::Ideal>) -> IdealOverF,
+        IdealOverFFromRef: Fn(&IdealOrZero<U::Ideal>) -> IdealOverF + Copy,
     {
         let mut rng = rng();
-        let transcript = Blake3Transcript::new();
 
-        let (proof, prover_state, ..) = run_ideal_check_prover_linear::<U, DEGREE_PLUS_ONE>(
-            num_vars,
-            &U::generate_random_trace(num_vars, &mut rng),
-            &mut transcript.clone(),
-        );
+        // Combined approach
+        {
+            let transcript = Blake3Transcript::new();
+            let (proof, prover_state, ..) = run_ideal_check_prover_combined::<U, DEGREE_PLUS_ONE>(
+                num_vars,
+                &U::generate_random_trace(num_vars, &mut rng),
+                &mut transcript.clone(),
+            );
 
-        let num_constraints = count_constraints::<U>();
+            let num_constraints = count_constraints::<U>();
 
-        let verifier_result = U::verify_as_subprotocol(
-            &mut transcript.clone(),
-            proof,
-            num_constraints,
-            num_vars,
-            ideal_over_f_from_ref,
-            &test_config(),
-        )
-        .expect("Verification failed");
+            let verifier_result = U::verify_as_subprotocol(
+                &mut transcript.clone(),
+                proof,
+                num_constraints,
+                num_vars,
+                ideal_over_f_from_ref,
+                &test_config(),
+            )
+            .expect("Verification failed");
 
-        assert_eq!(
-            prover_state.evaluation_point,
-            verifier_result.evaluation_point
-        );
-    }
+            assert_eq!(
+                prover_state.evaluation_point,
+                verifier_result.evaluation_point
+            );
+        }
 
-    fn test_successful_verification_combined<
-        U,
-        IdealOverF,
-        IdealOverFFromRef,
-        const DEGREE_PLUS_ONE: usize,
-    >(
-        num_vars: usize,
-        ideal_over_f_from_ref: IdealOverFFromRef,
-    ) where
-        U: Uair<Scalar = DensePolynomial<Int<5>, DEGREE_PLUS_ONE>>
-            + GenerateRandomTrace<DEGREE_PLUS_ONE, PolyCoeff = Int<5>, Int = Int<5>>
-            + IdealCheckProtocol,
-        IdealOverF: Ideal + IdealCheck<DynamicPolynomialF<MontyField<LIMBS>>>,
-        IdealOverFFromRef: Fn(&IdealOrZero<U::Ideal>) -> IdealOverF,
-    {
-        let mut rng = rng();
-        let transcript = Blake3Transcript::new();
+        // MLE-first
+        {
+            let transcript = Blake3Transcript::new();
+            let (proof, prover_state, ..) = run_ideal_check_prover_linear::<U, DEGREE_PLUS_ONE>(
+                num_vars,
+                &U::generate_random_trace(num_vars, &mut rng),
+                &mut transcript.clone(),
+            );
 
-        let (proof, prover_state, ..) = run_ideal_check_prover_combined::<U, DEGREE_PLUS_ONE>(
-            num_vars,
-            &U::generate_random_trace(num_vars, &mut rng),
-            &mut transcript.clone(),
-        );
+            let num_constraints = count_constraints::<U>();
 
-        let num_constraints = count_constraints::<U>();
+            let verifier_result = U::verify_as_subprotocol(
+                &mut transcript.clone(),
+                proof,
+                num_constraints,
+                num_vars,
+                ideal_over_f_from_ref,
+                &test_config(),
+            )
+            .expect("Verification failed");
 
-        let verifier_result = U::verify_as_subprotocol(
-            &mut transcript.clone(),
-            proof,
-            num_constraints,
-            num_vars,
-            ideal_over_f_from_ref,
-            &test_config(),
-        )
-        .expect("Verification failed");
-
-        assert_eq!(
-            prover_state.evaluation_point,
-            verifier_result.evaluation_point
-        );
+            assert_eq!(
+                prover_state.evaluation_point,
+                verifier_result.evaluation_point
+            );
+        }
     }
 
     #[test]
@@ -465,27 +448,14 @@ mod tests {
 
         let num_vars = 2;
 
-        // Linear UAIR with non-zero ideals: both approaches work; MLE-first
-        // dispatches every constraint through `evaluate_combined_polynomials`.
-        test_successful_verification_linear::<TestUairNoMultiplication<Int<5>>, _, _, 32>(
-            num_vars,
-            |ideal_over_ring| ideal_over_ring.map(|i| DegreeOneIdeal::from_with_cfg(i, &field_cfg)),
-        );
-        test_successful_verification_combined::<TestUairNoMultiplication<Int<5>>, _, _, 32>(
-            num_vars,
-            |ideal_over_ring| ideal_over_ring.map(|i| DegreeOneIdeal::from_with_cfg(i, &field_cfg)),
-        );
+        // Linear UAIR with non-zero ideals
+        do_test::<TestUairNoMultiplication<Int<5>>, _, _, 32>(num_vars, |ideal_over_ring| {
+            ideal_over_ring.map(|i| DegreeOneIdeal::from_with_cfg(i, &field_cfg))
+        });
 
-        // Non-linear UAIR with all-zero ideals: combined approach works
-        // unconditionally; MLE-first works too because the hybrid prover
-        // short-circuits zero-ideal constraints to zero regardless of degree.
-        test_successful_verification_combined::<TestUairSimpleMultiplication<Int<5>>, _, _, 32>(
-            num_vars,
-            |_ideal_over_ring| IdealOrZero::<DegreeOneIdeal<_>>::zero(),
-        );
-        test_successful_verification_linear::<TestUairSimpleMultiplication<Int<5>>, _, _, 32>(
-            num_vars,
-            |_ideal_over_ring| IdealOrZero::<DegreeOneIdeal<_>>::zero(),
-        );
+        // Non-linear UAIR with all-zero ideals
+        do_test::<TestUairSimpleMultiplication<Int<5>>, _, _, 32>(num_vars, |_ideal_over_ring| {
+            IdealOrZero::<DegreeOneIdeal<_>>::zero()
+        });
     }
 }

--- a/piop/src/ideal_check.rs
+++ b/piop/src/ideal_check.rs
@@ -5,7 +5,7 @@ mod structs;
 
 pub use structs::*;
 
-use crate::projections::{ColumnMajorTrace, RowMajorTrace};
+use crate::projections::{ColumnMajorTrace, RowMajorTrace, column_major_to_row_major};
 use batched_ideal_check::*;
 use crypto_primitives::PrimeField;
 use num_traits::ConstZero;
@@ -18,6 +18,7 @@ use zinc_poly::{
 use zinc_transcript::traits::{ConstTranscribable, Transcript};
 use zinc_uair::{
     Uair,
+    degree_counter::count_constraint_degrees,
     ideal::{Ideal, IdealCheck},
     ideal_collector::{IdealOrZero, collect_ideals},
 };
@@ -25,11 +26,19 @@ use zinc_utils::inner_transparent_field::InnerTransparentField;
 
 /// Ideal-check subprotocol.
 pub trait IdealCheckProtocol: Uair {
-    /// Prover for linear-only UAIRs using MLE-first evaluation.
+    /// Prover using MLE-first evaluation (column-indexed trace).
     ///
-    /// Uses column-indexed trace for efficient MLE evaluation:
-    /// evaluates trace columns at the challenge point first,
-    /// then applies constraints to the evaluated values.
+    /// Routes each constraint through the most efficient evaluation path:
+    /// - Linear constraints with non-zero ideals are batched through
+    ///   [`evaluate_combined_polynomials`], which evaluates trace column MLEs
+    ///   at the challenge point and then applies the constraints to the
+    ///   evaluated values.
+    /// - Non-linear constraints with non-zero ideals fall back to the row-major
+    ///   [`evaluate_for_constraints`] path; the trace is transposed on demand
+    ///   via [`column_major_to_row_major`].
+    /// - Constraints with zero ideals are short-circuited to zero (their
+    ///   combined polynomial value is zero by construction for an honest
+    ///   prover).
     ///
     /// # Parameters
     /// - `transcript`: the Fiat-Shamir transcript.
@@ -145,12 +154,35 @@ where
     {
         let evaluation_point = transcript.get_field_challenges(num_vars, field_cfg);
 
+        // Classify constraints to drive dispatch below:
+        // * Linear non-zero-ideal goes through the column-major MLE-first path
+        // * Linear zero-ideal constraints need no tracking — their value is zero by
+        //   construction.
+        // * Non-linear non-zero-ideal goes through the row-major fallback
+        // * Non-linear zero-ideal entries are zeroed afterwards.
         let ideal_collector = collect_ideals::<U>(num_constraints);
+        let degrees = count_constraint_degrees::<U>();
 
-        let all_zero = ideal_collector.ideals.iter().all(|i| i.is_zero_ideal());
-        let combined_mle_values = if all_zero {
-            vec![DynamicPolynomialF::ZERO; num_constraints]
-        } else {
+        let mut has_linear_nonzero: bool = false;
+        let mut nonlinear_nonzero: Vec<usize> = Vec::new();
+        let mut nonlinear_zero: Vec<usize> = Vec::new();
+        for (idx, ideal) in ideal_collector.ideals.iter().enumerate() {
+            if degrees[idx] <= 1 {
+                if !has_linear_nonzero && !ideal.is_zero_ideal() {
+                    has_linear_nonzero = true;
+                }
+            } else if ideal.is_zero_ideal() {
+                nonlinear_zero.push(idx);
+            } else {
+                nonlinear_nonzero.push(idx);
+            }
+        }
+
+        // When any linear non-zero-ideal constraint exists, run
+        // `evaluate_combined_polynomials` once: all linear entries (zero or not) come
+        // out correct.
+        // Non-linear entries are garbage and get replaced below.
+        let mut combined_mle_values: Vec<DynamicPolynomialF<F>> = if has_linear_nonzero {
             combined_poly_builder::evaluate_combined_polynomials::<_, U>(
                 trace_matrix,
                 projected_scalars,
@@ -158,7 +190,33 @@ where
                 &evaluation_point,
                 field_cfg,
             )?
+        } else {
+            vec![DynamicPolynomialF::ZERO; num_constraints]
         };
+
+        if !nonlinear_nonzero.is_empty() {
+            let row_major = column_major_to_row_major(trace_matrix);
+            let values = combined_poly_builder::evaluate_for_constraints::<_, U>(
+                &row_major,
+                projected_scalars,
+                num_constraints,
+                field_cfg,
+                &nonlinear_nonzero,
+                &evaluation_point,
+            )?;
+            for (&i, v) in nonlinear_nonzero.iter().zip(values) {
+                combined_mle_values[i] = v;
+            }
+        }
+
+        // Scrub garbage left by `evaluate_combined_polynomials` at non-linear
+        // zero-ideal indices. Skipped when the initializer already produced
+        // an all-zeros vector.
+        if !nonlinear_zero.is_empty() && has_linear_nonzero {
+            for &i in &nonlinear_zero {
+                combined_mle_values[i] = DynamicPolynomialF::ZERO;
+            }
+        }
 
         let mut transcription_buf: Vec<u8> = vec![0; F::Inner::NUM_BYTES];
 
@@ -407,7 +465,8 @@ mod tests {
 
         let num_vars = 2;
 
-        // Linear UAIR - test both approaches
+        // Linear UAIR with non-zero ideals: both approaches work; MLE-first
+        // dispatches every constraint through `evaluate_combined_polynomials`.
         test_successful_verification_linear::<TestUairNoMultiplication<Int<5>>, _, _, 32>(
             num_vars,
             |ideal_over_ring| ideal_over_ring.map(|i| DegreeOneIdeal::from_with_cfg(i, &field_cfg)),
@@ -417,8 +476,14 @@ mod tests {
             |ideal_over_ring| ideal_over_ring.map(|i| DegreeOneIdeal::from_with_cfg(i, &field_cfg)),
         );
 
-        // Non-linear UAIR - only combined approach works
+        // Non-linear UAIR with all-zero ideals: combined approach works
+        // unconditionally; MLE-first works too because the hybrid prover
+        // short-circuits zero-ideal constraints to zero regardless of degree.
         test_successful_verification_combined::<TestUairSimpleMultiplication<Int<5>>, _, _, 32>(
+            num_vars,
+            |_ideal_over_ring| IdealOrZero::<DegreeOneIdeal<_>>::zero(),
+        );
+        test_successful_verification_linear::<TestUairSimpleMultiplication<Int<5>>, _, _, 32>(
             num_vars,
             |_ideal_over_ring| IdealOrZero::<DegreeOneIdeal<_>>::zero(),
         );

--- a/piop/src/ideal_check/combined_poly_builder.rs
+++ b/piop/src/ideal_check/combined_poly_builder.rs
@@ -11,6 +11,7 @@ use zinc_poly::{
         DenseMultilinearExtension, MultilinearExtensionWithConfig, dense::CollectDenseMleWithZero,
     },
     univariate::dynamic::over_field::DynamicPolynomialF,
+    utils::{ArithErrors as PolyArithErrors, build_eq_x_r_vec},
 };
 use zinc_uair::{
     ColumnLayout, ConstraintBuilder, TraceRow, Uair,
@@ -21,22 +22,28 @@ use zinc_utils::{
     cfg_into_iter, cfg_iter, from_ref::FromRef, inner_transparent_field::InnerTransparentField,
 };
 
-/// Given a UAIR `U` and a trace `trace` this function
-/// obtains the combined polynomials' MLE coefficients.
-/// Since each coefficient is also a univariate polynomial
-/// we split the resulting MLE into coefficient MLEs.
+/// Evaluate combined polynomial MLEs at `evaluation_point` for a selected
+/// subset of constraints.
+///
+/// Runs `constrain_general` row-by-row to produce all constraint values (since
+/// it is monolithic), then selects only the entries at `constraint_indices`,
+/// builds their coefficient MLEs, and evaluates them via the eq table.
+///
+/// Returns one `DynamicPolynomialF<F>` per requested constraint index, in the
+/// same order as `constraint_indices`.
 ///
 /// `trace_matrix` is row-indexed: `trace_matrix[row][col]`.
 #[allow(clippy::arithmetic_side_effects)]
-pub fn compute_combined_polynomials<F, U>(
+pub fn evaluate_for_constraints<F, U>(
     trace_matrix: &RowMajorTrace<F>,
     projected_scalars: &HashMap<U::Scalar, DynamicPolynomialF<F>>,
     num_constraints: usize,
     field_cfg: &F::Config,
-    skip_constraints: &[bool],
-) -> Vec<Vec<DenseMultilinearExtension<F::Inner>>>
+    constraint_indices: &[usize],
+    evaluation_point: &[F],
+) -> Result<Vec<DynamicPolynomialF<F>>, PolyArithErrors>
 where
-    F: PrimeField,
+    F: InnerTransparentField,
     U: Uair,
 {
     let field_zero = F::zero_with_cfg(field_cfg);
@@ -45,69 +52,120 @@ where
 
     let num_rows = trace_matrix.len();
 
-    let mut max_degrees_and_combined_poly_rows: Vec<(usize, Vec<DynamicPolynomialF<F>>)> =
-        cfg_into_iter!(0..num_rows - 1)
-            .map(|row_idx| {
-                let up = &trace_matrix[row_idx];
+    // Evaluate all constraints at every row of the trace.
+    //
+    // `constrain_general` is monolithic - it produces all `num_constraints`
+    // values per call.  We keep the full vectors and select only the
+    // requested `constraint_indices` further down.
+    //
+    // `all_rows[row_idx][constraint_idx]` is a `DynamicPolynomialF<F>`:
+    // the combined polynomial value of constraint `constraint_idx` at
+    // trace row `row_idx`.
+    let mut all_rows: Vec<Vec<DynamicPolynomialF<F>>> = cfg_into_iter!(0..num_rows - 1)
+        .map(|row_idx| {
+            let up = &trace_matrix[row_idx];
 
-                let down: Vec<DynamicPolynomialF<F>> = uair_sig
-                    .shifts()
-                    .iter()
-                    .map(|spec| {
-                        if row_idx + spec.shift_amount() < num_rows {
-                            trace_matrix[row_idx + spec.shift_amount()][spec.source_col()].clone()
-                        } else {
-                            DynamicPolynomialF::zero() // zero padding
-                        }
+            let down: Vec<DynamicPolynomialF<F>> = uair_sig
+                .shifts()
+                .iter()
+                .map(|spec| {
+                    if row_idx + spec.shift_amount() < num_rows {
+                        trace_matrix[row_idx + spec.shift_amount()][spec.source_col()].clone()
+                    } else {
+                        DynamicPolynomialF::zero() // zero padding
+                    }
+                })
+                .collect();
+
+            evaluate_constraints_for_row::<F, U>(
+                up,
+                &down,
+                num_constraints,
+                projected_scalars,
+                down_layout,
+            )
+        })
+        .collect();
+
+    // Zero-pad to 2^num_vars evaluations for the MLE.
+    // TODO(Ilia): reimplement using Albert's idea with selector polynomials.
+    all_rows.push(vec![DynamicPolynomialF::zero(); num_constraints]);
+
+    // Determine the maximum polynomial degree across the selected
+    // constraints and all rows.  This controls how many coefficient MLEs
+    // we build per constraint (one MLE per coefficient 0..=max_degree).
+    let max_degree = all_rows
+        .iter()
+        .flat_map(|row| {
+            constraint_indices
+                .iter()
+                .map(|&ci| row[ci].degree().unwrap_or(0))
+        })
+        .max()
+        .unwrap_or(0);
+
+    let zero_inner = field_zero.inner();
+
+    // For each selected constraint, build its coefficient MLEs.
+    //
+    // Each combined polynomial value at row `b` is a univariate in X:
+    //   c(b, X) = c_0(b) + c_1(b) X + ... + c_d(b) X^d.
+    //
+    // For a fixed coefficient index `coeff`, the MLE is the multilinear
+    // extension of the table  b -> c_coeff(b)  over the Boolean hypercube.
+    let coeff_mles: Vec<Vec<DenseMultilinearExtension<F::Inner>>> =
+        cfg_into_iter!(0..constraint_indices.len())
+            .map(|sel_idx| {
+                let ci = constraint_indices[sel_idx];
+                (0..=max_degree)
+                    .map(|coeff| {
+                        all_rows
+                            .iter()
+                            .map(|row| {
+                                row[ci]
+                                    .coeffs
+                                    .get(coeff)
+                                    .map(|c| c.inner().clone())
+                                    .unwrap_or_else(|| zero_inner.clone())
+                            })
+                            .collect_dense_mle_with_zero(zero_inner)
                     })
-                    .collect();
-
-                combine_rows_and_get_max_degree::<F, U>(
-                    up,
-                    &down,
-                    num_constraints,
-                    projected_scalars,
-                    down_layout,
-                )
+                    .collect()
             })
             .collect();
 
-    let max_degree = *max_degrees_and_combined_poly_rows
-        .iter()
-        .map(|(max_degree, _)| max_degree)
-        .max()
-        .expect("We assume the number of constraints is not zero so this iterator is not empty");
+    // Step 4: Evaluate each coefficient MLE at the challenge point `r`.
+    //
+    // Uses the precomputed eq table eq(r, ·) so that evaluating one MLE
+    // is a single inner product.  Reassembling the per-coefficient results
+    // gives the univariate  sum_b eq(r, b) * c(b, X)  for each selected
+    // constraint.
+    let eq_table = build_eq_x_r_vec(evaluation_point, field_cfg)?;
 
-    // For the sake of padding we duplicate
-    // the last combined value
-    // to have N-sized mle at the end
-    // not N-1.
-    // This is essentially c^up and c^down
-    // thing from the whirlaway.
-    // TODO(Ilia): reimplement it using Albert's idea
-    //             with selector polynomials.
-    max_degrees_and_combined_poly_rows.push((0, vec![DynamicPolynomialF::zero(); num_constraints]));
+    let values: Vec<DynamicPolynomialF<F>> = cfg_into_iter!(coeff_mles)
+        .map(|mles| {
+            let coeffs: Vec<F> = mles
+                .into_iter()
+                .map(|mle| {
+                    zinc_poly::utils::mle_eval_with_eq_table(&mle.evaluations, &eq_table, field_cfg)
+                })
+                .collect();
+            DynamicPolynomialF::new_trimmed(coeffs)
+        })
+        .collect();
 
-    prepare_coefficient_mles(
-        num_constraints,
-        max_degree,
-        &max_degrees_and_combined_poly_rows,
-        field_zero.inner(),
-        skip_constraints,
-    )
+    Ok(values)
 }
 
-/// Apply combination polynomial to each row
-/// and compute the maximum degree of resulting polynomials
-/// to pad the resulting vector of MLEs accordingly.
+/// Evaluate all UAIR constraints for a single row and return trimmed results.
 #[allow(clippy::arithmetic_side_effects)]
-fn combine_rows_and_get_max_degree<F, U>(
+fn evaluate_constraints_for_row<F, U>(
     up: &[DynamicPolynomialF<F>],
     down: &[DynamicPolynomialF<F>],
     num_constraints: usize,
     projected_scalars: &HashMap<U::Scalar, DynamicPolynomialF<F>>,
     down_layout: &ColumnLayout,
-) -> (usize, Vec<DynamicPolynomialF<F>>)
+) -> Vec<DynamicPolynomialF<F>>
 where
     F: PrimeField,
     U: Uair,
@@ -131,51 +189,8 @@ where
     );
 
     let mut combined_evaluations = constraint_builder.combined_evaluations;
-
     combined_evaluations.iter_mut().for_each(|eval| eval.trim());
-
-    let max_degree = combined_evaluations
-        .iter()
-        .map(|eval| eval.degree().unwrap_or(0))
-        .max()
-        .expect("We assume the number of constraints is not zero so this iterator is not empty");
-
-    (max_degree, combined_evaluations)
-}
-
-/// Turn the resulting slice of vectors of dynamic polynomials
-/// into a vector of vectors of coefficient MLEs.
-fn prepare_coefficient_mles<F: PrimeField>(
-    num_constraints: usize,
-    max_degree: usize,
-    max_degrees_and_combined_poly_rows: &[(usize, Vec<DynamicPolynomialF<F>>)],
-    zero_as_field_inner: &F::Inner,
-    skip_constraints: &[bool],
-) -> Vec<Vec<DenseMultilinearExtension<F::Inner>>> {
-    cfg_into_iter!(0..num_constraints)
-        .map(|constraint| {
-            // Skip building coefficient MLEs for zero-ideal constraints.
-            // For an honest prover these MLEs are zero; the combined
-            // polynomial resolver handles the zero entries downstream.
-            if skip_constraints[constraint] {
-                return vec![];
-            }
-            (0..=max_degree)
-                .map(|coeff| {
-                    max_degrees_and_combined_poly_rows
-                        .iter()
-                        .map(|(_, row)| {
-                            if coeff >= row[constraint].coeffs.len() {
-                                zero_as_field_inner.clone()
-                            } else {
-                                row[constraint].coeffs[coeff].inner().clone()
-                            }
-                        })
-                        .collect_dense_mle_with_zero(zero_as_field_inner)
-                })
-                .collect()
-        })
-        .collect()
+    combined_evaluations
 }
 
 /// For linear UAIRs, evaluate combined polynomials directly

--- a/piop/src/ideal_check/combined_poly_builder.rs
+++ b/piop/src/ideal_check/combined_poly_builder.rs
@@ -13,11 +13,7 @@ use zinc_poly::{
     univariate::dynamic::over_field::DynamicPolynomialF,
     utils::{ArithErrors as PolyArithErrors, build_eq_x_r_vec},
 };
-use zinc_uair::{
-    ColumnLayout, ConstraintBuilder, TraceRow, Uair,
-    degree_counter::{count_constraint_degrees, count_max_degree},
-    ideal::ImpossibleIdeal,
-};
+use zinc_uair::{ColumnLayout, ConstraintBuilder, TraceRow, Uair, ideal::ImpossibleIdeal};
 use zinc_utils::{
     cfg_into_iter, cfg_iter, from_ref::FromRef, inner_transparent_field::InnerTransparentField,
 };
@@ -193,14 +189,18 @@ where
     combined_evaluations
 }
 
-/// For linear UAIRs, evaluate combined polynomials directly
-/// by first evaluating trace column MLEs at the evaluation point,
-/// then applying UAIR constraints to the evaluated values.
+/// Evaluate combined polynomials by first evaluating trace column MLEs at the
+/// evaluation point, then applying UAIR constraints to the evaluated values.
 ///
-/// This avoids building the full combined polynomial MLEs row by row
-/// and is more efficient for linear constraints because the evaluation
-/// of a linear combination of MLEs equals the linear combination of
-/// individual MLE evaluations.
+/// This avoids building per-row combined polynomials and is faster than
+/// `evaluate_for_constraints`. The technique relies on the evaluation of a
+/// linear combination of MLEs equalling the linear combination of individual
+/// MLE evaluations, so the entries of the returned vector are only correct
+/// for constraints that are linear in the column values; non-linear entries
+/// are garbage and must be ignored by the caller. The prover-side caller
+/// [`crate::ideal_check`] partitions constraints by degree and reads only
+/// the linear indices from this output, routing non-linear constraints
+/// through [`evaluate_for_constraints`] instead.
 ///
 /// `trace_matrix` is column-indexed: `trace_matrix[col]` is an MLE.
 ///
@@ -222,13 +222,6 @@ where
     let zero_inner = field_zero.inner().clone();
     let num_rows = trace_matrix.first().map(|c| c.len()).unwrap_or(0);
     let num_vars = evaluation_point.len();
-
-    // Sanity check: this approach only works for linear constraints
-    if count_max_degree::<U>() > 1 {
-        return Err(EvaluationError::UnsupportedConstraintDegrees {
-            degrees: count_constraint_degrees::<U>(),
-        });
-    }
 
     // Maximum number of coefficients across all trace entries
     let max_num_coeffs = trace_matrix

--- a/piop/src/multipoint_eval.rs
+++ b/piop/src/multipoint_eval.rs
@@ -163,7 +163,7 @@ where
                                 trace_mles[i].evaluations[b].clone(),
                                 field_cfg,
                             );
-                            acc + gamma.clone() * eval_f
+                            acc + eval_f * gamma
                         })
                         .into_inner()
                 })

--- a/piop/src/projections.rs
+++ b/piop/src/projections.rs
@@ -16,7 +16,7 @@ use zinc_utils::{
 
 /// Row-indexed trace matrix: `trace[row][col]`.
 /// Each row contains all column values for that row.
-/// Used by `compute_combined_polynomials` for non-linear constraints.
+/// Used by `evaluate_for_constraints` for non-linear constraints.
 pub type RowMajorTrace<F> = Vec<Vec<DynamicPolynomialF<F>>>;
 
 /// Column-indexed trace matrix: `trace[col][row]`.

--- a/piop/src/projections.rs
+++ b/piop/src/projections.rs
@@ -16,12 +16,12 @@ use zinc_utils::{
 
 /// Row-indexed trace matrix: `trace[row][col]`.
 /// Each row contains all column values for that row.
-/// Used by `evaluate_for_constraints` for non-linear constraints.
+/// Used by `evaluate_for_constraints`.
 pub type RowMajorTrace<F> = Vec<Vec<DynamicPolynomialF<F>>>;
 
 /// Column-indexed trace matrix: `trace[col][row]`.
 /// Each column is a `DenseMultilinearExtension` over the hypercube.
-/// Used by `evaluate_combined_polynomials` for linear constraints (MLE-first).
+/// Used by `evaluate_combined_polynomials` (MLE-first approach).
 pub type ColumnMajorTrace<F> = Vec<DenseMultilinearExtension<DynamicPolynomialF<F>>>;
 
 /// Holds the projected trace in either row-major or column-major layout,
@@ -36,7 +36,7 @@ pub enum ProjectedTrace<F: PrimeField> {
 /// matrix. Result: `trace[row][col]` where columns are ordered as binary_poly,
 /// arbitrary_poly, int.
 ///
-/// Use this for the combined polynomial approach (non-linear constraints).
+/// Use this for the combined polynomial approach.
 #[allow(clippy::arithmetic_side_effects)]
 pub fn project_trace_coeffs_row_major<F, PolyCoeff, Int, const DEGREE_PLUS_ONE: usize>(
     trace: &UairTrace<PolyCoeff, Int, DEGREE_PLUS_ONE>,
@@ -127,7 +127,7 @@ where
 /// Result: `trace[col]` is a
 /// `DenseMultilinearExtension<DynamicPolynomialF<F>>`.
 ///
-/// Use this for the MLE-first approach (linear constraints only).
+/// Use this for the MLE-first approach.
 #[allow(clippy::arithmetic_side_effects)]
 pub fn project_trace_coeffs_column_major<F, PolyCoeff, Int, const DEGREE_PLUS_ONE: usize>(
     trace: &UairTrace<PolyCoeff, Int, DEGREE_PLUS_ONE>,
@@ -218,6 +218,24 @@ where
     );
 
     result
+}
+
+/// Transpose a column-indexed trace into a row-indexed trace.
+///
+/// `result[row][col] = trace[col].evaluations[row].clone()`. Used by the
+/// MLE-first prover when it needs to fall back to the row-major
+/// `evaluate_for_constraints` path for non-linear constraints.
+pub fn column_major_to_row_major<F: PrimeField>(trace: &ColumnMajorTrace<F>) -> RowMajorTrace<F> {
+    let num_rows = trace.first().map(|c| c.evaluations.len()).unwrap_or(0);
+
+    cfg_into_iter!(0..num_rows)
+        .map(|row_idx| {
+            trace
+                .iter()
+                .map(|col| col.evaluations[row_idx].clone())
+                .collect()
+        })
+        .collect()
 }
 
 /// Evaluate a projected trace along `F[X] -> F` and return column-indexed

--- a/piop/src/projections.rs
+++ b/piop/src/projections.rs
@@ -323,13 +323,9 @@ pub fn project_scalars<F: PrimeField, U: Uair>(
     uair_scalars
         .into_iter()
         .map(|scalar| {
-            (scalar.clone(), {
-                let mut dynamic_poly = project(&scalar);
-
-                dynamic_poly.trim();
-
-                dynamic_poly
-            })
+            let mut dynamic_poly = project(&scalar);
+            dynamic_poly.trim();
+            (scalar, dynamic_poly)
         })
         .collect()
 }

--- a/piop/src/test_utils.rs
+++ b/piop/src/test_utils.rs
@@ -70,7 +70,7 @@ where
 
     let trace = project_trace_coeffs_column_major::<F, _, _, DEGREE_PLUS_ONE>(trace, &field_cfg);
 
-    let (proof, state) = U::prove_linear(
+    let (proof, state) = U::prove_mle_first(
         transcript,
         &trace,
         &scalars,

--- a/poly/src/lib.rs
+++ b/poly/src/lib.rs
@@ -33,6 +33,4 @@ pub enum EvaluationError {
     Overflow,
     #[error("Empty polynomials are not allowed to be evaluate")]
     EmptyPolynomial,
-    #[error("Unsupported constraint degrees: {degrees:?}")]
-    UnsupportedConstraintDegrees { degrees: Vec<usize> },
 }

--- a/protocol/benches/e2e.rs
+++ b/protocol/benches/e2e.rs
@@ -28,7 +28,6 @@ use zinc_test_uair::{
 use zinc_transcript::traits::ConstTranscribable;
 use zinc_uair::{
     Uair, UairTrace,
-    degree_counter::count_max_degree,
     ideal::{DegreeOneIdeal, Ideal, IdealCheck},
     ideal_collector::IdealOrZero,
 };
@@ -56,7 +55,7 @@ const PERFORM_CHECKS: bool = if cfg!(feature = "unchecked") {
 };
 
 /// Repetition factor for linear code, an inverse rate.
-const REP: usize = 4;
+const REP_FACTOR: usize = 8;
 
 #[allow(clippy::type_complexity)]
 #[derive(Debug, Clone, Copy)]
@@ -122,7 +121,7 @@ where
     CombDotChal: InnerProduct<Comb, Chal, CombR> + Clone + Debug + Send + Sync,
     ArrCombRDotChal: InnerProduct<[CombR], Chal, CombR> + Clone + Debug + Send + Sync,
 {
-    const NUM_COLUMN_OPENINGS: usize = 147;
+    const NUM_COLUMN_OPENINGS: usize = 96;
     type Eval = Eval;
     type Cw = Cw;
     type Fmod = Fmod;
@@ -226,9 +225,9 @@ where
         MBSInnerProduct,
     >;
 
-    type BinaryLc = IprsCode<Self::BinaryZt, PnttConfigF65537, REP, PERFORM_CHECKS>;
-    type ArbitraryLc = IprsCode<Self::ArbitraryZt, PnttConfigF65537, REP, PERFORM_CHECKS>;
-    type IntLc = IprsCode<Self::IntZt, PnttConfigF65537, REP, PERFORM_CHECKS>;
+    type BinaryLc = IprsCode<Self::BinaryZt, PnttConfigF65537, REP_FACTOR, PERFORM_CHECKS>;
+    type ArbitraryLc = IprsCode<Self::ArbitraryZt, PnttConfigF65537, REP_FACTOR, PERFORM_CHECKS>;
+    type IntLc = IprsCode<Self::IntZt, PnttConfigF65537, REP_FACTOR, PERFORM_CHECKS>;
 }
 
 //

--- a/protocol/benches/e2e.rs
+++ b/protocol/benches/e2e.rs
@@ -345,10 +345,7 @@ fn do_bench_e2e<Zt, U, IdealOverF>(
     }
 
     bench_prove!("Prove (Combined)", false);
-
-    if count_max_degree::<U>() <= 1 {
-        bench_prove!("Prove (MLE-first)", true);
-    }
+    bench_prove!("Prove (MLE-first)", true);
 
     let proof: Proof<F> =
         <zinc_plus!()>::prove::<false, PERFORM_CHECKS>(pp, trace, num_vars, project_scalar)
@@ -446,6 +443,7 @@ fn do_bench_steps<Zt, U, IdealOverF>(
 
     let p_committed = <piop!()>::step0_commit(pp, trace, num_vars).unwrap();
     let p_projected = p_committed.clone().step1_combined(project_scalar).unwrap();
+    let p_projected_mle = p_committed.clone().step1_mle_first(project_scalar).unwrap();
     let p_ideal_checked = p_projected.clone().step2_ideal_check().unwrap();
     let p_eval_projected = p_ideal_checked.clone().step3_eval_projection().unwrap();
     let p_sumchecked = p_eval_projected.clone().step4_sumcheck().unwrap();
@@ -464,13 +462,11 @@ fn do_bench_steps<Zt, U, IdealOverF>(
         run = |s| s.step1_combined(project_scalar),
     );
 
-    if count_max_degree::<U>() <= 1 {
-        step_bench!(
-            "Prove" / "1: Prime projection (MLE-first)",
-            setup = || p_committed.clone(),
-            run = |s| s.step1_mle_first(project_scalar),
-        );
-    }
+    step_bench!(
+        "Prove" / "1: Prime projection (MLE-first)",
+        setup = || p_committed.clone(),
+        run = |s| s.step1_mle_first(project_scalar),
+    );
 
     step_bench!(
         "Prove" / "2: Ideal check (Combined)",
@@ -478,14 +474,11 @@ fn do_bench_steps<Zt, U, IdealOverF>(
         run = |s| s.step2_ideal_check(),
     );
 
-    if count_max_degree::<U>() <= 1 {
-        let p_projected_mle = p_committed.clone().step1_mle_first(project_scalar).unwrap();
-        step_bench!(
-            "Prove" / "2: Ideal check (MLE-first)",
-            setup = || p_projected_mle.clone(),
-            run = |s| s.step2_ideal_check(),
-        );
-    }
+    step_bench!(
+        "Prove" / "2: Ideal check (MLE-first)",
+        setup = || p_projected_mle.clone(),
+        run = |s| s.step2_ideal_check(),
+    );
 
     step_bench!(
         "Prove" / "3: Eval projection",

--- a/protocol/benches/e2e.rs
+++ b/protocol/benches/e2e.rs
@@ -121,7 +121,7 @@ where
     CombDotChal: InnerProduct<Comb, Chal, CombR> + Clone + Debug + Send + Sync,
     ArrCombRDotChal: InnerProduct<[CombR], Chal, CombR> + Clone + Debug + Send + Sync,
 {
-    const NUM_COLUMN_OPENINGS: usize = 96;
+    const NUM_COLUMN_OPENINGS: usize = 100;
     type Eval = Eval;
     type Cw = Cw;
     type Fmod = Fmod;

--- a/protocol/src/lib.rs
+++ b/protocol/src/lib.rs
@@ -457,7 +457,7 @@ mod tests {
     const K: usize = INT_LIMBS * 4;
     const M: usize = INT_LIMBS * 8;
 
-    const REP: usize = 8;
+    const REP_FACTOR: usize = 8;
 
     type F = MontyField<FIELD_LIMBS>;
 
@@ -568,9 +568,9 @@ mod tests {
         type ArbitraryZt = ArbitraryPolyZipTypesIprs;
         type IntZt = IntZipTypes;
 
-        type BinaryLc = IprsCode<Self::BinaryZt, PnttConfigF65537, REP, CHECKED>;
-        type ArbitraryLc = IprsCode<Self::ArbitraryZt, PnttConfigF65537, REP, CHECKED>;
-        type IntLc = IprsCode<Self::IntZt, PnttConfigF65537, REP, CHECKED>;
+        type BinaryLc = IprsCode<Self::BinaryZt, PnttConfigF65537, REP_FACTOR, CHECKED>;
+        type ArbitraryLc = IprsCode<Self::ArbitraryZt, PnttConfigF65537, REP_FACTOR, CHECKED>;
+        type IntLc = IprsCode<Self::IntZt, PnttConfigF65537, REP_FACTOR, CHECKED>;
     }
 
     #[derive(Copy, Clone)]
@@ -595,13 +595,15 @@ mod tests {
         type ArbitraryZt = ArbitraryPolyZipTypesRaa;
         type IntZt = IntZipTypes;
 
-        type BinaryLc = RaaCode<Self::BinaryZt, TestRaaConfig, REP>;
-        type ArbitraryLc = RaaCode<Self::ArbitraryZt, TestRaaConfig, REP>;
-        type IntLc = RaaCode<Self::IntZt, TestRaaConfig, REP>;
+        type BinaryLc = RaaCode<Self::BinaryZt, TestRaaConfig, REP_FACTOR>;
+        type ArbitraryLc = RaaCode<Self::ArbitraryZt, TestRaaConfig, REP_FACTOR>;
+        type IntLc = RaaCode<Self::IntZt, TestRaaConfig, REP_FACTOR>;
     }
 
     /// Use row size equal to poly size, resulting in flat single-row matrices
-    fn make_iprs<Zt: ZipTypes>(num_vars: usize) -> IprsCode<Zt, PnttConfigF65537, REP, CHECKED> {
+    fn make_iprs<Zt: ZipTypes>(
+        num_vars: usize,
+    ) -> IprsCode<Zt, PnttConfigF65537, REP_FACTOR, CHECKED> {
         let poly_size = 1 << num_vars;
         IprsCode::new_with_optimal_depth(poly_size).unwrap()
     }

--- a/protocol/src/lib.rs
+++ b/protocol/src/lib.rs
@@ -432,9 +432,7 @@ mod tests {
         BigLinearUair, BigLinearUairWithPublicInput, BinaryDecompositionUair, GenerateRandomTrace,
         TestUairMixedShifts, TestUairNoMultiplication, TestUairSimpleMultiplication,
     };
-    use zinc_uair::{
-        ideal::DegreeOneIdeal, ideal_collector::IdealOrZero,
-    };
+    use zinc_uair::{ideal::DegreeOneIdeal, ideal_collector::IdealOrZero};
     use zinc_utils::{
         CHECKED,
         from_ref::FromRef,
@@ -459,14 +457,14 @@ mod tests {
     const K: usize = INT_LIMBS * 4;
     const M: usize = INT_LIMBS * 8;
 
-    const REP: usize = 4;
+    const REP: usize = 8;
 
     type F = MontyField<FIELD_LIMBS>;
 
     #[derive(Debug, Clone)]
     pub struct BinPolyZipTypes {}
     impl ZipTypes for BinPolyZipTypes {
-        const NUM_COLUMN_OPENINGS: usize = 147;
+        const NUM_COLUMN_OPENINGS: usize = 96;
         type Eval = BinaryPoly<DEGREE_PLUS_ONE>;
         type Cw = DensePolynomial<i64, DEGREE_PLUS_ONE>;
         type Fmod = Uint<FIELD_LIMBS>;
@@ -489,7 +487,7 @@ mod tests {
     #[derive(Debug, Clone)]
     pub struct ArbitraryPolyZipTypesIprs {}
     impl ZipTypes for ArbitraryPolyZipTypesIprs {
-        const NUM_COLUMN_OPENINGS: usize = 147;
+        const NUM_COLUMN_OPENINGS: usize = 96;
         type Eval = DensePolynomial<i64, DEGREE_PLUS_ONE>;
         type Cw = DensePolynomial<i64, DEGREE_PLUS_ONE>;
         type Fmod = Uint<FIELD_LIMBS>;
@@ -515,7 +513,7 @@ mod tests {
     #[derive(Debug, Clone)]
     pub struct ArbitraryPolyZipTypesRaa {}
     impl ZipTypes for ArbitraryPolyZipTypesRaa {
-        const NUM_COLUMN_OPENINGS: usize = 147;
+        const NUM_COLUMN_OPENINGS: usize = 96;
         type Eval = DensePolynomial<i64, DEGREE_PLUS_ONE>;
         type Cw = DensePolynomial<Int<K>, DEGREE_PLUS_ONE>;
         type Fmod = Uint<FIELD_LIMBS>;
@@ -541,7 +539,7 @@ mod tests {
     #[derive(Debug, Clone)]
     pub struct IntZipTypes {}
     impl ZipTypes for IntZipTypes {
-        const NUM_COLUMN_OPENINGS: usize = 147;
+        const NUM_COLUMN_OPENINGS: usize = 96;
         type Eval = ZtInt;
         type Cw = i128;
         type Fmod = Uint<FIELD_LIMBS>;

--- a/protocol/src/lib.rs
+++ b/protocol/src/lib.rs
@@ -433,7 +433,7 @@ mod tests {
         TestUairMixedShifts, TestUairNoMultiplication, TestUairSimpleMultiplication,
     };
     use zinc_uair::{
-        degree_counter::count_max_degree, ideal::DegreeOneIdeal, ideal_collector::IdealOrZero,
+        ideal::DegreeOneIdeal, ideal_collector::IdealOrZero,
     };
     use zinc_utils::{
         CHECKED,
@@ -704,10 +704,7 @@ mod tests {
 
         run_protocol!(false);
 
-        if count_max_degree::<U>() <= 1 {
-            // For linear constraints, also test the MLE-first ideal check approach.
-            run_protocol!(true);
-        }
+        run_protocol!(true);
     }
 
     /// End-to-end test: TestUairNoMultiplication.

--- a/protocol/src/lib.rs
+++ b/protocol/src/lib.rs
@@ -430,7 +430,7 @@ mod tests {
     use zinc_primality::MillerRabin;
     use zinc_test_uair::{
         BigLinearUair, BigLinearUairWithPublicInput, BinaryDecompositionUair, GenerateRandomTrace,
-        TestUairMixedShifts, TestUairNoMultiplication, TestUairSimpleMultiplication,
+        ShaProxy, TestUairMixedShifts, TestUairNoMultiplication, TestUairSimpleMultiplication,
     };
     use zinc_uair::{ideal::DegreeOneIdeal, ideal_collector::IdealOrZero};
     use zinc_utils::{
@@ -707,10 +707,10 @@ mod tests {
         run_protocol!(true);
     }
 
-    /// End-to-end test: TestUairNoMultiplication.
+    /// End-to-end test: [`TestUairNoMultiplication`].
     ///
-    /// UAIR constraint: a + b - c \in (X - 2)
-    /// (one constraint, no polynomial multiplication, ideal = <X - 2>).
+    /// UAIR constraint: `a + b - c \in (X - 2)`
+    /// (one constraint, no polynomial multiplication, ideal = `<X - 2>`).
     #[test]
     fn test_e2e_no_multiplication() {
         let num_vars = 8;
@@ -727,12 +727,14 @@ mod tests {
         );
     }
 
-    /// End-to-end test: TestUairSimpleMultiplication.
+    /// End-to-end test: [`TestUairSimpleMultiplication`].
     ///
     /// UAIR constraints (3 total, no ideals):
+    /// ```
     ///   up[0] * up[1] = down[0]
     ///   up[1] * up[2] = down[1]
     ///   up[0] * up[2] = down[2]
+    /// ```
     ///
     /// Uses RAA code with small num_vars (2) because chained polynomial
     /// multiplication causes exponential growth in both degree and coefficient
@@ -754,10 +756,10 @@ mod tests {
         );
     }
 
-    /// End-to-end test: TestUairMixedShifts.
+    /// End-to-end test: [`TestUairMixedShifts`].
     ///
     /// Uses mixed shift amounts (col a: shift 1, col b: shift 2).
-    /// Constraints: a[i+1] = a[i] + b[i], c[i] = b[i+2].
+    /// Constraints: `a[i+1] = a[i] + b[i], c[i] = b[i+2]`.
     #[test]
     fn test_e2e_mixed_shifts() {
         let num_vars = 8;
@@ -774,10 +776,10 @@ mod tests {
         );
     }
 
-    /// End-to-end test: BinaryDecompositionUair.
+    /// End-to-end test: [`BinaryDecompositionUair`].
     ///
     /// Uses binary_poly (1 col) and int (1 col) trace types.
-    /// UAIR constraint: binary_poly[0] - int[0] \in <X - 2>
+    /// UAIR constraint: `binary_poly[0] - int[0] \in <X - 2>`
     #[test]
     fn test_e2e_binary_decomposition() {
         let num_vars = 8;
@@ -794,13 +796,15 @@ mod tests {
         );
     }
 
-    /// End-to-end test: BigLinearUair.
+    /// End-to-end test: [`BigLinearUair`].
     ///
     /// Uses 16 binary_poly cols and 1 int col.
     /// UAIR constraints:
+    /// ```
     ///   sum(up.binary_poly[0..16]) - up.int[0] \in <X - 1>
     ///   down.binary_poly[0] - up.int[0] \in <X - 2>
     ///   up.binary_poly[i] - down.binary_poly[i] = 0, for i=1..15
+    /// ```
     #[test]
     fn test_e2e_big_linear() {
         let num_vars = 8;
@@ -817,7 +821,7 @@ mod tests {
         );
     }
 
-    /// End-to-end test: BigLinearUairWithPublicInput.
+    /// End-to-end test: [`BigLinearUairWithPublicInput`].
     ///
     /// Same as [`BigLinearUair`], but with the first few binary_poly columns as
     /// public inputs.
@@ -825,6 +829,34 @@ mod tests {
     fn test_e2e_big_linear_with_public_input() {
         let num_vars = 8;
         do_test::<TestZincTypesIprs, BigLinearUairWithPublicInput<ZtInt>>(
+            num_vars,
+            (
+                make_iprs(num_vars),
+                make_iprs(num_vars),
+                make_iprs(num_vars),
+            ),
+            default_project_ideal!(),
+            |_| {},
+            |res| res.unwrap(),
+        );
+    }
+
+    /// End-to-end test: [`ShaProxy`].
+    ///
+    /// SHA-flavored benchmarking UAIR: 14 binary_poly cols, 4 int cols, with
+    /// asymmetric shifts (`bp[0]` by 1, `bp[4]` by 4). UAIR constraints:
+    /// ```
+    ///   bp[0][t+1] - bp[1] - bp[2] - bp[3] - int[0] - int[1] - int[2] \in <X - 2>
+    ///   bp[4][t+4] - bp[5] - bp[6] - bp[7] - int[1] - int[2] - int[3] \in <X - 2>
+    ///   bp[8] - int[0] \in <X - 2>
+    ///   bp[9] - int[1] \in <X - 2>
+    ///   bp[10] - X * bp[11] \in <X - 1>
+    ///   bp[12] - X * bp[13] \in <X - 1>
+    /// ```
+    #[test]
+    fn test_e2e_sha_proxy() {
+        let num_vars = 8;
+        do_test::<TestZincTypesIprs, ShaProxy<ZtInt>>(
             num_vars,
             (
                 make_iprs(num_vars),

--- a/protocol/src/lib.rs
+++ b/protocol/src/lib.rs
@@ -464,7 +464,7 @@ mod tests {
     #[derive(Debug, Clone)]
     pub struct BinPolyZipTypes {}
     impl ZipTypes for BinPolyZipTypes {
-        const NUM_COLUMN_OPENINGS: usize = 96;
+        const NUM_COLUMN_OPENINGS: usize = 100;
         type Eval = BinaryPoly<DEGREE_PLUS_ONE>;
         type Cw = DensePolynomial<i64, DEGREE_PLUS_ONE>;
         type Fmod = Uint<FIELD_LIMBS>;
@@ -487,7 +487,7 @@ mod tests {
     #[derive(Debug, Clone)]
     pub struct ArbitraryPolyZipTypesIprs {}
     impl ZipTypes for ArbitraryPolyZipTypesIprs {
-        const NUM_COLUMN_OPENINGS: usize = 96;
+        const NUM_COLUMN_OPENINGS: usize = 100;
         type Eval = DensePolynomial<i64, DEGREE_PLUS_ONE>;
         type Cw = DensePolynomial<i64, DEGREE_PLUS_ONE>;
         type Fmod = Uint<FIELD_LIMBS>;
@@ -513,7 +513,7 @@ mod tests {
     #[derive(Debug, Clone)]
     pub struct ArbitraryPolyZipTypesRaa {}
     impl ZipTypes for ArbitraryPolyZipTypesRaa {
-        const NUM_COLUMN_OPENINGS: usize = 96;
+        const NUM_COLUMN_OPENINGS: usize = 100;
         type Eval = DensePolynomial<i64, DEGREE_PLUS_ONE>;
         type Cw = DensePolynomial<Int<K>, DEGREE_PLUS_ONE>;
         type Fmod = Uint<FIELD_LIMBS>;
@@ -539,7 +539,7 @@ mod tests {
     #[derive(Debug, Clone)]
     pub struct IntZipTypes {}
     impl ZipTypes for IntZipTypes {
-        const NUM_COLUMN_OPENINGS: usize = 96;
+        const NUM_COLUMN_OPENINGS: usize = 100;
         type Eval = ZtInt;
         type Cw = i128;
         type Fmod = Uint<FIELD_LIMBS>;

--- a/protocol/src/prover.rs
+++ b/protocol/src/prover.rs
@@ -361,7 +361,7 @@ impl_with_type_bounds!(ProverProjectedMleFirst
     ) -> Result<ProverIdealChecked<'a, Zt, U, F, D>, ProtocolError<F, U::Ideal>> {
         let num_constraints = count_constraints::<U>();
 
-        let (ic_proof, ic_prover_state) = U::prove_linear(
+        let (ic_proof, ic_prover_state) = U::prove_mle_first(
             &mut self.base.pcs_transcript.fs_transcript,
             &self.projected_trace,
             &self.projected_scalars_fx,

--- a/protocol/src/prover.rs
+++ b/protocol/src/prover.rs
@@ -306,7 +306,6 @@ impl_with_type_bounds!(ProverBase
     /// Step 1 (MLE-first / column-major): Prime projection
     /// (`\phi_q`: `Z[X] -> F_q[X]`). Samples a random prime, projects the
     /// full trace and scalars using the column-major layout.
-    /// Only suitable for linear constraints.
     pub fn step1_mle_first<S: Fn(&U::Scalar, &F::Config) -> DynamicPolynomialF<F>>(
         mut self,
         project_scalar: S,
@@ -354,8 +353,12 @@ impl_with_type_bounds!(ProverProjectedCombined
 
 impl_with_type_bounds!(ProverProjectedMleFirst
 {
-    /// Step 2 (MLE-first): Ideal check via `prove_linear` on the column-major
-    /// trace. Only suitable for linear constraints.
+    /// Step 2 (MLE-first): Ideal check via `prove_mle_first` on the
+    /// column-major trace. Works for any UAIR: linear non-zero-ideal
+    /// constraints go through the column-major MLE-first path, non-linear
+    /// non-zero-ideal constraints fall back to the row-major path (with an
+    /// internal transpose), and zero-ideal constraints are short-circuited
+    /// to zero.
     pub fn step2_ideal_check(
         mut self,
     ) -> Result<ProverIdealChecked<'a, Zt, U, F, D>, ProtocolError<F, U::Ideal>> {

--- a/zip-plus/benches/zip_benches.rs
+++ b/zip-plus/benches/zip_benches.rs
@@ -22,10 +22,12 @@ const PERFORM_CHECKS: bool = if cfg!(feature = "unchecked") {
 
 const INT_LIMBS: usize = U64::LIMBS;
 
+const REP_FACTOR: usize = 8;
+
 #[derive(Debug, Clone)]
 struct BenchZipTypes {}
 impl ZipTypes for BenchZipTypes {
-    const NUM_COLUMN_OPENINGS: usize = 147;
+    const NUM_COLUMN_OPENINGS: usize = 96;
     type Eval = i32;
     type Cw = i128;
     type Fmod = Uint<{ INT_LIMBS * 4 }>;
@@ -39,7 +41,7 @@ impl ZipTypes for BenchZipTypes {
     type ArrCombRDotChal = MBSInnerProduct;
 }
 
-type BenchIprsCode = IprsCode<BenchZipTypes, PnttConfigF65537, 4, PERFORM_CHECKS>;
+type BenchIprsCode = IprsCode<BenchZipTypes, PnttConfigF65537, REP_FACTOR, PERFORM_CHECKS>;
 
 fn zip_benchmarks(c: &mut Criterion) {
     let mut group = c.benchmark_group("Zip+ IPRS");

--- a/zip-plus/benches/zip_benches.rs
+++ b/zip-plus/benches/zip_benches.rs
@@ -27,7 +27,7 @@ const REP_FACTOR: usize = 8;
 #[derive(Debug, Clone)]
 struct BenchZipTypes {}
 impl ZipTypes for BenchZipTypes {
-    const NUM_COLUMN_OPENINGS: usize = 96;
+    const NUM_COLUMN_OPENINGS: usize = 100;
     type Eval = i32;
     type Cw = i128;
     type Fmod = Uint<{ INT_LIMBS * 4 }>;

--- a/zip-plus/benches/zip_plus_benches.rs
+++ b/zip-plus/benches/zip_plus_benches.rs
@@ -34,6 +34,8 @@ const PERFORM_CHECKS: bool = if cfg!(feature = "unchecked") {
 
 const INT_LIMBS: usize = U64::LIMBS;
 
+const REP_FACTOR: usize = 8;
+
 #[derive(Debug, Clone)]
 struct BenchZipPlusTypes<CwCoeff, const D_PLUS_ONE: usize>(PhantomData<CwCoeff>);
 
@@ -49,7 +51,7 @@ where
         + Sync,
     Int<5>: FromRef<CwCoeff>,
 {
-    const NUM_COLUMN_OPENINGS: usize = 147;
+    const NUM_COLUMN_OPENINGS: usize = 96;
     type Eval = BinaryPoly<D_PLUS_ONE>;
     type Cw = DensePolynomial<CwCoeff, D_PLUS_ONE>;
     type Fmod = Uint<{ INT_LIMBS * 4 }>;
@@ -72,10 +74,10 @@ impl RaaConfig for BenchRaaConfig {
 }
 
 type BenchRaaCode<const D_PLUS_ONE: usize> =
-    RaaCode<BenchZipPlusTypes<i32, D_PLUS_ONE>, BenchRaaConfig, 4>;
+    RaaCode<BenchZipPlusTypes<i32, D_PLUS_ONE>, BenchRaaConfig, REP_FACTOR>;
 
 type BenchIprsCode<Twiddle, const D_PLUS_ONE: usize> =
-    IprsCode<BenchZipPlusTypes<Twiddle, D_PLUS_ONE>, PnttConfigF65537, 4, PERFORM_CHECKS>;
+    IprsCode<BenchZipPlusTypes<Twiddle, D_PLUS_ONE>, PnttConfigF65537, REP_FACTOR, PERFORM_CHECKS>;
 
 fn zip_plus_benchmarks_raa(c: &mut Criterion) {
     let mut group = c.benchmark_group("Zip+ RAA");

--- a/zip-plus/benches/zip_plus_benches.rs
+++ b/zip-plus/benches/zip_plus_benches.rs
@@ -51,7 +51,7 @@ where
         + Sync,
     Int<5>: FromRef<CwCoeff>,
 {
-    const NUM_COLUMN_OPENINGS: usize = 96;
+    const NUM_COLUMN_OPENINGS: usize = 100;
     type Eval = BinaryPoly<D_PLUS_ONE>;
     type Cw = DensePolynomial<CwCoeff, D_PLUS_ONE>;
     type Fmod = Uint<{ INT_LIMBS * 4 }>;

--- a/zip-plus/src/code/iprs.rs
+++ b/zip-plus/src/code/iprs.rs
@@ -258,7 +258,7 @@ mod tests {
         #[derive(Clone, Debug)]
         struct BenchZipTypes {}
         impl ZipTypes for BenchZipTypes {
-            const NUM_COLUMN_OPENINGS: usize = 147;
+            const NUM_COLUMN_OPENINGS: usize = 96;
             type Eval = i32;
             type Cw = i128;
             type Fmod = Uint<{ INT_LIMBS * 4 }>;
@@ -294,7 +294,7 @@ mod tests {
                 + Sync,
             Int<5>: FromRef<CwCoeff>,
         {
-            const NUM_COLUMN_OPENINGS: usize = 147;
+            const NUM_COLUMN_OPENINGS: usize = 96;
             type Eval = BinaryPoly<D_PLUS_ONE>;
             type Cw = DensePolynomial<CwCoeff, D_PLUS_ONE>;
             type Fmod = Uint<{ INT_LIMBS * 4 }>;

--- a/zip-plus/src/code/iprs.rs
+++ b/zip-plus/src/code/iprs.rs
@@ -258,7 +258,7 @@ mod tests {
         #[derive(Clone, Debug)]
         struct BenchZipTypes {}
         impl ZipTypes for BenchZipTypes {
-            const NUM_COLUMN_OPENINGS: usize = 96;
+            const NUM_COLUMN_OPENINGS: usize = 100;
             type Eval = i32;
             type Cw = i128;
             type Fmod = Uint<{ INT_LIMBS * 4 }>;
@@ -294,7 +294,7 @@ mod tests {
                 + Sync,
             Int<5>: FromRef<CwCoeff>,
         {
-            const NUM_COLUMN_OPENINGS: usize = 96;
+            const NUM_COLUMN_OPENINGS: usize = 100;
             type Eval = BinaryPoly<D_PLUS_ONE>;
             type Cw = DensePolynomial<CwCoeff, D_PLUS_ONE>;
             type Fmod = Uint<{ INT_LIMBS * 4 }>;

--- a/zip-plus/src/pcs/structs.rs
+++ b/zip-plus/src/pcs/structs.rs
@@ -13,6 +13,7 @@ use zinc_utils::{
 };
 
 pub trait ZipTypes: Clone + Debug + Send + Sync {
+    /// For IPRS codes, 2^{-security_parameter} = rate^{num_openings / 3}
     const NUM_COLUMN_OPENINGS: usize;
 
     /// Semiring of witness/polynomial evaluations on boolean hypercube

--- a/zip-plus/src/pcs/test_utils.rs
+++ b/zip-plus/src/pcs/test_utils.rs
@@ -41,14 +41,14 @@ pub const IPRS_DEPTH: usize = 1;
 pub const IPRS_ROW_LEN: usize = 32 * (1 << (3 * IPRS_DEPTH)); // I.e. BASE_DIM = 32
 
 /// Linear code repetition factor (inverse rate).
-pub const REP_FACTOR: usize = 4;
+pub const REP_FACTOR: usize = 8;
 
 pub type TestIprsConfig = PnttConfigF65537;
 
 #[derive(Debug, Clone)]
 pub struct TestZipTypes<const N: usize, const K: usize, const M: usize> {}
 impl<const N: usize, const K: usize, const M: usize> ZipTypes for TestZipTypes<N, K, M> {
-    const NUM_COLUMN_OPENINGS: usize = 147;
+    const NUM_COLUMN_OPENINGS: usize = 96;
     type Eval = Int<N>;
     type Cw = Int<K>;
     type Fmod = Uint<K>;
@@ -67,7 +67,7 @@ pub struct TestBinPolyZipTypes<const K: usize, const M: usize, const DEGREE_PLUS
 impl<const K: usize, const M: usize, const DEGREE_PLUS_ONE: usize> ZipTypes
     for TestBinPolyZipTypes<K, M, DEGREE_PLUS_ONE>
 {
-    const NUM_COLUMN_OPENINGS: usize = 147;
+    const NUM_COLUMN_OPENINGS: usize = 96;
     type Eval = BinaryPoly<DEGREE_PLUS_ONE>;
     type Cw = DensePolynomial<i64, DEGREE_PLUS_ONE>;
     type Fmod = Uint<K>;

--- a/zip-plus/src/pcs/test_utils.rs
+++ b/zip-plus/src/pcs/test_utils.rs
@@ -48,7 +48,7 @@ pub type TestIprsConfig = PnttConfigF65537;
 #[derive(Debug, Clone)]
 pub struct TestZipTypes<const N: usize, const K: usize, const M: usize> {}
 impl<const N: usize, const K: usize, const M: usize> ZipTypes for TestZipTypes<N, K, M> {
-    const NUM_COLUMN_OPENINGS: usize = 96;
+    const NUM_COLUMN_OPENINGS: usize = 100;
     type Eval = Int<N>;
     type Cw = Int<K>;
     type Fmod = Uint<K>;
@@ -67,7 +67,7 @@ pub struct TestBinPolyZipTypes<const K: usize, const M: usize, const DEGREE_PLUS
 impl<const K: usize, const M: usize, const DEGREE_PLUS_ONE: usize> ZipTypes
     for TestBinPolyZipTypes<K, M, DEGREE_PLUS_ONE>
 {
-    const NUM_COLUMN_OPENINGS: usize = 96;
+    const NUM_COLUMN_OPENINGS: usize = 100;
     type Eval = BinaryPoly<DEGREE_PLUS_ONE>;
     type Cw = DensePolynomial<i64, DEGREE_PLUS_ONE>;
     type Fmod = Uint<K>;


### PR DESCRIPTION
1. In MLE-first approach, when the ideal is zero, the ideal check computation can be skipped - we know that the MLE evaluation is supposed to be 0, so P does not need to compute it: it just sends 0.
    * This only allows skippping MLE evaluation if ALL ideals are 0.
    * In combined polynomial ideal check, this was already handled but with more granularity - all zero ideal constraints were skipped while keeping non-zero ones.
2. Reworked MLE-first approach to handle linear constraints in MLE-first way while the rest are going through the regular combined subroutine. This allows using MLE-first approach for UAIRs with non-linear constraints.
3. Use IPRS code with rate 1/8 instead of 1/4, while also lowering number of column openings to 100 instead of 147.

Overall effect on E2E benchmarks (2^8 vars, parallel mode):
* Prover time (both combined and MLE-first) stayed pretty much the same
* Verifier time worsened by around to ~10%
* Proofs became smaller by ~30-40%, both compressed and uncompressed