### PR TITLE
Splice bit-op virtuals in ideal check

### DIFF
--- a/piop/benches/combined_poly_resolver.rs
+++ b/piop/benches/combined_poly_resolver.rs
@@ -69,7 +69,10 @@ fn bench_no_mult<const INT_LIMBS: usize, const FIELD_LIMBS: usize>(
             });
 
         let (ic_proof, ic_prover_state) =
-            <TestUairNoMultiplication<_> as IdealCheckProtocol>::prove_combined(
+            <TestUairNoMultiplication<_> as IdealCheckProtocol>::prove_combined::<
+                _,
+                DEGREE_PLUS_ONE,
+            >(
                 transcript,
                 &projected_trace,
                 &projected_scalars,
@@ -250,7 +253,10 @@ fn bench_simple_mult<const INT_LIMBS: usize, const FIELD_LIMBS: usize>(
         });
 
         let (ic_proof, ic_prover_state) =
-            <TestUairSimpleMultiplication<Int<INT_LIMBS>> as IdealCheckProtocol>::prove_combined(
+            <TestUairSimpleMultiplication<Int<INT_LIMBS>> as IdealCheckProtocol>::prove_combined::<
+                _,
+                DEGREE_PLUS_ONE,
+            >(
                 transcript,
                 &projected_trace,
                 &projected_scalars,

--- a/piop/benches/ideal_check.rs
+++ b/piop/benches/ideal_check.rs
@@ -70,7 +70,7 @@ fn bench_no_mult<const INT_LIMBS: usize, const FIELD_LIMBS: usize>(
 
         // Even though this UAIR is linear, using prove_combined yields much better
         // prover performance for it.
-        TestUairNoMultiplication::prove_combined(
+        TestUairNoMultiplication::prove_combined::<_, DEGREE_PLUS_ONE>(
             transcript,
             &trace,
             &projected_scalars,
@@ -162,7 +162,7 @@ fn bench_simple_mult<const INT_LIMBS: usize, const FIELD_LIMBS: usize>(
                 .collect()
         });
 
-        TestUairSimpleMultiplication::prove_combined(
+        TestUairSimpleMultiplication::prove_combined::<_, DEGREE_PLUS_ONE>(
             transcript,
             &trace,
             &projected_scalars,
@@ -254,7 +254,7 @@ fn bench_binary_decomposition<const FIELD_LIMBS: usize>(
                     .collect()
             });
 
-        BinaryDecompositionUair::prove_combined(
+        BinaryDecompositionUair::prove_combined::<_, DEGREE_PLUS_ONE>(
             transcript,
             &trace,
             &projected_scalars,
@@ -333,7 +333,7 @@ fn bench_big_linear_uair<const FIELD_LIMBS: usize>(
                         .collect()
                 });
 
-            BigLinearUair::$prove_fn(
+            BigLinearUair::$prove_fn::<_, DEGREE_PLUS_ONE>(
                 $transcript,
                 &trace,
                 &projected_scalars,

--- a/piop/src/ideal_check.rs
+++ b/piop/src/ideal_check.rs
@@ -51,7 +51,7 @@ pub trait IdealCheckProtocol: Uair {
     /// - `field_cfg`: random field configuration sampled on the previous steps
     ///   of the overall protocol.
     #[allow(clippy::type_complexity)]
-    fn prove_mle_first<F>(
+    fn prove_mle_first<F, const DEGREE_PLUS_ONE: usize>(
         transcript: &mut impl Transcript,
         trace_matrix: &ColumnMajorTrace<F>,
         projected_scalars: &HashMap<Self::Scalar, DynamicPolynomialF<F>>,
@@ -80,7 +80,7 @@ pub trait IdealCheckProtocol: Uair {
     /// - `field_cfg`: random field configuration sampled on the previous steps
     ///   of the overall protocol.
     #[allow(clippy::type_complexity)]
-    fn prove_combined<F>(
+    fn prove_combined<F, const DEGREE_PLUS_ONE: usize>(
         transcript: &mut impl Transcript,
         trace_matrix: &RowMajorTrace<F>,
         projected_scalars: &HashMap<Self::Scalar, DynamicPolynomialF<F>>,
@@ -139,7 +139,7 @@ where
     U: Uair,
 {
     #[allow(clippy::type_complexity)]
-    fn prove_mle_first<F>(
+    fn prove_mle_first<F, const DEGREE_PLUS_ONE: usize>(
         transcript: &mut impl Transcript,
         trace_matrix: &ColumnMajorTrace<F>,
         projected_scalars: &HashMap<U::Scalar, DynamicPolynomialF<F>>,
@@ -181,13 +181,14 @@ where
         // out correct.
         // Non-linear entries are garbage and get replaced below.
         let mut combined_mle_values: Vec<DynamicPolynomialF<F>> = if has_linear_nonzero {
-            let mut res = combined_poly_builder::evaluate_combined_polynomials::<_, U>(
-                trace_matrix,
-                projected_scalars,
-                num_constraints,
-                &evaluation_point,
-                field_cfg,
-            )?;
+            let mut res =
+                combined_poly_builder::evaluate_combined_polynomials::<_, U, DEGREE_PLUS_ONE>(
+                    trace_matrix,
+                    projected_scalars,
+                    num_constraints,
+                    &evaluation_point,
+                    field_cfg,
+                )?;
 
             // Scrub garbage left by `evaluate_combined_polynomials` at non-linear
             // zero-ideal indices.
@@ -205,7 +206,7 @@ where
             // transpose here.
             // TODO(alex): Can/should we avoid the transposition?
             let row_major = column_major_to_row_major(trace_matrix);
-            let values = combined_poly_builder::evaluate_for_constraints::<_, U>(
+            let values = combined_poly_builder::evaluate_for_constraints::<_, U, DEGREE_PLUS_ONE>(
                 &row_major,
                 projected_scalars,
                 num_constraints,
@@ -234,7 +235,7 @@ where
     }
 
     #[allow(clippy::type_complexity)]
-    fn prove_combined<F>(
+    fn prove_combined<F, const DEGREE_PLUS_ONE: usize>(
         transcript: &mut impl Transcript,
         trace_matrix: &RowMajorTrace<F>,
         projected_scalars: &HashMap<U::Scalar, DynamicPolynomialF<F>>,
@@ -262,7 +263,7 @@ where
 
         let mut combined_mle_values = vec![DynamicPolynomialF::ZERO; num_constraints];
         if !non_zero_indices.is_empty() {
-            let computed = combined_poly_builder::evaluate_for_constraints::<_, U>(
+            let computed = combined_poly_builder::evaluate_for_constraints::<_, U, DEGREE_PLUS_ONE>(
                 trace_matrix,
                 projected_scalars,
                 num_constraints,
@@ -357,7 +358,8 @@ mod tests {
     use rand::rng;
     use zinc_poly::univariate::{dense::DensePolynomial, dynamic::over_field::DynamicPolynomialF};
     use zinc_test_uair::{
-        GenerateRandomTrace, TestUairNoMultiplication, TestUairSimpleMultiplication,
+        GenerateRandomTrace, TestUairBitOpsMixedSplice, TestUairNoMultiplication,
+        TestUairSimpleMultiplication,
     };
     use zinc_transcript::Blake3Transcript;
     use zinc_uair::{
@@ -456,6 +458,11 @@ mod tests {
         // Non-linear UAIR with all-zero ideals
         do_test::<TestUairSimpleMultiplication<Int<5>>, _, _, 32>(num_vars, |_ideal_over_ring| {
             IdealOrZero::<DegreeOneIdeal<_>>::zero()
+        });
+
+        // Linear UAIR with bit-op virtuals and mixed down-row splicing.
+        do_test::<TestUairBitOpsMixedSplice<Int<5>>, _, _, 32>(num_vars, |ideal_over_ring| {
+            ideal_over_ring.map(|i| DegreeOneIdeal::from_with_cfg(i, &field_cfg))
         });
     }
 }

--- a/piop/src/ideal_check/combined_poly_builder.rs
+++ b/piop/src/ideal_check/combined_poly_builder.rs
@@ -13,9 +13,12 @@ use zinc_poly::{
     univariate::dynamic::over_field::DynamicPolynomialF,
     utils::{ArithErrors as PolyArithErrors, build_eq_x_r_vec},
 };
-use zinc_uair::{ColumnLayout, ConstraintBuilder, TraceRow, Uair, ideal::ImpossibleIdeal};
+use zinc_uair::{
+    BitOp, BitOpSpec, ColumnLayout, ConstraintBuilder, ShiftSpec, TraceRow, Uair, UairSignature,
+    ideal::ImpossibleIdeal,
+};
 use zinc_utils::{
-    cfg_into_iter, cfg_iter, from_ref::FromRef, inner_transparent_field::InnerTransparentField,
+    add, cfg_into_iter, cfg_iter, from_ref::FromRef, inner_transparent_field::InnerTransparentField,
 };
 
 /// Evaluate combined polynomial MLEs at `evaluation_point` for a selected
@@ -30,7 +33,7 @@ use zinc_utils::{
 ///
 /// `trace_matrix` is row-indexed: `trace_matrix[row][col]`.
 #[allow(clippy::arithmetic_side_effects)]
-pub fn evaluate_for_constraints<F, U>(
+pub fn evaluate_for_constraints<F, U, const DEGREE_PLUS_ONE: usize>(
     trace_matrix: &RowMajorTrace<F>,
     projected_scalars: &HashMap<U::Scalar, DynamicPolynomialF<F>>,
     num_constraints: usize,
@@ -57,21 +60,35 @@ where
     // `all_rows[row_idx][constraint_idx]` is a `DynamicPolynomialF<F>`:
     // the combined polynomial value of constraint `constraint_idx` at
     // trace row `row_idx`.
+    let bit_op_down_offset = bit_op_down_offset(&uair_sig);
     let mut all_rows: Vec<Vec<DynamicPolynomialF<F>>> = cfg_into_iter!(0..num_rows - 1)
         .map(|row_idx| {
             let up = &trace_matrix[row_idx];
 
-            let down: Vec<DynamicPolynomialF<F>> = uair_sig
-                .shifts()
-                .iter()
-                .map(|spec| {
-                    if row_idx + spec.shift_amount() < num_rows {
-                        trace_matrix[row_idx + spec.shift_amount()][spec.source_col()].clone()
-                    } else {
-                        DynamicPolynomialF::zero() // zero padding
-                    }
-                })
-                .collect();
+            // Build the down row in the canonical order:
+            //   [shifted_binary, bit_op_binary, shifted_arbitrary, shifted_int]
+            // (cf. `UairSignature::with_bit_op_specs`). Splicing bit-op
+            // virtuals into the binary_poly slice keeps `down` consistent
+            // with `down_layout`; appending at the tail would misalign
+            // constraints on mixed-type shift UAIRs.
+            let mut down: Vec<DynamicPolynomialF<F>> =
+                Vec::with_capacity(uair_sig.shifts().len() + uair_sig.bit_op_specs().len());
+
+            let shifts = uair_sig.shifts();
+            for spec in &shifts[..bit_op_down_offset] {
+                push_shifted_down_entry(&mut down, trace_matrix, row_idx, num_rows, spec);
+            }
+
+            for spec in uair_sig.bit_op_specs() {
+                let source = &trace_matrix[row_idx][spec.source_col()];
+                down.push(apply_bit_op_to_poly::<F, DEGREE_PLUS_ONE>(
+                    source, spec, field_cfg,
+                ));
+            }
+
+            for spec in &shifts[bit_op_down_offset..] {
+                push_shifted_down_entry(&mut down, trace_matrix, row_idx, num_rows, spec);
+            }
 
             evaluate_constraints_for_row::<F, U>(
                 up,
@@ -207,7 +224,7 @@ where
 /// Does `(num_columns + num_shifted_columns) * max_num_coeffs` evaluations of
 /// MLEs.
 #[allow(clippy::arithmetic_side_effects)]
-pub fn evaluate_combined_polynomials<F, U>(
+pub fn evaluate_combined_polynomials<F, U, const DEGREE_PLUS_ONE: usize>(
     trace_matrix: &ColumnMajorTrace<F>,
     projected_scalars: &HashMap<U::Scalar, DynamicPolynomialF<F>>,
     num_constraints: usize,
@@ -276,7 +293,7 @@ where
 
     // Evaluate down (only shifted columns, per-spec shift amount).
     let sorted_shifts = uair_sig.shifts();
-    let down_evals: Vec<DynamicPolynomialF<F>> = cfg_iter!(sorted_shifts)
+    let shift_down_evals: Vec<DynamicPolynomialF<F>> = cfg_iter!(sorted_shifts)
         .map(|spec| {
             let col = &trace_matrix[spec.source_col()];
             let coeffs: Vec<F> = (0..max_num_coeffs)
@@ -285,6 +302,29 @@ where
             Ok(DynamicPolynomialF::new_trimmed(coeffs))
         })
         .collect::<Result<Vec<_>, EvaluationError>>()?;
+
+    // Evaluate bit-op virtuals from the already-computed up evaluations:
+    // bit-ops act coefficient-wise, so MLE-eval-of-op at the same point is
+    // op-of-MLE-eval on the source coefficient vector.
+    let bit_op_down_offset = bit_op_down_offset(&uair_sig);
+    let bit_op_down_evals: Vec<DynamicPolynomialF<F>> = uair_sig
+        .bit_op_specs()
+        .iter()
+        .map(|spec| {
+            apply_bit_op_to_poly::<F, DEGREE_PLUS_ONE>(
+                &up_evals[spec.source_col()],
+                spec,
+                field_cfg,
+            )
+        })
+        .collect();
+
+    // Splice into the canonical down ordering; see UairSignature docs.
+    let mut down_evals: Vec<DynamicPolynomialF<F>> =
+        Vec::with_capacity(shift_down_evals.len() + bit_op_down_evals.len());
+    down_evals.extend_from_slice(&shift_down_evals[..bit_op_down_offset]);
+    down_evals.extend(bit_op_down_evals);
+    down_evals.extend_from_slice(&shift_down_evals[bit_op_down_offset..]);
 
     // Apply UAIR constraints to the evaluated trace values
     let mut constraint_builder = CombinedPolyRowBuilder::new(num_constraints);
@@ -309,6 +349,41 @@ where
     combined_evaluations.iter_mut().for_each(|eval| eval.trim());
 
     Ok(combined_evaluations)
+}
+
+fn bit_op_down_offset(uair_sig: &UairSignature) -> usize {
+    let binary_poly_end = uair_sig.total_cols().num_binary_poly_cols();
+    uair_sig
+        .shifts()
+        .iter()
+        .take_while(|spec| spec.source_col() < binary_poly_end)
+        .count()
+}
+
+fn push_shifted_down_entry<F: PrimeField>(
+    down: &mut Vec<DynamicPolynomialF<F>>,
+    trace_matrix: &RowMajorTrace<F>,
+    row_idx: usize,
+    num_rows: usize,
+    spec: &ShiftSpec,
+) {
+    let shifted_row_idx = add!(row_idx, spec.shift_amount());
+    if shifted_row_idx < num_rows {
+        down.push(trace_matrix[shifted_row_idx][spec.source_col()].clone());
+    } else {
+        down.push(DynamicPolynomialF::zero());
+    }
+}
+
+fn apply_bit_op_to_poly<F: PrimeField, const DEGREE_PLUS_ONE: usize>(
+    source: &DynamicPolynomialF<F>,
+    spec: &BitOpSpec,
+    field_cfg: &F::Config,
+) -> DynamicPolynomialF<F> {
+    match spec.op() {
+        BitOp::Rot(c) => source.rotate_right::<DEGREE_PLUS_ONE>(c, field_cfg),
+        BitOp::ShR(c) => source.shr::<DEGREE_PLUS_ONE>(c, field_cfg),
+    }
 }
 
 pub struct CombinedPolyRowBuilder<F: PrimeField> {

--- a/piop/src/test_utils.rs
+++ b/piop/src/test_utils.rs
@@ -11,7 +11,6 @@ use crate::{
 };
 use crypto_bigint::{Odd, modular::MontyParams};
 use crypto_primitives::{FromWithConfig, crypto_bigint_int::Int, crypto_bigint_monty::MontyField};
-use num_traits::Zero;
 use zinc_poly::univariate::{dense::DensePolynomial, dynamic::over_field::DynamicPolynomialF};
 use zinc_test_uair::GenerateRandomTrace;
 use zinc_transcript::traits::Transcript;
@@ -48,15 +47,9 @@ where
         + IdealCheckProtocol,
     F: FromWithConfig<Int<5>>,
 {
-    assert!(
-        U::signature()
-            .witness_cols()
-            .num_binary_poly_cols()
-            .is_zero()
-            && U::signature().witness_cols().num_int_cols().is_zero(),
-        "the signature should be single typed"
-    );
-
+    // These helpers intentionally accept mixed-type signatures. The projection
+    // layer handles binary_poly, arbitrary_poly, and int columns uniformly, and
+    // mixed fixtures are needed to regression-test down-row splicing.
     let field_cfg = test_config();
 
     let num_constraints = count_constraints::<U>();
@@ -70,7 +63,7 @@ where
 
     let trace: ColumnMajorTrace<F> = project_trace_coeffs_column_major(trace, &field_cfg);
 
-    let (proof, state) = U::prove_mle_first(
+    let (proof, state) = U::prove_mle_first::<_, DEGREE_PLUS_ONE>(
         transcript,
         &trace,
         &scalars,
@@ -102,15 +95,9 @@ where
         + IdealCheckProtocol,
     F: FromWithConfig<Int<5>>,
 {
-    assert!(
-        U::signature()
-            .witness_cols()
-            .num_binary_poly_cols()
-            .is_zero()
-            && U::signature().witness_cols().num_int_cols().is_zero(),
-        "the signature should be single typed"
-    );
-
+    // These helpers intentionally accept mixed-type signatures. The projection
+    // layer handles binary_poly, arbitrary_poly, and int columns uniformly, and
+    // mixed fixtures are needed to regression-test down-row splicing.
     let field_cfg = test_config();
 
     let num_constraints = count_constraints::<U>();
@@ -124,7 +111,7 @@ where
 
     let trace: RowMajorTrace<F> = project_trace_coeffs_row_major(trace, &field_cfg);
 
-    let (proof, state) = U::prove_combined(
+    let (proof, state) = U::prove_combined::<_, DEGREE_PLUS_ONE>(
         transcript,
         &trace,
         &scalars,

--- a/poly/src/univariate/dynamic/over_field.rs
+++ b/poly/src/univariate/dynamic/over_field.rs
@@ -77,6 +77,11 @@ impl<F: PrimeField> DynamicPolynomialF<F> {
             c > 0 && c < D,
             "rotate_right count {c} out of range (must satisfy 0 < c < {D})",
         );
+        assert!(
+            self.coeffs.len() <= D,
+            "rotate_right coefficient length {} exceeds width {D}",
+            self.coeffs.len(),
+        );
 
         let mut coeffs = self.coeffs.clone();
         coeffs.resize(D, F::zero_with_cfg(field_cfg));
@@ -96,6 +101,11 @@ impl<F: PrimeField> DynamicPolynomialF<F> {
         assert!(
             c > 0 && c < D,
             "shr count {c} out of range (must satisfy 0 < c < {D})",
+        );
+        assert!(
+            self.coeffs.len() <= D,
+            "shr coefficient length {} exceeds width {D}",
+            self.coeffs.len(),
         );
 
         let zero = F::zero_with_cfg(field_cfg);
@@ -898,6 +908,13 @@ mod tests {
     }
 
     #[test]
+    #[should_panic(expected = "rotate_right coefficient length 3 exceeds width 2")]
+    fn rotate_right_panics_when_coefficients_exceed_width() {
+        let field_cfg = test_config();
+        let _ = DynamicPolynomialF::new([f(1), f(2), f(3)]).rotate_right::<2>(1, &field_cfg);
+    }
+
+    #[test]
     #[should_panic(expected = "shr count 0 out of range")]
     fn shr_panics_on_zero() {
         let field_cfg = test_config();
@@ -909,6 +926,13 @@ mod tests {
     fn shr_panics_on_full_width() {
         let field_cfg = test_config();
         let _ = DynamicPolynomialF::new([f(1)]).shr::<5>(5, &field_cfg);
+    }
+
+    #[test]
+    #[should_panic(expected = "shr coefficient length 3 exceeds width 2")]
+    fn shr_panics_when_coefficients_exceed_width() {
+        let field_cfg = test_config();
+        let _ = DynamicPolynomialF::new([f(1), f(2), f(3)]).shr::<2>(1, &field_cfg);
     }
 
     #[test]

--- a/protocol/src/prover.rs
+++ b/protocol/src/prover.rs
@@ -440,7 +440,7 @@ impl_with_type_bounds!(ProverProjectedCombined
     ) -> Result<ProverIdealChecked<'a, Zt, U, F, D, FD>, ProtocolError<F, U::Ideal>> {
         let num_constraints = count_constraints::<U>();
 
-        let (ic_proof, ic_prover_state) = U::prove_combined(
+        let (ic_proof, ic_prover_state) = U::prove_combined::<_, D>(
             &mut self.base.pcs_transcript.fs_transcript,
             &self.projected_trace,
             &self.projected_scalars_fx,
@@ -473,7 +473,7 @@ impl_with_type_bounds!(ProverProjectedMleFirst
     ) -> Result<ProverIdealChecked<'a, Zt, U, F, D, FD>, ProtocolError<F, U::Ideal>> {
         let num_constraints = count_constraints::<U>();
 
-        let (ic_proof, ic_prover_state) = U::prove_mle_first(
+        let (ic_proof, ic_prover_state) = U::prove_mle_first::<_, D>(
             &mut self.base.pcs_transcript.fs_transcript,
             &self.projected_trace,
             &self.projected_scalars_fx,

--- a/test-uair/src/lib.rs
+++ b/test-uair/src/lib.rs
@@ -19,8 +19,8 @@ use zinc_poly::{
     },
 };
 use zinc_uair::{
-    ConstraintBuilder, PublicColumnLayout, ShiftSpec, TotalColumnLayout, TraceRow, Uair,
-    UairSignature, UairTrace,
+    BitOp, BitOpSpec, ConstraintBuilder, PublicColumnLayout, ShiftSpec, TotalColumnLayout,
+    TraceRow, Uair, UairSignature, UairTrace,
     ideal::{DegreeOneIdeal, ImpossibleIdeal},
 };
 use zinc_utils::from_ref::FromRef;
@@ -858,6 +858,109 @@ where
     }
 }
 
+/// Mixed-splice UAIR for bit-op virtual columns.
+///
+/// It populates three slots of the canonical down-row ordering at once:
+/// shifted binary, bit-op binary, and shifted arbitrary. This catches
+/// materialization code that appends bit-op virtuals at the tail instead of
+/// inserting them into the binary down slice.
+#[derive(Clone, Debug)]
+pub struct TestUairBitOpsMixedSplice<R>(PhantomData<R>);
+
+impl<R> Uair for TestUairBitOpsMixedSplice<R>
+where
+    R: ConstSemiring + 'static,
+{
+    type Ideal = DegreeOneIdeal<R>;
+    type Scalar = DensePolynomial<R, 32>;
+
+    fn signature() -> UairSignature {
+        let total = TotalColumnLayout::new(3, 2, 0);
+        let shifts = vec![ShiftSpec::new(0, 1), ShiftSpec::new(3, 1)];
+        let bit_op_specs = vec![BitOpSpec::new(0, BitOp::ShR(3))];
+        let sig = UairSignature::new(total, PublicColumnLayout::default(), shifts, vec![])
+            .with_bit_op_specs(bit_op_specs);
+        debug_assert_eq!(sig.down_cols().num_binary_poly_cols(), 2);
+        debug_assert_eq!(sig.down_cols().num_arbitrary_poly_cols(), 1);
+        debug_assert_eq!(sig.down_cols().num_int_cols(), 0);
+        sig
+    }
+
+    fn constrain_general<B, FromR, MulByScalar, IFromR>(
+        b: &mut B,
+        up: TraceRow<B::Expr>,
+        down: TraceRow<B::Expr>,
+        _from_ref: FromR,
+        _mbs: MulByScalar,
+        ideal_from_ref: IFromR,
+    ) where
+        B: ConstraintBuilder,
+        IFromR: Fn(&Self::Ideal) -> B::Ideal,
+    {
+        let one_ideal = ideal_from_ref(&DegreeOneIdeal::new(R::ONE));
+        b.assert_in_ideal(down.binary_poly[0].clone() - &up.binary_poly[2], &one_ideal);
+        b.assert_in_ideal(down.binary_poly[1].clone() - &up.binary_poly[1], &one_ideal);
+        b.assert_in_ideal(
+            down.arbitrary_poly[0].clone() - &up.arbitrary_poly[1],
+            &one_ideal,
+        );
+    }
+}
+
+impl<R> GenerateRandomTrace<32> for TestUairBitOpsMixedSplice<R>
+where
+    R: ConstSemiring + FixedSemiring + From<i8> + 'static,
+    StandardUniform: Distribution<R>,
+{
+    type PolyCoeff = R;
+    type Int = R;
+
+    fn generate_random_trace<Rng: RngCore + ?Sized>(
+        num_vars: usize,
+        rng: &mut Rng,
+    ) -> UairTrace<'static, R, R, 32, 32> {
+        let n = 1usize << num_vars;
+
+        let w_u32: Vec<u32> = (0..n).map(|_| rng.next_u32()).collect();
+        let w_col: DenseMultilinearExtension<BinaryPoly<32>> =
+            w_u32.iter().map(|w| BinaryPoly::from(*w)).collect();
+        let s_shr_col: DenseMultilinearExtension<BinaryPoly<32>> =
+            w_u32.iter().map(|w| BinaryPoly::from(w >> 3)).collect();
+        let t_col: DenseMultilinearExtension<BinaryPoly<32>> = (0..n)
+            .map(|i| {
+                if i + 1 < n {
+                    BinaryPoly::from(w_u32[i + 1])
+                } else {
+                    BinaryPoly::from(0u32)
+                }
+            })
+            .collect();
+
+        let a_cells: Vec<DensePolynomial<R, 32>> = (0..n)
+            .map(|_| DensePolynomial::new([R::from(rng.random::<i8>())]))
+            .collect();
+        let a_next_cells: Vec<DensePolynomial<R, 32>> = (0..n)
+            .map(|i| {
+                if i + 1 < n {
+                    a_cells[i + 1].clone()
+                } else {
+                    DensePolynomial::<R, 32>::zero()
+                }
+            })
+            .collect();
+
+        UairTrace {
+            binary_poly: vec![w_col, s_shr_col, t_col].into(),
+            arbitrary_poly: vec![
+                a_cells.into_iter().collect(),
+                a_next_cells.into_iter().collect(),
+            ]
+            .into(),
+            int: vec![].into(),
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use crypto_primitives::crypto_bigint_int::Int;
@@ -888,6 +991,7 @@ mod tests {
         assert_uair_shape::<BinaryDecompositionUair<u32>>(&[1]);
         assert_uair_shape::<BigLinearUair<u32>>(&[1; 17]);
         assert_uair_shape::<TestUairMixedShifts<Int<LIMBS>>>(&[1, 1]);
+        assert_uair_shape::<TestUairBitOpsMixedSplice<Int<LIMBS>>>(&[1, 1, 1]);
     }
 
     #[test]

--- a/uair/src/lib.rs
+++ b/uair/src/lib.rs
@@ -332,10 +332,9 @@ impl UairSignature {
 
     /// Attach bit-op virtual column specs to the signature.
     ///
-    /// Each spec must reference a binary_poly source column; bit-ops are only
-    /// defined on bit-polynomial cells. `cell_width` is the shared coefficient
-    /// width `W` of those cells, and every bit-op count must satisfy
-    /// `0 < count < W`.
+    /// Each spec must reference a binary_poly source column. The bit-op count
+    /// must be less than the binary-poly cell width `W`; materialization sites
+    /// check that bound with their const `DEGREE_PLUS_ONE` parameter.
     ///
     /// # Down-row ordering invariant
     ///
@@ -355,7 +354,7 @@ impl UairSignature {
     ///
     /// Insertion order of `bit_op_specs` determines the position of each
     /// bit-op virtual within its sub-slice.
-    pub fn with_bit_op_specs(mut self, cell_width: usize, bit_op_specs: Vec<BitOpSpec>) -> Self {
+    pub fn with_bit_op_specs(mut self, bit_op_specs: Vec<BitOpSpec>) -> Self {
         let binary_poly_end = self.total_cols.num_binary_poly_cols();
         for spec in &bit_op_specs {
             assert!(
@@ -365,12 +364,6 @@ impl UairSignature {
                  cell ring F_2[X]/(X^W).",
                 spec.source_col(),
                 binary_poly_end,
-            );
-            assert!(
-                spec.op().count() < cell_width,
-                "BitOpSpec count {} out of range (must satisfy 0 < count < {})",
-                spec.op().count(),
-                cell_width,
             );
         }
         self.bit_op_specs = bit_op_specs;
@@ -630,7 +623,7 @@ mod tests {
             BitOpSpec::new(1, BitOp::ShR(3)),
             BitOpSpec::new(0, BitOp::Rot(2)),
         ];
-        let sig = signature_with_mixed_shifts().with_bit_op_specs(8, specs.clone());
+        let sig = signature_with_mixed_shifts().with_bit_op_specs(specs.clone());
 
         assert_eq!(sig.bit_op_specs(), specs);
         assert_eq!(sig.bit_op_specs()[0].source_col(), 1);
@@ -643,7 +636,7 @@ mod tests {
 
     #[test]
     fn empty_bit_op_specs_keep_shift_only_down_layout() {
-        let sig = signature_with_mixed_shifts().with_bit_op_specs(8, vec![]);
+        let sig = signature_with_mixed_shifts().with_bit_op_specs(vec![]);
 
         assert!(sig.bit_op_specs().is_empty());
         assert_eq!(sig.down_cols().num_binary_poly_cols(), 1);
@@ -660,14 +653,7 @@ mod tests {
     #[test]
     #[should_panic(expected = "is not a binary_poly column")]
     fn bit_op_specs_reject_non_binary_source() {
-        let _ = signature_with_mixed_shifts()
-            .with_bit_op_specs(8, vec![BitOpSpec::new(2, BitOp::ShR(1))]);
-    }
-
-    #[test]
-    #[should_panic(expected = "out of range")]
-    fn bit_op_specs_reject_count_at_cell_width() {
-        let _ = signature_with_mixed_shifts()
-            .with_bit_op_specs(8, vec![BitOpSpec::new(0, BitOp::Rot(8))]);
+        let _ =
+            signature_with_mixed_shifts().with_bit_op_specs(vec![BitOpSpec::new(2, BitOp::ShR(1))]);
     }
 }


### PR DESCRIPTION
## Summary
- store the declared binary-poly cell width on `UairSignature` so runtime materialization sites can apply bit ops with the right width
- add runtime-width `DynamicPolynomialF` bit-op helpers and use them from ideal-check
- splice bit-op virtuals into the ideal-check down row as `[shifted_binary, bit_op_binary, shifted_arbitrary, shifted_int]`
- add a mixed-splice test UAIR and exercise it through both ideal-check prover paths

Part of #185. This intentionally stops before CPR/mp-eval/protocol proof-wire plumbing.

## Notes
- The ideal-check test helpers now allow mixed-type signatures. The projection layer already supports binary_poly, arbitrary_poly, and int columns; the mixed-splice fixture needs that to catch binary/bit-op/arbitrary down-row ordering regressions.

## Validation
- `.githooks/pre-push`
- `cargo test -p zinc-piop ideal_check::tests::test_successful_verification`
- `cargo test -p zinc-test-uair test_constraint_degrees`
- `cargo test -p zinc-uair bit_op_specs`
- `cargo test -p zinc-piop projections::tests`