### PR TITLE
Folded Zip+ in PIOP

### DIFF
--- a/piop/benches/combined_poly_resolver.rs
+++ b/piop/benches/combined_poly_resolver.rs
@@ -56,7 +56,7 @@ fn bench_no_mult<const INT_LIMBS: usize, const FIELD_LIMBS: usize>(
     let max_degree = count_max_degree::<TestUairNoMultiplication<Int<INT_LIMBS>>>();
 
     let prove_cpr = |field_cfg: &<F<FIELD_LIMBS> as PrimeField>::Config,
-                     trace: &UairTrace<_, _, DEGREE_PLUS_ONE>,
+                     trace: &UairTrace<_, _, _, _>,
                      transcript: &mut Blake3Transcript| {
         let projected_trace = project_trace_coeffs_row_major(trace, field_cfg);
 
@@ -235,7 +235,7 @@ fn bench_simple_mult<const INT_LIMBS: usize, const FIELD_LIMBS: usize>(
     let max_degree = count_max_degree::<TestUairSimpleMultiplication<Int<INT_LIMBS>>>();
 
     let prove_cpr = |field_cfg: &<F<FIELD_LIMBS> as PrimeField>::Config,
-                     trace: &UairTrace<_, _, DEGREE_PLUS_ONE>,
+                     trace: &UairTrace<_, _, _, _>,
                      transcript: &mut Blake3Transcript| {
         let projected_trace = project_trace_coeffs_row_major(trace, field_cfg);
 

--- a/piop/benches/ideal_check.rs
+++ b/piop/benches/ideal_check.rs
@@ -55,7 +55,7 @@ fn bench_no_mult<const INT_LIMBS: usize, const FIELD_LIMBS: usize>(
     let num_constraints = count_constraints::<TestUairNoMultiplication<Int<INT_LIMBS>>>();
 
     let prove = |field_cfg: &<F<FIELD_LIMBS> as PrimeField>::Config,
-                 trace: &UairTrace<_, _, DEGREE_PLUS_ONE>,
+                 trace: &UairTrace<_, _, _, _>,
                  transcript: &mut Blake3Transcript|
      -> Proof<F<FIELD_LIMBS>> {
         let trace = project_trace_coeffs_row_major(trace, field_cfg);
@@ -147,7 +147,7 @@ fn bench_simple_mult<const INT_LIMBS: usize, const FIELD_LIMBS: usize>(
     let num_constraints = count_constraints::<TestUairSimpleMultiplication<Int<INT_LIMBS>>>();
 
     let prove = |field_cfg: &<F<FIELD_LIMBS> as PrimeField>::Config,
-                 trace: &UairTrace<_, _, DEGREE_PLUS_ONE>,
+                 trace: &UairTrace<_, _, _, _>,
                  transcript: &mut Blake3Transcript|
      -> Proof<F<FIELD_LIMBS>> {
         let trace = project_trace_coeffs_row_major(trace, field_cfg);
@@ -241,7 +241,7 @@ fn bench_binary_decomposition<const FIELD_LIMBS: usize>(
     let num_constraints = count_constraints::<BinaryDecompositionUair<u32>>();
 
     let prove = |field_cfg: &<F<FIELD_LIMBS> as PrimeField>::Config,
-                 trace: &UairTrace<_, _, DEGREE_PLUS_ONE>,
+                 trace: &UairTrace<_, _, _, _>,
                  transcript: &mut Blake3Transcript|
      -> Proof<F<FIELD_LIMBS>> {
         let trace = project_trace_coeffs_row_major(trace, field_cfg);
@@ -323,7 +323,7 @@ fn bench_big_linear_uair<const FIELD_LIMBS: usize>(
 
     macro_rules! prove {
         ($transcript:expr, $field_cfg:expr, $gen_trace:ident, $prove_fn:ident) => {{
-            let trace = $gen_trace::<_, u32, u32, _>(&trace, $field_cfg);
+            let trace = $gen_trace::<_, u32, u32, _, _>(&trace, $field_cfg);
 
             let projected_scalars =
                 project_scalars::<F<FIELD_LIMBS>, BigLinearUair<u32>>(|scalar| {

--- a/piop/src/projections.rs
+++ b/piop/src/projections.rs
@@ -38,8 +38,8 @@ pub enum ProjectedTrace<F: PrimeField> {
 ///
 /// Use this for the combined polynomial approach.
 #[allow(clippy::arithmetic_side_effects)]
-pub fn project_trace_coeffs_row_major<F, PolyCoeff, Int, const DEGREE_PLUS_ONE: usize>(
-    trace: &UairTrace<PolyCoeff, Int, DEGREE_PLUS_ONE>,
+pub fn project_trace_coeffs_row_major<F, PolyCoeff, Int, const DB: usize, const DA: usize>(
+    trace: &UairTrace<PolyCoeff, Int, DB, DA>,
     field_cfg: &F::Config,
 ) -> RowMajorTrace<F>
 where
@@ -129,8 +129,8 @@ where
 ///
 /// Use this for the MLE-first approach.
 #[allow(clippy::arithmetic_side_effects)]
-pub fn project_trace_coeffs_column_major<F, PolyCoeff, Int, const DEGREE_PLUS_ONE: usize>(
-    trace: &UairTrace<PolyCoeff, Int, DEGREE_PLUS_ONE>,
+pub fn project_trace_coeffs_column_major<F, PolyCoeff, Int, const DB: usize, const DA: usize>(
+    trace: &UairTrace<PolyCoeff, Int, DB, DA>,
     field_cfg: &F::Config,
 ) -> ColumnMajorTrace<F>
 where

--- a/piop/src/test_utils.rs
+++ b/piop/src/test_utils.rs
@@ -34,7 +34,7 @@ type F = MontyField<4>;
 #[allow(clippy::type_complexity)]
 pub fn run_ideal_check_prover_linear<U, const DEGREE_PLUS_ONE: usize>(
     num_vars: usize,
-    trace: &UairTrace<Int<5>, Int<5>, DEGREE_PLUS_ONE>,
+    trace: &UairTrace<Int<5>, Int<5>, DEGREE_PLUS_ONE, DEGREE_PLUS_ONE>,
     transcript: &mut impl Transcript,
 ) -> (
     IdealCheckProof<F>,
@@ -68,7 +68,7 @@ where
             .collect()
     });
 
-    let trace = project_trace_coeffs_column_major::<F, _, _, DEGREE_PLUS_ONE>(trace, &field_cfg);
+    let trace: ColumnMajorTrace<F> = project_trace_coeffs_column_major(trace, &field_cfg);
 
     let (proof, state) = U::prove_mle_first(
         transcript,
@@ -88,7 +88,7 @@ where
 #[allow(clippy::type_complexity)]
 pub fn run_ideal_check_prover_combined<U, const DEGREE_PLUS_ONE: usize>(
     num_vars: usize,
-    trace: &UairTrace<Int<5>, Int<5>, DEGREE_PLUS_ONE>,
+    trace: &UairTrace<Int<5>, Int<5>, DEGREE_PLUS_ONE, DEGREE_PLUS_ONE>,
     transcript: &mut impl Transcript,
 ) -> (
     IdealCheckProof<F>,
@@ -122,7 +122,7 @@ where
             .collect()
     });
 
-    let trace = project_trace_coeffs_row_major::<F, _, _, DEGREE_PLUS_ONE>(trace, &field_cfg);
+    let trace: RowMajorTrace<F> = project_trace_coeffs_row_major(trace, &field_cfg);
 
     let (proof, state) = U::prove_combined(
         transcript,

--- a/poly/src/univariate/binary_u64.rs
+++ b/poly/src/univariate/binary_u64.rs
@@ -28,8 +28,19 @@ use zinc_utils::{
 pub struct BinaryU64Poly<const DEGREE_PLUS_ONE: usize>(u64); // we can fit up to degree 64, which is ok for now
 
 impl<const DEGREE_PLUS_ONE: usize> BinaryU64Poly<DEGREE_PLUS_ONE> {
+    const _DEGREE_CHECK: () = {
+        // Note that associated constants on generic types are evaluated lazily, so we
+        // have to "access" this to trigger the assertion.
+        assert!(
+            DEGREE_PLUS_ONE <= 64,
+            "For BinaryU64Poly, degree cannot exceed 63"
+        );
+    };
+
     #[inline(always)]
+    #[allow(clippy::let_unit_value)]
     pub const fn inner(&self) -> &u64 {
+        let _ = Self::_DEGREE_CHECK; // Force lazy evaluation of constraint
         &self.0
     }
 }
@@ -52,15 +63,30 @@ impl<const DEGREE_PLUS_ONE: usize> From<BinaryU64Poly<DEGREE_PLUS_ONE>>
     }
 }
 
-impl From<u32> for BinaryU64Poly<32> {
+impl<const DEGREE_PLUS_ONE: usize> From<u32> for BinaryU64Poly<DEGREE_PLUS_ONE> {
+    #[inline(always)]
     fn from(value: u32) -> Self {
-        Self(u64::from(value)) // we ignore upper bits
+        // Delegate to `From<u64>` so the masking contract is enforced in a
+        // single place. Bits at positions `>= DEGREE_PLUS_ONE` are dropped.
+        Self::from(u64::from(value))
     }
 }
 
-impl From<u64> for BinaryU64Poly<64> {
+impl<const DEGREE_PLUS_ONE: usize> From<u64> for BinaryU64Poly<DEGREE_PLUS_ONE> {
+    #[inline(always)]
+    #[allow(clippy::arithmetic_side_effects, clippy::let_unit_value)]
     fn from(value: u64) -> Self {
-        Self(value) // we don't ignore any bits
+        let _ = Self::_DEGREE_CHECK; // Force lazy evaluation of constraint
+
+        // Bit `i` of `value` becomes the coefficient of `X^i`.
+        if DEGREE_PLUS_ONE == 64 {
+            Self(value)
+        } else {
+            // Bits at positions `>= DEGREE_PLUS_ONE` are masked off so that no bits beyond
+            // the polynomial degree are set. This is important, as downstream
+            // code (such as `BinaryU64PolyInnerProduct::inner_product`) relies on it.
+            Self(value & ((1_u64 << DEGREE_PLUS_ONE) - 1))
+        }
     }
 }
 

--- a/protocol/benches/e2e.rs
+++ b/protocol/benches/e2e.rs
@@ -140,7 +140,7 @@ struct GenericBenchZincTypes<Int, CwR, Chal, Pt, CombR, Fmod, PrimeTest, const D
     PhantomData<(Int, CwR, Chal, Pt, CombR, Fmod, PrimeTest)>,
 );
 
-impl<Int, CwR, Chal, Pt, CombR, Fmod, PrimeTest, const D: usize> ZincTypes<D>
+impl<Int, CwR, Chal, Pt, CombR, Fmod, PrimeTest, const D: usize> ZincTypes<D, D>
     for GenericBenchZincTypes<Int, CwR, Chal, Pt, CombR, Fmod, PrimeTest, D>
 where
     Int: ConstIntSemiring
@@ -234,7 +234,8 @@ where
 // Constants and concrete types
 //
 
-const DEGREE_PLUS_ONE: usize = 32;
+/// Degree + 1 of polynomials used in the protocol, including the trace.
+const D: usize = 32;
 const INT_LIMBS: usize = U64::LIMBS;
 const FIELD_LIMBS: usize = U64::LIMBS * 3;
 
@@ -248,21 +249,12 @@ type BenchZincTypes = GenericBenchZincTypes<
     /* CombR = */ Int<{ INT_LIMBS * 6 }>,
     /* Fmod = */ Uint<FIELD_LIMBS>,
     MillerRabin,
-    DEGREE_PLUS_ONE,
+    D,
 >;
 type Pp<Zt> = (
-    ZipPlusParams<
-        <Zt as ZincTypes<DEGREE_PLUS_ONE>>::BinaryZt,
-        <Zt as ZincTypes<DEGREE_PLUS_ONE>>::BinaryLc,
-    >,
-    ZipPlusParams<
-        <Zt as ZincTypes<DEGREE_PLUS_ONE>>::ArbitraryZt,
-        <Zt as ZincTypes<DEGREE_PLUS_ONE>>::ArbitraryLc,
-    >,
-    ZipPlusParams<
-        <Zt as ZincTypes<DEGREE_PLUS_ONE>>::IntZt,
-        <Zt as ZincTypes<DEGREE_PLUS_ONE>>::IntLc,
-    >,
+    ZipPlusParams<<Zt as ZincTypes<D, D>>::BinaryZt, <Zt as ZincTypes<D, D>>::BinaryLc>,
+    ZipPlusParams<<Zt as ZincTypes<D, D>>::ArbitraryZt, <Zt as ZincTypes<D, D>>::ArbitraryLc>,
+    ZipPlusParams<<Zt as ZincTypes<D, D>>::IntZt, <Zt as ZincTypes<D, D>>::IntLc>,
 );
 
 /// Use row size equal to poly size, resulting in flat single-row matrices
@@ -295,11 +287,11 @@ fn do_bench_e2e<Zt, U, IdealOverF>(
     label: &str,
     num_vars: usize,
     pp: &Pp<Zt>,
-    trace: &UairTrace<'static, Zt::Int, Zt::Int, DEGREE_PLUS_ONE>,
+    trace: &UairTrace<'static, Zt::Int, Zt::Int, D>,
     project_scalar: impl Fn(&U::Scalar, &<F as PrimeField>::Config) -> DynamicPolynomialF<F> + Copy,
     project_ideal: impl Fn(&IdealOrZero<U::Ideal>, &<F as PrimeField>::Config) -> IdealOverF + Copy,
 ) where
-    Zt: ZincTypes<DEGREE_PLUS_ONE>,
+    Zt: ZincTypes<D, D>,
     Zt::Int: ProjectableToField<F>,
     <Zt::BinaryZt as ZipTypes>::Cw: ProjectableToField<F>,
     <Zt::ArbitraryZt as ZipTypes>::Eval: ProjectableToField<F>,
@@ -323,7 +315,7 @@ fn do_bench_e2e<Zt, U, IdealOverF>(
 
     macro_rules! zinc_plus {
         () => {
-            ZincPlusPiop::<Zt, U, F, DEGREE_PLUS_ONE>
+            ZincPlusPiop::<Zt, U, F, D, D>
         };
     }
 
@@ -385,11 +377,11 @@ fn do_bench_steps<Zt, U, IdealOverF>(
     label: &str,
     num_vars: usize,
     pp: &Pp<Zt>,
-    trace: &UairTrace<'static, Zt::Int, Zt::Int, DEGREE_PLUS_ONE>,
+    trace: &UairTrace<'static, Zt::Int, Zt::Int, D>,
     project_scalar: fn(&U::Scalar, &<F as PrimeField>::Config) -> DynamicPolynomialF<F>,
     project_ideal: impl Fn(&IdealOrZero<U::Ideal>, &<F as PrimeField>::Config) -> IdealOverF + Copy,
 ) where
-    Zt: ZincTypes<DEGREE_PLUS_ONE>,
+    Zt: ZincTypes<D, D>,
     Zt::Int: ProjectableToField<F>,
     <Zt::BinaryZt as ZipTypes>::Cw: ProjectableToField<F>,
     <Zt::ArbitraryZt as ZipTypes>::Eval: ProjectableToField<F>,
@@ -430,7 +422,7 @@ fn do_bench_steps<Zt, U, IdealOverF>(
 
     macro_rules! piop {
         () => {
-            ZincPlusPiop::<Zt, U, F, DEGREE_PLUS_ONE>
+            ZincPlusPiop::<Zt, U, F, D, D>
         };
     }
 
@@ -515,7 +507,7 @@ fn do_bench_steps<Zt, U, IdealOverF>(
 
     macro_rules! zinc_plus {
         () => {
-            ZincPlusPiop::<Zt, U, F, DEGREE_PLUS_ONE>
+            ZincPlusPiop::<Zt, U, F, D, D>
         };
     }
 
@@ -526,9 +518,12 @@ fn do_bench_steps<Zt, U, IdealOverF>(
     let sig = U::signature();
     let public_trace = trace.public(&sig);
 
-    let v_transcript = ZincPlusPiop::<Zt, U, F, DEGREE_PLUS_ONE>::step0_reconstruct_transcript::<
-        IdealOverF,
-    >(pp, proof.clone(), &public_trace, num_vars)
+    let v_transcript = ZincPlusPiop::<Zt, U, F, D, D>::step0_reconstruct_transcript::<IdealOverF>(
+        pp,
+        proof.clone(),
+        &public_trace,
+        num_vars,
+    )
     .unwrap();
     let v_prime_projected = v_transcript.clone().step1_prime_projection().unwrap();
     let v_ideal_checked = v_prime_projected
@@ -546,9 +541,12 @@ fn do_bench_steps<Zt, U, IdealOverF>(
     step_bench!(
         "Verify" / "0: Transcript reconstruct",
         setup = || proof.clone(),
-        run = |proof| ZincPlusPiop::<Zt, U, F, DEGREE_PLUS_ONE>::step0_reconstruct_transcript::<
-            IdealOverF,
-        >(pp, proof, &public_trace, num_vars,),
+        run = |proof| ZincPlusPiop::<Zt, U, F, D, D>::step0_reconstruct_transcript::<IdealOverF>(
+            pp,
+            proof,
+            &public_trace,
+            num_vars,
+        ),
     );
 
     step_bench!(
@@ -601,14 +599,14 @@ fn do_bench_steps<Zt, U, IdealOverF>(
 fn do_bench_uair<U>(group: &mut BenchmarkGroup<WallTime>, label: &str, num_vars: usize)
 where
     U: Uair<
-            Ideal = DegreeOneIdeal<<BenchZincTypes as ZincTypes<DEGREE_PLUS_ONE>>::Int>,
-            Scalar = DensePolynomial<<BenchZincTypes as ZincTypes<DEGREE_PLUS_ONE>>::Int, 32>,
+            Ideal = DegreeOneIdeal<<BenchZincTypes as ZincTypes<D, D>>::Int>,
+            Scalar = DensePolynomial<<BenchZincTypes as ZincTypes<D, D>>::Int, 32>,
         > + GenerateRandomTrace<
-            DEGREE_PLUS_ONE,
-            PolyCoeff = <BenchZincTypes as ZincTypes<DEGREE_PLUS_ONE>>::Int,
-            Int = <BenchZincTypes as ZincTypes<DEGREE_PLUS_ONE>>::Int,
+            D,
+            PolyCoeff = <BenchZincTypes as ZincTypes<D, D>>::Int,
+            Int = <BenchZincTypes as ZincTypes<D, D>>::Int,
         > + 'static,
-    F: for<'a> FromWithConfig<&'a <BenchZincTypes as ZincTypes<DEGREE_PLUS_ONE>>::Int>,
+    F: for<'a> FromWithConfig<&'a <BenchZincTypes as ZincTypes<D, D>>::Int>,
 {
     let mut rng = rng();
     let trace = U::generate_random_trace(num_vars, &mut rng);
@@ -633,14 +631,14 @@ where
 fn do_bench_steps_uair<U>(group: &mut BenchmarkGroup<WallTime>, label: &str, num_vars: usize)
 where
     U: Uair<
-            Ideal = DegreeOneIdeal<<BenchZincTypes as ZincTypes<DEGREE_PLUS_ONE>>::Int>,
-            Scalar = DensePolynomial<<BenchZincTypes as ZincTypes<DEGREE_PLUS_ONE>>::Int, 32>,
+            Ideal = DegreeOneIdeal<<BenchZincTypes as ZincTypes<D, D>>::Int>,
+            Scalar = DensePolynomial<<BenchZincTypes as ZincTypes<D, D>>::Int, 32>,
         > + GenerateRandomTrace<
-            DEGREE_PLUS_ONE,
-            PolyCoeff = <BenchZincTypes as ZincTypes<DEGREE_PLUS_ONE>>::Int,
-            Int = <BenchZincTypes as ZincTypes<DEGREE_PLUS_ONE>>::Int,
+            D,
+            PolyCoeff = <BenchZincTypes as ZincTypes<D, D>>::Int,
+            Int = <BenchZincTypes as ZincTypes<D, D>>::Int,
         > + 'static,
-    F: for<'a> FromWithConfig<&'a <BenchZincTypes as ZincTypes<DEGREE_PLUS_ONE>>::Int>,
+    F: for<'a> FromWithConfig<&'a <BenchZincTypes as ZincTypes<D, D>>::Int>,
 {
     let mut rng = rng();
     let trace = U::generate_random_trace(num_vars, &mut rng);

--- a/protocol/benches/e2e.rs
+++ b/protocol/benches/e2e.rs
@@ -747,23 +747,18 @@ fn e2e_benches(c: &mut Criterion) {
 
     bench_no_mult_e2e(&mut group, 8);
     bench_no_mult_e2e(&mut group, 10);
-    bench_no_mult_e2e(&mut group, 12);
 
     bench_binary_decomposition_e2e(&mut group, 8);
     bench_binary_decomposition_e2e(&mut group, 10);
-    bench_binary_decomposition_e2e(&mut group, 12);
 
     bench_big_linear_e2e(&mut group, 8);
     bench_big_linear_e2e(&mut group, 10);
-    bench_big_linear_e2e(&mut group, 12);
 
     bench_big_linear_public_input_e2e(&mut group, 8);
     bench_big_linear_public_input_e2e(&mut group, 10);
-    bench_big_linear_public_input_e2e(&mut group, 12);
 
     bench_sha_proxy_e2e(&mut group, 8);
     bench_sha_proxy_e2e(&mut group, 10);
-    bench_sha_proxy_e2e(&mut group, 12);
 
     group.finish();
 }
@@ -773,23 +768,18 @@ fn e2e_steps_benches(c: &mut Criterion) {
 
     bench_no_mult_steps(&mut group, 8);
     bench_no_mult_steps(&mut group, 10);
-    bench_no_mult_steps(&mut group, 12);
 
     bench_binary_decomposition_steps(&mut group, 8);
     bench_binary_decomposition_steps(&mut group, 10);
-    bench_binary_decomposition_steps(&mut group, 12);
 
     bench_big_linear_steps(&mut group, 8);
     bench_big_linear_steps(&mut group, 10);
-    bench_big_linear_steps(&mut group, 12);
 
     bench_big_linear_public_input_steps(&mut group, 8);
     bench_big_linear_public_input_steps(&mut group, 10);
-    bench_big_linear_public_input_steps(&mut group, 12);
 
     bench_sha_proxy_steps(&mut group, 8);
     bench_sha_proxy_steps(&mut group, 10);
-    bench_sha_proxy_steps(&mut group, 12);
 
     group.finish();
 }

--- a/protocol/benches/e2e.rs
+++ b/protocol/benches/e2e.rs
@@ -20,7 +20,7 @@ use zinc_poly::{
     },
 };
 use zinc_primality::{MillerRabin, PrimalityTest};
-use zinc_protocol::{Proof, ZincPlusPiop, ZincTypes};
+use zinc_protocol::{Proof, ZincPlusPiop, ZincTypes, fold::NoopFoldTrace};
 use zinc_test_uair::{
     BigLinearUair, BigLinearUairWithPublicInput, BinaryDecompositionUair, GenerateRandomTrace,
     ShaProxy, TestUairNoMultiplication,
@@ -224,6 +224,8 @@ where
         ScalarProduct,
         MBSInnerProduct,
     >;
+
+    type BinaryFold = NoopFoldTrace;
 
     type BinaryLc = IprsCode<Self::BinaryZt, PnttConfigF65537, REP_FACTOR, PERFORM_CHECKS>;
     type ArbitraryLc = IprsCode<Self::ArbitraryZt, PnttConfigF65537, REP_FACTOR, PERFORM_CHECKS>;
@@ -432,73 +434,80 @@ fn do_bench_steps<Zt, U, IdealOverF>(
 
     // Build the chain once; each bench clones the cached state.
 
-    let p_committed = <piop!()>::step0_commit(pp, trace, num_vars).unwrap();
-    let p_projected = p_committed.clone().step1_combined(project_scalar).unwrap();
-    let p_projected_mle = p_committed.clone().step1_mle_first(project_scalar).unwrap();
-    let p_ideal_checked = p_projected.clone().step2_ideal_check().unwrap();
-    let p_eval_projected = p_ideal_checked.clone().step3_eval_projection().unwrap();
-    let p_sumchecked = p_eval_projected.clone().step4_sumcheck().unwrap();
-    let p_mp_evaled = p_sumchecked.clone().step5_multipoint_eval().unwrap();
-    let p_lifted = p_mp_evaled.clone().step6_lift_and_project().unwrap();
+    let p_folded = <piop!()>::step0_fold(trace).unwrap();
+    let p_committed = p_folded.clone().step1_commit(pp, num_vars).unwrap();
+    let p_projected = p_committed.clone().step2_combined(project_scalar).unwrap();
+    let p_projected_mle = p_committed.clone().step2_mle_first(project_scalar).unwrap();
+    let p_ideal_checked = p_projected.clone().step3_ideal_check().unwrap();
+    let p_eval_projected = p_ideal_checked.clone().step4_eval_projection().unwrap();
+    let p_sumchecked = p_eval_projected.clone().step5_sumcheck().unwrap();
+    let p_mp_evaled = p_sumchecked.clone().step6_multipoint_eval().unwrap();
+    let p_lifted = p_mp_evaled.clone().step7_lift_and_project().unwrap();
 
     step_bench!(
-        "Prove" / "0: Commit",
+        "Prove" / "0: Fold",
         setup = || {},
-        run = |_s| <piop!()>::step0_commit(pp, trace, num_vars),
+        run = |_s| <piop!()>::step0_fold(trace),
     );
 
     step_bench!(
-        "Prove" / "1: Prime projection (Combined)",
+        "Prove" / "1: Commit",
+        setup = || p_folded.clone(),
+        run = |s| s.step1_commit(pp, num_vars),
+    );
+
+    step_bench!(
+        "Prove" / "2: Prime projection (Combined)",
         setup = || p_committed.clone(),
-        run = |s| s.step1_combined(project_scalar),
+        run = |s| s.step2_combined(project_scalar),
     );
 
     step_bench!(
-        "Prove" / "1: Prime projection (MLE-first)",
+        "Prove" / "2: Prime projection (MLE-first)",
         setup = || p_committed.clone(),
-        run = |s| s.step1_mle_first(project_scalar),
+        run = |s| s.step2_mle_first(project_scalar),
     );
 
     step_bench!(
-        "Prove" / "2: Ideal check (Combined)",
+        "Prove" / "3: Ideal check (Combined)",
         setup = || p_projected.clone(),
-        run = |s| s.step2_ideal_check(),
+        run = |s| s.step3_ideal_check(),
     );
 
     step_bench!(
-        "Prove" / "2: Ideal check (MLE-first)",
+        "Prove" / "3: Ideal check (MLE-first)",
         setup = || p_projected_mle.clone(),
-        run = |s| s.step2_ideal_check(),
+        run = |s| s.step3_ideal_check(),
     );
 
     step_bench!(
-        "Prove" / "3: Eval projection",
+        "Prove" / "4: Eval projection",
         setup = || p_ideal_checked.clone(),
-        run = |s| s.step3_eval_projection(),
+        run = |s| s.step4_eval_projection(),
     );
 
     step_bench!(
-        "Prove" / "4: Combined sumcheck",
+        "Prove" / "5: Combined sumcheck",
         setup = || p_eval_projected.clone(),
-        run = |s| s.step4_sumcheck(),
+        run = |s| s.step5_sumcheck(),
     );
 
     step_bench!(
-        "Prove" / "5: Multi-point eval",
+        "Prove" / "6: Multi-point eval",
         setup = || p_sumchecked.clone(),
-        run = |s| s.step5_multipoint_eval(),
+        run = |s| s.step6_multipoint_eval(),
     );
 
     step_bench!(
-        "Prove" / "6: Lift-and-project",
+        "Prove" / "7: Lift-and-project",
         setup = || p_mp_evaled.clone(),
-        run = |s| s.step6_lift_and_project(),
+        run = |s| s.step7_lift_and_project(),
     );
 
     step_bench!(
-        "Prove" / "7: PCS open",
+        "Prove" / "8: PCS open",
         setup = || p_lifted.clone(),
-        run = |s| s.step7_pcs_open::<PERFORM_CHECKS>(),
+        run = |s| s.step8_pcs_open::<PERFORM_CHECKS>(),
     );
 
     //

--- a/protocol/benches/e2e.rs
+++ b/protocol/benches/e2e.rs
@@ -287,7 +287,7 @@ fn do_bench_e2e<Zt, U, IdealOverF>(
     label: &str,
     num_vars: usize,
     pp: &Pp<Zt>,
-    trace: &UairTrace<'static, Zt::Int, Zt::Int, D>,
+    trace: &UairTrace<'static, Zt::Int, Zt::Int, D, D>,
     project_scalar: impl Fn(&U::Scalar, &<F as PrimeField>::Config) -> DynamicPolynomialF<F> + Copy,
     project_ideal: impl Fn(&IdealOrZero<U::Ideal>, &<F as PrimeField>::Config) -> IdealOverF + Copy,
 ) where
@@ -377,7 +377,7 @@ fn do_bench_steps<Zt, U, IdealOverF>(
     label: &str,
     num_vars: usize,
     pp: &Pp<Zt>,
-    trace: &UairTrace<'static, Zt::Int, Zt::Int, D>,
+    trace: &UairTrace<'static, Zt::Int, Zt::Int, D, D>,
     project_scalar: fn(&U::Scalar, &<F as PrimeField>::Config) -> DynamicPolynomialF<F>,
     project_ideal: impl Fn(&IdealOrZero<U::Ideal>, &<F as PrimeField>::Config) -> IdealOverF + Copy,
 ) where

--- a/protocol/benches/e2e.rs
+++ b/protocol/benches/e2e.rs
@@ -20,7 +20,10 @@ use zinc_poly::{
     },
 };
 use zinc_primality::{MillerRabin, PrimalityTest};
-use zinc_protocol::{Proof, ZincPlusPiop, ZincTypes, fold::NoopFoldTrace};
+use zinc_protocol::{
+    Proof, ZincPlusPiop, ZincTypes,
+    fold::{FoldBinaryTrace4x, FoldTrace},
+};
 use zinc_test_uair::{
     BigLinearUair, BigLinearUairWithPublicInput, BinaryDecompositionUair, GenerateRandomTrace,
     ShaProxy, TestUairNoMultiplication,
@@ -136,12 +139,32 @@ where
 }
 
 #[derive(Clone, Debug)]
-struct GenericBenchZincTypes<Int, CwR, Chal, Pt, CombR, Fmod, PrimeTest, const D: usize>(
-    PhantomData<(Int, CwR, Chal, Pt, CombR, Fmod, PrimeTest)>,
-);
+struct GenericBenchZincTypes<
+    Int,
+    CwR,
+    Chal,
+    Pt,
+    CombR,
+    Fmod,
+    PrimeTest,
+    const D: usize,
+    const HALF_D: usize,
+    const QUARTER_D: usize,
+>(PhantomData<(Int, CwR, Chal, Pt, CombR, Fmod, PrimeTest)>);
 
-impl<Int, CwR, Chal, Pt, CombR, Fmod, PrimeTest, const D: usize> ZincTypes<D, D>
-    for GenericBenchZincTypes<Int, CwR, Chal, Pt, CombR, Fmod, PrimeTest, D>
+impl<
+    Int,
+    CwR,
+    Chal,
+    Pt,
+    CombR,
+    Fmod,
+    PrimeTest,
+    const D: usize,
+    const HALF_D: usize,
+    const QUARTER_D: usize,
+> ZincTypes<D, QUARTER_D>
+    for GenericBenchZincTypes<Int, CwR, Chal, Pt, CombR, Fmod, PrimeTest, D, HALF_D, QUARTER_D>
 where
     Int: ConstIntSemiring
         + for<'a> MulByScalar<&'a i64, CwR>
@@ -186,16 +209,16 @@ where
     type PrimeTest = PrimeTest;
 
     type BinaryZt = GenericBenchZipTypes<
-        BinaryPoly<D>,
-        DensePolynomial<i64, D>,
+        BinaryPoly<QUARTER_D>,
+        DensePolynomial<i64, QUARTER_D>,
         Fmod,
         PrimeTest,
         Chal,
         Pt,
         CombR,
-        DensePolynomial<CombR, D>,
-        BinaryPolyInnerProduct<Chal, D>,
-        DensePolyInnerProduct<CombR, Chal, CombR, MBSInnerProduct, D>,
+        DensePolynomial<CombR, QUARTER_D>,
+        BinaryPolyInnerProduct<Chal, QUARTER_D>,
+        DensePolyInnerProduct<CombR, Chal, CombR, MBSInnerProduct, QUARTER_D>,
         MBSInnerProduct,
     >;
     type ArbitraryZt = GenericBenchZipTypes<
@@ -225,7 +248,7 @@ where
         MBSInnerProduct,
     >;
 
-    type BinaryFold = NoopFoldTrace;
+    type BinaryFold = FoldBinaryTrace4x<D, HALF_D, QUARTER_D>;
 
     type BinaryLc = IprsCode<Self::BinaryZt, PnttConfigF65537, REP_FACTOR, PERFORM_CHECKS>;
     type ArbitraryLc = IprsCode<Self::ArbitraryZt, PnttConfigF65537, REP_FACTOR, PERFORM_CHECKS>;
@@ -238,6 +261,8 @@ where
 
 /// Degree + 1 of polynomials used in the protocol, including the trace.
 const D: usize = 32;
+const HALF_D: usize = D / 2;
+const QUARTER_D: usize = D / 4;
 const INT_LIMBS: usize = U64::LIMBS;
 const FIELD_LIMBS: usize = U64::LIMBS * 3;
 
@@ -252,21 +277,33 @@ type BenchZincTypes = GenericBenchZincTypes<
     /* Fmod = */ Uint<FIELD_LIMBS>,
     MillerRabin,
     D,
+    HALF_D,
+    QUARTER_D,
 >;
 type Pp<Zt> = (
-    ZipPlusParams<<Zt as ZincTypes<D, D>>::BinaryZt, <Zt as ZincTypes<D, D>>::BinaryLc>,
-    ZipPlusParams<<Zt as ZincTypes<D, D>>::ArbitraryZt, <Zt as ZincTypes<D, D>>::ArbitraryLc>,
-    ZipPlusParams<<Zt as ZincTypes<D, D>>::IntZt, <Zt as ZincTypes<D, D>>::IntLc>,
+    ZipPlusParams<
+        <Zt as ZincTypes<D, QUARTER_D>>::BinaryZt,
+        <Zt as ZincTypes<D, QUARTER_D>>::BinaryLc,
+    >,
+    ZipPlusParams<
+        <Zt as ZincTypes<D, QUARTER_D>>::ArbitraryZt,
+        <Zt as ZincTypes<D, QUARTER_D>>::ArbitraryLc,
+    >,
+    ZipPlusParams<<Zt as ZincTypes<D, QUARTER_D>>::IntZt, <Zt as ZincTypes<D, QUARTER_D>>::IntLc>,
 );
 
 /// Use row size equal to poly size, resulting in flat single-row matrices
 #[allow(clippy::unwrap_used)]
 fn setup_pp(num_vars: usize) -> Pp<BenchZincTypes> {
+    let folded_num_vars =
+        num_vars + <BenchZincTypes as ZincTypes<_, _>>::BinaryFold::FOLDING_FACTOR.ilog2() as usize;
+
     let poly_size = 1 << num_vars;
+    let folded_poly_size = 1 << folded_num_vars;
     (
         ZipPlus::setup(
-            poly_size,
-            IprsCode::new_with_optimal_depth(poly_size).unwrap(),
+            folded_poly_size,
+            IprsCode::new_with_optimal_depth(folded_poly_size).unwrap(),
         ),
         ZipPlus::setup(
             poly_size,
@@ -293,7 +330,7 @@ fn do_bench_e2e<Zt, U, IdealOverF>(
     project_scalar: impl Fn(&U::Scalar, &<F as PrimeField>::Config) -> DynamicPolynomialF<F> + Copy,
     project_ideal: impl Fn(&IdealOrZero<U::Ideal>, &<F as PrimeField>::Config) -> IdealOverF + Copy,
 ) where
-    Zt: ZincTypes<D, D>,
+    Zt: ZincTypes<D, QUARTER_D>,
     Zt::Int: ProjectableToField<F>,
     <Zt::BinaryZt as ZipTypes>::Cw: ProjectableToField<F>,
     <Zt::ArbitraryZt as ZipTypes>::Eval: ProjectableToField<F>,
@@ -317,7 +354,7 @@ fn do_bench_e2e<Zt, U, IdealOverF>(
 
     macro_rules! zinc_plus {
         () => {
-            ZincPlusPiop::<Zt, U, F, D, D>
+            ZincPlusPiop::<Zt, U, F, D, QUARTER_D>
         };
     }
 
@@ -383,7 +420,7 @@ fn do_bench_steps<Zt, U, IdealOverF>(
     project_scalar: fn(&U::Scalar, &<F as PrimeField>::Config) -> DynamicPolynomialF<F>,
     project_ideal: impl Fn(&IdealOrZero<U::Ideal>, &<F as PrimeField>::Config) -> IdealOverF + Copy,
 ) where
-    Zt: ZincTypes<D, D>,
+    Zt: ZincTypes<D, QUARTER_D>,
     Zt::Int: ProjectableToField<F>,
     <Zt::BinaryZt as ZipTypes>::Cw: ProjectableToField<F>,
     <Zt::ArbitraryZt as ZipTypes>::Eval: ProjectableToField<F>,
@@ -424,7 +461,7 @@ fn do_bench_steps<Zt, U, IdealOverF>(
 
     macro_rules! piop {
         () => {
-            ZincPlusPiop::<Zt, U, F, D, D>
+            ZincPlusPiop::<Zt, U, F, D, QUARTER_D>
         };
     }
 
@@ -516,7 +553,7 @@ fn do_bench_steps<Zt, U, IdealOverF>(
 
     macro_rules! zinc_plus {
         () => {
-            ZincPlusPiop::<Zt, U, F, D, D>
+            ZincPlusPiop::<Zt, U, F, D, QUARTER_D>
         };
     }
 
@@ -527,7 +564,7 @@ fn do_bench_steps<Zt, U, IdealOverF>(
     let sig = U::signature();
     let public_trace = trace.public(&sig);
 
-    let v_transcript = ZincPlusPiop::<Zt, U, F, D, D>::step0_reconstruct_transcript::<IdealOverF>(
+    let v_transcript = <piop!()>::step0_reconstruct_transcript::<IdealOverF>(
         pp,
         proof.clone(),
         &public_trace,
@@ -550,7 +587,7 @@ fn do_bench_steps<Zt, U, IdealOverF>(
     step_bench!(
         "Verify" / "0: Transcript reconstruct",
         setup = || proof.clone(),
-        run = |proof| ZincPlusPiop::<Zt, U, F, D, D>::step0_reconstruct_transcript::<IdealOverF>(
+        run = |proof| <piop!()>::step0_reconstruct_transcript::<IdealOverF>(
             pp,
             proof,
             &public_trace,
@@ -608,14 +645,14 @@ fn do_bench_steps<Zt, U, IdealOverF>(
 fn do_bench_uair<U>(group: &mut BenchmarkGroup<WallTime>, label: &str, num_vars: usize)
 where
     U: Uair<
-            Ideal = DegreeOneIdeal<<BenchZincTypes as ZincTypes<D, D>>::Int>,
-            Scalar = DensePolynomial<<BenchZincTypes as ZincTypes<D, D>>::Int, 32>,
+            Ideal = DegreeOneIdeal<<BenchZincTypes as ZincTypes<D, QUARTER_D>>::Int>,
+            Scalar = DensePolynomial<<BenchZincTypes as ZincTypes<D, QUARTER_D>>::Int, 32>,
         > + GenerateRandomTrace<
             D,
-            PolyCoeff = <BenchZincTypes as ZincTypes<D, D>>::Int,
-            Int = <BenchZincTypes as ZincTypes<D, D>>::Int,
+            PolyCoeff = <BenchZincTypes as ZincTypes<D, QUARTER_D>>::Int,
+            Int = <BenchZincTypes as ZincTypes<D, QUARTER_D>>::Int,
         > + 'static,
-    F: for<'a> FromWithConfig<&'a <BenchZincTypes as ZincTypes<D, D>>::Int>,
+    F: for<'a> FromWithConfig<&'a <BenchZincTypes as ZincTypes<D, QUARTER_D>>::Int>,
 {
     let mut rng = rng();
     let trace = U::generate_random_trace(num_vars, &mut rng);
@@ -640,14 +677,14 @@ where
 fn do_bench_steps_uair<U>(group: &mut BenchmarkGroup<WallTime>, label: &str, num_vars: usize)
 where
     U: Uair<
-            Ideal = DegreeOneIdeal<<BenchZincTypes as ZincTypes<D, D>>::Int>,
-            Scalar = DensePolynomial<<BenchZincTypes as ZincTypes<D, D>>::Int, 32>,
+            Ideal = DegreeOneIdeal<<BenchZincTypes as ZincTypes<D, QUARTER_D>>::Int>,
+            Scalar = DensePolynomial<<BenchZincTypes as ZincTypes<D, QUARTER_D>>::Int, 32>,
         > + GenerateRandomTrace<
             D,
-            PolyCoeff = <BenchZincTypes as ZincTypes<D, D>>::Int,
-            Int = <BenchZincTypes as ZincTypes<D, D>>::Int,
+            PolyCoeff = <BenchZincTypes as ZincTypes<D, QUARTER_D>>::Int,
+            Int = <BenchZincTypes as ZincTypes<D, QUARTER_D>>::Int,
         > + 'static,
-    F: for<'a> FromWithConfig<&'a <BenchZincTypes as ZincTypes<D, D>>::Int>,
+    F: for<'a> FromWithConfig<&'a <BenchZincTypes as ZincTypes<D, QUARTER_D>>::Int>,
 {
     let mut rng = rng();
     let trace = U::generate_random_trace(num_vars, &mut rng);

--- a/protocol/src/fold.rs
+++ b/protocol/src/fold.rs
@@ -1,4 +1,11 @@
-use zinc_poly::mle::DenseMultilinearExtension;
+use crypto_primitives::{FromWithConfig, PrimeField, boolean::Boolean};
+use itertools::Itertools;
+use num_traits::Zero;
+use zinc_poly::{
+    mle::DenseMultilinearExtension,
+    univariate::{binary::BinaryPoly, binary_ref::BinaryRefPoly, binary_u64::BinaryU64Poly},
+};
+use zinc_utils::{add, mul};
 
 /// Fold a trace of one type into a trace of another (similar but smaller) type.
 ///
@@ -8,8 +15,83 @@ pub trait FoldTrace<From, To> {
     /// Folding factor, a positive power of 2.
     const FOLDING_FACTOR: usize;
 
-    fn fold_trace_column(column: &DenseMultilinearExtension<From>)
-    -> DenseMultilinearExtension<To>;
+    fn fold_trace_mle(mle: &DenseMultilinearExtension<From>) -> DenseMultilinearExtension<To>;
+
+    /// Verifier-side: compute one column's contribution to the folded PCS
+    /// eval-claim at the extended evaluation point
+    /// `r_0 || gamma_1 || ... || gamma_k`, where `k = log2(FOLDING_FACTOR)`.
+    ///
+    /// # Inputs:
+    /// - `bar_u_coeffs`: the column's unfolded lifted-eval coefficients in
+    ///   `F_q[X]`, of formal length `D`. May be shorter than `D` if trailing
+    ///   zero coefficients were trimmed.
+    /// - `alphas`: per-poly PCS alphas, of length `D / FOLDING_FACTOR`,
+    ///   matching the folded entry size.
+    /// - `folding_challenges`: `k` field-typed challenges sampled by the
+    ///   verifier, in sampling order (`gamma_1` first, `gamma_k` last).
+    ///
+    /// Returns the value `<alphas, bar_u_folded>` where `bar_u_folded` is the
+    /// column's lifted-eval polynomial after applying `k` chained 2x splits
+    /// and pinning the appended boolean variables to `(gamma_1, ..., gamma_k)`.
+    fn fold_eval_claim<F, A>(
+        bar_u_coeffs: &[F],
+        alphas: &[A],
+        folding_challenges: &[F],
+        field_cfg: &F::Config,
+    ) -> F
+    where
+        F: PrimeField + for<'a> FromWithConfig<&'a A>,
+    {
+        // MSB-first contiguous chained-2x-split chunking.
+        //
+        // `bar_u_coeffs` is partitioned into `FOLDING_FACTOR` contiguous chunks of
+        // length `D / FOLDING_FACTOR`.
+        //
+        // Their inner products with `alphas` form a `k`-variable multilinear polynomial
+        // which is then evaluated at `(gamma_1, ..., gamma_k)` with `gamma_1` paired
+        // with the high bit of the chunk index.
+        //
+        // This covers `NoopFoldTrace` (k = 0, degenerating to a single inner product)
+        // as well as chained 2x folds.
+
+        debug_assert_eq!(
+            1usize << folding_challenges.len(),
+            Self::FOLDING_FACTOR,
+            "fold_eval_claim: 1 << folding_challenges.len() must equal FOLDING_FACTOR",
+        );
+        debug_assert!(
+            bar_u_coeffs.len() <= mul!(alphas.len(), Self::FOLDING_FACTOR),
+            "fold_eval_claim: bar_u_coeffs.len() must not exceed alphas.len() * FOLDING_FACTOR",
+        );
+
+        let chunk_size = alphas.len();
+        let alphas = alphas
+            .iter()
+            .map(|a| F::from_with_cfg(a, field_cfg))
+            .collect_vec();
+
+        let zero = F::zero_with_cfg(field_cfg);
+
+        // Step 1: Per-chunk inner products
+        //   P_i = sum_{l < chunk_size} alphas[l] * bar_u_coeffs[i*chunk_size + j],
+        // Trimmed (missing-trailing-zero) coefficients are treated as zero.
+        let chunk_evals: Vec<F> = (0..Self::FOLDING_FACTOR)
+            .map(|i| {
+                let start = mul!(i, chunk_size);
+                let mut acc = zero.clone();
+                for (l, alpha) in alphas.iter().enumerate() {
+                    if let Some(coeff) = bar_u_coeffs.get(add!(start, l)) {
+                        acc += alpha.clone() * coeff;
+                    }
+                }
+                acc
+            })
+            .collect();
+
+        // Step 2: MLE-evaluate the per-chunk inner products at folding_challenges,
+        // MSB-first (gamma_1 = high bit, peeled first).
+        mle_eval_msb_first(chunk_evals, folding_challenges, field_cfg)
+    }
 }
 
 //
@@ -21,7 +103,141 @@ pub struct NoopFoldTrace;
 impl<T: Clone> FoldTrace<T, T> for NoopFoldTrace {
     const FOLDING_FACTOR: usize = 1;
 
-    fn fold_trace_column(trace: &DenseMultilinearExtension<T>) -> DenseMultilinearExtension<T> {
-        trace.clone()
+    fn fold_trace_mle(mle: &DenseMultilinearExtension<T>) -> DenseMultilinearExtension<T> {
+        mle.clone()
     }
+}
+
+//
+// Binary folds
+//
+
+pub struct FoldBinaryTrace2x<const D: usize, const HALF_D: usize>;
+
+impl<const D: usize, const HALF_D: usize> FoldTrace<BinaryPoly<D>, BinaryPoly<HALF_D>>
+    for FoldBinaryTrace2x<D, HALF_D>
+{
+    const FOLDING_FACTOR: usize = 2;
+
+    fn fold_trace_mle(
+        mle: &DenseMultilinearExtension<BinaryPoly<D>>,
+    ) -> DenseMultilinearExtension<BinaryPoly<HALF_D>> {
+        split_binary_poly_mle(mle)
+    }
+}
+
+pub struct FoldBinaryTrace4x<const D: usize, const HALF_D: usize, const QUARTER_D: usize>;
+
+impl<const D: usize, const HALF_D: usize, const QUARTER_D: usize>
+    FoldTrace<BinaryPoly<D>, BinaryPoly<QUARTER_D>> for FoldBinaryTrace4x<D, HALF_D, QUARTER_D>
+{
+    const FOLDING_FACTOR: usize = 4;
+
+    fn fold_trace_mle(
+        mle: &DenseMultilinearExtension<BinaryPoly<D>>,
+    ) -> DenseMultilinearExtension<BinaryPoly<QUARTER_D>> {
+        let mle = split_binary_poly_mle::<D, HALF_D>(mle);
+        split_binary_poly_mle::<HALF_D, QUARTER_D>(&mle)
+    }
+}
+
+//
+// Helper functions
+//
+
+/// Split a column of `BinaryPoly<D>` entries into a concatenated column
+/// of `BinaryPoly<HALF_D>` entries.
+///
+/// Each entry `v[i]` with `D` binary coefficients is split into:
+/// - `u[i]` = low `HALF_D` coefficients (indices `0..HALF_D`)
+/// - `w[i]` = high `HALF_D` coefficients (indices `HALF_D..D`)
+///
+/// so that `v[i] = u[i] + X^HALF_D · w[i]`.
+///
+/// Returns a column of length `2n` where:
+/// - `v'[0..n]   = u[0..n]`  (low halves)
+/// - `v'[n..2n]  = w[0..n]`  (high halves)
+///
+/// The returned MLE has `num_vars + 1` variables, with the last variable
+/// selecting between the low half (0) and high half (1).
+///
+/// Panics at compile-time if `D != 2 * HALF_D`.
+fn split_binary_poly_mle<const D: usize, const HALF_D: usize>(
+    mle: &DenseMultilinearExtension<BinaryPoly<D>>,
+) -> DenseMultilinearExtension<BinaryPoly<HALF_D>> {
+    const {
+        assert!(D == 2 * HALF_D, "split_column: D must equal 2 * HALF_D");
+    }
+
+    #[cfg(not(feature = "simd"))]
+    let res = split_binary_poly_mle_ref(mle);
+
+    #[cfg(feature = "simd")]
+    let res = split_binary_poly_mle_u64(mle);
+
+    res
+}
+
+#[allow(dead_code)]
+fn split_binary_poly_mle_ref<const D: usize, const HALF_D: usize>(
+    mle: &DenseMultilinearExtension<BinaryRefPoly<D>>,
+) -> DenseMultilinearExtension<BinaryRefPoly<HALF_D>> {
+    const {
+        assert!(D == 2 * HALF_D, "split_column: D must equal 2 * HALF_D");
+    }
+
+    let n = mle.evaluations.len();
+    let mut lo_evals = Vec::with_capacity(n);
+    let mut hi_evals = Vec::with_capacity(n);
+
+    for entry in &mle.evaluations {
+        let lo_arr: [Boolean; HALF_D] = std::array::from_fn(|i| entry[i]);
+        let hi_arr: [Boolean; HALF_D] = std::array::from_fn(|i| entry[add!(HALF_D, i)]);
+        lo_evals.push(BinaryRefPoly::<HALF_D>::new(lo_arr));
+        hi_evals.push(BinaryRefPoly::<HALF_D>::new(hi_arr));
+    }
+
+    // Concatenate: v' = u || w (low halves first, high halves second).
+    lo_evals.extend(hi_evals);
+
+    DenseMultilinearExtension::from_evaluations_vec(
+        add!(mle.num_vars, 1, "split_column: num_vars overflow"),
+        lo_evals,
+        Zero::zero(),
+    )
+}
+
+#[allow(dead_code)]
+fn split_binary_poly_mle_u64<const D: usize, const HALF_D: usize>(
+    mle: &DenseMultilinearExtension<BinaryU64Poly<D>>,
+) -> DenseMultilinearExtension<BinaryU64Poly<HALF_D>> {
+    todo!("{:?}", mle)
+}
+
+/// Multilinear evaluation of `values` (length `2^gammas.len()`, MSB-first
+/// indexed) at point `gammas`. Peels `gammas[0]` (the high bit, equivalently
+/// the first sampled challenge) at each recursive step, splitting `values`
+/// into a lower half (high bit = 0) and an upper half (high bit = 1).
+fn mle_eval_msb_first<F: PrimeField>(values: Vec<F>, gammas: &[F], field_cfg: &F::Config) -> F {
+    if gammas.is_empty() {
+        debug_assert_eq!(values.len(), 1);
+        return values.into_iter().next().expect("non-empty values");
+    }
+    debug_assert_eq!(values.len(), 1usize << gammas.len());
+
+    let half = values.len() >> 1;
+    let g = &gammas[0];
+    let one = F::one_with_cfg(field_cfg);
+    let one_minus_g = one - g;
+
+    let mut next: Vec<F> = Vec::with_capacity(half);
+    for i in 0..half {
+        let mut lo = one_minus_g.clone();
+        lo *= &values[i];
+        let mut hi = g.clone();
+        hi *= &values[add!(i, half)];
+        lo += &hi;
+        next.push(lo);
+    }
+    mle_eval_msb_first(next, &gammas[1..], field_cfg)
 }

--- a/protocol/src/fold.rs
+++ b/protocol/src/fold.rs
@@ -1,0 +1,27 @@
+use zinc_poly::mle::DenseMultilinearExtension;
+
+/// Fold a trace of one type into a trace of another (similar but smaller) type.
+///
+/// Note that folding will increase number of variables for MLEs by
+/// `ilog2(Self::FOLDING_FACTOR)`.
+pub trait FoldTrace<From, To> {
+    /// Folding factor, a positive power of 2.
+    const FOLDING_FACTOR: usize;
+
+    fn fold_trace_column(column: &DenseMultilinearExtension<From>)
+    -> DenseMultilinearExtension<To>;
+}
+
+//
+// NOOP fold
+//
+
+pub struct NoopFoldTrace;
+
+impl<T: Clone> FoldTrace<T, T> for NoopFoldTrace {
+    const FOLDING_FACTOR: usize = 1;
+
+    fn fold_trace_column(trace: &DenseMultilinearExtension<T>) -> DenseMultilinearExtension<T> {
+        trace.clone()
+    }
+}

--- a/protocol/src/fold.rs
+++ b/protocol/src/fold.rs
@@ -182,10 +182,6 @@ fn split_binary_poly_mle<const D: usize, const HALF_D: usize>(
 fn split_binary_poly_mle_ref<const D: usize, const HALF_D: usize>(
     mle: &DenseMultilinearExtension<BinaryRefPoly<D>>,
 ) -> DenseMultilinearExtension<BinaryRefPoly<HALF_D>> {
-    const {
-        assert!(D == 2 * HALF_D, "split_column: D must equal 2 * HALF_D");
-    }
-
     let n = mle.evaluations.len();
     let mut lo_evals = Vec::with_capacity(n);
     let mut hi_evals = Vec::with_capacity(n);
@@ -200,18 +196,30 @@ fn split_binary_poly_mle_ref<const D: usize, const HALF_D: usize>(
     // Concatenate: v' = u || w (low halves first, high halves second).
     lo_evals.extend(hi_evals);
 
-    DenseMultilinearExtension::from_evaluations_vec(
-        add!(mle.num_vars, 1, "split_column: num_vars overflow"),
-        lo_evals,
-        Zero::zero(),
-    )
+    DenseMultilinearExtension::from_evaluations_vec(add!(mle.num_vars, 1), lo_evals, Zero::zero())
 }
 
 #[allow(dead_code)]
 fn split_binary_poly_mle_u64<const D: usize, const HALF_D: usize>(
     mle: &DenseMultilinearExtension<BinaryU64Poly<D>>,
 ) -> DenseMultilinearExtension<BinaryU64Poly<HALF_D>> {
-    todo!("{:?}", mle)
+    let n = mle.evaluations.len();
+    let mut lo_evals: Vec<BinaryU64Poly<HALF_D>> = Vec::with_capacity(n);
+    let mut hi_evals: Vec<BinaryU64Poly<HALF_D>> = Vec::with_capacity(n);
+
+    for entry in &mle.evaluations {
+        let bits: u64 = *entry.inner();
+        // `From<u64>` masks off bits at positions `>= HALF_D` so each half
+        // upholds the `BinaryU64Poly<HALF_D>` invariant.
+        lo_evals.push(BinaryU64Poly::<HALF_D>::from(bits));
+        hi_evals.push(BinaryU64Poly::<HALF_D>::from(bits >> HALF_D));
+    }
+
+    // Concatenate: v' = u || w (low halves first, high halves second), matching
+    // the layout produced by `split_binary_poly_mle_ref`.
+    lo_evals.extend(hi_evals);
+
+    DenseMultilinearExtension::from_evaluations_vec(add!(mle.num_vars, 1), lo_evals, Zero::zero())
 }
 
 /// Multilinear evaluation of `values` (length `2^gammas.len()`, MSB-first
@@ -240,4 +248,146 @@ fn mle_eval_msb_first<F: PrimeField>(values: Vec<F>, gammas: &[F], field_cfg: &F
         next.push(lo);
     }
     mle_eval_msb_first(next, &gammas[1..], field_cfg)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rand::{Rng, rng};
+    use zinc_transcript::traits::GenTranscribable;
+
+    /// Build two MLEs (`BinaryRefPoly<D>` and `BinaryU64Poly<D>`) carrying the
+    /// same coefficient pattern from a list of bit-packed `u64` entries.
+    fn build_matched_mles<const D: usize>(
+        bits_list: &[u64],
+    ) -> (
+        DenseMultilinearExtension<BinaryRefPoly<D>>,
+        DenseMultilinearExtension<BinaryU64Poly<D>>,
+    ) {
+        let n = bits_list.len();
+        assert!(n.is_power_of_two(), "n must be a power of two");
+        let num_vars = n.trailing_zeros() as usize;
+
+        let ref_entries: Vec<BinaryRefPoly<D>> = bits_list
+            .iter()
+            .map(|&bits| BinaryRefPoly::read_transcription_bytes_exact(&bits.to_le_bytes()))
+            .collect();
+        let u64_entries: Vec<BinaryU64Poly<D>> = bits_list
+            .iter()
+            .map(|&bits| BinaryU64Poly::from(bits))
+            .collect();
+
+        let ref_mle =
+            DenseMultilinearExtension::from_evaluations_vec(num_vars, ref_entries, Zero::zero());
+        let u64_mle =
+            DenseMultilinearExtension::from_evaluations_vec(num_vars, u64_entries, Zero::zero());
+
+        (ref_mle, u64_mle)
+    }
+
+    /// Run both splitters on matched inputs and assert that every output
+    /// coefficient agrees bit-for-bit.
+    fn assert_split_matches<const D: usize, const HALF_D: usize>(bits_list: Vec<u64>) {
+        let (ref_mle, u64_mle) = build_matched_mles::<D>(&bits_list);
+
+        let split_ref = split_binary_poly_mle_ref::<D, HALF_D>(&ref_mle);
+        let split_u64 = split_binary_poly_mle_u64::<D, HALF_D>(&u64_mle);
+
+        assert_eq!(split_ref.num_vars, split_u64.num_vars);
+        assert_eq!(split_ref.evaluations.len(), split_u64.evaluations.len());
+        for (idx, (r, u)) in split_ref
+            .evaluations
+            .iter()
+            .zip(split_u64.evaluations.iter())
+            .enumerate()
+        {
+            // Compare bits in two different ways - directly, as via iterator
+
+            for i in 0..HALF_D {
+                let r_bit = r[i].inner();
+                let u_bit = ((*u.inner()) >> i) & 1 != 0;
+                assert_eq!(
+                    r_bit, u_bit,
+                    "mismatch at output entry {idx}, coefficient bit {i}",
+                );
+            }
+
+            for (i, pair) in r.iter().zip_longest(u.iter()).enumerate() {
+                match pair {
+                    itertools::EitherOrBoth::Both(r_bit, u_bit) => {
+                        assert_eq!(
+                            r_bit.inner(),
+                            *u_bit,
+                            "mismatch at output entry {idx}, coefficient bit {i}",
+                        );
+                    }
+                    itertools::EitherOrBoth::Left(_) | itertools::EitherOrBoth::Right(_) => {
+                        panic!("mismatch in number of coefficients at output entry {idx}");
+                    }
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn split_ref_and_u64_match_d4_exhaustive() {
+        // Single-entry input: enumerate all 16 bit patterns.
+        for bits in 0u64..16 {
+            assert_split_matches::<4, 2>(vec![bits]);
+        }
+
+        // 4-entry input: enumerate all 16^4 = 65536 patterns is too much; sample.
+        let mut rng = rng();
+        for _ in 0..32 {
+            let bits_list: Vec<u64> = (0..4).map(|_| rng.random::<u64>() & 0xF).collect();
+            assert_split_matches::<4, 2>(bits_list);
+        }
+    }
+
+    #[test]
+    fn split_ref_and_u64_match_random() {
+        let mut rng = rng();
+
+        for n_log in 0..=3 {
+            let n = 1usize << n_log;
+            let bits_list: Vec<u64> = (0..n).map(|_| rng.random::<u64>() & 0xF).collect();
+            assert_split_matches::<4, 2>(bits_list);
+        }
+
+        for n_log in 0..=4 {
+            let n = 1usize << n_log;
+            let bits_list: Vec<u64> = (0..n).map(|_| rng.random::<u64>() & 0xFF).collect();
+            assert_split_matches::<8, 4>(bits_list);
+        }
+
+        for n_log in 0..=5 {
+            let n = 1usize << n_log;
+            let bits_list: Vec<u64> = (0..n).map(|_| rng.random::<u64>() & 0xFFFF_FFFF).collect();
+            assert_split_matches::<32, 16>(bits_list);
+        }
+
+        for n_log in 0..=6 {
+            let n = 1usize << n_log;
+            let bits_list: Vec<u64> = (0..n).map(|_| rng.random::<u64>()).collect();
+            assert_split_matches::<64, 32>(bits_list);
+        }
+    }
+
+    #[test]
+    fn split_u64_pins_all_zero_entries() {
+        // Zero input should round-trip to all-zero output regardless of D.
+        let bits_list = vec![0u64; 8];
+        assert_split_matches::<8, 4>(bits_list.clone());
+        assert_split_matches::<32, 16>(bits_list.clone());
+        assert_split_matches::<64, 32>(bits_list);
+    }
+
+    #[test]
+    fn split_u64_handles_all_ones_d64() {
+        // All-ones (every bit set) is the high-edge case for D=64 since the
+        // mask `(1 << 64) - 1` is not directly representable. Expect lo = hi =
+        // 2^32 - 1 for D=64, HALF_D=32.
+        let bits_list = vec![u64::MAX; 4];
+        assert_split_matches::<64, 32>(bits_list);
+    }
 }

--- a/protocol/src/fold.rs
+++ b/protocol/src/fold.rs
@@ -71,16 +71,17 @@ pub trait FoldTrace<From, To> {
             .collect_vec();
 
         let zero = F::zero_with_cfg(field_cfg);
+        let one = F::one_with_cfg(field_cfg);
 
         // Step 1: Per-chunk inner products
-        //   P_i = sum_{l < chunk_size} alphas[l] * bar_u_coeffs[i*chunk_size + j],
+        //   P_i = sum_{j < chunk_size} alphas[j] * bar_u_coeffs[i*chunk_size + j],
         // Trimmed (missing-trailing-zero) coefficients are treated as zero.
         let chunk_evals: Vec<F> = (0..Self::FOLDING_FACTOR)
             .map(|i| {
                 let start = mul!(i, chunk_size);
                 let mut acc = zero.clone();
-                for (l, alpha) in alphas.iter().enumerate() {
-                    if let Some(coeff) = bar_u_coeffs.get(add!(start, l)) {
+                for (j, alpha) in alphas.iter().enumerate() {
+                    if let Some(coeff) = bar_u_coeffs.get(add!(start, j)) {
                         acc += alpha.clone() * coeff;
                     }
                 }
@@ -90,7 +91,7 @@ pub trait FoldTrace<From, To> {
 
         // Step 2: MLE-evaluate the per-chunk inner products at folding_challenges,
         // MSB-first (gamma_1 = high bit, peeled first).
-        mle_eval_msb_first(chunk_evals, folding_challenges, field_cfg)
+        mle_eval_msb_first(chunk_evals, folding_challenges, &one)
     }
 }
 
@@ -226,7 +227,7 @@ fn split_binary_poly_mle_u64<const D: usize, const HALF_D: usize>(
 /// indexed) at point `gammas`. Peels `gammas[0]` (the high bit, equivalently
 /// the first sampled challenge) at each recursive step, splitting `values`
 /// into a lower half (high bit = 0) and an upper half (high bit = 1).
-fn mle_eval_msb_first<F: PrimeField>(values: Vec<F>, gammas: &[F], field_cfg: &F::Config) -> F {
+fn mle_eval_msb_first<F: PrimeField>(values: Vec<F>, gammas: &[F], one: &F) -> F {
     if gammas.is_empty() {
         debug_assert_eq!(values.len(), 1);
         return values.into_iter().next().expect("non-empty values");
@@ -235,8 +236,7 @@ fn mle_eval_msb_first<F: PrimeField>(values: Vec<F>, gammas: &[F], field_cfg: &F
 
     let half = values.len() >> 1;
     let g = &gammas[0];
-    let one = F::one_with_cfg(field_cfg);
-    let one_minus_g = one - g;
+    let one_minus_g = one.clone() - g;
 
     let mut next: Vec<F> = Vec::with_capacity(half);
     for i in 0..half {
@@ -247,7 +247,7 @@ fn mle_eval_msb_first<F: PrimeField>(values: Vec<F>, gammas: &[F], field_cfg: &F
         lo += &hi;
         next.push(lo);
     }
-    mle_eval_msb_first(next, &gammas[1..], field_cfg)
+    mle_eval_msb_first(next, &gammas[1..], one)
 }
 
 #[cfg(test)]

--- a/protocol/src/lib.rs
+++ b/protocol/src/lib.rs
@@ -427,7 +427,7 @@ where
 #[cfg(not(miri))] // long running
 mod tests {
     use super::*;
-    use crate::fold::NoopFoldTrace;
+    use crate::fold::FoldBinaryTrace4x;
     use crypto_bigint::U64;
     use crypto_primitives::{
         Field, crypto_bigint_int::Int, crypto_bigint_monty::MontyField, crypto_bigint_uint::Uint,
@@ -460,7 +460,10 @@ mod tests {
 
     const INT_LIMBS: usize = U64::LIMBS;
     const FIELD_LIMBS: usize = U64::LIMBS * 3;
-    const DEGREE_PLUS_ONE: usize = 32;
+
+    const D: usize = 32;
+    const HALF_D: usize = D / 2;
+    const QUARTER_D: usize = D / 4;
 
     // Zip+ type parameters.
 
@@ -475,22 +478,17 @@ mod tests {
     pub struct BinPolyZipTypes {}
     impl ZipTypes for BinPolyZipTypes {
         const NUM_COLUMN_OPENINGS: usize = 100;
-        type Eval = BinaryPoly<DEGREE_PLUS_ONE>;
-        type Cw = DensePolynomial<i64, DEGREE_PLUS_ONE>;
+        type Eval = BinaryPoly<QUARTER_D>;
+        type Cw = DensePolynomial<i64, QUARTER_D>;
         type Fmod = Uint<FIELD_LIMBS>;
         type PrimeTest = MillerRabin;
         type Chal = i128;
         type Pt = i128;
         type CombR = Int<M>;
-        type Comb = DensePolynomial<Self::CombR, DEGREE_PLUS_ONE>;
-        type EvalDotChal = BinaryPolyInnerProduct<Self::Chal, DEGREE_PLUS_ONE>;
-        type CombDotChal = DensePolyInnerProduct<
-            Self::CombR,
-            Self::Chal,
-            Self::CombR,
-            MBSInnerProduct,
-            DEGREE_PLUS_ONE,
-        >;
+        type Comb = DensePolynomial<Self::CombR, QUARTER_D>;
+        type EvalDotChal = BinaryPolyInnerProduct<Self::Chal, QUARTER_D>;
+        type CombDotChal =
+            DensePolyInnerProduct<Self::CombR, Self::Chal, Self::CombR, MBSInnerProduct, QUARTER_D>;
         type ArrCombRDotChal = MBSInnerProduct;
     }
 
@@ -498,23 +496,17 @@ mod tests {
     pub struct ArbitraryPolyZipTypesIprs {}
     impl ZipTypes for ArbitraryPolyZipTypesIprs {
         const NUM_COLUMN_OPENINGS: usize = 100;
-        type Eval = DensePolynomial<i64, DEGREE_PLUS_ONE>;
-        type Cw = DensePolynomial<i64, DEGREE_PLUS_ONE>;
+        type Eval = DensePolynomial<i64, D>;
+        type Cw = DensePolynomial<i64, D>;
         type Fmod = Uint<FIELD_LIMBS>;
         type PrimeTest = MillerRabin;
         type Chal = i128;
         type Pt = i128;
         type CombR = Int<M>;
-        type Comb = DensePolynomial<Self::CombR, DEGREE_PLUS_ONE>;
-        type EvalDotChal =
-            DensePolyInnerProduct<i64, Self::Chal, Self::CombR, MBSInnerProduct, DEGREE_PLUS_ONE>;
-        type CombDotChal = DensePolyInnerProduct<
-            Self::CombR,
-            Self::Chal,
-            Self::CombR,
-            MBSInnerProduct,
-            DEGREE_PLUS_ONE,
-        >;
+        type Comb = DensePolynomial<Self::CombR, D>;
+        type EvalDotChal = DensePolyInnerProduct<i64, Self::Chal, Self::CombR, MBSInnerProduct, D>;
+        type CombDotChal =
+            DensePolyInnerProduct<Self::CombR, Self::Chal, Self::CombR, MBSInnerProduct, D>;
         type ArrCombRDotChal = MBSInnerProduct;
     }
 
@@ -524,23 +516,17 @@ mod tests {
     pub struct ArbitraryPolyZipTypesRaa {}
     impl ZipTypes for ArbitraryPolyZipTypesRaa {
         const NUM_COLUMN_OPENINGS: usize = 100;
-        type Eval = DensePolynomial<i64, DEGREE_PLUS_ONE>;
-        type Cw = DensePolynomial<Int<K>, DEGREE_PLUS_ONE>;
+        type Eval = DensePolynomial<i64, D>;
+        type Cw = DensePolynomial<Int<K>, D>;
         type Fmod = Uint<FIELD_LIMBS>;
         type PrimeTest = MillerRabin;
         type Chal = i128;
         type Pt = i128;
         type CombR = Int<M>;
-        type Comb = DensePolynomial<Self::CombR, DEGREE_PLUS_ONE>;
-        type EvalDotChal =
-            DensePolyInnerProduct<i64, Self::Chal, Self::CombR, MBSInnerProduct, DEGREE_PLUS_ONE>;
-        type CombDotChal = DensePolyInnerProduct<
-            Self::CombR,
-            Self::Chal,
-            Self::CombR,
-            MBSInnerProduct,
-            DEGREE_PLUS_ONE,
-        >;
+        type Comb = DensePolynomial<Self::CombR, D>;
+        type EvalDotChal = DensePolyInnerProduct<i64, Self::Chal, Self::CombR, MBSInnerProduct, D>;
+        type CombDotChal =
+            DensePolyInnerProduct<Self::CombR, Self::Chal, Self::CombR, MBSInnerProduct, D>;
         type ArrCombRDotChal = MBSInnerProduct;
     }
 
@@ -566,7 +552,7 @@ mod tests {
     #[derive(Clone, Debug)]
     struct TestZincTypesIprs;
 
-    impl ZincTypes<DEGREE_PLUS_ONE, DEGREE_PLUS_ONE> for TestZincTypesIprs {
+    impl ZincTypes<D, QUARTER_D> for TestZincTypesIprs {
         type Int = ZtInt;
         type Chal = i128;
         type Pt = i128;
@@ -578,7 +564,7 @@ mod tests {
         type ArbitraryZt = ArbitraryPolyZipTypesIprs;
         type IntZt = IntZipTypes;
 
-        type BinaryFold = NoopFoldTrace;
+        type BinaryFold = FoldBinaryTrace4x<D, HALF_D, QUARTER_D>;
 
         type BinaryLc = IprsCode<Self::BinaryZt, PnttConfigF65537, REP_FACTOR, CHECKED>;
         type ArbitraryLc = IprsCode<Self::ArbitraryZt, PnttConfigF65537, REP_FACTOR, CHECKED>;
@@ -595,7 +581,7 @@ mod tests {
     #[derive(Clone, Debug)]
     struct TestZincTypesRaa;
 
-    impl ZincTypes<DEGREE_PLUS_ONE, DEGREE_PLUS_ONE> for TestZincTypesRaa {
+    impl ZincTypes<D, QUARTER_D> for TestZincTypesRaa {
         type Int = i64;
         type Chal = i128;
         type Pt = i128;
@@ -607,7 +593,7 @@ mod tests {
         type ArbitraryZt = ArbitraryPolyZipTypesRaa;
         type IntZt = IntZipTypes;
 
-        type BinaryFold = NoopFoldTrace;
+        type BinaryFold = FoldBinaryTrace4x<D, HALF_D, QUARTER_D>;
 
         type BinaryLc = RaaCode<Self::BinaryZt, TestRaaConfig, REP_FACTOR>;
         type ArbitraryLc = RaaCode<Self::ArbitraryZt, TestRaaConfig, REP_FACTOR>;
@@ -623,7 +609,7 @@ mod tests {
     }
 
     /// Set up Zip+ PCS parameters for a given number of MLE variables.
-    #[allow(clippy::type_complexity)]
+    #[allow(clippy::type_complexity, clippy::arithmetic_side_effects)]
     fn setup_pp<Zt>(
         num_vars: usize,
         linear_codes: (Zt::BinaryLc, Zt::ArbitraryLc, Zt::IntLc),
@@ -633,11 +619,14 @@ mod tests {
         ZipPlusParams<Zt::IntZt, Zt::IntLc>,
     )
     where
-        Zt: ZincTypes<DEGREE_PLUS_ONE, DEGREE_PLUS_ONE>,
+        Zt: ZincTypes<D, QUARTER_D>,
     {
+        let folded_num_vars = num_vars + Zt::BinaryFold::FOLDING_FACTOR.ilog2() as usize;
+
         let poly_size = 1 << num_vars;
+        let folded_poly_size = 1 << folded_num_vars;
         (
-            ZipPlus::<Zt::BinaryZt, Zt::BinaryLc>::setup(poly_size, linear_codes.0),
+            ZipPlus::<Zt::BinaryZt, Zt::BinaryLc>::setup(folded_poly_size, linear_codes.0),
             ZipPlus::<Zt::ArbitraryZt, Zt::ArbitraryLc>::setup(poly_size, linear_codes.1),
             ZipPlus::<Zt::IntZt, Zt::IntLc>::setup(poly_size, linear_codes.2),
         )
@@ -661,13 +650,13 @@ mod tests {
         tamper: impl Fn(&mut Proof<F>),
         check_verification: impl Fn(Result<(), ProtocolError<F, IdealOrZero<DegreeOneIdeal<F>>>>),
     ) where
-        Zt: ZincTypes<DEGREE_PLUS_ONE, DEGREE_PLUS_ONE>,
+        Zt: ZincTypes<D, QUARTER_D>,
         <Zt::BinaryZt as ZipTypes>::Cw: ProjectableToField<F>,
         <Zt::ArbitraryZt as ZipTypes>::Eval: ProjectableToField<F>,
         <Zt::ArbitraryZt as ZipTypes>::Cw: ProjectableToField<F>,
         <Zt::IntZt as ZipTypes>::Cw: ProjectableToField<F>,
-        U: Uair<Scalar = DensePolynomial<Zt::Int, DEGREE_PLUS_ONE>>
-            + GenerateRandomTrace<DEGREE_PLUS_ONE, PolyCoeff = Zt::Int, Int = Zt::Int>
+        U: Uair<Scalar = DensePolynomial<Zt::Int, D>>
+            + GenerateRandomTrace<D, PolyCoeff = Zt::Int, Int = Zt::Int>
             + 'static,
         F: for<'a> FromWithConfig<&'a Zt::Int>
             + for<'a> FromWithConfig<&'a Zt::CombR>
@@ -686,7 +675,7 @@ mod tests {
 
         macro_rules! run_protocol {
             ($mle_first:ident) => {
-                let mut proof = ZincPlusPiop::<Zt, U, F, DEGREE_PLUS_ONE, DEGREE_PLUS_ONE>::prove::<
+                let mut proof = ZincPlusPiop::<Zt, U, F, D, QUARTER_D>::prove::<
                     { $mle_first },
                     CHECKED,
                 >(&pp, &trace, num_vars, project_scalar_fn)
@@ -704,7 +693,7 @@ mod tests {
                 tamper(&mut proof);
 
                 let verification_result =
-                    ZincPlusPiop::<Zt, U, F, DEGREE_PLUS_ONE, DEGREE_PLUS_ONE>::verify::<_, CHECKED>(
+                    ZincPlusPiop::<Zt, U, F, D, QUARTER_D>::verify::<_, CHECKED>(
                         &pp,
                         proof,
                         &public_trace,

--- a/protocol/src/lib.rs
+++ b/protocol/src/lib.rs
@@ -17,12 +17,14 @@
 //! - Step 6: lift-and-project (unprojected MLE evaluations at r_0)
 //! - Step 7: Zip+ PCS open/verify at r_0
 
+pub mod fold;
 pub mod prover;
 pub mod verifier;
 
 #[cfg(feature = "parallel")]
 use rayon::prelude::*;
 
+use crate::fold::FoldTrace;
 use crypto_primitives::{ConstIntRing, ConstIntSemiring, FromWithConfig, PrimeField, Semiring};
 use std::{fmt::Debug, marker::PhantomData};
 use thiserror::Error;
@@ -251,6 +253,8 @@ pub trait ZincTypes<const DEGREE_PLUS_ONE: usize, const FOLDED_DEG_PLUS_ONE: usi
             PrimeTest = Self::PrimeTest,
         >;
 
+    type BinaryFold: FoldTrace<BinaryPoly<DEGREE_PLUS_ONE>, BinaryPoly<FOLDED_DEG_PLUS_ONE>>;
+
     /// Linear code used in Zip+ for the binary polynomial trace columns.
     type BinaryLc: LinearCode<Self::BinaryZt>;
 
@@ -423,6 +427,7 @@ where
 #[cfg(not(miri))] // long running
 mod tests {
     use super::*;
+    use crate::fold::NoopFoldTrace;
     use crypto_bigint::U64;
     use crypto_primitives::{
         Field, crypto_bigint_int::Int, crypto_bigint_monty::MontyField, crypto_bigint_uint::Uint,
@@ -573,6 +578,8 @@ mod tests {
         type ArbitraryZt = ArbitraryPolyZipTypesIprs;
         type IntZt = IntZipTypes;
 
+        type BinaryFold = NoopFoldTrace;
+
         type BinaryLc = IprsCode<Self::BinaryZt, PnttConfigF65537, REP_FACTOR, CHECKED>;
         type ArbitraryLc = IprsCode<Self::ArbitraryZt, PnttConfigF65537, REP_FACTOR, CHECKED>;
         type IntLc = IprsCode<Self::IntZt, PnttConfigF65537, REP_FACTOR, CHECKED>;
@@ -599,6 +606,8 @@ mod tests {
         type BinaryZt = BinPolyZipTypes;
         type ArbitraryZt = ArbitraryPolyZipTypesRaa;
         type IntZt = IntZipTypes;
+
+        type BinaryFold = NoopFoldTrace;
 
         type BinaryLc = RaaCode<Self::BinaryZt, TestRaaConfig, REP_FACTOR>;
         type ArbitraryLc = RaaCode<Self::ArbitraryZt, TestRaaConfig, REP_FACTOR>;

--- a/protocol/src/lib.rs
+++ b/protocol/src/lib.rs
@@ -267,7 +267,9 @@ pub trait ZincTypes<const DEGREE_PLUS_ONE: usize, const FOLDED_DEG_PLUS_ONE: usi
 /// (Note that type parameters are further constrained in the impl blocks for
 /// the prover and verifier)
 #[derive(Copy, Clone, Default, Debug)]
-pub struct ZincPlusPiop<Zt, U, F, const DEGREE_PLUS_ONE: usize, const FOLDED_DEGREE_PLUS_ONE: usize>(PhantomData<(Zt, U, F)>)
+pub struct ZincPlusPiop<Zt, U, F, const DEGREE_PLUS_ONE: usize, const FOLDED_DEGREE_PLUS_ONE: usize>(
+    PhantomData<(Zt, U, F)>,
+)
 where
     Zt: ZincTypes<DEGREE_PLUS_ONE, FOLDED_DEGREE_PLUS_ONE>,
     U: Uair,

--- a/protocol/src/lib.rs
+++ b/protocol/src/lib.rs
@@ -189,7 +189,9 @@ where
 
 /// Trait bundling the various type parameters for the public inputs (NYI),
 /// witness and Zinc+ PIOP.
-pub trait ZincTypes<const DEGREE_PLUS_ONE: usize>: Clone + Debug {
+pub trait ZincTypes<const DEGREE_PLUS_ONE: usize, const FOLDED_DEG_PLUS_ONE: usize>:
+    Clone + Debug
+{
     /// Main integer type for the protocol, used as a coefficient type for the
     /// arbitrary polynomial trace columns and for the integer trace columns.
     type Int: Semiring
@@ -221,7 +223,7 @@ pub trait ZincTypes<const DEGREE_PLUS_ONE: usize>: Clone + Debug {
 
     /// Zip+ types for the binary polynomial trace columns.
     type BinaryZt: ZipTypes<
-            Eval = BinaryPoly<DEGREE_PLUS_ONE>,
+            Eval = BinaryPoly<FOLDED_DEG_PLUS_ONE>,
             Chal = Self::Chal,
             Pt = Self::Pt,
             CombR = Self::CombR,
@@ -265,9 +267,9 @@ pub trait ZincTypes<const DEGREE_PLUS_ONE: usize>: Clone + Debug {
 /// (Note that type parameters are further constrained in the impl blocks for
 /// the prover and verifier)
 #[derive(Copy, Clone, Default, Debug)]
-pub struct ZincPlusPiop<Zt, U, F, const DEGREE_PLUS_ONE: usize>(PhantomData<(Zt, U, F)>)
+pub struct ZincPlusPiop<Zt, U, F, const DEGREE_PLUS_ONE: usize, const FOLDED_DEGREE_PLUS_ONE: usize>(PhantomData<(Zt, U, F)>)
 where
-    Zt: ZincTypes<DEGREE_PLUS_ONE>,
+    Zt: ZincTypes<DEGREE_PLUS_ONE, FOLDED_DEGREE_PLUS_ONE>,
     U: Uair,
     F: PrimeField;
 
@@ -557,7 +559,7 @@ mod tests {
     #[derive(Clone, Debug)]
     struct TestZincTypesIprs;
 
-    impl ZincTypes<DEGREE_PLUS_ONE> for TestZincTypesIprs {
+    impl ZincTypes<DEGREE_PLUS_ONE, DEGREE_PLUS_ONE> for TestZincTypesIprs {
         type Int = ZtInt;
         type Chal = i128;
         type Pt = i128;
@@ -584,7 +586,7 @@ mod tests {
     #[derive(Clone, Debug)]
     struct TestZincTypesRaa;
 
-    impl ZincTypes<DEGREE_PLUS_ONE> for TestZincTypesRaa {
+    impl ZincTypes<DEGREE_PLUS_ONE, DEGREE_PLUS_ONE> for TestZincTypesRaa {
         type Int = i64;
         type Chal = i128;
         type Pt = i128;
@@ -620,7 +622,7 @@ mod tests {
         ZipPlusParams<Zt::IntZt, Zt::IntLc>,
     )
     where
-        Zt: ZincTypes<DEGREE_PLUS_ONE>,
+        Zt: ZincTypes<DEGREE_PLUS_ONE, DEGREE_PLUS_ONE>,
     {
         let poly_size = 1 << num_vars;
         (
@@ -648,7 +650,7 @@ mod tests {
         tamper: impl Fn(&mut Proof<F>),
         check_verification: impl Fn(Result<(), ProtocolError<F, IdealOrZero<DegreeOneIdeal<F>>>>),
     ) where
-        Zt: ZincTypes<DEGREE_PLUS_ONE>,
+        Zt: ZincTypes<DEGREE_PLUS_ONE, DEGREE_PLUS_ONE>,
         <Zt::BinaryZt as ZipTypes>::Cw: ProjectableToField<F>,
         <Zt::ArbitraryZt as ZipTypes>::Eval: ProjectableToField<F>,
         <Zt::ArbitraryZt as ZipTypes>::Cw: ProjectableToField<F>,
@@ -673,7 +675,7 @@ mod tests {
 
         macro_rules! run_protocol {
             ($mle_first:ident) => {
-                let mut proof = ZincPlusPiop::<Zt, U, F, DEGREE_PLUS_ONE>::prove::<
+                let mut proof = ZincPlusPiop::<Zt, U, F, DEGREE_PLUS_ONE, DEGREE_PLUS_ONE>::prove::<
                     { $mle_first },
                     CHECKED,
                 >(&pp, &trace, num_vars, project_scalar_fn)
@@ -691,7 +693,7 @@ mod tests {
                 tamper(&mut proof);
 
                 let verification_result =
-                    ZincPlusPiop::<Zt, U, F, DEGREE_PLUS_ONE>::verify::<_, CHECKED>(
+                    ZincPlusPiop::<Zt, U, F, DEGREE_PLUS_ONE, DEGREE_PLUS_ONE>::verify::<_, CHECKED>(
                         &pp,
                         proof,
                         &public_trace,

--- a/protocol/src/prover.rs
+++ b/protocol/src/prover.rs
@@ -36,11 +36,18 @@ use zip_plus::{
 /// Fiat-Shamir transcript, PCS parameters/hints/commitments, and trace
 /// reference.
 #[derive(Clone, Debug)]
-pub struct ProverBase<'a, Zt: ZincTypes<D, FD>, U: Uair, F: PrimeField, const D: usize, const FD: usize> {
+pub struct ProverBase<
+    'a,
+    Zt: ZincTypes<D, FD>,
+    U: Uair,
+    F: PrimeField,
+    const D: usize,
+    const FD: usize,
+> {
     num_vars: usize,
     uair_signature: UairSignature,
     pcs_transcript: PcsProverTranscript,
-    trace: &'a UairTrace<'static, Zt::Int, Zt::Int, D>,
+    trace: &'a UairTrace<'static, Zt::Int, Zt::Int, D, D>,
 
     // Commitment info
     pp_bin: &'a ZipPlusParams<Zt::BinaryZt, Zt::BinaryLc>,
@@ -63,8 +70,14 @@ pub struct ProverBase<'a, Zt: ZincTypes<D, FD>, U: Uair, F: PrimeField, const D:
 /// After step 1 via [`step1_combined`](ProverCommitted::step1_combined)
 /// (row-major / "combined" projection). `project_scalar` has been consumed.
 #[derive(Clone, Debug)]
-pub struct ProverProjectedCombined<'a, Zt: ZincTypes<D, FD>, U: Uair, F: PrimeField, const D: usize, const FD: usize>
-{
+pub struct ProverProjectedCombined<
+    'a,
+    Zt: ZincTypes<D, FD>,
+    U: Uair,
+    F: PrimeField,
+    const D: usize,
+    const FD: usize,
+> {
     base: ProverBase<'a, Zt, U, F, D, FD>,
     field_cfg: F::Config,
     projected_trace: RowMajorTrace<F>,
@@ -74,8 +87,14 @@ pub struct ProverProjectedCombined<'a, Zt: ZincTypes<D, FD>, U: Uair, F: PrimeFi
 /// After step 1 via [`step1_mle_first`](ProverCommitted::step1_mle_first)
 /// (column-major / MLE-first projection). `project_scalar` has been consumed.
 #[derive(Clone, Debug)]
-pub struct ProverProjectedMleFirst<'a, Zt: ZincTypes<D, FD>, U: Uair, F: PrimeField, const D: usize, const FD: usize>
-{
+pub struct ProverProjectedMleFirst<
+    'a,
+    Zt: ZincTypes<D, FD>,
+    U: Uair,
+    F: PrimeField,
+    const D: usize,
+    const FD: usize,
+> {
     base: ProverBase<'a, Zt, U, F, D, FD>,
     field_cfg: F::Config,
     projected_trace: ColumnMajorTrace<F>,
@@ -84,7 +103,14 @@ pub struct ProverProjectedMleFirst<'a, Zt: ZincTypes<D, FD>, U: Uair, F: PrimeFi
 
 /// After step 2 (ideal check).
 #[derive(Clone, Debug)]
-pub struct ProverIdealChecked<'a, Zt: ZincTypes<D, FD>, U: Uair, F: PrimeField, const D: usize, const FD: usize> {
+pub struct ProverIdealChecked<
+    'a,
+    Zt: ZincTypes<D, FD>,
+    U: Uair,
+    F: PrimeField,
+    const D: usize,
+    const FD: usize,
+> {
     base: ProverBase<'a, Zt, U, F, D, FD>,
     field_cfg: F::Config,
     projected_trace: ProjectedTrace<F>,
@@ -97,7 +123,14 @@ pub struct ProverIdealChecked<'a, Zt: ZincTypes<D, FD>, U: Uair, F: PrimeField, 
 
 /// After step 3 (eval projection). `projected_scalars_fx` has been consumed.
 #[derive(Clone, Debug)]
-pub struct ProverEvalProjected<'a, Zt: ZincTypes<D, FD>, U: Uair, F: PrimeField, const D: usize, const FD: usize> {
+pub struct ProverEvalProjected<
+    'a,
+    Zt: ZincTypes<D, FD>,
+    U: Uair,
+    F: PrimeField,
+    const D: usize,
+    const FD: usize,
+> {
     base: ProverBase<'a, Zt, U, F, D, FD>,
     field_cfg: F::Config,
     projected_trace: ProjectedTrace<F>,
@@ -112,7 +145,14 @@ pub struct ProverEvalProjected<'a, Zt: ZincTypes<D, FD>, U: Uair, F: PrimeField,
 /// After step 4 (sumcheck).
 #[allow(clippy::type_complexity)]
 #[derive(Clone, Debug)]
-pub struct ProverSumchecked<'a, Zt: ZincTypes<D, FD>, U: Uair, F: PrimeField, const D: usize, const FD: usize> {
+pub struct ProverSumchecked<
+    'a,
+    Zt: ZincTypes<D, FD>,
+    U: Uair,
+    F: PrimeField,
+    const D: usize,
+    const FD: usize,
+> {
     base: ProverBase<'a, Zt, U, F, D, FD>,
     field_cfg: F::Config,
     projected_trace: ProjectedTrace<F>,
@@ -128,7 +168,14 @@ pub struct ProverSumchecked<'a, Zt: ZincTypes<D, FD>, U: Uair, F: PrimeField, co
 
 /// After step 5 (multipoint eval).
 #[derive(Clone, Debug)]
-pub struct ProverMultipointEvaled<'a, Zt: ZincTypes<D, FD>, U: Uair, F: PrimeField, const D: usize, const FD: usize> {
+pub struct ProverMultipointEvaled<
+    'a,
+    Zt: ZincTypes<D, FD>,
+    U: Uair,
+    F: PrimeField,
+    const D: usize,
+    const FD: usize,
+> {
     base: ProverBase<'a, Zt, U, F, D, FD>,
     field_cfg: F::Config,
     projected_trace: ProjectedTrace<F>,
@@ -144,7 +191,14 @@ pub struct ProverMultipointEvaled<'a, Zt: ZincTypes<D, FD>, U: Uair, F: PrimeFie
 
 /// After step 6 (lift-and-project).
 #[derive(Clone, Debug)]
-pub struct ProverLifted<'a, Zt: ZincTypes<D, FD>, U: Uair, F: PrimeField, const D: usize, const FD: usize> {
+pub struct ProverLifted<
+    'a,
+    Zt: ZincTypes<D, FD>,
+    U: Uair,
+    F: PrimeField,
+    const D: usize,
+    const FD: usize,
+> {
     base: ProverBase<'a, Zt, U, F, D, FD>,
     field_cfg: F::Config,
     ic_proof: IdealCheckProof<F>,
@@ -163,7 +217,14 @@ pub struct ProverLifted<'a, Zt: ZincTypes<D, FD>, U: Uair, F: PrimeField, const 
 /// Ready for generating the final proof object in
 /// [`finish`](ProverPcsOpened::finish).
 #[derive(Clone, Debug)]
-pub struct ProverPcsOpened<'a, Zt: ZincTypes<D, FD>, U: Uair, F: PrimeField, const D: usize, const FD: usize> {
+pub struct ProverPcsOpened<
+    'a,
+    Zt: ZincTypes<D, FD>,
+    U: Uair,
+    F: PrimeField,
+    const D: usize,
+    const FD: usize,
+> {
     base: ProverBase<'a, Zt, U, F, D, FD>,
     ic_proof: IdealCheckProof<F>,
     cpr_proof: CombinedPolyResolverProof<F>,
@@ -223,7 +284,7 @@ where
             ZipPlusParams<Zt::ArbitraryZt, Zt::ArbitraryLc>,
             ZipPlusParams<Zt::IntZt, Zt::IntLc>,
         ),
-        trace: &'a UairTrace<'static, Zt::Int, Zt::Int, D>,
+        trace: &'a UairTrace<'static, Zt::Int, Zt::Int, D, D>,
         num_vars: usize,
     ) -> Result<ProverBase<'a, Zt, U, F, D, D>, ProtocolError<F, U::Ideal>> {
         let uair_signature = U::signature();
@@ -685,7 +746,7 @@ where
             ZipPlusParams<Zt::ArbitraryZt, Zt::ArbitraryLc>,
             ZipPlusParams<Zt::IntZt, Zt::IntLc>,
         ),
-        trace: &UairTrace<'static, Zt::Int, Zt::Int, D>,
+        trace: &UairTrace<'static, Zt::Int, Zt::Int, D, D>,
         num_vars: usize,
         project_scalar: impl Fn(&U::Scalar, &F::Config) -> DynamicPolynomialF<F>,
     ) -> Result<Proof<F>, ProtocolError<F, U::Ideal>> {

--- a/protocol/src/prover.rs
+++ b/protocol/src/prover.rs
@@ -36,7 +36,7 @@ use zip_plus::{
 /// Fiat-Shamir transcript, PCS parameters/hints/commitments, and trace
 /// reference.
 #[derive(Clone, Debug)]
-pub struct ProverBase<'a, Zt: ZincTypes<D>, U: Uair, F: PrimeField, const D: usize> {
+pub struct ProverBase<'a, Zt: ZincTypes<D, FD>, U: Uair, F: PrimeField, const D: usize, const FD: usize> {
     num_vars: usize,
     uair_signature: UairSignature,
     pcs_transcript: PcsProverTranscript,
@@ -63,8 +63,9 @@ pub struct ProverBase<'a, Zt: ZincTypes<D>, U: Uair, F: PrimeField, const D: usi
 /// After step 1 via [`step1_combined`](ProverCommitted::step1_combined)
 /// (row-major / "combined" projection). `project_scalar` has been consumed.
 #[derive(Clone, Debug)]
-pub struct ProverProjectedCombined<'a, Zt: ZincTypes<D>, U: Uair, F: PrimeField, const D: usize> {
-    base: ProverBase<'a, Zt, U, F, D>,
+pub struct ProverProjectedCombined<'a, Zt: ZincTypes<D, FD>, U: Uair, F: PrimeField, const D: usize, const FD: usize>
+{
+    base: ProverBase<'a, Zt, U, F, D, FD>,
     field_cfg: F::Config,
     projected_trace: RowMajorTrace<F>,
     projected_scalars_fx: HashMap<U::Scalar, DynamicPolynomialF<F>>,
@@ -73,8 +74,9 @@ pub struct ProverProjectedCombined<'a, Zt: ZincTypes<D>, U: Uair, F: PrimeField,
 /// After step 1 via [`step1_mle_first`](ProverCommitted::step1_mle_first)
 /// (column-major / MLE-first projection). `project_scalar` has been consumed.
 #[derive(Clone, Debug)]
-pub struct ProverProjectedMleFirst<'a, Zt: ZincTypes<D>, U: Uair, F: PrimeField, const D: usize> {
-    base: ProverBase<'a, Zt, U, F, D>,
+pub struct ProverProjectedMleFirst<'a, Zt: ZincTypes<D, FD>, U: Uair, F: PrimeField, const D: usize, const FD: usize>
+{
+    base: ProverBase<'a, Zt, U, F, D, FD>,
     field_cfg: F::Config,
     projected_trace: ColumnMajorTrace<F>,
     projected_scalars_fx: HashMap<U::Scalar, DynamicPolynomialF<F>>,
@@ -82,8 +84,8 @@ pub struct ProverProjectedMleFirst<'a, Zt: ZincTypes<D>, U: Uair, F: PrimeField,
 
 /// After step 2 (ideal check).
 #[derive(Clone, Debug)]
-pub struct ProverIdealChecked<'a, Zt: ZincTypes<D>, U: Uair, F: PrimeField, const D: usize> {
-    base: ProverBase<'a, Zt, U, F, D>,
+pub struct ProverIdealChecked<'a, Zt: ZincTypes<D, FD>, U: Uair, F: PrimeField, const D: usize, const FD: usize> {
+    base: ProverBase<'a, Zt, U, F, D, FD>,
     field_cfg: F::Config,
     projected_trace: ProjectedTrace<F>,
     projected_scalars_fx: HashMap<U::Scalar, DynamicPolynomialF<F>>,
@@ -95,8 +97,8 @@ pub struct ProverIdealChecked<'a, Zt: ZincTypes<D>, U: Uair, F: PrimeField, cons
 
 /// After step 3 (eval projection). `projected_scalars_fx` has been consumed.
 #[derive(Clone, Debug)]
-pub struct ProverEvalProjected<'a, Zt: ZincTypes<D>, U: Uair, F: PrimeField, const D: usize> {
-    base: ProverBase<'a, Zt, U, F, D>,
+pub struct ProverEvalProjected<'a, Zt: ZincTypes<D, FD>, U: Uair, F: PrimeField, const D: usize, const FD: usize> {
+    base: ProverBase<'a, Zt, U, F, D, FD>,
     field_cfg: F::Config,
     projected_trace: ProjectedTrace<F>,
     ic_proof: IdealCheckProof<F>,
@@ -110,8 +112,8 @@ pub struct ProverEvalProjected<'a, Zt: ZincTypes<D>, U: Uair, F: PrimeField, con
 /// After step 4 (sumcheck).
 #[allow(clippy::type_complexity)]
 #[derive(Clone, Debug)]
-pub struct ProverSumchecked<'a, Zt: ZincTypes<D>, U: Uair, F: PrimeField, const D: usize> {
-    base: ProverBase<'a, Zt, U, F, D>,
+pub struct ProverSumchecked<'a, Zt: ZincTypes<D, FD>, U: Uair, F: PrimeField, const D: usize, const FD: usize> {
+    base: ProverBase<'a, Zt, U, F, D, FD>,
     field_cfg: F::Config,
     projected_trace: ProjectedTrace<F>,
     ic_proof: IdealCheckProof<F>,
@@ -126,8 +128,8 @@ pub struct ProverSumchecked<'a, Zt: ZincTypes<D>, U: Uair, F: PrimeField, const 
 
 /// After step 5 (multipoint eval).
 #[derive(Clone, Debug)]
-pub struct ProverMultipointEvaled<'a, Zt: ZincTypes<D>, U: Uair, F: PrimeField, const D: usize> {
-    base: ProverBase<'a, Zt, U, F, D>,
+pub struct ProverMultipointEvaled<'a, Zt: ZincTypes<D, FD>, U: Uair, F: PrimeField, const D: usize, const FD: usize> {
+    base: ProverBase<'a, Zt, U, F, D, FD>,
     field_cfg: F::Config,
     projected_trace: ProjectedTrace<F>,
     ic_proof: IdealCheckProof<F>,
@@ -142,8 +144,8 @@ pub struct ProverMultipointEvaled<'a, Zt: ZincTypes<D>, U: Uair, F: PrimeField, 
 
 /// After step 6 (lift-and-project).
 #[derive(Clone, Debug)]
-pub struct ProverLifted<'a, Zt: ZincTypes<D>, U: Uair, F: PrimeField, const D: usize> {
-    base: ProverBase<'a, Zt, U, F, D>,
+pub struct ProverLifted<'a, Zt: ZincTypes<D, FD>, U: Uair, F: PrimeField, const D: usize, const FD: usize> {
+    base: ProverBase<'a, Zt, U, F, D, FD>,
     field_cfg: F::Config,
     ic_proof: IdealCheckProof<F>,
     cpr_proof: CombinedPolyResolverProof<F>,
@@ -161,8 +163,8 @@ pub struct ProverLifted<'a, Zt: ZincTypes<D>, U: Uair, F: PrimeField, const D: u
 /// Ready for generating the final proof object in
 /// [`finish`](ProverPcsOpened::finish).
 #[derive(Clone, Debug)]
-pub struct ProverPcsOpened<'a, Zt: ZincTypes<D>, U: Uair, F: PrimeField, const D: usize> {
-    base: ProverBase<'a, Zt, U, F, D>,
+pub struct ProverPcsOpened<'a, Zt: ZincTypes<D, FD>, U: Uair, F: PrimeField, const D: usize, const FD: usize> {
+    base: ProverBase<'a, Zt, U, F, D, FD>,
     ic_proof: IdealCheckProof<F>,
     cpr_proof: CombinedPolyResolverProof<F>,
     combined_sumcheck: MultiDegreeSumcheckProof<F>,
@@ -179,9 +181,9 @@ pub struct ProverPcsOpened<'a, Zt: ZincTypes<D>, U: Uair, F: PrimeField, const D
 /// define them
 macro_rules! impl_with_type_bounds {
     ($type_name:ident { $($code:tt)* }) => {
-        impl<'a, Zt, U, F, const D: usize> $type_name<'a, Zt, U, F, D>
+        impl<'a, Zt, U, F, const D: usize> $type_name<'a, Zt, U, F, D, D>
         where
-            Zt: ZincTypes<D>,
+            Zt: ZincTypes<D, D>,
             Zt::Int: ProjectableToField<F>,
             <Zt::ArbitraryZt as ZipTypes>::Eval: ProjectableToField<F>,
             U: Uair + 'static,
@@ -204,9 +206,9 @@ macro_rules! impl_with_type_bounds {
     };
 }
 
-impl<Zt, U, F, const D: usize> ZincPlusPiop<Zt, U, F, D>
+impl<Zt, U, F, const D: usize> ZincPlusPiop<Zt, U, F, D, D>
 where
-    Zt: ZincTypes<D>,
+    Zt: ZincTypes<D, D>,
     U: Uair,
     F: PrimeField,
     F::Inner: ConstTranscribable,
@@ -223,7 +225,7 @@ where
         ),
         trace: &'a UairTrace<'static, Zt::Int, Zt::Int, D>,
         num_vars: usize,
-    ) -> Result<ProverBase<'a, Zt, U, F, D>, ProtocolError<F, U::Ideal>> {
+    ) -> Result<ProverBase<'a, Zt, U, F, D, D>, ProtocolError<F, U::Ideal>> {
         let uair_signature = U::signature();
         let public_trace = trace.public(&uair_signature);
         let witness_trace = trace.witness(&uair_signature);
@@ -291,7 +293,7 @@ impl_with_type_bounds!(ProverBase
     pub fn step1_combined<S: Fn(&U::Scalar, &F::Config) -> DynamicPolynomialF<F>>(
         mut self,
         project_scalar: S,
-    ) -> Result<ProverProjectedCombined<'a, Zt, U, F, D>, ProtocolError<F, U::Ideal>> {
+    ) -> Result<ProverProjectedCombined<'a, Zt, U, F, D, D>, ProtocolError<F, U::Ideal>> {
         let (field_cfg, projected_scalars_fx) = self.project_common(project_scalar)?;
 
         let projected_trace = project_trace_coeffs_row_major(self.trace, &field_cfg);
@@ -309,7 +311,7 @@ impl_with_type_bounds!(ProverBase
     pub fn step1_mle_first<S: Fn(&U::Scalar, &F::Config) -> DynamicPolynomialF<F>>(
         mut self,
         project_scalar: S,
-    ) -> Result<ProverProjectedMleFirst<'a, Zt, U, F, D>, ProtocolError<F, U::Ideal>> {
+    ) -> Result<ProverProjectedMleFirst<'a, Zt, U, F, D, D>, ProtocolError<F, U::Ideal>> {
         let (field_cfg, projected_scalars_fx) = self.project_common(project_scalar)?;
 
         let projected_trace = project_trace_coeffs_column_major(self.trace, &field_cfg);
@@ -328,7 +330,7 @@ impl_with_type_bounds!(ProverProjectedCombined
     /// trace. Works for both linear and non-linear constraints.
     pub fn step2_ideal_check(
         mut self,
-    ) -> Result<ProverIdealChecked<'a, Zt, U, F, D>, ProtocolError<F, U::Ideal>> {
+    ) -> Result<ProverIdealChecked<'a, Zt, U, F, D, D>, ProtocolError<F, U::Ideal>> {
         let num_constraints = count_constraints::<U>();
 
         let (ic_proof, ic_prover_state) = U::prove_combined(
@@ -361,7 +363,7 @@ impl_with_type_bounds!(ProverProjectedMleFirst
     /// to zero.
     pub fn step2_ideal_check(
         mut self,
-    ) -> Result<ProverIdealChecked<'a, Zt, U, F, D>, ProtocolError<F, U::Ideal>> {
+    ) -> Result<ProverIdealChecked<'a, Zt, U, F, D, D>, ProtocolError<F, U::Ideal>> {
         let num_constraints = count_constraints::<U>();
 
         let (ic_proof, ic_prover_state) = U::prove_mle_first(
@@ -390,7 +392,7 @@ impl_with_type_bounds!(ProverIdealChecked
     /// `a in F_q`, evaluates polynomials at `X = a`.
     pub fn step3_eval_projection(
         mut self,
-    ) -> Result<ProverEvalProjected<'a, Zt, U, F, D>, ProtocolError<F, U::Ideal>> {
+    ) -> Result<ProverEvalProjected<'a, Zt, U, F, D, D>, ProtocolError<F, U::Ideal>> {
         let projecting_element: Zt::Chal = self.base.pcs_transcript.fs_transcript.get_challenge();
         let projecting_element_f: F = F::from_with_cfg(&projecting_element, &self.field_cfg);
 
@@ -421,7 +423,7 @@ impl_with_type_bounds!(ProverEvalProjected
     /// Produces `up_evals` and `down_evals` (CPR) and lookup auxiliary witnesses at `r*`.
     pub fn step4_sumcheck(
         mut self,
-    ) -> Result<ProverSumchecked<'a, Zt, U, F, D>, ProtocolError<F, U::Ideal>> {
+    ) -> Result<ProverSumchecked<'a, Zt, U, F, D, D>, ProtocolError<F, U::Ideal>> {
         let num_constraints = count_constraints::<U>();
         let max_degree = count_max_degree::<U>();
 
@@ -484,7 +486,7 @@ impl_with_type_bounds!(ProverSumchecked
     /// polynomial-valued `lifted_evals` in Step 6
     pub fn step5_multipoint_eval(
         mut self,
-    ) -> Result<ProverMultipointEvaled<'a, Zt, U, F, D>, ProtocolError<F, U::Ideal>> {
+    ) -> Result<ProverMultipointEvaled<'a, Zt, U, F, D, D>, ProtocolError<F, U::Ideal>> {
         let (mp_proof, mp_prover_state) = MultipointEval::prove_as_subprotocol(
             &mut self.base.pcs_transcript.fs_transcript,
             &self.projected_trace_f,
@@ -515,7 +517,7 @@ impl_with_type_bounds!(ProverMultipointEvaled
     /// evaluations at `r_0` in `F_q[X]` and absorbs them into the transcript.
     pub fn step6_lift_and_project(
         mut self,
-    ) -> Result<ProverLifted<'a, Zt, U, F, D>, ProtocolError<F, U::Ideal>> {
+    ) -> Result<ProverLifted<'a, Zt, U, F, D, D>, ProtocolError<F, U::Ideal>> {
         // Compute per-column polynomial MLE evaluations at r_0 in F_q[X]
         // (after \phi_q but before \psi_a). The verifier derives the scalar
         // open_evals via \psi_a for the sumcheck consistency check, and
@@ -554,7 +556,7 @@ impl_with_type_bounds!(ProverLifted
     /// Step 7: PCS open at `r_0` (witness columns only).
     pub fn step7_pcs_open<const CHECK_FOR_OVERFLOW: bool>(
         mut self,
-    ) -> Result<ProverPcsOpened<'a, Zt, U, F, D>, ProtocolError<F, U::Ideal>> {
+    ) -> Result<ProverPcsOpened<'a, Zt, U, F, D, D>, ProtocolError<F, U::Ideal>> {
         let witness_trace = self.base.trace.witness(&self.base.uair_signature);
 
         if let Some(hint_bin) = &self.base.hint_bin {
@@ -650,9 +652,9 @@ impl_with_type_bounds!(ProverPcsOpened
 // prove() wrapper
 //
 
-impl<Zt, U, F, const D: usize> ZincPlusPiop<Zt, U, F, D>
+impl<Zt, U, F, const D: usize> ZincPlusPiop<Zt, U, F, D, D>
 where
-    Zt: ZincTypes<D>,
+    Zt: ZincTypes<D, D>,
     Zt::Int: ProjectableToField<F>,
     <Zt::ArbitraryZt as ZipTypes>::Eval: ProjectableToField<F>,
     F: InnerTransparentField

--- a/protocol/src/prover.rs
+++ b/protocol/src/prover.rs
@@ -300,7 +300,7 @@ where
         let witness_trace = trace.witness(&uair_signature);
 
         let folded_bin_witness_trace = cfg_iter!(witness_trace.binary_poly)
-            .map(Zt::BinaryFold::fold_trace_column)
+            .map(Zt::BinaryFold::fold_trace_mle)
             .collect();
 
         let folded_witness_trace = UairTrace {
@@ -666,8 +666,8 @@ impl_with_type_bounds!(ProverLifted
     ) -> Result<ProverPcsOpened<'a, Zt, U, F, D, FD>, ProtocolError<F, U::Ideal>> {
         let witness_trace = &self.base.folded_witness_trace;
 
-        // Folded witness columns are proved using the extended evaluation point `r_0_ext`,
-        // which extends `r_0` with additional sampled folding challenges.
+        // Folded witness columns are proved using the extended evaluation point
+        // `r_0_ext = r_0 || folding_challenges`.
         let mut r_0_ext = self.r_0.clone();
         let num_folding_challenges = Zt::BinaryFold::FOLDING_FACTOR.ilog2();
         (0..num_folding_challenges).for_each(|_| {

--- a/protocol/src/prover.rs
+++ b/protocol/src/prover.rs
@@ -1,7 +1,7 @@
 use super::*;
 use crypto_primitives::{ConstIntSemiring, FromPrimitiveWithConfig, FromWithConfig};
 use num_traits::Zero;
-use std::{collections::HashMap, fmt::Debug};
+use std::{borrow::Cow, collections::HashMap, fmt::Debug};
 use zinc_piop::{
     combined_poly_resolver::CombinedPolyResolver,
     ideal_check::IdealCheckProtocol,
@@ -29,14 +29,34 @@ use zip_plus::{
 };
 
 //
-// Shared base
+// Type-state structs
 //
 
 /// Persistent prover infrastructure carried across every step: the
 /// Fiat-Shamir transcript, PCS parameters/hints/commitments, and trace
 /// reference.
 #[derive(Clone, Debug)]
-pub struct ProverBase<
+pub struct ProverFolded<
+    'a,
+    Zt: ZincTypes<D, FD>,
+    U: Uair,
+    F: PrimeField,
+    const D: usize,
+    const FD: usize,
+> {
+    uair_signature: UairSignature,
+    original_trace: &'a UairTrace<'static, Zt::Int, Zt::Int, D, D>,
+    folded_witness_trace: UairTrace<'a, Zt::Int, Zt::Int, FD, D>,
+
+    _phantom: PhantomData<(&'a u8, U, F)>,
+}
+
+/// Persistent prover infrastructure carried across every step: the
+/// Fiat-Shamir transcript, PCS parameters/hints/commitments, and trace
+/// reference.
+/// Obtained after step 1 via [`step1_commit`](ProverFolded::step1_commit).
+#[derive(Clone, Debug)]
+pub struct ProverCommitted<
     'a,
     Zt: ZincTypes<D, FD>,
     U: Uair,
@@ -46,8 +66,9 @@ pub struct ProverBase<
 > {
     num_vars: usize,
     uair_signature: UairSignature,
+    original_trace: &'a UairTrace<'static, Zt::Int, Zt::Int, D, D>,
+    folded_witness_trace: UairTrace<'a, Zt::Int, Zt::Int, FD, D>,
     pcs_transcript: PcsProverTranscript,
-    trace: &'a UairTrace<'static, Zt::Int, Zt::Int, D, D>,
 
     // Commitment info
     pp_bin: &'a ZipPlusParams<Zt::BinaryZt, Zt::BinaryLc>,
@@ -63,12 +84,8 @@ pub struct ProverBase<
     _phantom: PhantomData<(U, F)>,
 }
 
-//
-// Type-state structs
-//
-
-/// After step 1 via [`step1_combined`](ProverCommitted::step1_combined)
-/// (row-major / "combined" projection). `project_scalar` has been consumed.
+/// After step 2 via [`step2_combined`](ProverCommitted::step2_combined)
+/// (row-major / "combined" projection).
 #[derive(Clone, Debug)]
 pub struct ProverProjectedCombined<
     'a,
@@ -78,14 +95,14 @@ pub struct ProverProjectedCombined<
     const D: usize,
     const FD: usize,
 > {
-    base: ProverBase<'a, Zt, U, F, D, FD>,
+    base: ProverCommitted<'a, Zt, U, F, D, FD>,
     field_cfg: F::Config,
     projected_trace: RowMajorTrace<F>,
     projected_scalars_fx: HashMap<U::Scalar, DynamicPolynomialF<F>>,
 }
 
-/// After step 1 via [`step1_mle_first`](ProverCommitted::step1_mle_first)
-/// (column-major / MLE-first projection). `project_scalar` has been consumed.
+/// After step 2 via [`step2_mle_first`](ProverCommitted::step2_mle_first)
+/// (column-major / MLE-first projection).
 #[derive(Clone, Debug)]
 pub struct ProverProjectedMleFirst<
     'a,
@@ -95,13 +112,13 @@ pub struct ProverProjectedMleFirst<
     const D: usize,
     const FD: usize,
 > {
-    base: ProverBase<'a, Zt, U, F, D, FD>,
+    base: ProverCommitted<'a, Zt, U, F, D, FD>,
     field_cfg: F::Config,
     projected_trace: ColumnMajorTrace<F>,
     projected_scalars_fx: HashMap<U::Scalar, DynamicPolynomialF<F>>,
 }
 
-/// After step 2 (ideal check).
+/// After step 3 (ideal check).
 #[derive(Clone, Debug)]
 pub struct ProverIdealChecked<
     'a,
@@ -111,7 +128,7 @@ pub struct ProverIdealChecked<
     const D: usize,
     const FD: usize,
 > {
-    base: ProverBase<'a, Zt, U, F, D, FD>,
+    base: ProverCommitted<'a, Zt, U, F, D, FD>,
     field_cfg: F::Config,
     projected_trace: ProjectedTrace<F>,
     projected_scalars_fx: HashMap<U::Scalar, DynamicPolynomialF<F>>,
@@ -121,7 +138,7 @@ pub struct ProverIdealChecked<
     ic_eval_point: Vec<F>,
 }
 
-/// After step 3 (eval projection). `projected_scalars_fx` has been consumed.
+/// After step 4 (eval projection). `projected_scalars_fx` has been consumed.
 #[derive(Clone, Debug)]
 pub struct ProverEvalProjected<
     'a,
@@ -131,7 +148,7 @@ pub struct ProverEvalProjected<
     const D: usize,
     const FD: usize,
 > {
-    base: ProverBase<'a, Zt, U, F, D, FD>,
+    base: ProverCommitted<'a, Zt, U, F, D, FD>,
     field_cfg: F::Config,
     projected_trace: ProjectedTrace<F>,
     ic_proof: IdealCheckProof<F>,
@@ -142,7 +159,7 @@ pub struct ProverEvalProjected<
     projected_scalars_f: HashMap<U::Scalar, F>,
 }
 
-/// After step 4 (sumcheck).
+/// After step 5 (sumcheck).
 #[allow(clippy::type_complexity)]
 #[derive(Clone, Debug)]
 pub struct ProverSumchecked<
@@ -153,7 +170,7 @@ pub struct ProverSumchecked<
     const D: usize,
     const FD: usize,
 > {
-    base: ProverBase<'a, Zt, U, F, D, FD>,
+    base: ProverCommitted<'a, Zt, U, F, D, FD>,
     field_cfg: F::Config,
     projected_trace: ProjectedTrace<F>,
     ic_proof: IdealCheckProof<F>,
@@ -166,7 +183,7 @@ pub struct ProverSumchecked<
     lookup_proof: Option<BatchedLookupProof<F>>,
 }
 
-/// After step 5 (multipoint eval).
+/// After step 6 (multipoint eval).
 #[derive(Clone, Debug)]
 pub struct ProverMultipointEvaled<
     'a,
@@ -176,7 +193,7 @@ pub struct ProverMultipointEvaled<
     const D: usize,
     const FD: usize,
 > {
-    base: ProverBase<'a, Zt, U, F, D, FD>,
+    base: ProverCommitted<'a, Zt, U, F, D, FD>,
     field_cfg: F::Config,
     projected_trace: ProjectedTrace<F>,
     ic_proof: IdealCheckProof<F>,
@@ -189,7 +206,7 @@ pub struct ProverMultipointEvaled<
     r_0: Vec<F>,
 }
 
-/// After step 6 (lift-and-project).
+/// After step 7 (lift-and-project).
 #[derive(Clone, Debug)]
 pub struct ProverLifted<
     'a,
@@ -199,7 +216,7 @@ pub struct ProverLifted<
     const D: usize,
     const FD: usize,
 > {
-    base: ProverBase<'a, Zt, U, F, D, FD>,
+    base: ProverCommitted<'a, Zt, U, F, D, FD>,
     field_cfg: F::Config,
     ic_proof: IdealCheckProof<F>,
     cpr_proof: CombinedPolyResolverProof<F>,
@@ -212,7 +229,7 @@ pub struct ProverLifted<
     lifted_evals: Vec<DynamicPolynomialF<F>>,
 }
 
-/// After step 7 (PCS open). No new fields are added here, but the PCS
+/// After step 8 (PCS open). No new fields are added here, but the PCS
 /// transcript has been updated with the opening proof.
 /// Ready for generating the final proof object in
 /// [`finish`](ProverPcsOpened::finish).
@@ -225,7 +242,7 @@ pub struct ProverPcsOpened<
     const D: usize,
     const FD: usize,
 > {
-    base: ProverBase<'a, Zt, U, F, D, FD>,
+    base: ProverCommitted<'a, Zt, U, F, D, FD>,
     ic_proof: IdealCheckProof<F>,
     cpr_proof: CombinedPolyResolverProof<F>,
     combined_sumcheck: MultiDegreeSumcheckProof<F>,
@@ -242,9 +259,9 @@ pub struct ProverPcsOpened<
 /// define them
 macro_rules! impl_with_type_bounds {
     ($type_name:ident { $($code:tt)* }) => {
-        impl<'a, Zt, U, F, const D: usize> $type_name<'a, Zt, U, F, D, D>
+        impl<'a, Zt, U, F, const D: usize, const FD: usize> $type_name<'a, Zt, U, F, D, FD>
         where
-            Zt: ZincTypes<D, D>,
+            Zt: ZincTypes<D, FD>,
             Zt::Int: ProjectableToField<F>,
             <Zt::ArbitraryZt as ZipTypes>::Eval: ProjectableToField<F>,
             U: Uair + 'static,
@@ -267,34 +284,62 @@ macro_rules! impl_with_type_bounds {
     };
 }
 
-impl<Zt, U, F, const D: usize> ZincPlusPiop<Zt, U, F, D, D>
+impl<Zt, U, F, const D: usize, const FD: usize> ZincPlusPiop<Zt, U, F, D, FD>
 where
-    Zt: ZincTypes<D, D>,
+    Zt: ZincTypes<D, FD>,
     U: Uair,
     F: PrimeField,
     F::Inner: ConstTranscribable,
 {
-    /// Step 0: Prover entry point.
+    /// Step 1: Folding the trace.
+    #[allow(clippy::type_complexity)]
+    pub fn step0_fold<'a>(
+        trace: &'a UairTrace<'static, Zt::Int, Zt::Int, D, D>,
+    ) -> Result<ProverFolded<'a, Zt, U, F, D, FD>, ProtocolError<F, U::Ideal>> {
+        let uair_signature = U::signature();
+        let witness_trace = trace.witness(&uair_signature);
+
+        let folded_bin_witness_trace = cfg_iter!(witness_trace.binary_poly)
+            .map(Zt::BinaryFold::fold_trace_column)
+            .collect();
+
+        let folded_witness_trace = UairTrace {
+            binary_poly: Cow::Owned(folded_bin_witness_trace),
+            arbitrary_poly: witness_trace.arbitrary_poly.clone(),
+            int: witness_trace.int.clone(),
+        };
+
+        Ok(ProverFolded {
+            uair_signature,
+            original_trace: trace,
+            folded_witness_trace,
+            _phantom: PhantomData,
+        })
+    }
+}
+
+impl_with_type_bounds!(ProverFolded
+{
+    /// Step 1: Commitment.
     /// Commit *witness* columns via Zip+ PCS, absorb roots and public
     /// data into the Fiat-Shamir transcript.
     #[allow(clippy::type_complexity)]
-    pub fn step0_commit<'a>(
+    pub fn step1_commit(
+        self,
         (pp_bin, pp_arb, pp_int): &'a (
             ZipPlusParams<Zt::BinaryZt, Zt::BinaryLc>,
             ZipPlusParams<Zt::ArbitraryZt, Zt::ArbitraryLc>,
             ZipPlusParams<Zt::IntZt, Zt::IntLc>,
         ),
-        trace: &'a UairTrace<'static, Zt::Int, Zt::Int, D, D>,
         num_vars: usize,
-    ) -> Result<ProverBase<'a, Zt, U, F, D, D>, ProtocolError<F, U::Ideal>> {
-        let uair_signature = U::signature();
-        let public_trace = trace.public(&uair_signature);
-        let witness_trace = trace.witness(&uair_signature);
+    ) -> Result<ProverCommitted<'a, Zt, U, F, D, FD>, ProtocolError<F, U::Ideal>> {
+        let sig = &self.uair_signature;
+        let public_trace = self.original_trace.public(sig);
 
         let (res_bin, (res_arb, res_int)) = cfg_join!(
-            commit_optionally(pp_bin, &witness_trace.binary_poly),
-            commit_optionally(pp_arb, &witness_trace.arbitrary_poly),
-            commit_optionally(pp_int, &witness_trace.int),
+            commit_optionally(pp_bin, &self.folded_witness_trace.binary_poly),
+            commit_optionally(pp_arb, &self.folded_witness_trace.arbitrary_poly),
+            commit_optionally(pp_int, &self.folded_witness_trace.int),
         );
         let (hint_bin, commitment_bin) = res_bin?;
         let (hint_arb, commitment_arb) = res_arb?;
@@ -311,11 +356,12 @@ where
         );
         absorb_public_columns(&mut pcs_transcript.fs_transcript, &public_trace.int);
 
-        Ok(ProverBase {
+        Ok(ProverCommitted {
             num_vars,
-            uair_signature,
+            uair_signature: self.uair_signature,
+            original_trace: self.original_trace,
+            folded_witness_trace: self.folded_witness_trace,
             pcs_transcript,
-            trace,
             pp_bin,
             pp_arb,
             pp_int,
@@ -328,9 +374,9 @@ where
             _phantom: PhantomData,
         })
     }
-}
+});
 
-impl_with_type_bounds!(ProverBase
+impl_with_type_bounds!(ProverCommitted
 {
     #[allow(clippy::type_complexity)]
     fn project_common<S: Fn(&U::Scalar, &F::Config) -> DynamicPolynomialF<F>>(
@@ -347,17 +393,17 @@ impl_with_type_bounds!(ProverBase
         Ok((field_cfg, projected_scalars_fx))
     }
 
-    /// Step 1 (combined / row-major): Prime projection
+    /// Step 2 (combined / row-major): Prime projection
     /// (`\phi_q`: `Z[X] -> F_q[X]`). Samples a random prime, projects the
     /// full trace and scalars using the row-major layout.
     /// Works for both linear and non-linear constraints.
-    pub fn step1_combined<S: Fn(&U::Scalar, &F::Config) -> DynamicPolynomialF<F>>(
+    pub fn step2_combined<S: Fn(&U::Scalar, &F::Config) -> DynamicPolynomialF<F>>(
         mut self,
         project_scalar: S,
-    ) -> Result<ProverProjectedCombined<'a, Zt, U, F, D, D>, ProtocolError<F, U::Ideal>> {
+    ) -> Result<ProverProjectedCombined<'a, Zt, U, F, D, FD>, ProtocolError<F, U::Ideal>> {
         let (field_cfg, projected_scalars_fx) = self.project_common(project_scalar)?;
 
-        let projected_trace = project_trace_coeffs_row_major(self.trace, &field_cfg);
+        let projected_trace = project_trace_coeffs_row_major(self.original_trace, &field_cfg);
         Ok(ProverProjectedCombined {
             base: self,
             field_cfg,
@@ -366,16 +412,16 @@ impl_with_type_bounds!(ProverBase
         })
     }
 
-    /// Step 1 (MLE-first / column-major): Prime projection
+    /// Step 2 (MLE-first / column-major): Prime projection
     /// (`\phi_q`: `Z[X] -> F_q[X]`). Samples a random prime, projects the
     /// full trace and scalars using the column-major layout.
-    pub fn step1_mle_first<S: Fn(&U::Scalar, &F::Config) -> DynamicPolynomialF<F>>(
+    pub fn step2_mle_first<S: Fn(&U::Scalar, &F::Config) -> DynamicPolynomialF<F>>(
         mut self,
         project_scalar: S,
-    ) -> Result<ProverProjectedMleFirst<'a, Zt, U, F, D, D>, ProtocolError<F, U::Ideal>> {
+    ) -> Result<ProverProjectedMleFirst<'a, Zt, U, F, D, FD>, ProtocolError<F, U::Ideal>> {
         let (field_cfg, projected_scalars_fx) = self.project_common(project_scalar)?;
 
-        let projected_trace = project_trace_coeffs_column_major(self.trace, &field_cfg);
+        let projected_trace = project_trace_coeffs_column_major(self.original_trace, &field_cfg);
         Ok(ProverProjectedMleFirst {
             base: self,
             field_cfg,
@@ -387,11 +433,11 @@ impl_with_type_bounds!(ProverBase
 
 impl_with_type_bounds!(ProverProjectedCombined
 {
-    /// Step 2 (combined): Ideal check via `prove_combined` on the row-major
+    /// Step 3 (combined): Ideal check via `prove_combined` on the row-major
     /// trace. Works for both linear and non-linear constraints.
-    pub fn step2_ideal_check(
+    pub fn step3_ideal_check(
         mut self,
-    ) -> Result<ProverIdealChecked<'a, Zt, U, F, D, D>, ProtocolError<F, U::Ideal>> {
+    ) -> Result<ProverIdealChecked<'a, Zt, U, F, D, FD>, ProtocolError<F, U::Ideal>> {
         let num_constraints = count_constraints::<U>();
 
         let (ic_proof, ic_prover_state) = U::prove_combined(
@@ -416,15 +462,15 @@ impl_with_type_bounds!(ProverProjectedCombined
 
 impl_with_type_bounds!(ProverProjectedMleFirst
 {
-    /// Step 2 (MLE-first): Ideal check via `prove_mle_first` on the
+    /// Step 3 (MLE-first): Ideal check via `prove_mle_first` on the
     /// column-major trace. Works for any UAIR: linear non-zero-ideal
     /// constraints go through the column-major MLE-first path, non-linear
     /// non-zero-ideal constraints fall back to the row-major path (with an
     /// internal transpose), and zero-ideal constraints are short-circuited
     /// to zero.
-    pub fn step2_ideal_check(
+    pub fn step3_ideal_check(
         mut self,
-    ) -> Result<ProverIdealChecked<'a, Zt, U, F, D, D>, ProtocolError<F, U::Ideal>> {
+    ) -> Result<ProverIdealChecked<'a, Zt, U, F, D, FD>, ProtocolError<F, U::Ideal>> {
         let num_constraints = count_constraints::<U>();
 
         let (ic_proof, ic_prover_state) = U::prove_mle_first(
@@ -449,11 +495,11 @@ impl_with_type_bounds!(ProverProjectedMleFirst
 
 impl_with_type_bounds!(ProverIdealChecked
 {
-    /// Step 3: Evaluation projection (`\psi_a`: `F_q[X] -> F_q`). Samples
+    /// Step 4: Evaluation projection (`\psi_a`: `F_q[X] -> F_q`). Samples
     /// `a in F_q`, evaluates polynomials at `X = a`.
-    pub fn step3_eval_projection(
+    pub fn step4_eval_projection(
         mut self,
-    ) -> Result<ProverEvalProjected<'a, Zt, U, F, D, D>, ProtocolError<F, U::Ideal>> {
+    ) -> Result<ProverEvalProjected<'a, Zt, U, F, D, FD>, ProtocolError<F, U::Ideal>> {
         let projecting_element: Zt::Chal = self.base.pcs_transcript.fs_transcript.get_challenge();
         let projecting_element_f: F = F::from_with_cfg(&projecting_element, &self.field_cfg);
 
@@ -478,13 +524,13 @@ impl_with_type_bounds!(ProverIdealChecked
 
 impl_with_type_bounds!(ProverEvalProjected
 {
-    /// Step 4: Combined CPR + Lookup multi-degree sumcheck over F_q.
+    /// Step 5: Combined CPR + Lookup multi-degree sumcheck over F_q.
     /// Batches the CPR constraint claim (degree `max_deg+2`) with lookup groups
     /// (one per table type) into a single sumcheck sharing one evaluation point `r*`.
     /// Produces `up_evals` and `down_evals` (CPR) and lookup auxiliary witnesses at `r*`.
-    pub fn step4_sumcheck(
+    pub fn step5_sumcheck(
         mut self,
-    ) -> Result<ProverSumchecked<'a, Zt, U, F, D, D>, ProtocolError<F, U::Ideal>> {
+    ) -> Result<ProverSumchecked<'a, Zt, U, F, D, FD>, ProtocolError<F, U::Ideal>> {
         let num_constraints = count_constraints::<U>();
         let max_degree = count_max_degree::<U>();
 
@@ -541,13 +587,13 @@ impl_with_type_bounds!(ProverEvalProjected
 
 impl_with_type_bounds!(ProverSumchecked
 {
-    /// Step 5: Multi-point evaluation sumcheck. Combines `up_evals` and
+    /// Step 6: Multi-point evaluation sumcheck. Combines `up_evals` and
     /// `down_evals` at `r'` into a single evaluation point `r_0`.
     /// Only the sumcheck proof is sent; scalar evaluations at `r_0` are derived from the
-    /// polynomial-valued `lifted_evals` in Step 6
-    pub fn step5_multipoint_eval(
+    /// polynomial-valued `lifted_evals` in Step 7.
+    pub fn step6_multipoint_eval(
         mut self,
-    ) -> Result<ProverMultipointEvaled<'a, Zt, U, F, D, D>, ProtocolError<F, U::Ideal>> {
+    ) -> Result<ProverMultipointEvaled<'a, Zt, U, F, D, FD>, ProtocolError<F, U::Ideal>> {
         let (mp_proof, mp_prover_state) = MultipointEval::prove_as_subprotocol(
             &mut self.base.pcs_transcript.fs_transcript,
             &self.projected_trace_f,
@@ -574,18 +620,18 @@ impl_with_type_bounds!(ProverSumchecked
 
 impl_with_type_bounds!(ProverMultipointEvaled
 {
-    /// Step 6: Lift-and-project. Computes per-column polynomial MLE
+    /// Step 7: Lift-and-project. Computes per-column polynomial MLE
     /// evaluations at `r_0` in `F_q[X]` and absorbs them into the transcript.
-    pub fn step6_lift_and_project(
+    pub fn step7_lift_and_project(
         mut self,
-    ) -> Result<ProverLifted<'a, Zt, U, F, D, D>, ProtocolError<F, U::Ideal>> {
+    ) -> Result<ProverLifted<'a, Zt, U, F, D, FD>, ProtocolError<F, U::Ideal>> {
         // Compute per-column polynomial MLE evaluations at r_0 in F_q[X]
         // (after \phi_q but before \psi_a). The verifier derives the scalar
         // open_evals via \psi_a for the sumcheck consistency check, and
         // supplies these to the Zip+ PCS for alpha-projection.
-        let lifted_evals = compute_lifted_evals::<F, D>(
+        let lifted_evals = compute_lifted_evals(
             &self.r_0,
-            &self.base.trace.binary_poly,
+            &self.base.original_trace.binary_poly,
             &self.projected_trace,
             &self.field_cfg,
         );
@@ -614,18 +660,28 @@ impl_with_type_bounds!(ProverMultipointEvaled
 
 impl_with_type_bounds!(ProverLifted
 {
-    /// Step 7: PCS open at `r_0` (witness columns only).
-    pub fn step7_pcs_open<const CHECK_FOR_OVERFLOW: bool>(
+    /// Step 8: PCS open at `r_0` (witness columns only).
+    pub fn step8_pcs_open<const CHECK_FOR_OVERFLOW: bool>(
         mut self,
-    ) -> Result<ProverPcsOpened<'a, Zt, U, F, D, D>, ProtocolError<F, U::Ideal>> {
-        let witness_trace = self.base.trace.witness(&self.base.uair_signature);
+    ) -> Result<ProverPcsOpened<'a, Zt, U, F, D, FD>, ProtocolError<F, U::Ideal>> {
+        let witness_trace = &self.base.folded_witness_trace;
+
+        // Folded witness columns are proved using the extended evaluation point `r_0_ext`,
+        // which extends `r_0` with additional sampled folding challenges.
+        let mut r_0_ext = self.r_0.clone();
+        let num_folding_challenges = Zt::BinaryFold::FOLDING_FACTOR.ilog2();
+        (0..num_folding_challenges).for_each(|_| {
+            let g_chal: Zt::Chal = self.base.pcs_transcript.fs_transcript.get_challenge();
+            let gamma = F::from_with_cfg(&g_chal, &self.field_cfg);
+            r_0_ext.push(gamma);
+        });
 
         if let Some(hint_bin) = &self.base.hint_bin {
             let _ = ZipPlus::<Zt::BinaryZt, Zt::BinaryLc>::prove_f::<_, CHECK_FOR_OVERFLOW>(
                 &mut self.base.pcs_transcript,
                 self.base.pp_bin,
                 &witness_trace.binary_poly,
-                &self.r_0,
+                &r_0_ext,
                 hint_bin,
                 &self.field_cfg,
             )?;
@@ -713,9 +769,9 @@ impl_with_type_bounds!(ProverPcsOpened
 // prove() wrapper
 //
 
-impl<Zt, U, F, const D: usize> ZincPlusPiop<Zt, U, F, D, D>
+impl<Zt, U, F, const D: usize, const FD: usize> ZincPlusPiop<Zt, U, F, D, FD>
 where
-    Zt: ZincTypes<D, D>,
+    Zt: ZincTypes<D, FD>,
     Zt::Int: ProjectableToField<F>,
     <Zt::ArbitraryZt as ZipTypes>::Eval: ProjectableToField<F>,
     F: InnerTransparentField
@@ -737,7 +793,7 @@ where
     /// Zinc+ full PIOP prover.
     ///
     /// Runs all protocol steps in sequence and returns the assembled proof.
-    /// For per-step control, start with [`Self::step0_commit`] and chain the
+    /// For per-step control, start with [`Self::step1_commit`] and chain the
     /// individual `stepN_*` methods.
     #[allow(clippy::too_many_arguments, clippy::type_complexity)]
     pub fn prove<const MLE_FIRST: bool, const CHECK_FOR_OVERFLOW: bool>(
@@ -750,24 +806,24 @@ where
         num_vars: usize,
         project_scalar: impl Fn(&U::Scalar, &F::Config) -> DynamicPolynomialF<F>,
     ) -> Result<Proof<F>, ProtocolError<F, U::Ideal>> {
-        let committed = Self::step0_commit(pp, trace, num_vars)?;
+        let committed = Self::step0_fold(trace)?.step1_commit(pp, num_vars)?;
 
         let ideal_checked = if MLE_FIRST {
             committed
-                .step1_mle_first(project_scalar)?
-                .step2_ideal_check()?
+                .step2_mle_first(project_scalar)?
+                .step3_ideal_check()?
         } else {
             committed
-                .step1_combined(project_scalar)?
-                .step2_ideal_check()?
+                .step2_combined(project_scalar)?
+                .step3_ideal_check()?
         };
 
         ideal_checked
-            .step3_eval_projection()?
-            .step4_sumcheck()?
-            .step5_multipoint_eval()?
-            .step6_lift_and_project()?
-            .step7_pcs_open::<CHECK_FOR_OVERFLOW>()?
+            .step4_eval_projection()?
+            .step5_sumcheck()?
+            .step6_multipoint_eval()?
+            .step7_lift_and_project()?
+            .step8_pcs_open::<CHECK_FOR_OVERFLOW>()?
             .finish()
     }
 }

--- a/protocol/src/verifier.rs
+++ b/protocol/src/verifier.rs
@@ -38,7 +38,7 @@ use zip_plus::{
 
 /// Persistent verifier infrastructure carried across every step.
 #[derive(Clone, Debug)]
-pub struct VerifierBase<'a, Zt: ZincTypes<D, D>, const D: usize> {
+pub struct VerifierBase<'a, Zt: ZincTypes<D, FD>, const D: usize, const FD: usize> {
     num_vars: usize,
     uair_signature: UairSignature,
     pcs_transcript: PcsVerifierTranscript,
@@ -58,13 +58,14 @@ pub struct VerifierBase<'a, Zt: ZincTypes<D, D>, const D: usize> {
 #[derive(Clone, Debug)]
 pub struct VerifierTranscriptReconstructed<
     'a,
-    Zt: ZincTypes<D, D>,
+    Zt: ZincTypes<D, FD>,
     U: Uair,
     F: PrimeField,
     IdealOverF,
     const D: usize,
+    const FD: usize,
 > {
-    base: VerifierBase<'a, Zt, D>,
+    base: VerifierBase<'a, Zt, D, FD>,
 
     // Proof leftovers
     proof_commitments: (ZipPlusCommitment, ZipPlusCommitment, ZipPlusCommitment),
@@ -81,13 +82,14 @@ pub struct VerifierTranscriptReconstructed<
 #[derive(Clone, Debug)]
 pub struct VerifierPrimeProjected<
     'a,
-    Zt: ZincTypes<D, D>,
+    Zt: ZincTypes<D, FD>,
     U: Uair,
     F: PrimeField,
     IdealOverF,
     const D: usize,
+    const FD: usize,
 > {
-    base: VerifierBase<'a, Zt, D>,
+    base: VerifierBase<'a, Zt, D, FD>,
     field_cfg: F::Config,
 
     // Proof leftovers
@@ -105,13 +107,14 @@ pub struct VerifierPrimeProjected<
 #[derive(Clone, Debug)]
 pub struct VerifierIdealChecked<
     'a,
-    Zt: ZincTypes<D, D>,
+    Zt: ZincTypes<D, FD>,
     U: Uair,
     F: PrimeField,
     IdealOverF,
     const D: usize,
+    const FD: usize,
 > {
-    base: VerifierBase<'a, Zt, D>,
+    base: VerifierBase<'a, Zt, D, FD>,
     field_cfg: F::Config,
     ic_subclaim: ideal_check::VerifierSubclaim<F>,
 
@@ -129,13 +132,14 @@ pub struct VerifierIdealChecked<
 #[derive(Clone, Debug)]
 pub struct VerifierEvalProjected<
     'a,
-    Zt: ZincTypes<D, D>,
+    Zt: ZincTypes<D, FD>,
     U: Uair,
     F: PrimeField,
     IdealOverF,
     const D: usize,
+    const FD: usize,
 > {
-    base: VerifierBase<'a, Zt, D>,
+    base: VerifierBase<'a, Zt, D, FD>,
     field_cfg: F::Config,
     ic_subclaim: ideal_check::VerifierSubclaim<F>,
     projecting_element_f: F,
@@ -153,8 +157,15 @@ pub struct VerifierEvalProjected<
 
 /// After step 4 (sumcheck verify).
 #[derive(Clone, Debug)]
-pub struct VerifierSumchecked<'a, Zt: ZincTypes<D, D>, F: PrimeField, IdealOverF, const D: usize> {
-    base: VerifierBase<'a, Zt, D>,
+pub struct VerifierSumchecked<
+    'a,
+    Zt: ZincTypes<D, FD>,
+    F: PrimeField,
+    IdealOverF,
+    const D: usize,
+    const FD: usize,
+> {
+    base: VerifierBase<'a, Zt, D, FD>,
     field_cfg: F::Config,
     projecting_element_f: F,
     cpr_subclaim: combined_poly_resolver::VerifierSubclaim<F>,
@@ -171,12 +182,13 @@ pub struct VerifierSumchecked<'a, Zt: ZincTypes<D, D>, F: PrimeField, IdealOverF
 #[derive(Clone, Debug)]
 pub struct VerifierMultipointEvaled<
     'a,
-    Zt: ZincTypes<D, D>,
+    Zt: ZincTypes<D, FD>,
     F: PrimeField,
     IdealOverF,
     const D: usize,
+    const FD: usize,
 > {
-    base: VerifierBase<'a, Zt, D>,
+    base: VerifierBase<'a, Zt, D, FD>,
     field_cfg: F::Config,
     projecting_element_f: F,
     mp_subclaim: multipoint_eval::Subclaim<F>,
@@ -193,12 +205,13 @@ pub struct VerifierMultipointEvaled<
 #[allow(dead_code)]
 pub struct VerifierLiftedEvalsChecked<
     'a,
-    Zt: ZincTypes<D, D>,
+    Zt: ZincTypes<D, FD>,
     F: PrimeField,
     IdealOverF,
     const D: usize,
+    const FD: usize,
 > {
-    base: VerifierBase<'a, Zt, D>,
+    base: VerifierBase<'a, Zt, D, FD>,
     field_cfg: F::Config,
     mp_subclaim: multipoint_eval::Subclaim<F>,
     all_lifted_evals: Vec<DynamicPolynomialF<F>>,
@@ -220,9 +233,9 @@ pub struct VerifierPcsVerified<IdealOverF> {
 // Step implementations
 //
 
-impl<Zt, U, F, const D: usize> ZincPlusPiop<Zt, U, F, D, D>
+impl<Zt, U, F, const D: usize, const FD: usize> ZincPlusPiop<Zt, U, F, D, FD>
 where
-    Zt: ZincTypes<D, D>,
+    Zt: ZincTypes<D, FD>,
     U: Uair,
     F: PrimeField,
     F::Inner: ConstTranscribable,
@@ -240,7 +253,7 @@ where
         public_trace: &'a UairTrace<'a, Zt::Int, Zt::Int, D, D>,
         num_vars: usize,
     ) -> Result<
-        VerifierTranscriptReconstructed<'a, Zt, U, F, IdealOverF, D>,
+        VerifierTranscriptReconstructed<'a, Zt, U, F, IdealOverF, D, FD>,
         ProtocolError<F, IdealOverF>,
     >
     where
@@ -295,10 +308,10 @@ where
     }
 }
 
-impl<'a, Zt, U, F, IdealOverF, const D: usize>
-    VerifierTranscriptReconstructed<'a, Zt, U, F, IdealOverF, D>
+impl<'a, Zt, U, F, IdealOverF, const D: usize, const FD: usize>
+    VerifierTranscriptReconstructed<'a, Zt, U, F, IdealOverF, D, FD>
 where
-    Zt: ZincTypes<D, D>,
+    Zt: ZincTypes<D, FD>,
     F: InnerTransparentField + FromPrimitiveWithConfig + FromRef<F> + Send + Sync + 'static,
     F::Inner: ConstIntSemiring + ConstTranscribable + Send + Sync + Zero + Default,
     F::Modulus: ConstTranscribable + FromRef<Zt::Fmod>,
@@ -309,7 +322,7 @@ where
     #[allow(clippy::type_complexity)]
     pub fn step1_prime_projection(
         mut self,
-    ) -> Result<VerifierPrimeProjected<'a, Zt, U, F, IdealOverF, D>, ProtocolError<F, IdealOverF>>
+    ) -> Result<VerifierPrimeProjected<'a, Zt, U, F, IdealOverF, D, FD>, ProtocolError<F, IdealOverF>>
     {
         let field_cfg = self
             .base
@@ -332,9 +345,10 @@ where
     }
 }
 
-impl<'a, Zt, U, F, IdealOverF, const D: usize> VerifierPrimeProjected<'a, Zt, U, F, IdealOverF, D>
+impl<'a, Zt, U, F, IdealOverF, const D: usize, const FD: usize>
+    VerifierPrimeProjected<'a, Zt, U, F, IdealOverF, D, FD>
 where
-    Zt: ZincTypes<D, D>,
+    Zt: ZincTypes<D, FD>,
     Zt::Int: ProjectableToField<F>,
     <Zt::ArbitraryZt as ZipTypes>::Eval: ProjectableToField<F>,
     F: InnerTransparentField
@@ -357,7 +371,7 @@ where
     pub fn step2_ideal_check(
         mut self,
         project_ideal: impl Fn(&IdealOrZero<U::Ideal>, &F::Config) -> IdealOverF,
-    ) -> Result<VerifierIdealChecked<'a, Zt, U, F, IdealOverF, D>, ProtocolError<F, IdealOverF>>
+    ) -> Result<VerifierIdealChecked<'a, Zt, U, F, IdealOverF, D, FD>, ProtocolError<F, IdealOverF>>
     {
         let num_constraints = count_constraints::<U>();
 
@@ -385,9 +399,10 @@ where
     }
 }
 
-impl<'a, Zt, U, F, IdealOverF, const D: usize> VerifierIdealChecked<'a, Zt, U, F, IdealOverF, D>
+impl<'a, Zt, U, F, IdealOverF, const D: usize, const FD: usize>
+    VerifierIdealChecked<'a, Zt, U, F, IdealOverF, D, FD>
 where
-    Zt: ZincTypes<D, D>,
+    Zt: ZincTypes<D, FD>,
     F: InnerTransparentField
         + for<'b> FromWithConfig<&'b Zt::Chal>
         + FromRef<F>
@@ -403,7 +418,7 @@ where
     pub fn step3_eval_projection(
         mut self,
         project_scalar: impl Fn(&U::Scalar, &F::Config) -> DynamicPolynomialF<F>,
-    ) -> Result<VerifierEvalProjected<'a, Zt, U, F, IdealOverF, D>, ProtocolError<F, IdealOverF>>
+    ) -> Result<VerifierEvalProjected<'a, Zt, U, F, IdealOverF, D, FD>, ProtocolError<F, IdealOverF>>
     {
         let projecting_element: Zt::Chal = self.base.pcs_transcript.fs_transcript.get_challenge();
         let projecting_element_f: F = F::from_with_cfg(&projecting_element, &self.field_cfg);
@@ -430,9 +445,10 @@ where
     }
 }
 
-impl<'a, Zt, U, F, IdealOverF, const D: usize> VerifierEvalProjected<'a, Zt, U, F, IdealOverF, D>
+impl<'a, Zt, U, F, IdealOverF, const D: usize, const FD: usize>
+    VerifierEvalProjected<'a, Zt, U, F, IdealOverF, D, FD>
 where
-    Zt: ZincTypes<D, D>,
+    Zt: ZincTypes<D, FD>,
     Zt::Int: ProjectableToField<F>,
     <Zt::ArbitraryZt as ZipTypes>::Eval: ProjectableToField<F>,
     F: InnerTransparentField
@@ -453,7 +469,8 @@ where
     /// Step 4: Sumcheck verification (CPR + lookup groups).
     pub fn step4_sumcheck_verify(
         mut self,
-    ) -> Result<VerifierSumchecked<'a, Zt, F, IdealOverF, D>, ProtocolError<F, IdealOverF>> {
+    ) -> Result<VerifierSumchecked<'a, Zt, F, IdealOverF, D, FD>, ProtocolError<F, IdealOverF>>
+    {
         let num_constraints = count_constraints::<U>();
 
         let cpr_verifier_ancillary = CombinedPolyResolver::prepare_verifier::<U>(
@@ -501,9 +518,10 @@ where
     }
 }
 
-impl<'a, Zt, F, IdealOverF, const D: usize> VerifierSumchecked<'a, Zt, F, IdealOverF, D>
+impl<'a, Zt, F, IdealOverF, const D: usize, const FD: usize>
+    VerifierSumchecked<'a, Zt, F, IdealOverF, D, FD>
 where
-    Zt: ZincTypes<D, D>,
+    Zt: ZincTypes<D, FD>,
     F: InnerTransparentField + FromPrimitiveWithConfig + FromRef<F> + Send + Sync + 'static,
     F::Inner: ConstIntSemiring + ConstTranscribable + Send + Sync + Zero + Default,
     F::Modulus: ConstTranscribable + FromRef<Zt::Fmod>,
@@ -512,7 +530,7 @@ where
     /// Step 5: Multi-point evaluation sumcheck.
     pub fn step5_multipoint_eval<U: Uair>(
         mut self,
-    ) -> Result<VerifierMultipointEvaled<'a, Zt, F, IdealOverF, D>, ProtocolError<F, IdealOverF>>
+    ) -> Result<VerifierMultipointEvaled<'a, Zt, F, IdealOverF, D, FD>, ProtocolError<F, IdealOverF>>
     {
         let mp_subclaim = MultipointEval::verify_as_subprotocol(
             &mut self.base.pcs_transcript.fs_transcript,
@@ -538,9 +556,10 @@ where
     }
 }
 
-impl<'a, Zt, F, IdealOverF, const D: usize> VerifierMultipointEvaled<'a, Zt, F, IdealOverF, D>
+impl<'a, Zt, F, IdealOverF, const D: usize, const FD: usize>
+    VerifierMultipointEvaled<'a, Zt, F, IdealOverF, D, FD>
 where
-    Zt: ZincTypes<D, D>,
+    Zt: ZincTypes<D, FD>,
     Zt::Int: ProjectableToField<F>,
     <Zt::ArbitraryZt as ZipTypes>::Eval: ProjectableToField<F>,
     F: InnerTransparentField
@@ -560,8 +579,10 @@ where
     /// multipoint eval subclaim, and absorb all lifted_evals into transcript.
     pub fn step6_lifted_evals<U: Uair>(
         mut self,
-    ) -> Result<VerifierLiftedEvalsChecked<'a, Zt, F, IdealOverF, D>, ProtocolError<F, IdealOverF>>
-    {
+    ) -> Result<
+        VerifierLiftedEvalsChecked<'a, Zt, F, IdealOverF, D, FD>,
+        ProtocolError<F, IdealOverF>,
+    > {
         let r_0 = &self.mp_subclaim.sumcheck_subclaim.point;
 
         let pub_cols = self.base.uair_signature.public_cols();
@@ -633,9 +654,10 @@ where
     }
 }
 
-impl<'a, Zt, F, IdealOverF, const D: usize> VerifierLiftedEvalsChecked<'a, Zt, F, IdealOverF, D>
+impl<'a, Zt, F, IdealOverF, const D: usize, const FD: usize>
+    VerifierLiftedEvalsChecked<'a, Zt, F, IdealOverF, D, FD>
 where
-    Zt: ZincTypes<D, D>,
+    Zt: ZincTypes<D, FD>,
     Zt::Int: ProjectableToField<F>,
     <Zt::BinaryZt as ZipTypes>::Cw: ProjectableToField<F>,
     <Zt::ArbitraryZt as ZipTypes>::Eval: ProjectableToField<F>,
@@ -675,31 +697,52 @@ where
         let field_cfg = &self.field_cfg;
         let all_lifted_evals = &self.all_lifted_evals;
 
+        let zero = F::zero_with_cfg(field_cfg);
+
         macro_rules! verify_pcs_batch {
-            ($Zt:ty, $Lc:ty, $vp:expr, $idx:tt, [$evals_range:expr]) => {{
+            // Non-folded variant
+            ($Zt:ty, $Lc:ty, $vp:expr, $idx:tt, $pt:expr, [$evals_range:expr]) => {{
+                verify_pcs_batch!(
+                    $Zt,
+                    $Lc,
+                    $vp,
+                    $idx,
+                    $pt,
+                    [$evals_range],
+                    |bar_u: &DynamicPolynomialF<F>, alphas: &[_]| {
+                        let mut eval_j = zero.clone();
+                        for (coeff, alpha) in bar_u.coeffs.iter().zip(alphas.iter()) {
+                            let mut term = F::from_with_cfg(alpha, field_cfg);
+                            term *= coeff;
+                            eval_j += &term;
+                        }
+                        eval_j
+                    }
+                )
+            }};
+
+            // Universal variant with custom eval_j computation (used for folded columns)
+            ($Zt:ty, $Lc:ty, $vp:expr, $idx:tt, $pt:expr, [$evals_range:expr], $compute_eval_j:expr) => {{
                 let comm = &commitments.$idx;
                 if comm.batch_size > 0 {
                     let per_poly_alphas = ZipPlus::<$Zt, $Lc>::sample_alphas(
                         &mut pcs_transcript.fs_transcript,
                         comm.batch_size,
                     );
-                    let mut eval_f = F::zero_with_cfg(field_cfg);
+                    let mut eval_f = zero.clone();
                     for (bar_u, alphas) in all_lifted_evals[$evals_range]
                         .iter()
                         .zip(per_poly_alphas.iter())
                     {
-                        for (coeff, alpha) in bar_u.coeffs.iter().zip(alphas.iter()) {
-                            let mut term = F::from_with_cfg(alpha, field_cfg);
-                            term *= coeff;
-                            eval_f += &term;
-                        }
+                        let eval_j = $compute_eval_j(bar_u, alphas);
+                        eval_f += eval_j;
                     }
                     ZipPlus::<$Zt, $Lc>::verify_with_alphas::<F, CHECK_FOR_OVERFLOW>(
                         pcs_transcript,
                         $vp,
                         comm,
                         field_cfg,
-                        r_0,
+                        $pt,
                         &eval_f,
                         &per_poly_alphas,
                     )
@@ -709,7 +752,7 @@ where
         }
 
         // Folded witness columns are proved using the extended evaluation point
-        // `r_0_ext`, which extends `r_0` with additional sampled folding challenges.
+        // `r_0_ext = r_0 || folding_challenges`.
         let num_folding_challenges = Zt::BinaryFold::FOLDING_FACTOR.ilog2();
         let folding_challenges = (0..num_folding_challenges)
             .map(|_| {
@@ -725,13 +768,23 @@ where
             Zt::BinaryLc,
             self.base.vp_bin,
             0,
-            [num_pub_bin..num_total_bin]
+            &r_0_ext,
+            [num_pub_bin..num_total_bin],
+            |bar_u: &DynamicPolynomialF<F>, alphas: &[_]| {
+                Zt::BinaryFold::fold_eval_claim(
+                    &bar_u.coeffs,
+                    alphas,
+                    &folding_challenges,
+                    field_cfg,
+                )
+            }
         );
         verify_pcs_batch!(
             Zt::ArbitraryZt,
             Zt::ArbitraryLc,
             self.base.vp_arb,
             1,
+            &r_0,
             [add!(num_total_bin, num_pub_arb)..add!(num_total_bin, num_total_arb)]
         );
         verify_pcs_batch!(
@@ -739,6 +792,7 @@ where
             Zt::IntLc,
             self.base.vp_int,
             2,
+            &r_0,
             [add!(add!(num_total_bin, num_total_arb), num_pub_int)..]
         );
 
@@ -759,9 +813,9 @@ impl<IdealOverF: Ideal> VerifierPcsVerified<IdealOverF> {
 // verify() wrapper
 //
 
-impl<Zt, U, F, const D: usize> ZincPlusPiop<Zt, U, F, D, D>
+impl<Zt, U, F, const D: usize, const FD: usize> ZincPlusPiop<Zt, U, F, D, FD>
 where
-    Zt: ZincTypes<D, D>,
+    Zt: ZincTypes<D, FD>,
     Zt::Int: ProjectableToField<F>,
     <Zt::BinaryZt as ZipTypes>::Cw: ProjectableToField<F>,
     <Zt::ArbitraryZt as ZipTypes>::Eval: ProjectableToField<F>,
@@ -803,7 +857,7 @@ where
     where
         IdealOverF: Ideal + IdealCheck<DynamicPolynomialF<F>>,
     {
-        ZincPlusPiop::<Zt, U, F, D, D>::step0_reconstruct_transcript::<IdealOverF>(
+        ZincPlusPiop::<Zt, U, F, D, FD>::step0_reconstruct_transcript::<IdealOverF>(
             vp,
             proof,
             public_trace,

--- a/protocol/src/verifier.rs
+++ b/protocol/src/verifier.rs
@@ -1,5 +1,6 @@
 use super::*;
 use crypto_primitives::{ConstIntSemiring, FromPrimitiveWithConfig, FromWithConfig};
+use itertools::Itertools;
 use num_traits::Zero;
 use std::{collections::HashMap, io::Cursor};
 use zinc_piop::{
@@ -706,6 +707,18 @@ where
                 }
             }};
         }
+
+        // Folded witness columns are proved using the extended evaluation point
+        // `r_0_ext`, which extends `r_0` with additional sampled folding challenges.
+        let num_folding_challenges = Zt::BinaryFold::FOLDING_FACTOR.ilog2();
+        let folding_challenges = (0..num_folding_challenges)
+            .map(|_| {
+                let g_chal: Zt::Chal = pcs_transcript.fs_transcript.get_challenge();
+                F::from_with_cfg(&g_chal, &self.field_cfg)
+            })
+            .collect_vec();
+        let mut r_0_ext = r_0.clone();
+        r_0_ext.extend(folding_challenges.clone());
 
         verify_pcs_batch!(
             Zt::BinaryZt,

--- a/protocol/src/verifier.rs
+++ b/protocol/src/verifier.rs
@@ -37,7 +37,7 @@ use zip_plus::{
 
 /// Persistent verifier infrastructure carried across every step.
 #[derive(Clone, Debug)]
-pub struct VerifierBase<'a, Zt: ZincTypes<D>, const D: usize> {
+pub struct VerifierBase<'a, Zt: ZincTypes<D, D>, const D: usize> {
     num_vars: usize,
     uair_signature: UairSignature,
     pcs_transcript: PcsVerifierTranscript,
@@ -57,7 +57,7 @@ pub struct VerifierBase<'a, Zt: ZincTypes<D>, const D: usize> {
 #[derive(Clone, Debug)]
 pub struct VerifierTranscriptReconstructed<
     'a,
-    Zt: ZincTypes<D>,
+    Zt: ZincTypes<D, D>,
     U: Uair,
     F: PrimeField,
     IdealOverF,
@@ -80,7 +80,7 @@ pub struct VerifierTranscriptReconstructed<
 #[derive(Clone, Debug)]
 pub struct VerifierPrimeProjected<
     'a,
-    Zt: ZincTypes<D>,
+    Zt: ZincTypes<D, D>,
     U: Uair,
     F: PrimeField,
     IdealOverF,
@@ -104,7 +104,7 @@ pub struct VerifierPrimeProjected<
 #[derive(Clone, Debug)]
 pub struct VerifierIdealChecked<
     'a,
-    Zt: ZincTypes<D>,
+    Zt: ZincTypes<D, D>,
     U: Uair,
     F: PrimeField,
     IdealOverF,
@@ -128,7 +128,7 @@ pub struct VerifierIdealChecked<
 #[derive(Clone, Debug)]
 pub struct VerifierEvalProjected<
     'a,
-    Zt: ZincTypes<D>,
+    Zt: ZincTypes<D, D>,
     U: Uair,
     F: PrimeField,
     IdealOverF,
@@ -152,7 +152,7 @@ pub struct VerifierEvalProjected<
 
 /// After step 4 (sumcheck verify).
 #[derive(Clone, Debug)]
-pub struct VerifierSumchecked<'a, Zt: ZincTypes<D>, F: PrimeField, IdealOverF, const D: usize> {
+pub struct VerifierSumchecked<'a, Zt: ZincTypes<D, D>, F: PrimeField, IdealOverF, const D: usize> {
     base: VerifierBase<'a, Zt, D>,
     field_cfg: F::Config,
     projecting_element_f: F,
@@ -168,8 +168,13 @@ pub struct VerifierSumchecked<'a, Zt: ZincTypes<D>, F: PrimeField, IdealOverF, c
 
 /// After step 5 (multi-point eval).
 #[derive(Clone, Debug)]
-pub struct VerifierMultipointEvaled<'a, Zt: ZincTypes<D>, F: PrimeField, IdealOverF, const D: usize>
-{
+pub struct VerifierMultipointEvaled<
+    'a,
+    Zt: ZincTypes<D, D>,
+    F: PrimeField,
+    IdealOverF,
+    const D: usize,
+> {
     base: VerifierBase<'a, Zt, D>,
     field_cfg: F::Config,
     projecting_element_f: F,
@@ -187,7 +192,7 @@ pub struct VerifierMultipointEvaled<'a, Zt: ZincTypes<D>, F: PrimeField, IdealOv
 #[allow(dead_code)]
 pub struct VerifierLiftedEvalsChecked<
     'a,
-    Zt: ZincTypes<D>,
+    Zt: ZincTypes<D, D>,
     F: PrimeField,
     IdealOverF,
     const D: usize,
@@ -214,9 +219,9 @@ pub struct VerifierPcsVerified<IdealOverF> {
 // Step implementations
 //
 
-impl<Zt, U, F, const D: usize> ZincPlusPiop<Zt, U, F, D>
+impl<Zt, U, F, const D: usize> ZincPlusPiop<Zt, U, F, D, D>
 where
-    Zt: ZincTypes<D>,
+    Zt: ZincTypes<D, D>,
     U: Uair,
     F: PrimeField,
     F::Inner: ConstTranscribable,
@@ -292,7 +297,7 @@ where
 impl<'a, Zt, U, F, IdealOverF, const D: usize>
     VerifierTranscriptReconstructed<'a, Zt, U, F, IdealOverF, D>
 where
-    Zt: ZincTypes<D>,
+    Zt: ZincTypes<D, D>,
     F: InnerTransparentField + FromPrimitiveWithConfig + FromRef<F> + Send + Sync + 'static,
     F::Inner: ConstIntSemiring + ConstTranscribable + Send + Sync + Zero + Default,
     F::Modulus: ConstTranscribable + FromRef<Zt::Fmod>,
@@ -328,7 +333,7 @@ where
 
 impl<'a, Zt, U, F, IdealOverF, const D: usize> VerifierPrimeProjected<'a, Zt, U, F, IdealOverF, D>
 where
-    Zt: ZincTypes<D>,
+    Zt: ZincTypes<D, D>,
     Zt::Int: ProjectableToField<F>,
     <Zt::ArbitraryZt as ZipTypes>::Eval: ProjectableToField<F>,
     F: InnerTransparentField
@@ -381,7 +386,7 @@ where
 
 impl<'a, Zt, U, F, IdealOverF, const D: usize> VerifierIdealChecked<'a, Zt, U, F, IdealOverF, D>
 where
-    Zt: ZincTypes<D>,
+    Zt: ZincTypes<D, D>,
     F: InnerTransparentField
         + for<'b> FromWithConfig<&'b Zt::Chal>
         + FromRef<F>
@@ -426,7 +431,7 @@ where
 
 impl<'a, Zt, U, F, IdealOverF, const D: usize> VerifierEvalProjected<'a, Zt, U, F, IdealOverF, D>
 where
-    Zt: ZincTypes<D>,
+    Zt: ZincTypes<D, D>,
     Zt::Int: ProjectableToField<F>,
     <Zt::ArbitraryZt as ZipTypes>::Eval: ProjectableToField<F>,
     F: InnerTransparentField
@@ -497,7 +502,7 @@ where
 
 impl<'a, Zt, F, IdealOverF, const D: usize> VerifierSumchecked<'a, Zt, F, IdealOverF, D>
 where
-    Zt: ZincTypes<D>,
+    Zt: ZincTypes<D, D>,
     F: InnerTransparentField + FromPrimitiveWithConfig + FromRef<F> + Send + Sync + 'static,
     F::Inner: ConstIntSemiring + ConstTranscribable + Send + Sync + Zero + Default,
     F::Modulus: ConstTranscribable + FromRef<Zt::Fmod>,
@@ -534,7 +539,7 @@ where
 
 impl<'a, Zt, F, IdealOverF, const D: usize> VerifierMultipointEvaled<'a, Zt, F, IdealOverF, D>
 where
-    Zt: ZincTypes<D>,
+    Zt: ZincTypes<D, D>,
     Zt::Int: ProjectableToField<F>,
     <Zt::ArbitraryZt as ZipTypes>::Eval: ProjectableToField<F>,
     F: InnerTransparentField
@@ -629,7 +634,7 @@ where
 
 impl<'a, Zt, F, IdealOverF, const D: usize> VerifierLiftedEvalsChecked<'a, Zt, F, IdealOverF, D>
 where
-    Zt: ZincTypes<D>,
+    Zt: ZincTypes<D, D>,
     Zt::Int: ProjectableToField<F>,
     <Zt::BinaryZt as ZipTypes>::Cw: ProjectableToField<F>,
     <Zt::ArbitraryZt as ZipTypes>::Eval: ProjectableToField<F>,
@@ -737,11 +742,13 @@ impl<IdealOverF: Ideal> VerifierPcsVerified<IdealOverF> {
     }
 }
 
-// ── verify() wrapper ───────────────────────────────────────────────────
+//
+// verify() wrapper
+//
 
-impl<Zt, U, F, const D: usize> ZincPlusPiop<Zt, U, F, D>
+impl<Zt, U, F, const D: usize> ZincPlusPiop<Zt, U, F, D, D>
 where
-    Zt: ZincTypes<D>,
+    Zt: ZincTypes<D, D>,
     Zt::Int: ProjectableToField<F>,
     <Zt::BinaryZt as ZipTypes>::Cw: ProjectableToField<F>,
     <Zt::ArbitraryZt as ZipTypes>::Eval: ProjectableToField<F>,
@@ -783,7 +790,7 @@ where
     where
         IdealOverF: Ideal + IdealCheck<DynamicPolynomialF<F>>,
     {
-        ZincPlusPiop::<Zt, U, F, D>::step0_reconstruct_transcript::<IdealOverF>(
+        ZincPlusPiop::<Zt, U, F, D, D>::step0_reconstruct_transcript::<IdealOverF>(
             vp,
             proof,
             public_trace,

--- a/protocol/src/verifier.rs
+++ b/protocol/src/verifier.rs
@@ -761,7 +761,7 @@ where
             })
             .collect_vec();
         let mut r_0_ext = r_0.clone();
-        r_0_ext.extend(folding_challenges.clone());
+        r_0_ext.extend_from_slice(&folding_challenges);
 
         verify_pcs_batch!(
             Zt::BinaryZt,

--- a/protocol/src/verifier.rs
+++ b/protocol/src/verifier.rs
@@ -41,7 +41,7 @@ pub struct VerifierBase<'a, Zt: ZincTypes<D, D>, const D: usize> {
     num_vars: usize,
     uair_signature: UairSignature,
     pcs_transcript: PcsVerifierTranscript,
-    public_trace: &'a UairTrace<'a, Zt::Int, Zt::Int, D>,
+    public_trace: &'a UairTrace<'a, Zt::Int, Zt::Int, D, D>,
 
     // Commitment info
     vp_bin: &'a ZipPlusParams<Zt::BinaryZt, Zt::BinaryLc>,
@@ -236,7 +236,7 @@ where
             ZipPlusParams<Zt::IntZt, Zt::IntLc>,
         ),
         mut proof: Proof<F>,
-        public_trace: &'a UairTrace<'a, Zt::Int, Zt::Int, D>,
+        public_trace: &'a UairTrace<'a, Zt::Int, Zt::Int, D, D>,
         num_vars: usize,
     ) -> Result<
         VerifierTranscriptReconstructed<'a, Zt, U, F, IdealOverF, D>,
@@ -573,7 +573,7 @@ where
         let num_wit_arb = wit_cols.num_arbitrary_poly_cols();
 
         let public_lifted = if add!(add!(num_pub_bin, num_pub_arb), num_pub_int) > 0 {
-            let projected_public = project_trace_coeffs_row_major::<F, Zt::Int, Zt::Int, D>(
+            let projected_public = project_trace_coeffs_row_major::<F, Zt::Int, Zt::Int, D, D>(
                 self.base.public_trace,
                 &self.field_cfg,
             );
@@ -782,7 +782,7 @@ where
             ZipPlusParams<Zt::IntZt, Zt::IntLc>,
         ),
         proof: Proof<F>,
-        public_trace: &UairTrace<Zt::Int, Zt::Int, D>,
+        public_trace: &UairTrace<Zt::Int, Zt::Int, D, D>,
         num_vars: usize,
         project_scalar: impl Fn(&U::Scalar, &F::Config) -> DynamicPolynomialF<F>,
         project_ideal: impl Fn(&IdealOrZero<U::Ideal>, &F::Config) -> IdealOverF,

--- a/test-uair/src/generate_trace.rs
+++ b/test-uair/src/generate_trace.rs
@@ -11,5 +11,5 @@ pub trait GenerateRandomTrace<const DEGREE_PLUS_ONE: usize>: Uair {
     fn generate_random_trace<Rng: RngCore + ?Sized>(
         num_vars: usize,
         rng: &mut Rng,
-    ) -> UairTrace<'static, Self::PolyCoeff, Self::Int, DEGREE_PLUS_ONE>;
+    ) -> UairTrace<'static, Self::PolyCoeff, Self::Int, DEGREE_PLUS_ONE, DEGREE_PLUS_ONE>;
 }

--- a/test-uair/src/lib.rs
+++ b/test-uair/src/lib.rs
@@ -71,7 +71,7 @@ where
     fn generate_random_trace<Rng: RngCore + ?Sized>(
         num_vars: usize,
         rng: &mut Rng,
-    ) -> UairTrace<'static, R, R, 32> {
+    ) -> UairTrace<'static, R, R, 32, 32> {
         let mut a: Vec<DynamicPolynomialFS<R>> =
             vec![DynamicPolynomialFS::new(vec![R::from(rng.random::<i8>())])];
         let mut b: Vec<DynamicPolynomialFS<R>> = vec![DynamicPolynomialFS::new(vec![
@@ -178,7 +178,7 @@ where
     fn generate_random_trace<Rng: rand::RngCore + ?Sized>(
         num_vars: usize,
         rng: &mut Rng,
-    ) -> UairTrace<'static, R, R, 32> {
+    ) -> UairTrace<'static, R, R, 32, 32> {
         let a: DenseMultilinearExtension<DensePolynomial<R, 32>> =
             DenseMultilinearExtension::rand(num_vars, rng)
                 .into_iter()
@@ -304,7 +304,7 @@ where
     fn generate_random_trace<Rng: rand::RngCore + ?Sized>(
         num_vars: usize,
         rng: &mut Rng,
-    ) -> UairTrace<'static, R, R, 32> {
+    ) -> UairTrace<'static, R, R, 32, 32> {
         let int_col_u32: DenseMultilinearExtension<u32> =
             DenseMultilinearExtension::rand(num_vars, rng);
 
@@ -391,7 +391,7 @@ where
     fn generate_random_trace<Rng: rand::RngCore + ?Sized>(
         num_vars: usize,
         rng: &mut Rng,
-    ) -> UairTrace<'static, R, R, 32> {
+    ) -> UairTrace<'static, R, R, 32, 32> {
         /// Generate a random binary polynomial with the given number of 1-bits.
         fn random_binary_poly_with_popcount(
             popcount: u32,
@@ -498,7 +498,7 @@ where
     fn generate_random_trace<Rng: RngCore + ?Sized>(
         num_vars: usize,
         rng: &mut Rng,
-    ) -> UairTrace<'static, Self::PolyCoeff, Self::Int, 32> {
+    ) -> UairTrace<'static, Self::PolyCoeff, Self::Int, 32, 32> {
         BigLinearUair::<R>::generate_random_trace(num_vars, rng)
     }
 }
@@ -615,7 +615,7 @@ where
     fn generate_random_trace<Rng: rand::RngCore + ?Sized>(
         num_vars: usize,
         rng: &mut Rng,
-    ) -> UairTrace<'static, R, R, 32> {
+    ) -> UairTrace<'static, R, R, 32, 32> {
         /// Generate a random binary polynomial with the given number of 1-bits.
         fn random_binary_poly_with_popcount(
             popcount: u32,
@@ -820,7 +820,7 @@ where
     fn generate_random_trace<Rng: rand::RngCore + ?Sized>(
         num_vars: usize,
         rng: &mut Rng,
-    ) -> UairTrace<'static, R, R, 32> {
+    ) -> UairTrace<'static, R, R, 32, 32> {
         let n = 1 << num_vars;
 
         // Random b column (degree-0 polynomials to stay under degree 32)

--- a/uair/src/lib.rs
+++ b/uair/src/lib.rs
@@ -316,16 +316,18 @@ impl UairSignature {
 /// If owned, it contains the full trace, otherwise it contains a view on the
 /// full trace (e.g. only public columns).
 #[derive(Debug, Clone, Default)]
-pub struct UairTrace<'a, PolyCoeff: Clone, Int: Clone, const D: usize> {
-    pub binary_poly: Cow<'a, [DenseMultilinearExtension<BinaryPoly<D>>]>,
-    pub arbitrary_poly: Cow<'a, [DenseMultilinearExtension<DensePolynomial<PolyCoeff, D>>]>,
+pub struct UairTrace<'a, PolyCoeff: Clone, Int: Clone, const DB: usize, const DA: usize> {
+    pub binary_poly: Cow<'a, [DenseMultilinearExtension<BinaryPoly<DB>>]>,
+    pub arbitrary_poly: Cow<'a, [DenseMultilinearExtension<DensePolynomial<PolyCoeff, DA>>]>,
     pub int: Cow<'a, [DenseMultilinearExtension<Int>]>,
 }
 
-impl<PolyCoeff: Clone, Int: Clone, const D: usize> UairTrace<'static, PolyCoeff, Int, D> {
+impl<PolyCoeff: Clone, Int: Clone, const DB: usize, const DA: usize>
+    UairTrace<'static, PolyCoeff, Int, DB, DA>
+{
     /// Returns a sub-trace containing only public columns.
     /// Returned trace is borrowed from the full trace.
-    pub fn public(&self, sig: &UairSignature) -> UairTrace<'_, PolyCoeff, Int, D> {
+    pub fn public(&self, sig: &UairSignature) -> UairTrace<'_, PolyCoeff, Int, DB, DA> {
         let p = sig.public_cols();
         UairTrace {
             binary_poly: Cow::Borrowed(&self.binary_poly[0..p.num_binary_poly_cols()]),
@@ -336,7 +338,7 @@ impl<PolyCoeff: Clone, Int: Clone, const D: usize> UairTrace<'static, PolyCoeff,
 
     /// Returns a sub-trace containing only witness columns.
     /// Returned trace is borrowed from the full trace.
-    pub fn witness(&self, sig: &UairSignature) -> UairTrace<'_, PolyCoeff, Int, D> {
+    pub fn witness(&self, sig: &UairSignature) -> UairTrace<'_, PolyCoeff, Int, DB, DA> {
         let p = sig.public_cols();
         UairTrace {
             binary_poly: Cow::Borrowed(&self.binary_poly[p.num_binary_poly_cols()..]),

--- a/uair/src/lib.rs
+++ b/uair/src/lib.rs
@@ -316,9 +316,18 @@ impl UairSignature {
 /// If owned, it contains the full trace, otherwise it contains a view on the
 /// full trace (e.g. only public columns).
 #[derive(Debug, Clone, Default)]
-pub struct UairTrace<'a, PolyCoeff: Clone, Int: Clone, const DB: usize, const DA: usize> {
-    pub binary_poly: Cow<'a, [DenseMultilinearExtension<BinaryPoly<DB>>]>,
-    pub arbitrary_poly: Cow<'a, [DenseMultilinearExtension<DensePolynomial<PolyCoeff, DA>>]>,
+pub struct UairTrace<
+    'a,
+    PolyCoeff: Clone,
+    Int: Clone,
+    const BINARY_POLY_DEGREE_PLUS_ONE: usize,
+    const ARBITRARY_POLY_DEGREE_PLUS_ONE: usize,
+> {
+    pub binary_poly: Cow<'a, [DenseMultilinearExtension<BinaryPoly<BINARY_POLY_DEGREE_PLUS_ONE>>]>,
+    pub arbitrary_poly: Cow<
+        'a,
+        [DenseMultilinearExtension<DensePolynomial<PolyCoeff, ARBITRARY_POLY_DEGREE_PLUS_ONE>>],
+    >,
     pub int: Cow<'a, [DenseMultilinearExtension<Int>]>,
 }
 

--- a/zip-plus/src/code/iprs.rs
+++ b/zip-plus/src/code/iprs.rs
@@ -41,7 +41,7 @@ where
     /// Currently, keeps number of columns <= 2^8 but this might be tweaked in
     /// the future.
     pub fn new_with_optimal_depth(row_len: usize) -> Result<Self, ZipError> {
-        const MAX_BASE_COLS_LOG2: usize = 8;
+        const MAX_BASE_COLS_LOG2: usize = 6;
 
         let target_base_len = 1 << MAX_BASE_COLS_LOG2;
         // We want depth to be at least 1.

--- a/zip-plus/src/code/iprs.rs
+++ b/zip-plus/src/code/iprs.rs
@@ -316,6 +316,6 @@ mod tests {
             type ArrCombRDotChal = MBSInnerProduct;
         }
 
-        do_encode::<BenchZipPlusTypes<i64>, 4>(14);
+        do_encode::<BenchZipPlusTypes<i64>, 4>(12);
     }
 }


### PR DESCRIPTION
Resolves #139 

* `UairTrace` now has two separate degrees, one for binary and one for arbitrary polynomials.
* For the initially provided trace, as well as public trace during the whole PIOP, those degrees are equal.
* P and V now do the folding trick, reducing the degree of binary polynomials by 4x (so 8 instead of 32).
* For P, steps are shifted, step 0 being the folding.
* Folding shortens proof but also worsens verifier time. To counteract it somewhat, IPRS heuristics has been lowered in order to increase depth.
  * Note that as the result, we can only encode polynomials with up to 12 variables.
  * Given that 4x folding increases number of variables by 2, we can no longer go above 10 variables in E2E benchmarks.

Technically, this trick could also be applied to integers, but it's not in this PR.

See #139 for the detailed description of the folding trick.

| # vars | `ShaProxy` bench  | Before  | After   | Change |
| ------ | ----------------- | ------- | ------- | ------ |
| 8      | P time (par)      | 23 ms   | 26 ms   | +15%   |
| 8      | V time (par)      | 3.2 ms  | 4.8 ms  | +50%   |
| 8      | Proof size (comp) | 218 KiB | 147 KiB | -30%   |
| 10     | P time (par)      | 64 ms   | 60 ms   | -5%    |
| 10     | V time (par)      | 9.5 ms  | 12 ms   | +25%   |
| 10     | Proof size (comp) | 258 KiB | 216 KiB | -15%   |