### PR TITLE
Fix rustdoc warnings

### DIFF
--- a/piop/src/combined_poly_resolver.rs
+++ b/piop/src/combined_poly_resolver.rs
@@ -47,13 +47,15 @@ impl<F: InnerTransparentField + FromPrimitiveWithConfig + Send + Sync> CombinedP
     /// polynomial identity:
     ///
     /// $$
-    /// \sum_{b \in H} (f_0(b, x_0[b],...,x_n[b], x_0ˆdown[b],...,x_nˆdown[b])
+    /// \sum_{b \in H} (f_0(b, x_0\[b\],...,x_n\[b\],
+    /// x_0ˆdown\[b\],...,x_nˆdown\[b\])
     ///                 + \alpha f_1(...) + ... + \alpha^k f_k(...)) = v_0 +
     ///                   \alpha * v_1 + ... + \alphaˆk * v_k,
     /// $$
-    /// where $f_i(b, x_0[b],...,x_n[b], x_0ˆdown[b],...,x_nˆdown[b])
+    /// where $f_i(b, x_0\[b\],...,x_n\[b\], x_0ˆdown\[b\],...,x_nˆdown\[b\])
     ///         = eq(r, b) * (1 - eq(r, 1,...1))
-    ///             * g_i(x_0[b],...,x_n[b], x_0ˆdown[b],...,x_nˆdown[b])$
+    ///             * g_i(x_0\[b\],...,x_n\[b\],
+    ///               x_0ˆdown\[b\],...,x_nˆdown\[b\])$
     /// and `g_i` is a constraint polynomial given by the UAIR `U`.
     /// `v_0,...,v_k` are the claimed evaluations of the combined polynomials.
     ///
@@ -191,8 +193,8 @@ impl<F: InnerTransparentField + FromPrimitiveWithConfig + Send + Sync> CombinedP
     /// - `transcript`: FS-transcript (absorbs `up_evals` and `down_evals`).
     /// - `sumcheck_prover_state`: The CPR group's `ProverState` from
     ///   `MultiDegreeSumcheck::prove_as_subprotocol` (states\[0\]).
-    /// - `ancillary`: Produced by [`prepare_sumcheck_group`]; carries column
-    ///   counts and `num_vars` needed to split the flat eval vector.
+    /// - `ancillary`: Produced by [`Self::prepare_sumcheck_group`]; carries
+    ///   column counts and `num_vars` needed to split the flat eval vector.
     /// - `field_cfg`: Field configuration.
     #[allow(clippy::arithmetic_side_effects)]
     pub fn finalize_prover(
@@ -250,8 +252,9 @@ impl<F: InnerTransparentField + FromPrimitiveWithConfig + Send + Sync> CombinedP
 
     /// Pre-sumcheck half of the CPR verifier.
     ///
-    /// Must run before [`MultiDegreeSumcheck::verify_as_subprotocol`] to
-    /// maintain transcript ordering (samples folding challenge α here).
+    /// Must run before
+    /// [`crate::sumcheck::multi_degree::MultiDegreeSumcheck::verify_as_subprotocol`]
+    /// to maintain transcript ordering (samples folding challenge α here).
     ///
     /// # Parameters
     /// - `transcript`: FS-transcript.
@@ -338,8 +341,9 @@ impl<F: InnerTransparentField + FromPrimitiveWithConfig + Send + Sync> CombinedP
 
     /// Post-sumcheck half of the CPR verifier.
     ///
-    /// Runs after [`MultiDegreeSumcheck::verify_as_subprotocol`] produces the
-    /// shared evaluation point.
+    /// Runs after
+    /// [`crate::sumcheck::multi_degree::MultiDegreeSumcheck::verify_as_subprotocol`]
+    /// produces the shared evaluation point.
     ///
     /// # Parameters
     /// - `transcript`: FS-transcript (absorbs `up_evals` and `down_evals`).
@@ -348,7 +352,7 @@ impl<F: InnerTransparentField + FromPrimitiveWithConfig + Send + Sync> CombinedP
     ///   sumcheck.
     /// - `expected_evaluation`: `md_subclaims.expected_evaluations()[0]` — the
     ///   expected value of the CPR combination function at `r*`.
-    /// - `ancillary`: Produced by [`prepare_verifier`]; carries folding
+    /// - `ancillary`: Produced by [`Self::prepare_verifier`]; carries folding
     ///   challenge powers, ideal-check evaluation point, and `num_vars`.
     /// - `projected_scalars`: UAIR scalars projected to `F`.
     /// - `field_cfg`: Field configuration.

--- a/piop/src/multipoint_eval.rs
+++ b/piop/src/multipoint_eval.rs
@@ -24,7 +24,7 @@
 //!
 //! This corresponds to the T=2 case of Pi_{BMLE} in the paper. Following
 //! the paper, the prover sends only the polynomial-valued lifted evaluations
-//! (alpha'_j in F_q[X]); the scalar open_evals are derived by the verifier
+//! (alpha'_j in F_q\[X\]); the scalar open_evals are derived by the verifier
 //! via \psi_a rather than being sent as a separate proof element.
 
 #[cfg(feature = "parallel")]

--- a/piop/src/projections.rs
+++ b/piop/src/projections.rs
@@ -32,9 +32,9 @@ pub enum ProjectedTrace<F: PrimeField> {
     ColumnMajor(ColumnMajorTrace<F>),
 }
 
-/// Project a multi-typed trace onto F[X], returning a row-indexed (transposed)
-/// matrix. Result: `trace[row][col]` where columns are ordered as binary_poly,
-/// arbitrary_poly, int.
+/// Project a multi-typed trace onto F\[X\], returning a row-indexed
+/// (transposed) matrix. Result: `trace[row][col]` where columns are ordered as
+/// binary_poly, arbitrary_poly, int.
 ///
 /// Use this for the combined polynomial approach (non-linear constraints).
 #[allow(clippy::arithmetic_side_effects)]
@@ -294,7 +294,7 @@ pub fn evaluate_trace_to_column_mles<F: PrimeField + 'static>(
     }
 }
 
-/// Project scalars of a UAIR onto F[X].
+/// Project scalars of a UAIR onto F\[X\].
 pub fn project_scalars<F: PrimeField, U: Uair>(
     project: impl Fn(&U::Scalar) -> DynamicPolynomialF<F>,
 ) -> HashMap<U::Scalar, DynamicPolynomialF<F>> {
@@ -316,7 +316,7 @@ pub fn project_scalars<F: PrimeField, U: Uair>(
         .collect()
 }
 
-/// Project scalars of a UAIR along F[X] -> F.
+/// Project scalars of a UAIR along F\[X\] -> F.
 #[allow(clippy::arithmetic_side_effects)]
 pub fn project_scalars_to_field<R: Semiring + 'static, F: PrimeField>(
     scalars: HashMap<R, DynamicPolynomialF<F>>,

--- a/poly/src/utils.rs
+++ b/poly/src/utils.rs
@@ -317,7 +317,7 @@ pub fn next_mle_inner<F: Field>(
 /// Evaluates the next MLE in O(n), by reusing suffix equality and prefix carry
 /// products across carry positions.
 ///
-/// Improved from O(n²) approach here: https://github.com/TomWambsgans/Whirlaway/blob/9e3592b/crates/air/src/utils.rs#L92
+/// Improved from O(n²) approach here: <https://github.com/TomWambsgans/Whirlaway/blob/9e3592b/crates/air/src/utils.rs#L92>
 ///
 /// `next_mle(u, v) = 1` iff `Val(v) = Val(u) + 1` and `Val(u) < 2^n - 1`.
 ///

--- a/protocol/src/lib.rs
+++ b/protocol/src/lib.rs
@@ -73,7 +73,7 @@ pub struct Proof<F: PrimeField> {
     /// Multi-point evaluation sumcheck proof (combines up_evals and
     /// down_evals at r' into a single evaluation point r_0).
     pub multipoint_eval: MultipointEvalProof<F>,
-    /// Witness-only polynomial MLE evaluations at r_0 in F_q[X]
+    /// Witness-only polynomial MLE evaluations at r_0 in F_q\[X\]
     /// (after \phi_q, before \psi_a), ordered as
     /// `[wit_bin..., wit_arb..., wit_int...]`.
     /// The verifier recomputes public lifted_evals from public data,

--- a/protocol/src/prover.rs
+++ b/protocol/src/prover.rs
@@ -60,7 +60,7 @@ pub struct ProverBase<'a, Zt: ZincTypes<D>, U: Uair, F: PrimeField, const D: usi
 // Type-state structs
 //
 
-/// After step 1 via [`step1_combined`](ProverCommitted::step1_combined)
+/// After step 1 via [`step1_combined`](ProverBase::step1_combined)
 /// (row-major / "combined" projection). `project_scalar` has been consumed.
 #[derive(Clone, Debug)]
 pub struct ProverProjectedCombined<'a, Zt: ZincTypes<D>, U: Uair, F: PrimeField, const D: usize> {
@@ -70,7 +70,7 @@ pub struct ProverProjectedCombined<'a, Zt: ZincTypes<D>, U: Uair, F: PrimeField,
     projected_scalars_fx: HashMap<U::Scalar, DynamicPolynomialF<F>>,
 }
 
-/// After step 1 via [`step1_mle_first`](ProverCommitted::step1_mle_first)
+/// After step 1 via [`step1_mle_first`](ProverBase::step1_mle_first)
 /// (column-major / MLE-first projection). `project_scalar` has been consumed.
 #[derive(Clone, Debug)]
 pub struct ProverProjectedMleFirst<'a, Zt: ZincTypes<D>, U: Uair, F: PrimeField, const D: usize> {

--- a/transcript/src/traits.rs
+++ b/transcript/src/traits.rs
@@ -107,8 +107,8 @@ impl<T: ConstTranscribable> Transcribable for T {
     }
 }
 
-/// Should not be used directly — use [`delegate_transcribable!`] or
-/// [`delegate_const_transcribable!`] instead.
+/// Should not be used directly — use [`crate::delegate_transcribable!`] or
+/// [`crate::delegate_const_transcribable!`] instead.
 #[macro_export]
 macro_rules! delegate_gen_transcribable {
     ($wrapper:ident { $field:tt : $inner_ty:ty }) => {
@@ -172,8 +172,8 @@ macro_rules! delegate_gen_transcribable {
 }
 
 /// Delegates `Transcribable` to the single inner field of a newtype.
-/// Use this instead of [`delegate_const_transcribable!`] when the inner type
-/// only implements `Transcribable` (e.g. `BoxedUint`).
+/// Use this instead of [`crate::delegate_const_transcribable!`] when the
+/// inner type only implements `Transcribable` (e.g. `BoxedUint`).
 ///
 /// Supports non-generic and generic types with optional `where` clauses:
 /// ```ignore

--- a/uair/src/lookup_types.rs
+++ b/uair/src/lookup_types.rs
@@ -3,8 +3,8 @@
 //! Pure data types describing which trace columns need lookup verification
 //! and against which table type. These live in `zinc-uair` because they
 //! belong to the AIR's structural interface — UAIRs declare them as part
-//! of [`UairSignature`] via `UairSignature::new(..., lookup_specs)`, the
-//! same way shifts are declared.
+//! of [`crate::UairSignature`] via `UairSignature::new(..., lookup_specs)`,
+//! the same way shifts are declared.
 
 /// Describes the type of lookup table a column should be checked against.
 /// Full table size = `2^width` for each type; decomposed into chunks of

--- a/zip-plus/src/code/raa.rs
+++ b/zip-plus/src/code/raa.rs
@@ -15,7 +15,7 @@ pub trait RaaConfig: Copy + Send + Sync {
 }
 
 /// Implementation of a repeat-accumulate-accumulate (RAA) codes over the binary
-/// field, as defined by the Blaze paper (https://eprint.iacr.org/2024/1609)
+/// field, as defined by the Blaze paper (<https://eprint.iacr.org/2024/1609>)
 #[derive(Clone)]
 pub struct RaaCode<Zt: ZipTypes, Config: RaaConfig, const REP: usize> {
     pub(crate) row_len: usize,

--- a/zip-plus/src/merkle.rs
+++ b/zip-plus/src/merkle.rs
@@ -358,7 +358,7 @@ impl MerkleProof {
         Ok(())
     }
 
-    /// Estimate the number of bytes that would be written to [[PcsTranscript]]
+    /// Estimate the number of bytes that would be written to the PCS transcript
     /// when an instance of this type is transcribed.
     #[allow(clippy::arithmetic_side_effects)] // Overflow isn't possible
     pub fn estimate_transcribed_size(merkle_tree_height: usize) -> usize {


### PR DESCRIPTION
Closes #180.

`cargo doc --workspace --all-features --no-deps` was emitting 30 warnings across 6 crates. This PR drives them to zero.

Categories of fixes:

- **Math notation parsed as broken intra-doc links.** `[b]`, `F[X]`, `F_q[X]` etc. inside doc comments triggered `unresolved link to b`/`X` warnings. Escaped the brackets with backslashes so rustdoc leaves them alone (KaTeX still renders fine inside `$...$`/`$$...$$`).
- **Bare URLs.** Wrapped two URLs in `<>` (`poly/src/utils.rs`, `zip-plus/src/code/raa.rs`) to silence `bare_urls`.
- **Intra-doc links to siblings/other modules.** Qualified `prepare_sumcheck_group` / `prepare_verifier` with `Self::`, and pointed `MultiDegreeSumcheck::verify_as_subprotocol` at its full crate path. Same treatment for `crate::UairSignature` in `uair/src/lookup_types.rs`.
- **Exported macros.** `delegate_transcribable!` / `delegate_const_transcribable!` resolve via `crate::` (rustdoc note: *macro_rules exists in this crate, but is not in scope at this link's location*).
- **Stale type names.** `ProverCommitted::step1_*` references in `protocol/src/prover.rs` updated to `ProverBase::step1_*` (the methods live on `ProverBase` per the `impl_with_type_bounds!(ProverBase ...)` block).
- **Typo'd link.** `[[PcsTranscript]]` in `zip-plus/src/merkle.rs` referenced a type that doesn't exist; replaced with prose since the helper applies to both `PcsProverTranscript` and `PcsVerifierTranscript`.

Verified locally:

```
RUSTDOCFLAGS="--html-in-header katex-header.html" cargo doc --workspace --all-features --no-deps
# 0 warnings
cargo +nightly fmt --all -- --check
cargo clippy --all-targets --all-features -- -D warnings
```