### PR TITLE
Binary polynomial lookup

### DIFF
--- a/_typos.toml
+++ b/_typos.toml
@@ -1,5 +1,10 @@
+[files]
+extend-exclude = [
+    "*.svg", # SVG files, produced by flamegraph
+]
+
 [default]
 extend-ignore-re = [
     "0x[0-9a-fA-F]+", # Hexadecimal numbers
+    "anc", # Short for "ancillary"
 ]
-

--- a/piop/src/lookup/booleanity.rs
+++ b/piop/src/lookup/booleanity.rs
@@ -1,0 +1,653 @@
+//! Booleanity (binary-polynomial lookup) argument.
+//!
+//! Proves that every coefficient of every witness binary-polynomial column is
+//! a bit `\in {0,1}`. The argument is structured as a single
+//! [`MultiDegreeSumcheckGroup`] of degree 3, batched alongside the existing
+//! CPR group with shared randomness, and discharges its bit-slice claims for
+//! free against the existing `lifted_evals` payload.
+//!
+//! # Relation
+//!
+//! For each witness binary-poly column `u_j \in (F_q^{<D}[X])^n` with
+//! `n = 2^\mu`, decompose row-wise as
+//! `u_j[b](X) = \sum_{i=0}^{D-1} v_{j,i,b} * X^i`. The booleanity claim is:
+//!
+//! ```text
+//!   \forall j, i, b:  v_{j,i,b} \in {0,1}
+//! ```
+//!
+//! Equivalently, the MLE statement
+//! `\widetilde{v_{j,i}}(b)*(\widetilde{v_{j,i}}(b)-1) = 0` for all
+//! `b \in {0,1}^\mu`. The protocol reduces this to a single batched sumcheck
+//!
+//! ```text
+//!   \sum_{b in {0,1}^\mu} eq(r, b) *
+//!     \sum_{j=0}^{N-1} \sum_{i=0}^{D-1} delta^j * gamma^i *
+//!       \widetilde{v_{j,i}}(b) * (\widetilde{v_{j,i}}(b) - 1)  =  0
+//! ```
+//!
+//! with batching challenges `gamma` (over the `D` bit-slices) and `delta`
+//! (over the `N` witness binary-poly columns), and zerocheck point `r`.
+//! After the sumcheck reaches `r*`, the prover sends `bit_slice_evals` =
+//! `(\widetilde{v_{j,i}}(r*))` to the verifier; these are then folded by
+//! `MultipointEval` into the standard evaluation point `r_0` together with
+//! the CPR up/down evals. At `r_0` the bit-slice MLE evaluations are exactly
+//! the coefficients of the polynomial-valued `lifted_evals` (by the
+//! MLE-commutes-with-coefficient-extraction identity), so the verifier
+//! discharges them for free.
+
+use crate::{
+    CombFn,
+    sumcheck::{
+        SumCheckError, multi_degree::MultiDegreeSumcheckGroup,
+        prover::ProverState as SumcheckProverState,
+    },
+};
+use crypto_primitives::PrimeField;
+use num_traits::Zero;
+use std::{marker::PhantomData, slice};
+use thiserror::Error;
+use zinc_poly::{
+    EvaluationError,
+    mle::{DenseMultilinearExtension, MultilinearExtensionWithConfig},
+    univariate::binary::BinaryPoly,
+    utils::{ArithErrors, build_eq_x_r_inner, eq_eval},
+};
+use zinc_transcript::{
+    delegate_transcribable,
+    traits::{ConstTranscribable, Transcript},
+};
+use zinc_utils::{add, inner_transparent_field::InnerTransparentField, mul, powers};
+
+//
+// Structs
+//
+
+/// Booleanity sumcheck group constructor / verifier.
+pub struct BooleanityChecker<F: InnerTransparentField>(PhantomData<F>);
+
+/// Proof produced by the booleanity prover. Carries only the flat list of
+/// bit-slice MLE evaluations at the multi-degree sumcheck output point
+/// `r*`. The remaining open-eval consistency check at `r_0` is discharged
+/// by the protocol-layer caller against `lifted_evals.coeffs`.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct BooleanityProof<F: PrimeField> {
+    /// Flat list of `\widetilde{v_{j,i}}(r*)`, ordered `(j-major, i-minor)`.
+    /// Length = `num_wit_bin_cols * D`.
+    pub bit_slice_evals: Vec<F>,
+}
+
+delegate_transcribable!(BooleanityProof<F> { bit_slice_evals: Vec<F> }
+    where F: PrimeField, F::Inner: ConstTranscribable, F::Modulus: ConstTranscribable);
+
+/// Ancillary data produced by [`BooleanityChecker::prepare_sumcheck_group`]
+/// and consumed by [`BooleanityChecker::finalize_prover`].
+pub struct BoolProverAncillary {
+    /// Number of witness binary-poly columns (`N`).
+    pub num_wit_bin_cols: usize,
+    /// Bit-width of each binary-poly coefficient cell (`D`).
+    pub bit_width: usize,
+    /// Number of variables of the trace MLEs.
+    pub num_vars: usize,
+}
+
+/// Ancillary data produced by [`BooleanityChecker::prepare_verifier`] and
+/// consumed by [`BooleanityChecker::finalize_verifier`].
+pub struct BoolVerifierAncillary<F: PrimeField> {
+    /// Powers of the bit-slice batching challenge:
+    /// `[1, gamma, ..., gamma^{D-1}]`.
+    pub gamma_powers: Vec<F>,
+    /// Powers of the column batching challenge:
+    /// `[1, delta, ..., delta^{N-1}]`.
+    pub delta_powers: Vec<F>,
+    /// The zerocheck point `r` sampled before the multi-degree sumcheck.
+    pub zerocheck_point: Vec<F>,
+    /// Number of witness binary-poly columns (`N`).
+    pub num_wit_bin_cols: usize,
+    /// Bit-width of each binary-poly coefficient cell (`D`).
+    pub bit_width: usize,
+    /// Number of variables (for sanity-checking the shared point length).
+    pub num_vars: usize,
+}
+
+/// Subclaim emitted by [`BooleanityChecker::finalize_verifier`].
+///
+/// Carries the (now-validated against the sumcheck residue)
+/// `bit_slice_evals` at the shared multi-degree sumcheck point `r*`. The
+/// protocol-layer caller threads these as additional `up_evals` into
+/// [`crate::multipoint_eval::MultipointEval`], whose final consistency
+/// check at `r_0` is discharged against the coefficients of the existing
+/// `lifted_evals` polynomials.
+#[derive(Clone, Debug)]
+pub struct BoolVerifierSubclaim<F: PrimeField> {
+    /// Bit-slice MLE evaluations at `r*`, in `(j-major, i-minor)` order.
+    pub bit_slice_evals: Vec<F>,
+    /// Shared evaluation point `r*` from the multi-degree sumcheck.
+    pub evaluation_point: Vec<F>,
+}
+
+//
+// Protocol
+//
+
+impl<F> BooleanityChecker<F>
+where
+    F: InnerTransparentField + Send + Sync + 'static,
+    F::Inner: ConstTranscribable + Clone + Send + Sync + Zero + Default,
+    F::Modulus: ConstTranscribable,
+{
+    /// Build the booleanity sumcheck group, to be appended to the
+    /// multi-degree sumcheck.
+    pub fn prepare_sumcheck_group<const D: usize>(
+        transcript: &mut impl Transcript,
+        trace_bin_poly: &[DenseMultilinearExtension<BinaryPoly<D>>],
+        num_vars: usize,
+        field_cfg: &F::Config,
+    ) -> Result<(MultiDegreeSumcheckGroup<F>, BoolProverAncillary), BooleanityError<F>> {
+        let n = trace_bin_poly.len();
+        let one = F::one_with_cfg(field_cfg);
+        let zero = F::zero_with_cfg(field_cfg);
+
+        // Order of challenge squeezing must match between prover and verifier.
+
+        // 1. Zerocheck point r.
+        let r: Vec<F> = transcript.get_field_challenges(num_vars, field_cfg);
+
+        // 2. Slice batching challenge gamma and its powers.
+        let gamma: F = transcript.get_field_challenge(field_cfg);
+        let gamma_powers: Vec<F> = powers(gamma, one.clone(), D);
+
+        // 3. Column batching challenge delta and its powers.
+        let delta: F = transcript.get_field_challenge(field_cfg);
+        let delta_powers: Vec<F> = powers(delta, one.clone(), n);
+
+        // 4. Build eq(r, *) MLE.
+        let eq_r = build_eq_x_r_inner(&r, field_cfg)?;
+
+        // 5. Build N*D bit-slice MLEs in canonical (j-major, i-minor) order.
+        let mut mles = Vec::with_capacity(add!(n.saturating_mul(D), 1));
+        mles.push(eq_r);
+        mles.extend(build_witness_bit_slice_mles::<F, D>(
+            trace_bin_poly,
+            field_cfg,
+        ));
+
+        // 6. Build comb_fn (degree 3 in the variables):
+        //   eq_r(b) * sum_{j,i} delta^j * gamma^i * v_{j,i}(b) * (v_{j,i}(b) - 1)
+        let comb_fn: CombFn<F> = Box::new(move |mle_values: &[F]| {
+            let eq_r_val = &mle_values[0];
+            let sum =
+                batched_booleanity_sum(&mle_values[1..], &delta_powers, &gamma_powers, &zero, &one);
+            sum * eq_r_val
+        });
+
+        Ok((
+            MultiDegreeSumcheckGroup::new(3, mles, comb_fn),
+            BoolProverAncillary {
+                num_wit_bin_cols: n,
+                bit_width: D,
+                num_vars,
+            },
+        ))
+    }
+
+    /// Finalize the booleanity proof after the multi-degree sumcheck
+    /// completes.
+    ///
+    /// Mirrors the structure of `CombinedPolyResolver::finalize_prover`:
+    /// evaluates each bit-slice MLE at the final sumcheck challenge,
+    /// emits the flat `bit_slice_evals` vector, and absorbs it into the
+    /// transcript.
+    pub fn finalize_prover(
+        transcript: &mut impl Transcript,
+        sumcheck_prover_state: SumcheckProverState<F>,
+        ancillary: BoolProverAncillary,
+        field_cfg: &F::Config,
+    ) -> Result<BooleanityProof<F>, BooleanityError<F>> {
+        debug_assert!(
+            sumcheck_prover_state
+                .mles
+                .iter()
+                .all(|mle| mle.num_vars == 1),
+            "sumcheck should reduce MLEs to num_vars == 1"
+        );
+
+        let last_sumcheck_challenge = sumcheck_prover_state
+            .randomness
+            .last()
+            .expect("sumcheck cannot have had 0 rounds")
+            .clone();
+
+        let expected_len = ancillary
+            .num_wit_bin_cols
+            .saturating_mul(ancillary.bit_width);
+
+        let mut mles = sumcheck_prover_state.mles;
+        // Skip MLE 0 = eq_r (verifier recomputes it).
+        let bit_slice_evals: Vec<F> = mles
+            .drain(1..)
+            .map(|mle| {
+                mle.evaluate_with_config(slice::from_ref(&last_sumcheck_challenge), field_cfg)
+            })
+            .collect::<Result<Vec<_>, _>>()?;
+
+        debug_assert_eq!(bit_slice_evals.len(), expected_len);
+
+        let mut transcription_buf: Vec<u8> = vec![0; F::Inner::NUM_BYTES];
+        transcript.absorb_random_field_slice(&bit_slice_evals, &mut transcription_buf);
+
+        Ok(BooleanityProof { bit_slice_evals })
+    }
+
+    /// Pre-sumcheck half of the booleanity verifier.
+    ///
+    /// Must run after the CPR `prepare_verifier` and before
+    /// `MultiDegreeSumcheck::verify_as_subprotocol` to maintain transcript
+    /// ordering.
+    pub fn prepare_verifier(
+        transcript: &mut impl Transcript,
+        claimed_sum: &F,
+        num_wit_bin_cols: usize,
+        bit_width: usize,
+        num_vars: usize,
+        field_cfg: &F::Config,
+    ) -> Result<BoolVerifierAncillary<F>, BooleanityError<F>> {
+        if num_wit_bin_cols == 0 {
+            return Err(BooleanityError::NoBinaryPolyColumns);
+        }
+        if !F::is_zero(claimed_sum) {
+            return Err(BooleanityError::NonZeroClaimedSum {
+                got: claimed_sum.clone(),
+            });
+        }
+
+        let one = F::one_with_cfg(field_cfg);
+
+        // Re-squeeze in the same order as the prover.
+        let zerocheck_point: Vec<F> = transcript.get_field_challenges(num_vars, field_cfg);
+        let gamma: F = transcript.get_field_challenge(field_cfg);
+        let gamma_powers: Vec<F> = powers(gamma, one.clone(), bit_width);
+        let delta: F = transcript.get_field_challenge(field_cfg);
+        let delta_powers: Vec<F> = powers(delta, one, num_wit_bin_cols);
+
+        Ok(BoolVerifierAncillary {
+            gamma_powers,
+            delta_powers,
+            zerocheck_point,
+            num_wit_bin_cols,
+            bit_width,
+            num_vars,
+        })
+    }
+
+    /// Post-sumcheck half of the booleanity verifier.
+    ///
+    /// Validates the length of `bit_slice_evals`, recomputes the expected
+    /// combination-function evaluation at the shared sumcheck point `r*`
+    /// using the received `bit_slice_evals`, and compares it against the
+    /// sumcheck's `expected_evaluation`. On success, absorbs
+    /// `bit_slice_evals` into the transcript (mirroring the prover's
+    /// final absorption in `finalize_prover`).
+    pub fn finalize_verifier(
+        transcript: &mut impl Transcript,
+        proof: BooleanityProof<F>,
+        shared_point: Vec<F>,
+        expected_evaluation: &F,
+        ancillary: BoolVerifierAncillary<F>,
+        field_cfg: &F::Config,
+    ) -> Result<BoolVerifierSubclaim<F>, BooleanityError<F>> {
+        let expected_len = ancillary
+            .num_wit_bin_cols
+            .saturating_mul(ancillary.bit_width);
+        if proof.bit_slice_evals.len() != expected_len {
+            return Err(BooleanityError::WrongBitSliceEvalsNumber {
+                expected: expected_len,
+                got: proof.bit_slice_evals.len(),
+            });
+        }
+
+        let one = F::one_with_cfg(field_cfg);
+        let zero = F::zero_with_cfg(field_cfg);
+
+        // eq(r*, r) — selector value at the shared sumcheck point.
+        let eq_r_val = eq_eval(&shared_point, &ancillary.zerocheck_point, one.clone())?;
+
+        // Recompute the comb_fn body at r* using the received bit-slice evals.
+        let sum = batched_booleanity_sum(
+            &proof.bit_slice_evals,
+            &ancillary.delta_powers,
+            &ancillary.gamma_powers,
+            &zero,
+            &one,
+        );
+        let expected_claim_value = sum * eq_r_val;
+
+        if expected_claim_value != *expected_evaluation {
+            return Err(BooleanityError::ClaimValueDoesNotMatch {
+                expected: expected_claim_value,
+                got: expected_evaluation.clone(),
+            });
+        }
+
+        let mut transcription_buf: Vec<u8> = vec![0; F::Inner::NUM_BYTES];
+        transcript.absorb_random_field_slice(&proof.bit_slice_evals, &mut transcription_buf);
+
+        Ok(BoolVerifierSubclaim {
+            bit_slice_evals: proof.bit_slice_evals,
+            evaluation_point: shared_point,
+        })
+    }
+}
+
+/// Errors from the booleanity subprotocol.
+#[derive(Debug, Error)]
+pub enum BooleanityError<F: PrimeField> {
+    #[error("no binary polynomial columns provided to booleanity checker")]
+    NoBinaryPolyColumns,
+    #[error("sumcheck error: {0}")]
+    SumcheckError(#[from] SumCheckError<F>),
+    #[error("expected booleanity claimed sum is non-zero: got {got}")]
+    NonZeroClaimedSum { got: F },
+    #[error("wrong number of bit-slice evaluations: expected {expected}, got {got}")]
+    WrongBitSliceEvalsNumber { expected: usize, got: usize },
+    #[error("booleanity claim value does not match: expected {expected}, got {got}")]
+    ClaimValueDoesNotMatch { expected: F, got: F },
+    #[error("error evaluating MLE: {0}")]
+    MleEvaluationError(#[from] EvaluationError),
+    #[error("arithmetic error: {0}")]
+    Arith(#[from] ArithErrors),
+}
+
+//
+// Helpers
+//
+
+/// Compute the booleanity residue
+///
+/// ```text
+///   sum_{j=0}^{N-1} sum_{i=0}^{D-1} delta^j * gamma^i * v_{j,i} * (v_{j,i} - 1)
+/// ```
+///
+/// over a flat `(j-major, i-minor)` slice of bit-slice values
+/// (`N = delta_powers.len()`, `D = gamma_powers.len()`,
+/// `bit_slice_values.len() == N * D`).
+///
+/// This is the body of the booleanity sumcheck's combination function
+/// (without the leading `eq_r` factor).
+fn batched_booleanity_sum<F: PrimeField>(
+    bit_slice_values: &[F],
+    delta_powers: &[F],
+    gamma_powers: &[F],
+    zero: &F,
+    one: &F,
+) -> F {
+    let n = delta_powers.len();
+    let d = gamma_powers.len();
+    debug_assert_eq!(bit_slice_values.len(), mul!(n, d));
+
+    let mut sum = zero.clone();
+    for j in 0..n {
+        let delta_j = &delta_powers[j];
+        let jd = mul!(j, d);
+        for i in 0..d {
+            let v = &bit_slice_values[add!(i, jd)];
+            let gamma_i = &gamma_powers[i];
+            let booleanity = (v.clone() - one) * v;
+            sum += booleanity * delta_j * gamma_i;
+        }
+    }
+    sum
+}
+
+/// Build per-bit-slice MLEs for a set of binary-poly columns.
+///
+/// Returns `N * D` MLEs in `(j-major, i-minor)` order:
+/// `[v_{0,0}, v_{0,1}, ..., v_{0,D-1}, v_{1,0}, ...]`. The j-th column,
+/// i-th bit MLE evaluates at hypercube point `b` to the i-th bit of the
+/// row entry `trace_bin_poly[j][b]`.
+///
+/// This helper is the single source of truth for MLE ordering. Both the
+/// booleanity sumcheck group and the `MultipointEval` extension call it
+/// to guarantee identical ordering between prover and verifier.
+pub fn build_witness_bit_slice_mles<F, const D: usize>(
+    trace_bin_poly: &[DenseMultilinearExtension<BinaryPoly<D>>],
+    field_cfg: &F::Config,
+) -> Vec<DenseMultilinearExtension<F::Inner>>
+where
+    F: PrimeField,
+    F::Inner: Clone + Send + Sync,
+{
+    let zero_inner = F::zero_with_cfg(field_cfg).into_inner();
+    let one_inner = F::one_with_cfg(field_cfg).into_inner();
+
+    let mut out = Vec::with_capacity(trace_bin_poly.len().saturating_mul(D));
+    for col in trace_bin_poly {
+        let num_vars = col.num_vars;
+        let n_rows = col.evaluations.len();
+        for i in 0..D {
+            let mut evals: Vec<F::Inner> = Vec::with_capacity(n_rows);
+            for entry in col.iter() {
+                let bit = entry
+                    .iter()
+                    .nth(i)
+                    .expect("BinaryPoly<D> has D coefficients")
+                    .into_inner();
+                evals.push(if bit {
+                    one_inner.clone()
+                } else {
+                    zero_inner.clone()
+                });
+            }
+            out.push(DenseMultilinearExtension {
+                num_vars,
+                evaluations: evals,
+            });
+        }
+    }
+    out
+}
+
+//
+// Tests
+//
+
+#[cfg(test)]
+#[allow(
+    clippy::cast_possible_truncation,
+    clippy::cast_precision_loss,
+    clippy::cast_sign_loss
+)]
+mod tests {
+    use super::*;
+    use crate::sumcheck::multi_degree::MultiDegreeSumcheck;
+    use crypto_bigint::{U128, const_monty_params};
+    use crypto_primitives::crypto_bigint_const_monty::ConstMontyField;
+    use zinc_transcript::Blake3Transcript;
+
+    const_monty_params!(TestParams, U128, "00000000b933426489189cb5b47d567f");
+    type F = ConstMontyField<TestParams, { U128::LIMBS }>;
+
+    const D: usize = 4;
+
+    /// Build a `BinaryPoly<D>` whose i-th coefficient is `bits[i]` (LSB-first).
+    fn binp_from_bits(bits: [bool; D]) -> BinaryPoly<D> {
+        let value: u64 = bits
+            .iter()
+            .enumerate()
+            .filter_map(|(i, &b)| b.then_some(1_u64 << i))
+            .fold(0_u64, |acc, mask| acc | mask);
+        BinaryPoly::from(value)
+    }
+
+    /// Build a single binary-poly trace column from a vec of row-bit patterns.
+    fn build_col(rows: Vec<[bool; D]>) -> DenseMultilinearExtension<BinaryPoly<D>> {
+        let num_vars = (rows.len() as f64).log2().round() as usize;
+        debug_assert_eq!(rows.len(), 1usize << num_vars);
+        let zero = BinaryPoly::zero();
+        let mut evals: Vec<BinaryPoly<D>> = rows.into_iter().map(binp_from_bits).collect();
+        // Sanity: replace any padding (none expected here) with zero.
+        if evals.is_empty() {
+            evals.push(zero);
+        }
+        DenseMultilinearExtension {
+            num_vars,
+            evaluations: evals,
+        }
+    }
+
+    /// Helper: 4 rows of all-zero bits.
+    fn zero_col_4rows() -> DenseMultilinearExtension<BinaryPoly<D>> {
+        build_col(vec![[false; D]; 4])
+    }
+
+    fn make_transcript() -> Blake3Transcript {
+        let mut t = Blake3Transcript::default();
+        t.absorb_slice(b"booleanity test");
+        t
+    }
+
+    /// Run prepare → MultiDegreeSumcheck::prove → finalize on the prover,
+    /// then prepare → verify → finalize on the verifier, asserting the
+    /// outcome via `expect_ok`.
+    fn run_roundtrip(
+        cols: &[DenseMultilinearExtension<BinaryPoly<D>>],
+        num_vars: usize,
+        tamper_proof: impl FnOnce(&mut BooleanityProof<F>),
+        expect_err_is: impl FnOnce(&BooleanityError<F>) -> bool,
+        expect_ok: bool,
+    ) {
+        let cfg = &();
+
+        // Prover side.
+        let mut pt = make_transcript();
+        let (group, anc) =
+            BooleanityChecker::<F>::prepare_sumcheck_group::<D>(&mut pt, cols, num_vars, cfg)
+                .expect("prepare_sumcheck_group failed");
+        let (md_proof, states) =
+            MultiDegreeSumcheck::<F>::prove_as_subprotocol(&mut pt, vec![group], num_vars, cfg);
+        let state = states.into_iter().next().unwrap();
+        let mut proof = BooleanityChecker::<F>::finalize_prover(&mut pt, state, anc, cfg)
+            .expect("finalize prover");
+        tamper_proof(&mut proof);
+
+        // Verifier side.
+        let mut vt = make_transcript();
+        let anc_v = BooleanityChecker::<F>::prepare_verifier(
+            &mut vt,
+            &md_proof.claimed_sums()[0],
+            cols.len(),
+            D,
+            num_vars,
+            cfg,
+        )
+        .expect("prepare_verifier (claimed sum should be zero for honest input)");
+        let md_subclaims =
+            MultiDegreeSumcheck::<F>::verify_as_subprotocol(&mut vt, num_vars, &md_proof, cfg)
+                .expect("md verify");
+
+        let res = BooleanityChecker::<F>::finalize_verifier(
+            &mut vt,
+            proof,
+            md_subclaims.point().to_vec(),
+            &md_subclaims.expected_evaluations()[0],
+            anc_v,
+            cfg,
+        );
+
+        if expect_ok {
+            res.expect("finalize_verifier should succeed");
+        } else {
+            let err = res.expect_err("finalize_verifier should fail");
+            assert!(
+                expect_err_is(&err),
+                "unexpected booleanity error variant: {err:?}",
+            );
+        }
+    }
+
+    #[test]
+    fn happy_path_all_bits() {
+        // Two columns, 4 rows each, all valid bit patterns.
+        let c0 = build_col(vec![
+            [true, false, true, false],
+            [false, true, false, true],
+            [true, true, false, false],
+            [false, false, true, true],
+        ]);
+        let c1 = build_col(vec![
+            [false, false, false, false],
+            [true, true, true, true],
+            [false, true, true, false],
+            [true, false, false, true],
+        ]);
+        run_roundtrip(&[c0, c1], 2, |_| {}, |_| false, true);
+    }
+
+    #[test]
+    fn empty_column_set_is_supported_by_helper() {
+        // The helper itself returns an empty Vec for N = 0. We don't run a
+        // sumcheck (MultiDegreeSumcheck requires at least one group) but we
+        // do exercise the helper for the empty case.
+        let cols: Vec<DenseMultilinearExtension<BinaryPoly<D>>> = vec![];
+        let mles = build_witness_bit_slice_mles::<F, D>(&cols, &());
+        assert!(mles.is_empty());
+    }
+
+    #[test]
+    fn tampered_bit_slice_evals_rejected() {
+        let c0 = zero_col_4rows();
+        // Tamper one entry of bit_slice_evals to a non-{0,1} value. The
+        // booleanity comb_fn is v*(v-1) which vanishes on {0,1}, so we must
+        // pick a non-bit value to actually corrupt the recomputed residue.
+        run_roundtrip(
+            &[c0],
+            2,
+            |proof| {
+                proof.bit_slice_evals[0] += F::from(7u32);
+            },
+            |err| matches!(err, BooleanityError::ClaimValueDoesNotMatch { .. }),
+            false,
+        );
+    }
+
+    #[test]
+    fn non_bit_witness_rejected() {
+        // Build cols honestly, then directly tamper one bit-slice eval in
+        // the proof to simulate a malicious prover whose actual witness
+        // had a non-bit entry. Note: we cannot inject a non-bit entry
+        // through `BinaryPoly<D>` (it stores `Boolean`), so this is the
+        // verifier-visible failure mode of a non-bit witness:
+        // `bit_slice_evals` whose recomputed booleanity residue is
+        // non-zero at the sumcheck point.
+        let c0 = build_col(vec![
+            [true, true, false, false],
+            [false, true, true, false],
+            [false, false, false, true],
+            [true, false, true, true],
+        ]);
+        run_roundtrip(
+            &[c0],
+            2,
+            |proof| {
+                // Two of v=0/1 nudges that produce a non-{0,1} residue.
+                proof.bit_slice_evals[1] += F::from(3u32);
+            },
+            |err| matches!(err, BooleanityError::ClaimValueDoesNotMatch { .. }),
+            false,
+        );
+    }
+
+    #[test]
+    fn wrong_bit_slice_evals_length_rejected() {
+        let c0 = zero_col_4rows();
+        run_roundtrip(
+            &[c0],
+            2,
+            |proof| {
+                proof.bit_slice_evals.pop();
+            },
+            |err| matches!(err, BooleanityError::WrongBitSliceEvalsNumber { .. }),
+            false,
+        );
+    }
+}

--- a/piop/src/lookup/booleanity.rs
+++ b/piop/src/lookup/booleanity.rs
@@ -386,8 +386,7 @@ fn batched_booleanity_sum<F: PrimeField>(
     debug_assert_eq!(bit_slice_values.len(), mul!(n, d));
 
     let mut sum = zero.clone();
-    for j in 0..n {
-        let delta_j = &delta_powers[j];
+    for (j, delta_j) in delta_powers.iter().enumerate().take(n) {
         let jd = mul!(j, d);
         for i in 0..d {
             let v = &bit_slice_values[add!(i, jd)];

--- a/piop/src/lookup/booleanity.rs
+++ b/piop/src/lookup/booleanity.rs
@@ -1,37 +1,42 @@
 //! Booleanity (binary-polynomial lookup) argument.
 //!
 //! Proves that every coefficient of every witness binary-polynomial column is
-//! a bit `\in {0,1}`. The argument is structured as a single
+//! a bit $\in \\{0,1\\}$. The argument is structured as a single
 //! [`MultiDegreeSumcheckGroup`] of degree 3, batched alongside the existing
 //! CPR group with shared randomness, and discharges its bit-slice claims for
 //! free against the existing `lifted_evals` payload.
 //!
 //! # Relation
 //!
-//! For each witness binary-poly column `u_j \in (F_q^{<D}[X])^n` with
-//! `n = 2^\mu`, decompose row-wise as
-//! `u_j[b](X) = \sum_{i=0}^{D-1} v_{j,i,b} * X^i`. The booleanity claim is:
+//! For each witness binary-poly column $u_j \in (F_q^{<D}[X])^n$ with
+//! $n = 2^\mu$, decompose row-wise as
 //!
-//! ```text
-//!   \forall j, i, b:  v_{j,i,b} \in {0,1}
-//! ```
+//! $$
+//! {u_j}[b](X) = \sum_{i=0}^{D-1} v_{j,i,b} * X^i
+//! $$
+//!
+//! The booleanity claim is:
+//!
+//! $$
+//!   \forall j, i, b:  v_{j,i,b} \in \\{0,1\\}
+//! $$
 //!
 //! Equivalently, the MLE statement
-//! `\widetilde{v_{j,i}}(b)*(\widetilde{v_{j,i}}(b)-1) = 0` for all
-//! `b \in {0,1}^\mu`. The protocol reduces this to a single batched sumcheck
+//! $\widetilde{v_{j,i}}(b)*(\widetilde{v_{j,i}}(b)-1) = 0$ for all
+//! $b \in {0,1}^\mu$. The protocol reduces this to a single batched sumcheck
 //!
-//! ```text
-//!   \sum_{b in {0,1}^\mu} eq(r, b) *
-//!     \sum_{j=0}^{N-1} \sum_{i=0}^{D-1} delta^j * gamma^i *
-//!       \widetilde{v_{j,i}}(b) * (\widetilde{v_{j,i}}(b) - 1)  =  0
-//! ```
+//! $$
+//! \sum_{b in {0,1}^\mu} eq(r, b) *
+//!   \sum_{j=0}^{N-1} \sum_{i=0}^{D-1} \delta^j * \gamma^i *
+//!     \widetilde{v_{j,i}}(b) * (\widetilde{v_{j,i}}(b) - 1)  =  0
+//! $$
 //!
-//! with batching challenges `gamma` (over the `D` bit-slices) and `delta`
-//! (over the `N` witness binary-poly columns), and zerocheck point `r`.
-//! After the sumcheck reaches `r*`, the prover sends `bit_slice_evals` =
-//! `(\widetilde{v_{j,i}}(r*))` to the verifier; these are then folded by
-//! `MultipointEval` into the standard evaluation point `r_0` together with
-//! the CPR up/down evals. At `r_0` the bit-slice MLE evaluations are exactly
+//! with batching challenges $\gamma$ (over the `D` bit-slices) and $\delta$
+//! (over the `N` witness binary-poly columns), and zerocheck point $r$.
+//! After the sumcheck reaches $r*$, the prover sends `bit_slice_evals` =
+//! $(\widetilde{v_{j,i}}(r*))$ to the verifier; these are then folded by
+//! `MultipointEval` into the standard evaluation point $r_0$ together with
+//! the CPR up/down evals. At $r_0$ the bit-slice MLE evaluations are exactly
 //! the coefficients of the polynomial-valued `lifted_evals` (by the
 //! MLE-commutes-with-coefficient-extraction identity), so the verifier
 //! discharges them for free.
@@ -68,7 +73,7 @@ pub struct BooleanityChecker<F: InnerTransparentField>(PhantomData<F>);
 
 /// Proof produced by the booleanity prover. Carries only the flat list of
 /// bit-slice MLE evaluations at the multi-degree sumcheck output point
-/// `r*`. The remaining open-eval consistency check at `r_0` is discharged
+/// $r*$. The remaining open-eval consistency check at $r_0$ is discharged
 /// by the protocol-layer caller against `lifted_evals.coeffs`.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct BooleanityProof<F: PrimeField> {
@@ -364,9 +369,10 @@ pub enum BooleanityError<F: PrimeField> {
 
 /// Compute the booleanity residue
 ///
-/// ```text
-///   sum_{j=0}^{N-1} sum_{i=0}^{D-1} delta^j * gamma^i * v_{j,i} * (v_{j,i} - 1)
-/// ```
+/// $$
+/// sum_{j=0}^{N-1} sum_{i=0}^{D-1}
+///   \delta^j * \gamma^i * v_{j,i} * (v_{j,i} - 1)
+/// $$
 ///
 /// over a flat `(j-major, i-minor)` slice of bit-slice values
 /// (`N = delta_powers.len()`, `D = gamma_powers.len()`,
@@ -401,7 +407,7 @@ fn batched_booleanity_sum<F: PrimeField>(
 /// Build per-bit-slice MLEs for a set of binary-poly columns.
 ///
 /// Returns `N * D` MLEs in `(j-major, i-minor)` order:
-/// `[v_{0,0}, v_{0,1}, ..., v_{0,D-1}, v_{1,0}, ...]`. The j-th column,
+/// $[v_{0,0}, v_{0,1}, ..., v_{0,D-1}, v_{1,0}, ...]$. The j-th column,
 /// i-th bit MLE evaluates at hypercube point `b` to the i-th bit of the
 /// row entry `trace_bin_poly[j][b]`.
 ///

--- a/piop/src/lookup/mod.rs
+++ b/piop/src/lookup/mod.rs
@@ -1,4 +1,5 @@
 //! Lookup argument for the Zinc+ PIOP.
+pub mod booleanity;
 pub mod structs;
 
 pub use structs::*;

--- a/poly/src/univariate/binary_ref.rs
+++ b/poly/src/univariate/binary_ref.rs
@@ -62,18 +62,23 @@ impl<const DEGREE_PLUS_ONE: usize> From<BinaryRefPoly<DEGREE_PLUS_ONE>>
     }
 }
 
-impl From<u32> for BinaryRefPoly<32> {
+impl<const DEGREE_PLUS_ONE: usize> From<u32> for BinaryRefPoly<DEGREE_PLUS_ONE> {
+    #[inline(always)]
     fn from(value: u32) -> Self {
-        Self(DensePolynomial {
-            coeffs: array::from_fn(|i| Boolean::new(value & (1 << i) != 0)),
-        })
+        // Keep masking enforced in a single place
+        Self::from(u64::from(value))
     }
 }
 
-impl From<u64> for BinaryRefPoly<64> {
+impl<const DEGREE_PLUS_ONE: usize> From<u64> for BinaryRefPoly<DEGREE_PLUS_ONE> {
+    #[inline(always)]
     fn from(value: u64) -> Self {
+        // Bit `i` of `value` becomes the coefficient of `X^i`. Bits at
+        // positions `>= 64` are not present in `u64` and are therefore zero;
+        // bits at positions `>= DEGREE_PLUS_ONE` are dropped by virtue of
+        // the fixed-size coefficient array.
         Self(DensePolynomial {
-            coeffs: array::from_fn(|i| Boolean::new(value & (1 << i) != 0)),
+            coeffs: array::from_fn(|i| Boolean::new(i < 64 && value & (1_u64 << i) != 0)),
         })
     }
 }

--- a/poly/src/univariate/binary_u64.rs
+++ b/poly/src/univariate/binary_u64.rs
@@ -66,8 +66,7 @@ impl<const DEGREE_PLUS_ONE: usize> From<BinaryU64Poly<DEGREE_PLUS_ONE>>
 impl<const DEGREE_PLUS_ONE: usize> From<u32> for BinaryU64Poly<DEGREE_PLUS_ONE> {
     #[inline(always)]
     fn from(value: u32) -> Self {
-        // Delegate to `From<u64>` so the masking contract is enforced in a
-        // single place. Bits at positions `>= DEGREE_PLUS_ONE` are dropped.
+        // Keep masking enforced in a single place
         Self::from(u64::from(value))
     }
 }

--- a/protocol/src/lib.rs
+++ b/protocol/src/lib.rs
@@ -31,7 +31,10 @@ use thiserror::Error;
 use zinc_piop::{
     combined_poly_resolver::{CombinedPolyResolverError, Proof as CombinedPolyResolverProof},
     ideal_check::{IdealCheckError, Proof as IdealCheckProof},
-    lookup::{BatchedLookupProof, LookupError},
+    lookup::{
+        BatchedLookupProof, LookupError,
+        booleanity::{BooleanityError, BooleanityProof},
+    },
     multipoint_eval::{MultipointEvalError, Proof as MultipointEvalProof},
     projections::ProjectedTrace,
     sumcheck::multi_degree::MultiDegreeSumcheckProof,
@@ -84,6 +87,10 @@ pub struct Proof<F: PrimeField> {
     pub witness_lifted_evals: Vec<DynamicPolynomialF<F>>,
     /// Lookup argument proof. `None` when the UAIR has no lookup specs.
     pub lookup_proof: Option<BatchedLookupProof<F>>,
+    /// Binary-polynomial booleanity argument proof. `None` when the UAIR
+    /// has no witness binary-poly columns (the argument is omitted from
+    /// the multi-degree sumcheck in that case).
+    pub booleanity_proof: Option<BooleanityProof<F>>,
 }
 
 impl<F> GenTranscribable for Proof<F>
@@ -113,6 +120,16 @@ where
         let (witness_vec, bytes) = DynamicPolyVecF::<F>::read_transcription_bytes_subset(bytes);
         let witness_lifted_evals = witness_vec.0;
 
+        // booleanity_proof: presence flag (u32: 0 = absent, 1 = present)
+        // followed by the proof body (length-prefixed) when present.
+        let (presence, bytes) = u32::read_transcription_bytes_subset(bytes);
+        let (booleanity_proof, bytes) = if presence != 0 {
+            let (p, rest) = BooleanityProof::<F>::read_transcription_bytes_subset(bytes);
+            (Some(p), rest)
+        } else {
+            (None, bytes)
+        };
+
         // TODO: deserialize lookup_proof once BatchedLookupProof gets
         // Transcribable impls (lookup is not yet implemented).
         assert!(bytes.is_empty(), "All bytes should be consumed");
@@ -126,6 +143,7 @@ where
             multipoint_eval,
             witness_lifted_evals,
             lookup_proof: None,
+            booleanity_proof,
         }
     }
 
@@ -155,10 +173,25 @@ where
         buf = self.multipoint_eval.write_transcription_bytes_subset(buf);
 
         // witness_lifted_evals: u32 length prefix + DynamicPolyVecF encoding
+        buf = DynamicPolyVecF::reinterpret(&self.witness_lifted_evals)
+            .write_transcription_bytes_subset(buf);
+
+        // booleanity_proof: u32 presence flag, then (optionally) the body
+        // with its own length prefix.
+        let presence: u32 = if self.booleanity_proof.is_some() {
+            1
+        } else {
+            0
+        };
+        presence.write_transcription_bytes_exact(&mut buf[..u32::NUM_BYTES]);
+        buf = &mut buf[u32::NUM_BYTES..];
+        if let Some(ref bp) = self.booleanity_proof {
+            buf = bp.write_transcription_bytes_subset(buf);
+        }
+
         // TODO: serialize lookup_proof once BatchedLookupProof gets
         // Transcribable impls (lookup is not yet implemented).
-        DynamicPolyVecF::reinterpret(&self.witness_lifted_evals)
-            .write_transcription_bytes_subset(buf);
+        let _ = buf;
     }
 }
 
@@ -171,6 +204,10 @@ where
     #[allow(clippy::arithmetic_side_effects)]
     fn get_num_bytes(&self) -> usize {
         let witness_vec = DynamicPolyVecF::reinterpret(&self.witness_lifted_evals);
+        let booleanity_bytes = match &self.booleanity_proof {
+            Some(bp) => BooleanityProof::<F>::LENGTH_NUM_BYTES + bp.get_num_bytes(),
+            None => 0,
+        };
         3 * ZipPlusCommitment::NUM_BYTES
             + u32::NUM_BYTES
             + self.zip.len()
@@ -186,6 +223,9 @@ where
             // Transcribable impls (lookup is not yet implemented).
             + DynamicPolyVecF::<F>::LENGTH_NUM_BYTES
             + witness_vec.get_num_bytes()
+            // booleanity presence flag + optional payload
+            + u32::NUM_BYTES
+            + booleanity_bytes
     }
 }
 
@@ -295,6 +335,10 @@ pub enum ProtocolError<F: PrimeField, I: Ideal> {
     LiftedEvalProjection(PolyEvaluationError),
     #[error("lookup argument failed: {0}")]
     Lookup(#[from] LookupError),
+    #[error("booleanity argument failed: {0}")]
+    Booleanity(#[from] BooleanityError<F>),
+    #[error("booleanity proof missing from proof object")]
+    BooleanityProofMissing,
     #[error("PCS error: {0}")]
     Pcs(#[from] ZipError),
     #[error("PCS verification failed at column {0}: {1}")]
@@ -425,6 +469,11 @@ where
 
 #[cfg(test)]
 #[cfg(not(miri))] // long running
+#[allow(
+    clippy::arithmetic_side_effects,
+    clippy::result_large_err,
+    clippy::type_complexity
+)]
 mod tests {
     use super::*;
     use crate::fold::FoldBinaryTrace4x;
@@ -609,7 +658,6 @@ mod tests {
     }
 
     /// Set up Zip+ PCS parameters for a given number of MLE variables.
-    #[allow(clippy::type_complexity, clippy::arithmetic_side_effects)]
     fn setup_pp<Zt>(
         num_vars: usize,
         linear_codes: (Zt::BinaryLc, Zt::ArbitraryLc, Zt::IntLc),
@@ -638,7 +686,6 @@ mod tests {
         };
     }
 
-    #[allow(clippy::result_large_err)]
     fn do_test<Zt, U>(
         num_vars: usize,
         linear_codes: (Zt::BinaryLc, Zt::ArbitraryLc, Zt::IntLc),
@@ -961,6 +1008,108 @@ mod tests {
             |proof| proof.commitments.0.root = Default::default(),
             |res| {
                 assert!(matches!(res.unwrap_err(), ProtocolError::IdealCheck(..)));
+            },
+        );
+    }
+
+    //
+    // Booleanity-specific end-to-end tests. `BigLinearUair` has 16 binary-poly
+    // witness columns, so the booleanity argument is exercised by all of the
+    // protocol tests above. The tests here verify that tampering with the
+    // booleanity proof and with witness bit values produces well-typed
+    // verifier errors.
+    //
+
+    /// Swapping two entries of `booleanity_proof.bit_slice_evals` breaks
+    /// the recomputed booleanity residue at `r*`, which the verifier's
+    /// `finalize_verifier` catches against the sumcheck's
+    /// `expected_evaluation`. (With overwhelming probability over the
+    /// random transcript, two distinct bit-slice MLE evaluations at `r*`
+    /// produce different `v*(v-1)` residues.)
+    #[test]
+    fn test_big_linear_tamper_booleanity_evals() {
+        use zinc_piop::lookup::booleanity::BooleanityError;
+        let num_vars = 8;
+        do_test::<TestZincTypesIprs, BigLinearUair<ZtInt>>(
+            num_vars,
+            (
+                make_iprs(num_vars),
+                make_iprs(num_vars),
+                make_iprs(num_vars),
+            ),
+            default_project_ideal!(),
+            |proof| {
+                let bp = proof
+                    .booleanity_proof
+                    .as_mut()
+                    .expect("BigLinearUair has binary-poly witnesses");
+                // Double one entry: x -> 2x. The booleanity residue at x is
+                // x*(x-1); at 2x it is 2x*(2x-1). For random F_q-valued x
+                // these differ with overwhelming probability.
+                let dup = bp.bit_slice_evals[0].clone();
+                bp.bit_slice_evals[0] += dup;
+            },
+            |res| {
+                assert!(matches!(
+                    res.unwrap_err(),
+                    ProtocolError::Booleanity(BooleanityError::ClaimValueDoesNotMatch { .. })
+                ));
+            },
+        );
+    }
+
+    /// Removing entries from `booleanity_proof.bit_slice_evals` breaks the
+    /// length invariant; `finalize_verifier` detects this via
+    /// `WrongBitSliceEvalsNumber` before the residue check.
+    #[test]
+    fn test_big_linear_tamper_booleanity_evals_length() {
+        use zinc_piop::lookup::booleanity::BooleanityError;
+        let num_vars = 8;
+        do_test::<TestZincTypesIprs, BigLinearUair<ZtInt>>(
+            num_vars,
+            (
+                make_iprs(num_vars),
+                make_iprs(num_vars),
+                make_iprs(num_vars),
+            ),
+            default_project_ideal!(),
+            |proof| {
+                let bp = proof
+                    .booleanity_proof
+                    .as_mut()
+                    .expect("BigLinearUair has binary-poly witnesses");
+                bp.bit_slice_evals.pop();
+            },
+            |res| {
+                assert!(matches!(
+                    res.unwrap_err(),
+                    ProtocolError::Booleanity(BooleanityError::WrongBitSliceEvalsNumber { .. })
+                ));
+            },
+        );
+    }
+
+    /// Removing `booleanity_proof` entirely when the UAIR has bin-poly
+    /// witnesses produces `BooleanityProofMissing`.
+    #[test]
+    fn test_big_linear_drop_booleanity_proof() {
+        let num_vars = 8;
+        do_test::<TestZincTypesIprs, BigLinearUair<ZtInt>>(
+            num_vars,
+            (
+                make_iprs(num_vars),
+                make_iprs(num_vars),
+                make_iprs(num_vars),
+            ),
+            default_project_ideal!(),
+            |proof| {
+                proof.booleanity_proof = None;
+            },
+            |res| {
+                assert!(matches!(
+                    res.unwrap_err(),
+                    ProtocolError::BooleanityProofMissing
+                ));
             },
         );
     }

--- a/protocol/src/lib.rs
+++ b/protocol/src/lib.rs
@@ -10,12 +10,12 @@
 //!
 //! After the three compiler steps, the protocol continues with:
 //!
-//! - Step 4: combined CPR + Lookup multi-degree sumcheck (CPR group at degree
+//! - Combined CPR + Lookup multi-degree sumcheck (CPR group at degree
 //!   `max_deg+2`, one lookup group per table type; shared eval point `r*`)
-//! - Step 5: multi-point evaluation sumcheck (combines up/down evals at r* into
-//!   a single evaluation point r_0)
-//! - Step 6: lift-and-project (unprojected MLE evaluations at r_0)
-//! - Step 7: Zip+ PCS open/verify at r_0
+//! - Multi-point evaluation sumcheck (combines up/down evals at r* into a
+//!   single evaluation point r_0)
+//! - Lift-and-project (unprojected MLE evaluations at r_0)
+//! - Zip+ PCS open/verify at r_0
 
 pub mod fold;
 pub mod prover;

--- a/protocol/src/prover.rs
+++ b/protocol/src/prover.rs
@@ -5,6 +5,7 @@ use std::{borrow::Cow, collections::HashMap, fmt::Debug};
 use zinc_piop::{
     combined_poly_resolver::CombinedPolyResolver,
     ideal_check::IdealCheckProtocol,
+    lookup::booleanity::{self, BooleanityChecker, BooleanityProof},
     multipoint_eval::{MultipointEval, Proof as MultipointEvalProof},
     projections::{
         ColumnMajorTrace, ProjectedTrace, RowMajorTrace, evaluate_trace_to_column_mles,
@@ -181,6 +182,7 @@ pub struct ProverSumchecked<
     cpr_eval_point: Vec<F>,
     combined_sumcheck: MultiDegreeSumcheckProof<F>,
     lookup_proof: Option<BatchedLookupProof<F>>,
+    booleanity_proof: Option<BooleanityProof<F>>,
 }
 
 /// After step 6 (multipoint eval).
@@ -200,6 +202,7 @@ pub struct ProverMultipointEvaled<
     cpr_proof: CombinedPolyResolverProof<F>,
     combined_sumcheck: MultiDegreeSumcheckProof<F>,
     lookup_proof: Option<BatchedLookupProof<F>>,
+    booleanity_proof: Option<BooleanityProof<F>>,
 
     // New
     mp_proof: MultipointEvalProof<F>,
@@ -222,6 +225,7 @@ pub struct ProverLifted<
     cpr_proof: CombinedPolyResolverProof<F>,
     combined_sumcheck: MultiDegreeSumcheckProof<F>,
     lookup_proof: Option<BatchedLookupProof<F>>,
+    booleanity_proof: Option<BooleanityProof<F>>,
     mp_proof: MultipointEvalProof<F>,
     r_0: Vec<F>,
 
@@ -247,6 +251,7 @@ pub struct ProverPcsOpened<
     cpr_proof: CombinedPolyResolverProof<F>,
     combined_sumcheck: MultiDegreeSumcheckProof<F>,
     lookup_proof: Option<BatchedLookupProof<F>>,
+    booleanity_proof: Option<BooleanityProof<F>>,
     mp_proof: MultipointEvalProof<F>,
     lifted_evals: Vec<DynamicPolynomialF<F>>,
 }
@@ -524,10 +529,12 @@ impl_with_type_bounds!(ProverIdealChecked
 
 impl_with_type_bounds!(ProverEvalProjected
 {
-    /// Step 5: Combined CPR + Lookup multi-degree sumcheck over F_q.
-    /// Batches the CPR constraint claim (degree `max_deg+2`) with lookup groups
-    /// (one per table type) into a single sumcheck sharing one evaluation point `r*`.
-    /// Produces `up_evals` and `down_evals` (CPR) and lookup auxiliary witnesses at `r*`.
+    /// Step 5: Combined CPR + Booleanity + Lookup multi-degree sumcheck over F_q.
+    /// Batches the CPR constraint claim (degree `max_deg+2`), the booleanity
+    /// argument (degree 3), and lookup groups (one per table type) into a
+    /// single sumcheck sharing one evaluation point `r*`. Produces
+    /// `up_evals`/`down_evals` (CPR), `bit_slice_evals` (booleanity), and
+    /// lookup auxiliary witnesses at `r*`.
     pub fn step5_sumcheck(
         mut self,
     ) -> Result<ProverSumchecked<'a, Zt, U, F, D, FD>, ProtocolError<F, U::Ideal>> {
@@ -545,28 +552,65 @@ impl_with_type_bounds!(ProverEvalProjected
             &self.field_cfg,
         )?;
 
-        // 4b: Lookup prepare — placeholder
-        let lookup_specs = &self.base.uair_signature;
-        let groups = vec![cpr_group];
+        let mut groups = vec![cpr_group];
+
+        // Booleanity: prepare optional group over witness binary-poly cols.
+        let trace_wit_bin_poly = {
+            let sig = &self.base.uair_signature;
+            let num_pub_bin = sig.public_cols().num_binary_poly_cols();
+            let num_total_bin = sig.total_cols().num_binary_poly_cols();
+            &self.base.original_trace.binary_poly[num_pub_bin..num_total_bin]
+        };
+
+        let bool_ancillary = if !trace_wit_bin_poly.is_empty() {
+            let (bool_group, anc) = BooleanityChecker::prepare_sumcheck_group::<D>(
+                &mut self.base.pcs_transcript.fs_transcript,
+                trace_wit_bin_poly,
+                self.base.num_vars,
+                &self.field_cfg,
+            )
+            .map_err(ProtocolError::Booleanity)?;
+            groups.push(bool_group);
+            Some(anc)
+        } else {
+            None
+        };
+
         // TODO: for each LookupGroup from group_lookup_specs(lookup_specs):
         //   - call prepare_batched_lookup_group(transcript, instance, &field_cfg)
         //   - push triple into groups, collect pending proofs + metas
-        let _ = lookup_specs; // suppress unused warning until logup is implemented
 
-        // 4c: Multi-degree sumcheck width CPR group and lookup groups
+        // Multi-degree sumcheck over CPR (+ booleanity + lookup groups).
         let (combined_sumcheck, md_states) = MultiDegreeSumcheck::prove_as_subprotocol(
             &mut self.base.pcs_transcript.fs_transcript,
             groups,
             self.base.num_vars,
             &self.field_cfg,
         );
-        // 4c: Finalize up_evals, down_evals
+
+        let mut md_iter = md_states.into_iter();
+
         let (cpr_proof, cpr_prover_state) = CombinedPolyResolver::finalize_prover(
             &mut self.base.pcs_transcript.fs_transcript,
-            md_states.into_iter().next().expect("one CPR group"),
+            md_iter.next().expect("CPR group always present"),
             cpr_ancillary,
             &self.field_cfg,
         )?;
+
+        let booleanity_proof = if let Some(anc) = bool_ancillary {
+            let state = md_iter.next().expect("booleanity group present");
+            Some(
+                BooleanityChecker::finalize_prover(
+                    &mut self.base.pcs_transcript.fs_transcript,
+                    state,
+                    anc,
+                    &self.field_cfg,
+                )
+                .map_err(ProtocolError::Booleanity)?,
+            )
+        } else {
+            None
+        };
 
         // TODO: build BatchedLookupProof from collected lookup_proofs + lookup_metas
         let lookup_proof = None;
@@ -581,6 +625,7 @@ impl_with_type_bounds!(ProverEvalProjected
             cpr_eval_point: cpr_prover_state.evaluation_point,
             combined_sumcheck,
             lookup_proof,
+            booleanity_proof,
         })
     }
 });
@@ -590,15 +635,43 @@ impl_with_type_bounds!(ProverSumchecked
     /// Step 6: Multi-point evaluation sumcheck. Combines `up_evals` and
     /// `down_evals` at `r'` into a single evaluation point `r_0`.
     /// Only the sumcheck proof is sent; scalar evaluations at `r_0` are derived from the
-    /// polynomial-valued `lifted_evals` in Step 7.
+    /// polynomial-valued `lifted_evals` in Step 7. When the booleanity argument
+    /// is present, its bit-slice MLEs and `bit_slice_evals` are appended to
+    /// the `trace_mles` / `up_evals` passed to `MultipointEval`; the
+    /// corresponding `r_0`-side scalar claims are discharged for free by the
+    /// verifier against `lifted_evals.coeffs` in step 6.
     pub fn step6_multipoint_eval(
         mut self,
     ) -> Result<ProverMultipointEvaled<'a, Zt, U, F, D, FD>, ProtocolError<F, U::Ideal>> {
+        // Build extended trace_mles and up_evals: append witness bit-slice
+        // MLEs and their evaluations at r*, in the canonical order produced
+        // by `build_witness_bit_slice_mles` (j-major, i-minor).
+        let (extended_trace_mles, extended_up_evals) = if let Some(bp) = &self.booleanity_proof {
+            let trace_wit_bin_poly = {
+                let sig = &self.base.uair_signature;
+                let num_pub_bin = sig.public_cols().num_binary_poly_cols();
+                let num_total_bin = sig.total_cols().num_binary_poly_cols();
+                &self.base.original_trace.binary_poly[num_pub_bin..num_total_bin]
+            };
+
+            let mut trace_mles = self.projected_trace_f.clone();
+            trace_mles.extend(booleanity::build_witness_bit_slice_mles::<F, D>(
+                trace_wit_bin_poly,
+                &self.field_cfg,
+            ));
+
+            let mut up_evals = self.cpr_proof.up_evals.clone();
+            up_evals.extend_from_slice(&bp.bit_slice_evals);
+            (trace_mles, up_evals)
+        } else {
+            (self.projected_trace_f.clone(), self.cpr_proof.up_evals.clone())
+        };
+
         let (mp_proof, mp_prover_state) = MultipointEval::prove_as_subprotocol(
             &mut self.base.pcs_transcript.fs_transcript,
-            &self.projected_trace_f,
+            &extended_trace_mles,
             &self.cpr_eval_point,
-            &self.cpr_proof.up_evals,
+            &extended_up_evals,
             &self.cpr_proof.down_evals,
             self.base.uair_signature.shifts(),
             &self.field_cfg,
@@ -612,6 +685,7 @@ impl_with_type_bounds!(ProverSumchecked
             cpr_proof: self.cpr_proof,
             combined_sumcheck: self.combined_sumcheck,
             lookup_proof: self.lookup_proof,
+            booleanity_proof: self.booleanity_proof,
             mp_proof,
             r_0: mp_prover_state.eval_point,
         })
@@ -651,6 +725,7 @@ impl_with_type_bounds!(ProverMultipointEvaled
             cpr_proof: self.cpr_proof,
             combined_sumcheck: self.combined_sumcheck,
             lookup_proof: self.lookup_proof,
+            booleanity_proof: self.booleanity_proof,
             mp_proof: self.mp_proof,
             r_0: self.r_0,
             lifted_evals,
@@ -713,6 +788,7 @@ impl_with_type_bounds!(ProverLifted
             cpr_proof: self.cpr_proof,
             combined_sumcheck: self.combined_sumcheck,
             lookup_proof: self.lookup_proof,
+            booleanity_proof: self.booleanity_proof,
             mp_proof: self.mp_proof,
             lifted_evals: self.lifted_evals,
         })
@@ -761,6 +837,7 @@ impl_with_type_bounds!(ProverPcsOpened
             zip: zip_proof,
             witness_lifted_evals,
             lookup_proof: self.lookup_proof,
+            booleanity_proof: self.booleanity_proof,
         })
     }
 });

--- a/protocol/src/verifier.rs
+++ b/protocol/src/verifier.rs
@@ -6,6 +6,7 @@ use std::{collections::HashMap, io::Cursor};
 use zinc_piop::{
     combined_poly_resolver::{self, CombinedPolyResolver},
     ideal_check::{self, IdealCheckProtocol},
+    lookup::booleanity::{BoolVerifierSubclaim, BooleanityChecker, BooleanityProof},
     multipoint_eval::{self, MultipointEval},
     projections::{
         ProjectedTrace, project_scalars, project_scalars_to_field, project_trace_coeffs_row_major,
@@ -75,6 +76,7 @@ pub struct VerifierTranscriptReconstructed<
     proof_multipoint_eval: MultipointEvalProof<F>,
     proof_witness_lifted_evals: Vec<DynamicPolynomialF<F>>,
     proof_lookup_proof: Option<BatchedLookupProof<F>>,
+    proof_booleanity: Option<BooleanityProof<F>>,
     _phantom: PhantomData<(U, IdealOverF)>,
 }
 
@@ -100,6 +102,7 @@ pub struct VerifierPrimeProjected<
     proof_multipoint_eval: MultipointEvalProof<F>,
     proof_witness_lifted_evals: Vec<DynamicPolynomialF<F>>,
     proof_lookup_proof: Option<BatchedLookupProof<F>>,
+    proof_booleanity: Option<BooleanityProof<F>>,
     _phantom: PhantomData<(U, IdealOverF)>,
 }
 
@@ -125,6 +128,7 @@ pub struct VerifierIdealChecked<
     proof_multipoint_eval: MultipointEvalProof<F>,
     proof_witness_lifted_evals: Vec<DynamicPolynomialF<F>>,
     proof_lookup_proof: Option<BatchedLookupProof<F>>,
+    proof_booleanity: Option<BooleanityProof<F>>,
     _phantom: PhantomData<(U, IdealOverF)>,
 }
 
@@ -152,6 +156,7 @@ pub struct VerifierEvalProjected<
     proof_multipoint_eval: MultipointEvalProof<F>,
     proof_witness_lifted_evals: Vec<DynamicPolynomialF<F>>,
     proof_lookup_proof: Option<BatchedLookupProof<F>>,
+    proof_booleanity: Option<BooleanityProof<F>>,
     _phantom: PhantomData<(U, IdealOverF)>,
 }
 
@@ -169,6 +174,7 @@ pub struct VerifierSumchecked<
     field_cfg: F::Config,
     projecting_element_f: F,
     cpr_subclaim: combined_poly_resolver::VerifierSubclaim<F>,
+    bool_subclaim: Option<BoolVerifierSubclaim<F>>,
 
     // Proof leftovers
     proof_commitments: (ZipPlusCommitment, ZipPlusCommitment, ZipPlusCommitment),
@@ -192,6 +198,10 @@ pub struct VerifierMultipointEvaled<
     field_cfg: F::Config,
     projecting_element_f: F,
     mp_subclaim: multipoint_eval::Subclaim<F>,
+    /// Indicates the booleanity argument participated in the sumcheck,
+    /// so step 6 must append D coefficients per witness binary-poly col
+    /// to `open_evals`.
+    booleanity_present: bool,
 
     // Proof leftovers
     proof_commitments: (ZipPlusCommitment, ZipPlusCommitment, ZipPlusCommitment),
@@ -303,6 +313,7 @@ where
             proof_multipoint_eval: proof.multipoint_eval,
             proof_witness_lifted_evals: proof.witness_lifted_evals,
             proof_lookup_proof: proof.lookup_proof,
+            proof_booleanity: proof.booleanity_proof,
             _phantom: PhantomData,
         })
     }
@@ -340,6 +351,7 @@ where
             proof_multipoint_eval: self.proof_multipoint_eval,
             proof_witness_lifted_evals: self.proof_witness_lifted_evals,
             proof_lookup_proof: self.proof_lookup_proof,
+            proof_booleanity: self.proof_booleanity,
             _phantom: PhantomData,
         })
     }
@@ -394,6 +406,7 @@ where
             proof_multipoint_eval: self.proof_multipoint_eval,
             proof_witness_lifted_evals: self.proof_witness_lifted_evals,
             proof_lookup_proof: self.proof_lookup_proof,
+            proof_booleanity: self.proof_booleanity,
             _phantom: PhantomData,
         })
     }
@@ -440,6 +453,7 @@ where
             proof_multipoint_eval: self.proof_multipoint_eval,
             proof_witness_lifted_evals: self.proof_witness_lifted_evals,
             proof_lookup_proof: self.proof_lookup_proof,
+            proof_booleanity: self.proof_booleanity,
             _phantom: PhantomData,
         })
     }
@@ -466,13 +480,15 @@ where
     U: Uair + 'static,
     IdealOverF: Ideal,
 {
-    /// Step 4: Sumcheck verification (CPR + lookup groups).
+    /// Step 4: Sumcheck verification (CPR + optional booleanity + lookup
+    /// groups).
     pub fn step4_sumcheck_verify(
         mut self,
     ) -> Result<VerifierSumchecked<'a, Zt, F, IdealOverF, D, FD>, ProtocolError<F, IdealOverF>>
     {
         let num_constraints = count_constraints::<U>();
 
+        // CPR pre-sumcheck: squeezes folding challenge \alpha.
         let cpr_verifier_ancillary = CombinedPolyResolver::prepare_verifier::<U>(
             &mut self.base.pcs_transcript.fs_transcript,
             &self.proof_resolver,
@@ -483,6 +499,36 @@ where
             &self.projecting_element_f,
             &self.field_cfg,
         )?;
+
+        // Booleanity pre-sumcheck: squeezes r, \gamma, \delta in that order.
+        // Determined statically from the UAIR signature, so prover and
+        // verifier always agree on the presence flag.
+        let sig = self.base.uair_signature.clone();
+        let num_pub_bin = sig.public_cols().num_binary_poly_cols();
+        let num_total_bin = sig.total_cols().num_binary_poly_cols();
+        let bool_present = num_total_bin > num_pub_bin;
+
+        let bool_verifier_ancillary = if bool_present {
+            // booleanity is group index 1 (right after CPR)
+            let bool_claimed_sum = self
+                .proof_combined_sumcheck
+                .claimed_sums()
+                .get(1)
+                .ok_or(ProtocolError::BooleanityProofMissing)?;
+            let num_wit_bin = num_total_bin.saturating_sub(num_pub_bin);
+            let anc = BooleanityChecker::<F>::prepare_verifier(
+                &mut self.base.pcs_transcript.fs_transcript,
+                bool_claimed_sum,
+                num_wit_bin,
+                D,
+                self.base.num_vars,
+                &self.field_cfg,
+            )
+            .map_err(ProtocolError::Booleanity)?;
+            Some(anc)
+        } else {
+            None
+        };
 
         let md_subclaims = MultiDegreeSumcheck::verify_as_subprotocol(
             &mut self.base.pcs_transcript.fs_transcript,
@@ -502,6 +548,30 @@ where
             &self.field_cfg,
         )?;
 
+        let bool_subclaim = if let Some(anc) = bool_verifier_ancillary {
+            let booleanity_proof = self
+                .proof_booleanity
+                .take()
+                .ok_or(ProtocolError::BooleanityProofMissing)?;
+            let expected_evaluation = md_subclaims
+                .expected_evaluations()
+                .get(1)
+                .ok_or(ProtocolError::BooleanityProofMissing)?;
+            Some(
+                BooleanityChecker::<F>::finalize_verifier(
+                    &mut self.base.pcs_transcript.fs_transcript,
+                    booleanity_proof,
+                    md_subclaims.point().to_vec(),
+                    expected_evaluation,
+                    anc,
+                    &self.field_cfg,
+                )
+                .map_err(ProtocolError::Booleanity)?,
+            )
+        } else {
+            None
+        };
+
         let _ = &self.proof_lookup_proof;
 
         Ok(VerifierSumchecked {
@@ -509,6 +579,7 @@ where
             field_cfg: self.field_cfg,
             projecting_element_f: self.projecting_element_f,
             cpr_subclaim,
+            bool_subclaim,
             proof_commitments: self.proof_commitments,
             proof_multipoint_eval: self.proof_multipoint_eval,
             proof_witness_lifted_evals: self.proof_witness_lifted_evals,
@@ -532,11 +603,24 @@ where
         mut self,
     ) -> Result<VerifierMultipointEvaled<'a, Zt, F, IdealOverF, D, FD>, ProtocolError<F, IdealOverF>>
     {
+        // When the booleanity argument is present, the bit-slice claims
+        // produced by [`BooleanityChecker::finalize_verifier`] at `r*` are
+        // appended to `up_evals` and folded into the same `r_0` as the CPR
+        // claims. The corresponding scalar evaluations at `r_0` are
+        // discharged for free in step 6 against `lifted_evals.coeffs`.
+        let extended_up_evals: Vec<F> = if let Some(ref bs) = self.bool_subclaim {
+            let mut v = self.cpr_subclaim.up_evals;
+            v.extend_from_slice(&bs.bit_slice_evals);
+            v
+        } else {
+            self.cpr_subclaim.up_evals
+        };
+
         let mp_subclaim = MultipointEval::verify_as_subprotocol(
             &mut self.base.pcs_transcript.fs_transcript,
             self.proof_multipoint_eval,
             &self.cpr_subclaim.evaluation_point,
-            &self.cpr_subclaim.up_evals,
+            &extended_up_evals,
             &self.cpr_subclaim.down_evals,
             self.base.uair_signature.shifts(),
             self.base.num_vars,
@@ -548,6 +632,7 @@ where
             field_cfg: self.field_cfg,
             projecting_element_f: self.projecting_element_f,
             mp_subclaim,
+            booleanity_present: self.bool_subclaim.is_some(),
             proof_commitments: self.proof_commitments,
             proof_witness_lifted_evals: self.proof_witness_lifted_evals,
             proof_lookup_proof: self.proof_lookup_proof,
@@ -621,11 +706,25 @@ where
             .cloned()
             .collect();
 
-        let open_evals: Vec<F> = all_lifted_evals
+        let mut open_evals: Vec<F> = all_lifted_evals
             .iter()
             .map(|bar_u| bar_u.evaluate_at_point(&self.projecting_element_f))
             .collect::<Result<Vec<_>, _>>()
             .map_err(ProtocolError::LiftedEvalProjection)?;
+
+        // When the booleanity argument was active, the extended `up_evals`
+        // passed to MultipointEval included one entry per (witness bin-poly
+        // column, bit position). Their corresponding `open_evals` at r_0
+        // are precisely `lifted_evals[j].coeffs[i]` (already a scalar in
+        // F_q, not a polynomial).
+        if self.booleanity_present {
+            let zero = F::zero_with_cfg(&self.field_cfg);
+            for bar_u in all_lifted_evals.iter().skip(num_pub_bin).take(num_wit_bin) {
+                for i in 0..D {
+                    open_evals.push(bar_u.coeffs.get(i).cloned().unwrap_or_else(|| zero.clone()));
+                }
+            }
+        }
 
         MultipointEval::verify_subclaim(
             &self.mp_subclaim,


### PR DESCRIPTION
Resolves #183 

* Added batched booleanity sumcheck proving that boolean polynomial witness columns do in fact have bit coefficients (i.e. `v * (v + 1) == 0`)
* Fixed/unified both binary polynomial implementations `From<uX>` to work for any polynomial degree, discarding excessive bits

Impact on UAIRs with mostly binary columns where it's visible the most:
| # vars | Bench (par)           | Change (approx) |
| ------ | --------------------- | --------------- |
| 8, 10  | `BigLinearPI` bench P | +35%            |
| 8, 10  | `BigLinearPI` bench V | ~same           |
| 8, 10  | Proof size (comp)     | +5%             |
| 8, 10  | `ShaProxy` bench P    | +50%            |
| 8, 10  | `ShaProxy` bench V    | ~same           |
| 8, 10  | Proof size (comp)     | +5%             |