### PR TITLE
Add bit-op virtual column foundations

### DIFF
--- a/poly/src/univariate/dense.rs
+++ b/poly/src/univariate/dense.rs
@@ -20,11 +20,13 @@ use std::{
 };
 use zinc_transcript::traits::{ConstTranscribable, GenTranscribable};
 use zinc_utils::{
+    add,
     from_ref::FromRef,
     inner_product::{InnerProduct, InnerProductError},
     mul_by_scalar::MulByScalar,
     named::Named,
     projectable_to_field::ProjectableToField,
+    rem,
 };
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -59,59 +61,34 @@ impl<R: Semiring + Zero, const DEGREE_PLUS_ONE: usize> DensePolynomial<R, DEGREE
         DensePolynomial { coeffs }
     }
 
-    /// Right-rotation by `c` bit positions on the bounded-degree coefficient
-    /// vector `R^{<W}[X]`, where `W = DEGREE_PLUS_ONE`.
+    /// Right-rotate the coefficient vector by `c` positions.
     ///
-    /// Concretely, the result's coefficient at position `i` is the source's
-    /// at `(i + c) mod W`. Equivalently, viewing the input as `sum u_i X^i`,
-    /// this returns `u * X^{W - c}` reduced modulo `X^W - 1` (cf. Lemma 8.8
-    /// of the Zinc+ paper); `rot_c` may therefore also be read as an
-    /// endomorphism of the quotient ring `R[X]/(X^W - 1)`.
-    ///
-    /// The map is `R`-linear (per Lemma 2.3) and defined for any commutative
-    /// ring `R`. The same routine is used (a) by the prover on
-    /// bit-polynomial cells with `{0,1}` coefficients during CPR
-    /// materialization, and (b) by the verifier on the lifted opening in
-    /// `F_q^{<W}[X]` at the multi-point evaluation endpoint.
-    ///
-    /// Panics if `c == 0` or `c >= W`.
-    #[allow(clippy::arithmetic_side_effects)]
-    pub fn rot_c(&self, c: usize) -> Self {
+    /// The output coefficient at position `i` is the input coefficient at
+    /// `(i + c) mod DEGREE_PLUS_ONE`.
+    pub fn rotate_right(&self, c: usize) -> Self {
         assert!(
             c > 0 && c < DEGREE_PLUS_ONE,
-            "rot_c count {} out of range (must satisfy 0 < c < {})",
+            "rotate_right count {} out of range (must satisfy 0 < c < {})",
             c,
             DEGREE_PLUS_ONE,
         );
-        let coeffs = array::from_fn(|i| self.coeffs[(i + c) % DEGREE_PLUS_ONE].clone());
+        let coeffs = array::from_fn(|i| self.coeffs[rem!(add!(i, c), DEGREE_PLUS_ONE)].clone());
         DensePolynomial { coeffs }
     }
 
-    /// Right-shift by `c` bit positions on the bounded-degree coefficient
-    /// vector `R^{<W}[X]`, where `W = DEGREE_PLUS_ONE`.
+    /// Right-shift the coefficient vector by `c` positions.
     ///
-    /// The result's coefficient at position `i` is the source's at `i + c`
-    /// when `i + c < W`, and zero otherwise: the low `c` coefficients are
-    /// dropped and the top `c` positions are zero-padded. This is `R`-linear
-    /// in the input (per Lemma 2.3) but is *not* a quotient-ring
-    /// endomorphism; unlike [`Self::rot_c`], `shift_r_c` cannot be viewed
-    /// as a map on `R[X]/(X^W - 1)`.
-    ///
-    /// Defined for any commutative ring `R` with a `Zero`; same dual use as
-    /// [`Self::rot_c`] across prover (bit-polynomial cells) and verifier
-    /// (lifted opening in `F_q^{<W}[X]`).
-    ///
-    /// Panics if `c == 0` or `c >= W`.
-    #[allow(clippy::arithmetic_side_effects)]
-    pub fn shift_r_c(&self, c: usize) -> Self {
+    /// The output coefficient at position `i` is the input coefficient at
+    /// `i + c`, or zero when that index is outside the coefficient vector.
+    pub fn shr(&self, c: usize) -> Self {
         assert!(
             c > 0 && c < DEGREE_PLUS_ONE,
-            "shift_r_c count {} out of range (must satisfy 0 < c < {})",
+            "shr count {} out of range (must satisfy 0 < c < {})",
             c,
             DEGREE_PLUS_ONE,
         );
         let coeffs = array::from_fn(|i| {
-            let j = i + c;
+            let j = add!(i, c);
             if j < DEGREE_PLUS_ONE {
                 self.coeffs[j].clone()
             } else {
@@ -754,65 +731,65 @@ mod tests {
     }
 
     #[test]
-    fn rot_c_permutes_coefficients() {
-        // Non-periodic pattern: rot_c by different counts must yield
+    fn rotate_right_permutes_coefficients() {
+        // Non-periodic pattern: rotate_right by different counts must yield
         // observably different outputs.
         let u = bits([1, 1, 1, 0, 0, 1, 0, 0]);
-        // rot_c(u, 3).coeffs[i] = u.coeffs[(i + 3) mod 8]
+        // rotate_right(u, 3).coeffs[i] = u.coeffs[(i + 3) mod 8]
         // (u[3], u[4], u[5], u[6], u[7], u[0], u[1], u[2])
         // = (0,    0,    1,    0,    0,    1,    1,    1)
-        assert_eq!(u.rot_c(3), bits([0, 0, 1, 0, 0, 1, 1, 1]));
-        // rot_c(u, 5).coeffs[i] = u.coeffs[(i + 5) mod 8]
+        assert_eq!(u.rotate_right(3), bits([0, 0, 1, 0, 0, 1, 1, 1]));
+        // rotate_right(u, 5).coeffs[i] = u.coeffs[(i + 5) mod 8]
         // (u[5], u[6], u[7], u[0], u[1], u[2], u[3], u[4])
         // = (1,    0,    0,    1,    1,    1,    0,    0)
-        assert_eq!(u.rot_c(5), bits([1, 0, 0, 1, 1, 1, 0, 0]));
-        // Distinct outputs witness that rot_c is not periodic on this input.
-        assert_ne!(u.rot_c(3), u.rot_c(5));
+        assert_eq!(u.rotate_right(5), bits([1, 0, 0, 1, 1, 1, 0, 0]));
+        // Distinct outputs witness that rotation is not periodic on this input.
+        assert_ne!(u.rotate_right(3), u.rotate_right(5));
     }
 
     #[test]
-    fn rot_c_is_cyclic() {
+    fn rotate_right_is_cyclic() {
         let u = bits([1, 1, 0, 0, 1, 0, 0, 0]);
-        let r1 = u.rot_c(3);
-        let r2 = r1.rot_c(5); // (3 + 5) mod 8 == 0, identity
+        let r1 = u.rotate_right(3);
+        let r2 = r1.rotate_right(5); // (3 + 5) mod 8 == 0, identity
         assert_eq!(r2, u);
     }
 
     #[test]
-    fn shift_r_c_drops_low_bits_and_zero_pads_top() {
+    fn shr_drops_low_bits_and_zero_pads_top() {
         let u = bits([1, 0, 1, 0, 1, 0, 1, 0]);
-        // shift_r_c(u, 3).coeffs[i] = u.coeffs[i + 3] if i + 3 < 8 else 0
-        assert_eq!(u.shift_r_c(3), bits([0, 1, 0, 1, 0, 0, 0, 0]));
+        // shr(u, 3).coeffs[i] = u.coeffs[i + 3] if i + 3 < 8 else 0
+        assert_eq!(u.shr(3), bits([0, 1, 0, 1, 0, 0, 0, 0]));
     }
 
     #[test]
-    fn shift_r_c_max_zeros_all_but_top() {
+    fn shr_max_zeros_all_but_top() {
         let u = bits([1, 1, 1, 1, 1, 1, 1, 1]);
         // c = 7 keeps only u.coeffs[7] at position 0
-        assert_eq!(u.shift_r_c(7), bits([1, 0, 0, 0, 0, 0, 0, 0]));
+        assert_eq!(u.shr(7), bits([1, 0, 0, 0, 0, 0, 0, 0]));
     }
 
     #[test]
-    #[should_panic(expected = "rot_c count")]
-    fn rot_c_panics_on_zero() {
-        let _ = bits([1, 0, 0, 0, 0, 0, 0, 0]).rot_c(0);
+    #[should_panic(expected = "rotate_right count")]
+    fn rotate_right_panics_on_zero() {
+        let _ = bits([1, 0, 0, 0, 0, 0, 0, 0]).rotate_right(0);
     }
 
     #[test]
-    #[should_panic(expected = "rot_c count")]
-    fn rot_c_panics_on_full_width() {
-        let _ = bits([1, 0, 0, 0, 0, 0, 0, 0]).rot_c(8);
+    #[should_panic(expected = "rotate_right count")]
+    fn rotate_right_panics_on_full_width() {
+        let _ = bits([1, 0, 0, 0, 0, 0, 0, 0]).rotate_right(8);
     }
 
     #[test]
-    #[should_panic(expected = "shift_r_c count")]
-    fn shift_r_c_panics_on_zero() {
-        let _ = bits([1, 0, 0, 0, 0, 0, 0, 0]).shift_r_c(0);
+    #[should_panic(expected = "shr count")]
+    fn shr_panics_on_zero() {
+        let _ = bits([1, 0, 0, 0, 0, 0, 0, 0]).shr(0);
     }
 
     #[test]
-    #[should_panic(expected = "shift_r_c count")]
-    fn shift_r_c_panics_on_full_width() {
-        let _ = bits([1, 0, 0, 0, 0, 0, 0, 0]).shift_r_c(8);
+    #[should_panic(expected = "shr count")]
+    fn shr_panics_on_full_width() {
+        let _ = bits([1, 0, 0, 0, 0, 0, 0, 0]).shr(8);
     }
 }

--- a/poly/src/univariate/dense.rs
+++ b/poly/src/univariate/dense.rs
@@ -58,6 +58,68 @@ impl<R: Semiring + Zero, const DEGREE_PLUS_ONE: usize> DensePolynomial<R, DEGREE
 
         DensePolynomial { coeffs }
     }
+
+    /// Right-rotation by `c` bit positions on the bounded-degree coefficient
+    /// vector `R^{<W}[X]`, where `W = DEGREE_PLUS_ONE`.
+    ///
+    /// Concretely, the result's coefficient at position `i` is the source's
+    /// at `(i + c) mod W`. Equivalently, viewing the input as `sum u_i X^i`,
+    /// this returns `u * X^{W - c}` reduced modulo `X^W - 1` (cf. Lemma 8.8
+    /// of the Zinc+ paper); `rot_c` may therefore also be read as an
+    /// endomorphism of the quotient ring `R[X]/(X^W - 1)`.
+    ///
+    /// The map is `R`-linear (per Lemma 2.3) and defined for any commutative
+    /// ring `R`. The same routine is used (a) by the prover on
+    /// bit-polynomial cells with `{0,1}` coefficients during CPR
+    /// materialization, and (b) by the verifier on the lifted opening in
+    /// `F_q^{<W}[X]` at the multi-point evaluation endpoint.
+    ///
+    /// Panics if `c == 0` or `c >= W`.
+    #[allow(clippy::arithmetic_side_effects)]
+    pub fn rot_c(&self, c: usize) -> Self {
+        assert!(
+            c > 0 && c < DEGREE_PLUS_ONE,
+            "rot_c count {} out of range (must satisfy 0 < c < {})",
+            c,
+            DEGREE_PLUS_ONE,
+        );
+        let coeffs = array::from_fn(|i| self.coeffs[(i + c) % DEGREE_PLUS_ONE].clone());
+        DensePolynomial { coeffs }
+    }
+
+    /// Right-shift by `c` bit positions on the bounded-degree coefficient
+    /// vector `R^{<W}[X]`, where `W = DEGREE_PLUS_ONE`.
+    ///
+    /// The result's coefficient at position `i` is the source's at `i + c`
+    /// when `i + c < W`, and zero otherwise: the low `c` coefficients are
+    /// dropped and the top `c` positions are zero-padded. This is `R`-linear
+    /// in the input (per Lemma 2.3) but is *not* a quotient-ring
+    /// endomorphism; unlike [`Self::rot_c`], `shift_r_c` cannot be viewed
+    /// as a map on `R[X]/(X^W - 1)`.
+    ///
+    /// Defined for any commutative ring `R` with a `Zero`; same dual use as
+    /// [`Self::rot_c`] across prover (bit-polynomial cells) and verifier
+    /// (lifted opening in `F_q^{<W}[X]`).
+    ///
+    /// Panics if `c == 0` or `c >= W`.
+    #[allow(clippy::arithmetic_side_effects)]
+    pub fn shift_r_c(&self, c: usize) -> Self {
+        assert!(
+            c > 0 && c < DEGREE_PLUS_ONE,
+            "shift_r_c count {} out of range (must satisfy 0 < c < {})",
+            c,
+            DEGREE_PLUS_ONE,
+        );
+        let coeffs = array::from_fn(|i| {
+            let j = i + c;
+            if j < DEGREE_PLUS_ONE {
+                self.coeffs[j].clone()
+            } else {
+                R::zero()
+            }
+        });
+        DensePolynomial { coeffs }
+    }
 }
 
 impl<R: Semiring, const DEGREE_PLUS_ONE: usize> DensePolynomial<R, DEGREE_PLUS_ONE> {
@@ -678,5 +740,79 @@ where
         zero: Out,
     ) -> Result<Out, InnerProductError> {
         I::inner_product::<CHECK>(&lhs.coeffs, rhs, zero)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn bits(coeffs: [u8; 8]) -> DensePolynomial<Boolean, 8> {
+        DensePolynomial {
+            coeffs: coeffs.map(|b| Boolean::new(b != 0)),
+        }
+    }
+
+    #[test]
+    fn rot_c_permutes_coefficients() {
+        // Non-periodic pattern: rot_c by different counts must yield
+        // observably different outputs.
+        let u = bits([1, 1, 1, 0, 0, 1, 0, 0]);
+        // rot_c(u, 3).coeffs[i] = u.coeffs[(i + 3) mod 8]
+        // (u[3], u[4], u[5], u[6], u[7], u[0], u[1], u[2])
+        // = (0,    0,    1,    0,    0,    1,    1,    1)
+        assert_eq!(u.rot_c(3), bits([0, 0, 1, 0, 0, 1, 1, 1]));
+        // rot_c(u, 5).coeffs[i] = u.coeffs[(i + 5) mod 8]
+        // (u[5], u[6], u[7], u[0], u[1], u[2], u[3], u[4])
+        // = (1,    0,    0,    1,    1,    1,    0,    0)
+        assert_eq!(u.rot_c(5), bits([1, 0, 0, 1, 1, 1, 0, 0]));
+        // Distinct outputs witness that rot_c is not periodic on this input.
+        assert_ne!(u.rot_c(3), u.rot_c(5));
+    }
+
+    #[test]
+    fn rot_c_is_cyclic() {
+        let u = bits([1, 1, 0, 0, 1, 0, 0, 0]);
+        let r1 = u.rot_c(3);
+        let r2 = r1.rot_c(5); // (3 + 5) mod 8 == 0, identity
+        assert_eq!(r2, u);
+    }
+
+    #[test]
+    fn shift_r_c_drops_low_bits_and_zero_pads_top() {
+        let u = bits([1, 0, 1, 0, 1, 0, 1, 0]);
+        // shift_r_c(u, 3).coeffs[i] = u.coeffs[i + 3] if i + 3 < 8 else 0
+        assert_eq!(u.shift_r_c(3), bits([0, 1, 0, 1, 0, 0, 0, 0]));
+    }
+
+    #[test]
+    fn shift_r_c_max_zeros_all_but_top() {
+        let u = bits([1, 1, 1, 1, 1, 1, 1, 1]);
+        // c = 7 keeps only u.coeffs[7] at position 0
+        assert_eq!(u.shift_r_c(7), bits([1, 0, 0, 0, 0, 0, 0, 0]));
+    }
+
+    #[test]
+    #[should_panic(expected = "rot_c count")]
+    fn rot_c_panics_on_zero() {
+        let _ = bits([1, 0, 0, 0, 0, 0, 0, 0]).rot_c(0);
+    }
+
+    #[test]
+    #[should_panic(expected = "rot_c count")]
+    fn rot_c_panics_on_full_width() {
+        let _ = bits([1, 0, 0, 0, 0, 0, 0, 0]).rot_c(8);
+    }
+
+    #[test]
+    #[should_panic(expected = "shift_r_c count")]
+    fn shift_r_c_panics_on_zero() {
+        let _ = bits([1, 0, 0, 0, 0, 0, 0, 0]).shift_r_c(0);
+    }
+
+    #[test]
+    #[should_panic(expected = "shift_r_c count")]
+    fn shift_r_c_panics_on_full_width() {
+        let _ = bits([1, 0, 0, 0, 0, 0, 0, 0]).shift_r_c(8);
     }
 }

--- a/uair/src/lib.rs
+++ b/uair/src/lib.rs
@@ -76,6 +76,80 @@ impl ShiftSpec {
 }
 
 // ---------------------------------------------------------------------------
+// BitOp virtual columns
+// ---------------------------------------------------------------------------
+
+/// An entry-wise `R`-linear endomorphism of the bounded-degree coefficient
+/// module `R^{<W}[X]` (cf. Section 2.1.1 of the Zinc+ paper) that defines a
+/// virtual column.
+///
+/// Per Lemma 2.3, any `R`-linear coordinate-wise map on `R^{<W}[X]` commutes
+/// with multilinear extension over the row hypercube. Consequently the column
+/// `T(v)` need not be committed: the prover materializes it during the
+/// constraint-aggregation sumcheck, and the verifier reconstructs its MLE
+/// evaluation at the final point `r_0` by applying `T` to the source
+/// column's lifted opening, its `W` `F_q`-coefficients, directly.
+///
+/// `Rot(c)` admits an alternative description as multiplication by `X^{W-c}`
+/// modulo `X^W - 1`, i.e. as an endomorphism of `R[X]/(X^W - 1)`. `ShR(c)` is
+/// pure zero-padding on coefficient indices and is *not* a quotient-ring
+/// operation; both, however, are `R`-linear maps on `R^{<W}[X]` and fall
+/// under the same Lemma 2.3 frame.
+///
+/// Bit-ops are defined only on binary_poly source columns.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub enum BitOp {
+    /// Right-rotation by `c` bit positions. The result's coefficient at
+    /// position `i` is the source's at `(i + c) mod W`, where `W` is the
+    /// cell width.
+    Rot(usize),
+    /// Right-shift by `c` bit positions. The result's coefficient at
+    /// position `i` is the source's at `i + c` if `i + c < W`, else zero.
+    ShR(usize),
+}
+
+impl BitOp {
+    /// The rotation / shift count.
+    pub fn count(&self) -> usize {
+        match self {
+            BitOp::Rot(c) | BitOp::ShR(c) => *c,
+        }
+    }
+}
+
+/// Specifies a bit-op virtual column.
+///
+/// `BitOpSpec { source_col: 0, op: BitOp::ShR(3) }` declares a virtual column
+/// whose row `i` is `ShR^3` applied entry-wise to the `i`-th cell of column 0.
+///
+/// `source_col` must reference a binary_poly column; bit-ops are only defined
+/// on bit-polynomial cells, i.e. elements of `R^{<W}[X]` with `{0,1}`
+/// coefficients.
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+pub struct BitOpSpec {
+    /// Flat index of the binary_poly source column. Uses the same
+    /// `binary_poly || arbitrary_poly || int` indexing as `ShiftSpec`.
+    source_col: usize,
+    /// The bit-op applied entry-wise to the source column.
+    op: BitOp,
+}
+
+impl BitOpSpec {
+    pub fn new(source_col: usize, op: BitOp) -> Self {
+        assert!(op.count() > 0, "bit-op count must be non-zero");
+        Self { source_col, op }
+    }
+
+    pub fn source_col(&self) -> usize {
+        self.source_col
+    }
+
+    pub fn op(&self) -> BitOp {
+        self.op
+    }
+}
+
+// ---------------------------------------------------------------------------
 // Column layout types
 // ---------------------------------------------------------------------------
 
@@ -182,7 +256,16 @@ pub struct UairSignature {
     witness_cols: WitnessColumnLayout,
     /// Shifted columns info sorted by `source_col`.
     shifts: Vec<ShiftSpec>,
-    /// Column-type layout of the shifted (down) row.
+    /// Bit-op virtual column specs, in insertion order. Each spec references a
+    /// binary_poly source column and contributes one extra entry to the
+    /// binary_poly slice of the down row, appended after the shifted entries.
+    bit_op_specs: Vec<BitOpSpec>,
+    /// Cell width shared by binary_poly bit-op virtual columns.
+    ///
+    /// `None` iff no bit-op virtual columns are declared. When present, each
+    /// bit-op count is guaranteed to satisfy `0 < count < cell_width`.
+    binary_poly_cell_width: Option<usize>,
+    /// Column-type layout of the down row (shifted virtuals + bit-op virtuals).
     down_cols: VirtualColumnLayout,
     /// Lookup specifications: which trace columns are constrained against
     /// which table types.
@@ -228,7 +311,7 @@ impl UairSignature {
         }
 
         shifts.sort_by_key(|spec| spec.source_col());
-        let down_cols = Self::compute_down_layout(&total_cols, &shifts);
+        let down_cols = Self::compute_down_layout(&total_cols, &shifts, &[]);
         let witness_cols = WitnessColumnLayout::new(
             sub!(
                 total_cols.num_binary_poly_cols(),
@@ -245,10 +328,66 @@ impl UairSignature {
             total_cols,
             public_cols,
             shifts,
+            bit_op_specs: Vec::new(),
+            binary_poly_cell_width: None,
             down_cols,
             witness_cols,
             lookup_specs,
         }
+    }
+
+    /// Attach bit-op virtual column specs to the signature.
+    ///
+    /// Each spec must reference a binary_poly source column; bit-ops are only
+    /// defined on bit-polynomial cells. `cell_width` is the shared coefficient
+    /// width `W` of those cells, and every bit-op count must satisfy
+    /// `0 < count < W`.
+    ///
+    /// # Down-row ordering invariant
+    ///
+    /// Bit-op virtuals slot into the `binary_poly` slice of the down
+    /// `TraceRow`, *after* the shifted-binary entries and *before* any
+    /// non-binary entries. The full ordering of the down row is:
+    ///
+    /// ```text
+    /// [shifted_binary_poly..., bit_op_binary_poly..., shifted_arbitrary_poly..., shifted_int...]
+    /// ```
+    ///
+    /// This keeps `down` consistent with `ColumnLayout`'s
+    /// `binary_poly || arbitrary_poly || int` partitioning. Materialization
+    /// code in CPR / mp_eval must respect this order; appending bit-op evals
+    /// at the tail of `down_evals` would silently misalign constraint indices
+    /// on mixed-type shift UAIRs.
+    ///
+    /// Insertion order of `bit_op_specs` determines the position of each
+    /// bit-op virtual within its sub-slice.
+    pub fn with_bit_op_specs(mut self, cell_width: usize, bit_op_specs: Vec<BitOpSpec>) -> Self {
+        let binary_poly_end = self.total_cols.num_binary_poly_cols();
+        for spec in &bit_op_specs {
+            assert!(
+                spec.source_col() < binary_poly_end,
+                "BitOpSpec source_col {} is not a binary_poly column \
+                 (binary_poly_end = {}). Bit-ops are only defined on the \
+                 cell ring F_2[X]/(X^W).",
+                spec.source_col(),
+                binary_poly_end,
+            );
+            assert!(
+                spec.op().count() < cell_width,
+                "BitOpSpec count {} out of range (must satisfy 0 < count < {})",
+                spec.op().count(),
+                cell_width,
+            );
+        }
+        self.binary_poly_cell_width = if bit_op_specs.is_empty() {
+            None
+        } else {
+            Some(cell_width)
+        };
+        self.bit_op_specs = bit_op_specs;
+        self.down_cols =
+            Self::compute_down_layout(&self.total_cols, &self.shifts, &self.bit_op_specs);
+        self
     }
 
     pub fn lookup_specs(&self) -> &[LookupColumnSpec] {
@@ -258,6 +397,7 @@ impl UairSignature {
     fn compute_down_layout(
         total_cols: &TotalColumnLayout,
         shifts: &[ShiftSpec],
+        bit_op_specs: &[BitOpSpec],
     ) -> VirtualColumnLayout {
         let binary_poly_end = total_cols.num_binary_poly_cols();
         let arbitrary_poly_end = add!(binary_poly_end, total_cols.num_arbitrary_poly_cols());
@@ -273,6 +413,7 @@ impl UairSignature {
                 num_int = add!(num_int, 1);
             }
         }
+        num_binary_poly = add!(num_binary_poly, bit_op_specs.len());
         VirtualColumnLayout::new(num_binary_poly, num_arbitrary_poly, num_int)
     }
 
@@ -293,7 +434,21 @@ impl UairSignature {
         &self.shifts
     }
 
-    /// Column-type layout of the shifted (down) row.
+    /// Bit-op virtual column specs, in insertion order. Each spec contributes
+    /// one binary_poly entry to the down row, appended after the shifted
+    /// entries.
+    pub fn bit_op_specs(&self) -> &[BitOpSpec] {
+        &self.bit_op_specs
+    }
+
+    /// Shared coefficient width for binary_poly bit-op virtual columns.
+    ///
+    /// Returns `None` iff no bit-op virtual columns are declared.
+    pub fn binary_poly_cell_width(&self) -> Option<usize> {
+        self.binary_poly_cell_width
+    }
+
+    /// Column-type layout of the down row (shifted virtuals + bit-op virtuals).
     pub fn down_cols(&self) -> &VirtualColumnLayout {
         &self.down_cols
     }

--- a/uair/src/lib.rs
+++ b/uair/src/lib.rs
@@ -260,11 +260,6 @@ pub struct UairSignature {
     /// binary_poly source column and contributes one extra entry to the
     /// binary_poly slice of the down row, appended after the shifted entries.
     bit_op_specs: Vec<BitOpSpec>,
-    /// Cell width shared by binary_poly bit-op virtual columns.
-    ///
-    /// `None` iff no bit-op virtual columns are declared. When present, each
-    /// bit-op count is guaranteed to satisfy `0 < count < cell_width`.
-    binary_poly_cell_width: Option<usize>,
     /// Column-type layout of the down row (shifted virtuals + bit-op virtuals).
     down_cols: VirtualColumnLayout,
     /// Lookup specifications: which trace columns are constrained against
@@ -329,7 +324,6 @@ impl UairSignature {
             public_cols,
             shifts,
             bit_op_specs: Vec::new(),
-            binary_poly_cell_width: None,
             down_cols,
             witness_cols,
             lookup_specs,
@@ -379,11 +373,6 @@ impl UairSignature {
                 cell_width,
             );
         }
-        self.binary_poly_cell_width = if bit_op_specs.is_empty() {
-            None
-        } else {
-            Some(cell_width)
-        };
         self.bit_op_specs = bit_op_specs;
         self.down_cols =
             Self::compute_down_layout(&self.total_cols, &self.shifts, &self.bit_op_specs);
@@ -439,13 +428,6 @@ impl UairSignature {
     /// entries.
     pub fn bit_op_specs(&self) -> &[BitOpSpec] {
         &self.bit_op_specs
-    }
-
-    /// Shared coefficient width for binary_poly bit-op virtual columns.
-    ///
-    /// Returns `None` iff no bit-op virtual columns are declared.
-    pub fn binary_poly_cell_width(&self) -> Option<usize> {
-        self.binary_poly_cell_width
     }
 
     /// Column-type layout of the down row (shifted virtuals + bit-op virtuals).
@@ -622,5 +604,70 @@ pub trait Uair: Clone {
             |x, y| B::Expr::mul_by_scalar::<UNCHECKED>(x, y),
             B::Ideal::from_ref,
         )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn signature_with_mixed_shifts() -> UairSignature {
+        UairSignature::new(
+            TotalColumnLayout::new(2, 1, 1),
+            PublicColumnLayout::new(0, 0, 0),
+            vec![
+                ShiftSpec::new(0, 1),
+                ShiftSpec::new(2, 1),
+                ShiftSpec::new(3, 1),
+            ],
+            vec![],
+        )
+    }
+
+    #[test]
+    fn bit_op_specs_extend_binary_down_layout() {
+        let specs = vec![
+            BitOpSpec::new(1, BitOp::ShR(3)),
+            BitOpSpec::new(0, BitOp::Rot(2)),
+        ];
+        let sig = signature_with_mixed_shifts().with_bit_op_specs(8, specs.clone());
+
+        assert_eq!(sig.bit_op_specs(), specs);
+        assert_eq!(sig.bit_op_specs()[0].source_col(), 1);
+        assert_eq!(sig.bit_op_specs()[0].op(), BitOp::ShR(3));
+        assert_eq!(sig.bit_op_specs()[0].op().count(), 3);
+        assert_eq!(sig.down_cols().num_binary_poly_cols(), 3);
+        assert_eq!(sig.down_cols().num_arbitrary_poly_cols(), 1);
+        assert_eq!(sig.down_cols().num_int_cols(), 1);
+    }
+
+    #[test]
+    fn empty_bit_op_specs_keep_shift_only_down_layout() {
+        let sig = signature_with_mixed_shifts().with_bit_op_specs(8, vec![]);
+
+        assert!(sig.bit_op_specs().is_empty());
+        assert_eq!(sig.down_cols().num_binary_poly_cols(), 1);
+        assert_eq!(sig.down_cols().num_arbitrary_poly_cols(), 1);
+        assert_eq!(sig.down_cols().num_int_cols(), 1);
+    }
+
+    #[test]
+    #[should_panic(expected = "bit-op count must be non-zero")]
+    fn bit_op_spec_rejects_zero_count() {
+        let _ = BitOpSpec::new(0, BitOp::Rot(0));
+    }
+
+    #[test]
+    #[should_panic(expected = "is not a binary_poly column")]
+    fn bit_op_specs_reject_non_binary_source() {
+        let _ = signature_with_mixed_shifts()
+            .with_bit_op_specs(8, vec![BitOpSpec::new(2, BitOp::ShR(1))]);
+    }
+
+    #[test]
+    #[should_panic(expected = "out of range")]
+    fn bit_op_specs_reject_count_at_cell_width() {
+        let _ = signature_with_mixed_shifts()
+            .with_bit_op_specs(8, vec![BitOpSpec::new(0, BitOp::Rot(8))]);
     }
 }


### PR DESCRIPTION
## Summary

- add UAIR metadata for bit-op virtual columns (`ROTR` / `SHR`) over binary polynomial cells
- validate bit-op source columns and counts against the declared binary polynomial cell width without storing that width in the signature
- add reusable dense-polynomial coefficient transforms for right-rotation and right-shift (`rotate_right` / `shr`)
- document the future down-row ordering invariant for shifted and bit-op virtual columns

## Context

Part of #185. This PR is the small foundation PR: it only adds the typed foundation needed by later protocol plumbing. It does not change prover/verifier behavior yet.

Follow-up PRs will wire these specs through CPR / multipoint evaluation and add the end-to-end SHA-relevant bit-op tests.

## Validation

- `.githooks/pre-push`
- `cargo test -p zinc-uair bit_op`
- `cargo test -p zinc-poly rotate_right`
- `cargo test -p zinc-poly shr`