### PR TITLE
Optimize booleanity lookup

### DIFF
--- a/piop/src/lookup/booleanity.rs
+++ b/piop/src/lookup/booleanity.rs
@@ -401,7 +401,6 @@ where
     /// With overwhelming probability over the random $a$, agreement forces
     /// `bit_slice_evals` to be the true bit decomposition of the committed
     /// parent column at $r^\star$.
-    #[allow(clippy::arithmetic_side_effects)]
     pub fn verify_bit_decomposition_consistency(
         bit_slice_evals: &[F],
         parent_evals: &[F],
@@ -431,7 +430,7 @@ where
             let mut recombined = zero.clone();
             for (a_pow, bit_eval) in a_powers
                 .iter()
-                .zip(&bit_slice_evals[base..base + bits_per_col])
+                .zip(&bit_slice_evals[base..add!(base, bits_per_col)])
             {
                 recombined += a_pow.clone() * bit_eval;
             }

--- a/piop/src/lookup/booleanity.rs
+++ b/piop/src/lookup/booleanity.rs
@@ -5,8 +5,7 @@
 //! [`MultiDegreeSumcheckGroup`] of degree 3, batched alongside the existing
 //! CPR group with shared randomness, and emits bit-slice claims at the
 //! multi-degree sumcheck output point $r^\star$ for the protocol layer's
-//! $\alpha'$ substitution into multipoint-eval (see "Soundness bridge"
-//! below).
+//! $\alpha'$ bridge into multipoint-eval (see "Soundness bridge" below).
 //!
 //! # Relation
 //!
@@ -45,24 +44,26 @@
 //! at $r^\star$. The protocol-layer caller squeezes a fresh challenge
 //! $\alpha'$ from the transcript **after** `bit_slice_evals` are absorbed
 //! (the absorption is performed by [`BooleanityChecker::finalize_prover`] /
-//! `finalize_verifier`), then substitutes the multipoint-eval input value
-//! for each witness binary-poly column $u_j$ with
+//! `finalize_verifier`), then, for each witness binary-poly column $u_j$,
+//! *appends* one extra column to the multipoint-eval input list:
+//! - an extra MLE $\widetilde{\psi_{\alpha'}(u_j)}$ (the prover-side
+//!   $\alpha'$-projection of $u_j$), and
+//! - an extra up-eval scalar $c'_j \;:=\; \sum_{i=0}^{D-1}
+//!   b_{j,i}\,\alpha'^{\,i}$ (where $b_{j,i} = \widetilde{v_{j,i}}(r^\star)$
+//!   from `bit_slice_evals`).
 //!
-//! $$
-//!   c'_j \;:=\; \sum_{i=0}^{D-1} b_{j,i}\,\alpha'^{\,i}.
-//! $$
+//! No `ShiftSpec` references the appended slot, so down-evals / shifts
+//! pass through unchanged: row-shifted projections of witness binary-poly
+//! columns inherit booleanity from the un-shifted, $\psi_a$-projected
+//! slot they already reference in the multipoint-eval sumcheck.
 //!
-//! Multipoint-eval / PCS is $\psi$-oblivious, so swapping the value at
-//! the multipoint-eval boundary and evaluating each $\bar u_j$ at
-//! $\alpha'$ in the lifted-evals step enforces
+//! Multipoint-eval / PCS is $\psi$-oblivious, so the appended slot
+//! combined with the lifted-evals step evaluating the corresponding
+//! $\bar u_j$ at $\alpha'$ enforces
 //! $\widetilde{\psi_{\alpha'}(u_j)}(r^\star) = c'_j$ via the PCS chain.
 //! By Schwartz–Zippel on the indeterminate $X$, if `bit_slice_evals` are
 //! not the true bit-decomposition then equality fails with probability
 //! $\le (D-1)/|F|$, so the verifier rejects.
-//!
-//! Row-shifted projections of witness binary-poly columns (used when a
-//! UAIR `ShiftSpec` sources from such a column) are bound implicitly by
-//! the multipoint-eval sumcheck's through original columns.
 
 use crate::{
     CombFn,
@@ -146,8 +147,9 @@ pub struct BoolVerifierAncillary<F: PrimeField> {
 /// Carries the (sumcheck-residue-validated) bit-slice evaluations at the
 /// shared multi-degree sumcheck point $r^\star$. The protocol-layer
 /// caller squeezes $\alpha'$ from the transcript (after this struct
-/// is produced) and uses it together with these values to substitute the
-/// multipoint-eval inputs for witness binary-poly columns.
+/// is produced) and uses it together with these values to *append* one
+/// extra multipoint-eval column (and up-eval $c'_j$) per witness
+/// binary-poly column — see the module-level docs.
 #[derive(Clone, Debug)]
 pub struct BoolVerifierSubclaim<F: PrimeField> {
     /// Bit-slice MLE evaluations at `r*`, in `(j-major, i-minor)` order.
@@ -343,8 +345,10 @@ where
     /// absorbs `bit_slice_evals` into the transcript.
     ///
     /// The bit-decomposition consistency at $r^\star$ is **not** checked
-    /// here; the protocol layer squeezes $\alpha'$ and substitutes
-    /// the multipoint-eval inputs against `bit_slice_evals`.
+    /// here; the protocol layer squeezes $\alpha'$ and appends an extra
+    /// multipoint-eval column (and up-eval $c'_j$) per witness
+    /// binary-poly column derived from `bit_slice_evals` — see the
+    /// module-level docs.
     pub fn finalize_verifier(
         transcript: &mut impl Transcript,
         proof: BooleanityProof<F>,
@@ -634,9 +638,10 @@ fn batched_booleanity_sum<F: PrimeField>(
 /// i-th bit MLE evaluates at hypercube point `b` to the i-th bit of the
 /// row entry `trace_bin_poly[j][b]`.
 ///
-/// This helper is the single source of truth for MLE ordering. Both the
-/// booleanity sumcheck group and the `MultipointEval` extension call it
-/// to guarantee identical ordering between prover and verifier.
+/// Used by the `num_vars == 1` fallback of
+/// [`BooleanityRound1FastPath::fold_with_challenge`] (where the standard
+/// prover never performs the round-1 fold, so the fast path must emit
+/// the un-folded MLE bundle directly) and by booleanity unit tests.
 fn build_witness_bit_slice_mles<F, const D: usize>(
     trace_bin_poly: &[DenseMultilinearExtension<BinaryPoly<D>>],
     field_cfg: &F::Config,
@@ -815,13 +820,13 @@ mod tests {
     }
 
     /// Exercises the fast-path edge case where `eq_other_table = [1]`
-    // (empty product) and `fold_with_r1` produces 0-variable MLEs,
-    // after which the rounds-2..num_vars loop runs zero times.
+    /// (empty product) and `fold_with_challenge` produces 0-variable
+    /// MLEs, after which the rounds-2..num_vars loop runs zero times.
     #[test]
     fn happy_path_num_vars_one() {
         // Two columns, two rows each. Mixed bit patterns so the bit-slice
         // MLEs are not all-zero (exercises every branch of the 4-way
-        // bit-fold table in `fold_with_r1`).
+        // bit-fold table in `fold_with_challenge`).
         let c0 = build_col(vec![[true, false, true, false], [false, true, true, true]]);
         let c1 = build_col(vec![[false, false, true, true], [true, true, false, false]]);
         run_roundtrip(&[c0, c1], 1, |_| {}, |_| false, true);
@@ -1039,9 +1044,9 @@ mod tests {
         );
     }
 
-    /// Post-round-1 MLE values from `fold_with_r1(r_1)` are bit-identical
-    /// to what `fix_variables_with_config(&[r_1], cfg)` would produce on
-    /// the standard-path full-size MLEs.
+    /// Post-round-1 MLE values from `fold_with_challenge(&r_1)` are
+    /// bit-identical to what `fix_variables_with_config(&[r_1], cfg)`
+    /// would produce on the standard-path full-size MLEs.
     #[test]
     fn fast_path_fold_with_r1_matches_standard_fix_variables() {
         let cfg = &();

--- a/piop/src/lookup/booleanity.rs
+++ b/piop/src/lookup/booleanity.rs
@@ -65,11 +65,13 @@
 use crate::{
     CombFn,
     sumcheck::{
-        SumCheckError, multi_degree::MultiDegreeSumcheckGroup,
+        SumCheckError,
+        multi_degree::{MultiDegreeSumcheckGroup, Round1FastPath, Round1Output},
         prover::ProverState as SumcheckProverState,
     },
 };
 use crypto_primitives::PrimeField;
+use itertools::Itertools;
 use num_traits::Zero;
 use std::{marker::PhantomData, slice};
 use thiserror::Error;
@@ -83,7 +85,7 @@ use zinc_transcript::{
     delegate_transcribable,
     traits::{ConstTranscribable, Transcript},
 };
-use zinc_utils::{add, inner_transparent_field::InnerTransparentField, powers};
+use zinc_utils::{add, inner_transparent_field::InnerTransparentField, mul, powers};
 
 //
 // Structs
@@ -160,6 +162,12 @@ where
 {
     /// Build the booleanity sumcheck group, to be appended to the
     /// multi-degree sumcheck.
+    ///
+    /// Installs a [`BooleanityRound1FastPath`] hook on the returned group:
+    /// the round-1 polynomial and the post-round-1 MLE fold are computed
+    /// in closed form directly from the `BinaryPoly`-typed trace columns
+    /// (no full-size `F`-valued bit-slice MLEs are ever materialized).
+    /// Verifier doesn't see a difference.
     pub fn prepare_sumcheck_group<const D: usize>(
         transcript: &mut impl Transcript,
         trace_bin_poly: &[DenseMultilinearExtension<BinaryPoly<D>>],
@@ -180,27 +188,53 @@ where
         let alpha: F = transcript.get_field_challenge(field_cfg);
         let alpha_powers: Vec<F> = powers(alpha, one.clone(), n.saturating_mul(D));
 
-        // 3. Build eq(r, *) MLE.
-        let eq_r = build_eq_x_r_inner(&r, field_cfg)?;
+        // 3. comb_fn (degree 3 in the variables), used by `MultiDegreeSumcheck` in
+        //    rounds 2..num_vars:
+        //
+        //       eq_r(b) * sum_k alpha^k * v_k(b) * (v_k(b) - 1)
+        //
+        //    The fast path emits the round-1 message and the post-round-1
+        //    folded MLEs directly; this closure is *not* invoked in round 1.
+        let comb_fn: CombFn<F> = {
+            let alpha_powers = alpha_powers.clone();
+            let one = one.clone();
+            let zero = zero.clone();
+            Box::new(move |mle_values: &[F]| {
+                let eq_r_val = &mle_values[0];
+                let sum = batched_booleanity_sum(&mle_values[1..], &alpha_powers, &zero, &one);
+                sum * eq_r_val
+            })
+        };
 
-        // 4. Build N*D bit-slice MLEs in canonical (j-major, i-minor) order.
-        let mut mles = Vec::with_capacity(add!(n.saturating_mul(D), 1));
-        mles.push(eq_r);
-        mles.extend(build_witness_bit_slice_mles::<F, D>(
-            trace_bin_poly,
-            field_cfg,
-        ));
+        // 4. Precompute `E_other(b')` = eq(b', r[1..]) for the fast path.
+        //    `build_eq_x_r_inner` rejects empty inputs, so handle num_vars == 1
+        //    explicitly by emitting the empty-product table `[1]`.
+        let eq_other_table: Vec<F::Inner> = if num_vars <= 1 {
+            vec![one.clone().into_inner()]
+        } else {
+            build_eq_x_r_inner(&r[1..], field_cfg)?.evaluations
+        };
 
-        // 5. Build comb_fn (degree 3 in the variables):
-        //   eq_r(b) * sum_k alpha^k * v_k(b) * (v_k(b) - 1)
-        let comb_fn: CombFn<F> = Box::new(move |mle_values: &[F]| {
-            let eq_r_val = &mle_values[0];
-            let sum = batched_booleanity_sum(&mle_values[1..], &alpha_powers, &zero, &one);
-            sum * eq_r_val
-        });
+        let r_first_coord = r
+            .into_iter()
+            .next()
+            .expect("num_vars >= 1 guarantees a first coordinate");
+
+        let fast_path = BooleanityRound1FastPath::<F, D> {
+            binary_cols: trace_bin_poly.to_vec(),
+            alpha_powers,
+            eq_other_table,
+            r_first_coord,
+            num_vars,
+        };
 
         Ok((
-            MultiDegreeSumcheckGroup::new(3, mles, comb_fn),
+            MultiDegreeSumcheckGroup::new_with_fast_path(
+                3,
+                Vec::new(),
+                comb_fn,
+                Box::new(fast_path),
+            ),
             BoolProverAncillary {
                 num_wit_bin_cols: n,
                 bit_width: D,
@@ -415,6 +449,172 @@ where
     }
 }
 
+//
+// Round-1 fast path
+//
+
+/// Closed-form round-1 message and round-1 fold for the booleanity sumcheck
+/// group. Bit-identical to running [`SumcheckProverState::prove_round`].
+///
+/// Algebraic identities exploited:
+///
+/// 1. Bit-slice $v(v-1)$ collapse: for $v(X, b') = (1-X) \cdot A + X \cdot B$
+///    with $A, B \in \\{0,1\\}$, $$ v(X, b') (v(X, b') - 1) = (A \oplus B)
+///    \cdot X(X-1). $$ Only the bit `A XOR B` depends on data; the factor
+///    $X(X-1)$ is universal.
+/// 2. $eq_r$ factorization on the first variable: $$\widetilde{eq_r}(X, b') =
+///    e_0(X) \cdot E_{\text{other}}(b'),$$ with $e_0(X) = (1-X)(1-r_0) + X r_0$
+///    and $E_{\text{other}}(b') = \widetilde{eq_{r_{[1..]}}}(b')$.
+///
+/// The round-1 polynomial collapses to
+/// $$
+/// p_1(X) = e_0(X) \cdot X(X-1) \cdot T_1, \quad T_1 = \sum_{b'} S(b')
+///   E_{\text{other}}(b'), \quad S(b') = \sum_k \alpha^k (A_k(b') \oplus
+///   B_k(b')),
+/// $$
+/// The round-1 fold consumes the verifier challenge $r_1$ and writes each
+/// post-fold bit-slice entry via a 4-way table lookup keyed by $(A, B) \in
+/// \{0,1\}^2$.
+struct BooleanityRound1FastPath<F: PrimeField, const D: usize> {
+    /// Per-column binary trace (cloned to avoid lifetime issues).
+    binary_cols: Vec<DenseMultilinearExtension<BinaryPoly<D>>>,
+    /// Powers of the batching challenge over the flat `(j-major, i-minor)`
+    /// index: `[1, alpha, ..., alpha^{N*D - 1}]`.
+    alpha_powers: Vec<F>,
+    /// Evaluations of $E_{\text{other}}(b') = \widetilde{eq_{r_{[1..]}}}(b')$
+    /// on `{0,1}^{num_vars - 1}`. When `num_vars == 1` this is the single
+    /// entry `[1]` (the empty product).
+    eq_other_table: Vec<F::Inner>,
+    /// The first coordinate of the zerocheck point, $r_0$.
+    r_first_coord: F,
+    /// Number of variables of the sumcheck.
+    num_vars: usize,
+}
+
+impl<F, const D: usize> Round1FastPath<F> for BooleanityRound1FastPath<F, D>
+where
+    F: InnerTransparentField + Send + Sync + 'static,
+    F::Inner: Clone + Send + Sync,
+{
+    fn round_1_message(&self, config: &F::Config) -> Round1Output<F> {
+        let zero = F::zero_with_cfg(config);
+        let one = F::one_with_cfg(config);
+        let half_n: usize = 1_usize << self.num_vars.saturating_sub(1);
+
+        // T_1 = sum_{b'} S(b') * E_other(b').
+        let mut t1 = zero.clone();
+        for b_prime in 0..half_n {
+            let mut s_b = zero.clone();
+            for (j, col) in self.binary_cols.iter().enumerate() {
+                let two_b = mul!(2, b_prime);
+                let row_a = &col.evaluations[two_b];
+                let row_b = &col.evaluations[add!(two_b, 1)];
+                for (i, (a_bit, b_bit)) in row_a.iter().zip(row_b.iter()).enumerate() {
+                    if a_bit != b_bit {
+                        let k = add!(i, mul!(j, D));
+                        s_b += &self.alpha_powers[k];
+                    }
+                }
+            }
+            let eq_other = F::new_unchecked_with_cfg(self.eq_other_table[b_prime].clone(), config);
+            t1 += s_b * &eq_other;
+        }
+
+        // Closed-form tail evaluations (with X(X-1) = 0 at X=1):
+        //   p_1(1) = 0
+        //   p_1(2) = e_0(2) * 2*1*T_1 = 2 * (3*r_0 - 1) * T_1
+        //   p_1(3) = e_0(3) * 3*2*T_1 = 6 * (5*r_0 - 2) * T_1
+        let two = one.clone() + &one;
+        let three = two.clone() + &one;
+        let five = three.clone() + &two;
+        let six = three.clone() * &two;
+
+        let three_r0_minus_one = three * &self.r_first_coord - &one;
+        let five_r0_minus_two = five * &self.r_first_coord - &two;
+
+        let p1_at_1 = zero.clone();
+        let p1_at_2 = two * three_r0_minus_one * &t1;
+        let p1_at_3 = six * five_r0_minus_two * &t1;
+
+        Round1Output {
+            // Booleanity is a zerocheck; the asserted sum p_1(0)+p_1(1) is 0.
+            asserted_sum: zero,
+            tail_evaluations: vec![p1_at_1, p1_at_2, p1_at_3],
+        }
+    }
+
+    fn fold_with_challenge(
+        self: Box<Self>,
+        r_1: &F,
+        config: &F::Config,
+    ) -> Vec<DenseMultilinearExtension<F::Inner>> {
+        let n_cols = self.binary_cols.len();
+        let total_bit_slices = n_cols.saturating_mul(D);
+        let new_num_vars = self.num_vars.saturating_sub(1);
+        let half_n: usize = 1_usize << new_num_vars;
+
+        let one = F::one_with_cfg(config);
+
+        // 4-way table for bit-slice fold: index = (A as usize) << 1 | (B as usize).
+        //   (0,0) -> 0
+        //   (0,1) -> r_1
+        //   (1,0) -> 1 - r_1
+        //   (1,1) -> 1
+        let zero_inner = F::zero_with_cfg(config).into_inner();
+        let one_inner = one.inner().clone();
+        let r1_inner = r_1.inner().clone();
+        let one_minus_r1_inner = (one.clone() - r_1).into_inner();
+        let bit_fold_table: [F::Inner; 4] = [zero_inner, r1_inner, one_minus_r1_inner, one_inner];
+
+        // eq_r fold: e_0(r_1) * E_other(b').
+        // e_0(r_1) = (1 - r_1)(1 - r_0) + r_1 * r_0.
+        let one_minus_r0 = one.clone() - &self.r_first_coord;
+        let one_minus_r1 = one - r_1;
+        let e_0_r1: F = (one_minus_r1 * &one_minus_r0) + (r_1.clone() * &self.r_first_coord);
+
+        let folded_eq_r_evals = (0..half_n)
+            .map(|b_prime| {
+                let e_other =
+                    F::new_unchecked_with_cfg(self.eq_other_table[b_prime].clone(), config);
+                (e_0_r1.clone() * &e_other).into_inner()
+            })
+            .collect_vec();
+
+        // Length = N*D + 1
+        let mut out: Vec<DenseMultilinearExtension<F::Inner>> =
+            Vec::with_capacity(total_bit_slices.saturating_add(1));
+        out.push(DenseMultilinearExtension {
+            num_vars: new_num_vars,
+            evaluations: folded_eq_r_evals,
+        });
+
+        // Bit-slice fold via 4-way table lookup; emit MLEs in
+        // (j-major, i-minor) order.
+        for col in &self.binary_cols {
+            let mut col_evals: Vec<Vec<F::Inner>> =
+                (0..D).map(|_| Vec::with_capacity(half_n)).collect();
+            for b_prime in 0..half_n {
+                let two_b = mul!(2, b_prime);
+                let row_a = &col.evaluations[two_b];
+                let row_b = &col.evaluations[add!(two_b, 1)];
+                for (i, (a_bit, b_bit)) in row_a.iter().zip(row_b.iter()).enumerate() {
+                    let idx =
+                        (usize::from(a_bit.into_inner()) << 1) | usize::from(b_bit.into_inner());
+                    col_evals[i].push(bit_fold_table[idx].clone());
+                }
+            }
+            for evals in col_evals {
+                out.push(DenseMultilinearExtension {
+                    num_vars: new_num_vars,
+                    evaluations: evals,
+                });
+            }
+        }
+
+        out
+    }
+}
+
 /// Errors from the booleanity subprotocol.
 #[derive(Debug, Error)]
 pub enum BooleanityError<F: PrimeField> {
@@ -527,13 +727,15 @@ where
 #[allow(
     clippy::cast_possible_truncation,
     clippy::cast_precision_loss,
-    clippy::cast_sign_loss
+    clippy::cast_sign_loss,
+    clippy::clone_on_copy
 )]
 mod tests {
     use super::*;
     use crate::sumcheck::multi_degree::MultiDegreeSumcheck;
     use crypto_bigint::{U128, const_monty_params};
     use crypto_primitives::crypto_bigint_const_monty::ConstMontyField;
+    use num_traits::One;
     use zinc_transcript::Blake3Transcript;
 
     const_monty_params!(TestParams, U128, "00000000b933426489189cb5b47d567f");
@@ -554,7 +756,7 @@ mod tests {
     /// Build a single binary-poly trace column from a vec of row-bit patterns.
     fn build_col(rows: Vec<[bool; D]>) -> DenseMultilinearExtension<BinaryPoly<D>> {
         let num_vars = (rows.len() as f64).log2().round() as usize;
-        debug_assert_eq!(rows.len(), 1usize << num_vars);
+        debug_assert_eq!(rows.len(), 1_usize << num_vars);
         let zero = BinaryPoly::zero();
         let mut evals: Vec<BinaryPoly<D>> = rows.into_iter().map(binp_from_bits).collect();
         // Sanity: replace any padding (none expected here) with zero.
@@ -726,8 +928,8 @@ mod tests {
     /// Honest `bit_slice_evals` recombine to the parent eval via $\psi_a$.
     #[test]
     fn consistency_check_happy_path() {
-        let cfg = &();
-        let one = F::one_with_cfg(cfg);
+        let zero = F::zero();
+        let one = F::one();
         let two = one + one;
         let three = two + one;
         let a = three; // arbitrary nonzero projection element
@@ -741,7 +943,6 @@ mod tests {
             .collect();
 
         let mut parent_evals: Vec<F> = Vec::with_capacity(n);
-        let zero = F::zero_with_cfg(cfg);
         for j in 0..n {
             let mut acc = zero;
             let mut a_pow = one;
@@ -757,7 +958,7 @@ mod tests {
             &parent_evals,
             &a,
             D,
-            cfg,
+            &(),
         )
         .expect("honest recombination should match");
     }
@@ -766,17 +967,16 @@ mod tests {
     /// `col_idx = k / D`.
     #[test]
     fn consistency_check_tampered_bit_slice_rejected() {
-        let cfg = &();
-        let one = F::one_with_cfg(cfg);
+        let zero = F::zero();
+        let one = F::one();
         let two = one + one;
-        let a = two + one; // 3
+        let a = two + one; // arbitrary nonzero projection element
 
         let n = 2usize;
         let mut bit_slice_evals: Vec<F> = (0..n * D)
             .map(|k| F::from(((k as u32) * 7 + 11) % 13))
             .collect();
 
-        let zero = F::zero_with_cfg(cfg);
         let mut parent_evals: Vec<F> = Vec::with_capacity(n);
         for j in 0..n {
             let mut acc = zero;
@@ -796,7 +996,7 @@ mod tests {
             &parent_evals,
             &a,
             D,
-            cfg,
+            &(),
         )
         .expect_err("tamper should be rejected");
 
@@ -809,19 +1009,18 @@ mod tests {
     /// Length mismatch is reported as `WrongBitSliceEvalsNumber`.
     #[test]
     fn consistency_check_wrong_length_rejected() {
-        let cfg = &();
-        let one = F::one_with_cfg(cfg);
+        let one = F::one();
         let a = one + one;
 
-        let parent_evals = vec![F::zero_with_cfg(cfg); 2];
-        let bit_slice_evals = vec![F::zero_with_cfg(cfg); 2 * D - 1];
+        let parent_evals = vec![F::zero(); 2];
+        let bit_slice_evals = vec![F::zero(); 2 * D - 1];
 
         let err = BooleanityChecker::<F>::verify_bit_decomposition_consistency(
             &bit_slice_evals,
             &parent_evals,
             &a,
             D,
-            cfg,
+            &(),
         )
         .expect_err("length mismatch should be rejected");
 
@@ -829,5 +1028,187 @@ mod tests {
             matches!(err, BooleanityError::WrongBitSliceEvalsNumber { .. }),
             "expected WrongBitSliceEvalsNumber, got {err:?}"
         );
+    }
+
+    //
+    // Round-1 fast path cross-validation.
+    //
+    // These tests pin down the fast path's bit-identical equivalence with
+    // the standard prover (`prove_round` + `fix_variables_with_config`) on
+    // the same booleanity inputs. If either of these fails the fast path
+    // has diverged from the standard path and the verifier will reject.
+    //
+
+    /// Inputs shared between the two cross-validation tests.
+    struct FastPathHarness {
+        cols: Vec<DenseMultilinearExtension<BinaryPoly<D>>>,
+        num_vars: usize,
+        r: Vec<F>,
+        alpha_powers: Vec<F>,
+        zero: F,
+        one: F,
+    }
+
+    #[allow(clippy::arithmetic_side_effects)]
+    fn cross_validation_inputs() -> FastPathHarness {
+        // Three columns, eight rows, mixed bit patterns. nvars = 3 exercises
+        // both round-1 (closed form) and rounds 2..num_vars (standard path).
+        let c0 = build_col(vec![
+            [true, false, true, false],
+            [false, true, false, true],
+            [true, true, false, false],
+            [false, false, true, true],
+            [true, true, true, false],
+            [false, true, true, false],
+            [true, false, false, true],
+            [false, false, false, false],
+        ]);
+        let c1 = build_col(vec![
+            [false, false, false, false],
+            [true, true, true, true],
+            [false, true, true, false],
+            [true, false, false, true],
+            [false, false, true, false],
+            [true, true, false, true],
+            [false, true, false, true],
+            [true, false, true, false],
+        ]);
+        let c2 = build_col(vec![
+            [true; D],
+            [false; D],
+            [true, false, false, false],
+            [false, false, false, true],
+            [true, true, false, false],
+            [false, false, true, true],
+            [true, false, true, true],
+            [false, true, false, false],
+        ]);
+        let cols = vec![c0, c1, c2];
+
+        let num_vars = 3usize;
+        let one = F::one();
+        let zero = F::zero();
+
+        // Arbitrary (but deterministic) zerocheck point and batching challenge.
+        let r: Vec<F> = (0..num_vars)
+            .map(|i| F::from((i as u32) * 13 + 41))
+            .collect();
+        let alpha = F::from(23u32);
+        let alpha_powers = powers(alpha, one.clone(), cols.len() * D);
+
+        FastPathHarness {
+            cols,
+            num_vars,
+            r,
+            alpha_powers,
+            zero,
+            one,
+        }
+    }
+
+    fn standard_path_mles(
+        cols: &[DenseMultilinearExtension<BinaryPoly<D>>],
+        r: &[F],
+        cfg: &(),
+    ) -> Vec<DenseMultilinearExtension<<F as crypto_primitives::Field>::Inner>> {
+        let mut mles = Vec::with_capacity(1_usize.saturating_add(cols.len().saturating_mul(D)));
+        mles.push(build_eq_x_r_inner(r, cfg).expect("eq_r build"));
+        mles.extend(build_witness_bit_slice_mles::<F, D>(cols, cfg));
+        mles
+    }
+
+    #[allow(clippy::arithmetic_side_effects)]
+    fn make_comb_fn(alpha_powers: Vec<F>, zero: F, one: F) -> CombFn<F> {
+        Box::new(move |mle_values: &[F]| {
+            let eq_r_val = &mle_values[0];
+            let sum = batched_booleanity_sum(&mle_values[1..], &alpha_powers, &zero, &one);
+            sum * eq_r_val
+        })
+    }
+
+    fn make_fast_path(h: &FastPathHarness, cfg: &()) -> BooleanityRound1FastPath<F, D> {
+        let eq_other_table: Vec<<F as crypto_primitives::Field>::Inner> = if h.num_vars <= 1 {
+            vec![h.one.clone().into_inner()]
+        } else {
+            build_eq_x_r_inner(&h.r[1..], cfg)
+                .expect("eq_other build")
+                .evaluations
+        };
+        BooleanityRound1FastPath::<F, D> {
+            binary_cols: h.cols.clone(),
+            alpha_powers: h.alpha_powers.clone(),
+            eq_other_table,
+            r_first_coord: h.r[0].clone(),
+            num_vars: h.num_vars,
+        }
+    }
+
+    /// Round-1 polynomial tail and asserted sum produced by the fast path
+    /// match what `SumcheckProverState::prove_round` would emit on the same
+    /// inputs.
+    #[test]
+    fn fast_path_round_1_matches_standard_prove_round() {
+        let cfg = &();
+        let h = cross_validation_inputs();
+        let fast_path = make_fast_path(&h, cfg);
+
+        let fp_out = fast_path.round_1_message(cfg);
+
+        // Standard path: build full-size MLEs, then run a single prove_round
+        // (with no verifier message — this is the first round).
+        let mles = standard_path_mles(&h.cols, &h.r, cfg);
+        let comb_fn = make_comb_fn(h.alpha_powers.clone(), h.zero.clone(), h.one.clone());
+        let mut state = SumcheckProverState::<F>::new(mles, h.num_vars, 3);
+        let std_msg = state.prove_round(&None, &comb_fn, cfg);
+
+        assert_eq!(
+            fp_out.tail_evaluations, std_msg.0.tail_evaluations,
+            "round-1 tail evaluations differ between fast and standard paths"
+        );
+        assert_eq!(
+            Some(fp_out.asserted_sum.clone()),
+            state.asserted_sum,
+            "round-1 asserted sums differ between fast and standard paths"
+        );
+        assert_eq!(
+            fp_out.asserted_sum, h.zero,
+            "booleanity is a zerocheck — asserted sum must be 0"
+        );
+    }
+
+    /// Post-round-1 MLE values from `fold_with_r1(r_1)` are bit-identical
+    /// to what `fix_variables_with_config(&[r_1], cfg)` would produce on
+    /// the standard-path full-size MLEs.
+    #[test]
+    fn fast_path_fold_with_r1_matches_standard_fix_variables() {
+        let cfg = &();
+        let h = cross_validation_inputs();
+        let r_1 = F::from(97u32);
+
+        // Fast path.
+        let fast_path = Box::new(make_fast_path(&h, cfg));
+        let fp_mles = fast_path.fold_with_challenge(&r_1, cfg);
+
+        // Standard path: build full-size MLEs, then fold the first variable.
+        let mut std_mles = standard_path_mles(&h.cols, &h.r, cfg);
+        for mle in &mut std_mles {
+            mle.fix_variables_with_config(std::slice::from_ref(&r_1), cfg);
+        }
+
+        assert_eq!(
+            fp_mles.len(),
+            std_mles.len(),
+            "fast and standard paths must produce the same number of MLEs"
+        );
+        for (k, (fp_mle, std_mle)) in fp_mles.iter().zip(std_mles.iter()).enumerate() {
+            assert_eq!(
+                fp_mle.num_vars, std_mle.num_vars,
+                "num_vars mismatch on folded MLE #{k}"
+            );
+            assert_eq!(
+                fp_mle.evaluations, std_mle.evaluations,
+                "evaluations mismatch on folded MLE #{k}"
+            );
+        }
     }
 }

--- a/piop/src/lookup/booleanity.rs
+++ b/piop/src/lookup/booleanity.rs
@@ -3,9 +3,10 @@
 //! Proves that every coefficient of every witness binary-polynomial column is
 //! a bit $\in \\{0,1\\}$. The argument is structured as a single
 //! [`MultiDegreeSumcheckGroup`] of degree 3, batched alongside the existing
-//! CPR group with shared randomness, and verifies its bit-slice claims at
-//! the multi-degree sumcheck output point $r^\star$ against the projected
-//! parent column evaluations (CPR `up_evals`) using the $\psi_a$ identity.
+//! CPR group with shared randomness, and emits bit-slice claims at the
+//! multi-degree sumcheck output point $r^\star$ for the protocol layer's
+//! $\alpha'$ substitution into multipoint-eval (see "Soundness bridge"
+//! below).
 //!
 //! # Relation
 //!
@@ -38,29 +39,30 @@
 //! sends `bit_slice_evals` $= (\widetilde{v_{j,i}}(r^\star))$ to the
 //! verifier.
 //!
-//! # Bit-decomposition consistency check at $r^\star$
+//! # Soundness bridge to multipoint-eval ($\alpha'$)
 //!
-//! The bit-slice claims at $r^\star$ are tied back to the committed parent
-//! columns via the $\psi_a$ identity at the MLE level: for every binary-poly
-//! column $u_j$,
+//! Booleanity does **not** itself close the bit-decomposition consistency
+//! at $r^\star$. The protocol-layer caller squeezes a fresh challenge
+//! $\alpha'$ from the transcript **after** `bit_slice_evals` are absorbed
+//! (the absorption is performed by [`BooleanityChecker::finalize_prover`] /
+//! `finalize_verifier`), then substitutes the multipoint-eval input value
+//! for each witness binary-poly column $u_j$ with
 //!
 //! $$
-//!   \psi_a\bigl(\widetilde{u_j}(r^\star)\bigr)
-//!     = \sum_{i=0}^{D-1} a^i \cdot \widetilde{v_{j,i}}(r^\star).
+//!   c'_j \;:=\; \sum_{i=0}^{D-1} b_{j,i}\,\alpha'^{\,i}.
 //! $$
 //!
-//! The left-hand side is already available to the verifier as
-//! `cpr_subclaim.up_evals[num_pub_bin + j]` (the projected MLE evaluation of
-//! the $j$-th witness binary-poly column at $r^\star$, coming out of the
-//! CPR group). The right-hand side is rebuilt from the prover-supplied
-//! `bit_slice_evals`. With overwhelming probability over the random $a$
-//! used by $\psi_a$, this linear pin-down forces the `bit_slice_evals` to
-//! be the true bit decomposition of $u_j$ at $r^\star$.
+//! Multipoint-eval / PCS is $\psi$-oblivious, so swapping the value at
+//! the multipoint-eval boundary and evaluating each $\bar u_j$ at
+//! $\alpha'$ in the lifted-evals step enforces
+//! $\widetilde{\psi_{\alpha'}(u_j)}(r^\star) = c'_j$ via the PCS chain.
+//! By Schwartz–Zippel on the indeterminate $X$, if `bit_slice_evals` are
+//! not the true bit-decomposition then equality fails with probability
+//! $\le (D-1)/|F|$, so the verifier rejects.
 //!
-//! Because the consistency check closes at $r^\star$, the bit-slice MLEs
-//! are **not** routed through `MultipointEval`: they participate only in
-//! the booleanity sumcheck group and then vanish from the rest of the
-//! protocol.
+//! Row-shifted projections of witness binary-poly columns (used when a
+//! UAIR `ShiftSpec` sources from such a column) are bound implicitly by
+//! the multipoint-eval sumcheck's through original columns.
 
 use crate::{
     CombFn,
@@ -94,11 +96,14 @@ use zinc_utils::{add, inner_transparent_field::InnerTransparentField, mul, power
 /// Booleanity sumcheck group constructor / verifier.
 pub struct BooleanityChecker<F: InnerTransparentField>(PhantomData<F>);
 
-/// Proof produced by the booleanity prover. Carries only the flat list of
-/// bit-slice MLE evaluations at the multi-degree sumcheck output point
-/// $r*$. The bit-decomposition consistency at $r^\star$ is verified by
-/// the protocol-layer caller against the CPR `up_evals` of the witness
-/// binary-poly columns.
+/// Proof produced by the booleanity prover.
+///
+/// Carries `bit_slice_evals`: per-column bit-slice MLE evaluations at the
+/// multi-degree sumcheck output point $r^\star$, flat in
+/// `(j-major, i-minor)` order with length `num_wit_bin_cols * D`. It is
+/// absorbed into the transcript by `finalize_prover` / `finalize_verifier`,
+/// after which the protocol layer squeezes the $\alpha'$ challenge
+/// used to bind the bit-decomposition into the multipoint-eval boundary.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct BooleanityProof<F: PrimeField> {
     /// Flat list of `\widetilde{v_{j,i}}(r*)`, ordered `(j-major, i-minor)`.
@@ -138,12 +143,11 @@ pub struct BoolVerifierAncillary<F: PrimeField> {
 
 /// Subclaim emitted by [`BooleanityChecker::finalize_verifier`].
 ///
-/// Carries the (now-validated against the sumcheck residue)
-/// `bit_slice_evals` at the shared multi-degree sumcheck point `r*``.
-/// The protocol-layer caller passes these into
-/// [`BooleanityChecker::verify_bit_decomposition_consistency`] together
-/// with the CPR `up_evals` for the witness binary-poly columns to close
-/// the booleanity argument entirely inside step 4.
+/// Carries the (sumcheck-residue-validated) bit-slice evaluations at the
+/// shared multi-degree sumcheck point $r^\star$. The protocol-layer
+/// caller squeezes $\alpha'$ from the transcript (after this struct
+/// is produced) and uses it together with these values to substitute the
+/// multipoint-eval inputs for witness binary-poly columns.
 #[derive(Clone, Debug)]
 pub struct BoolVerifierSubclaim<F: PrimeField> {
     /// Bit-slice MLE evaluations at `r*`, in `(j-major, i-minor)` order.
@@ -194,7 +198,7 @@ where
         //       eq_r(b) * sum_k alpha^k * v_k(b) * (v_k(b) - 1)
         //
         //    The fast path emits the round-1 message and the post-round-1
-        //    folded MLEs directly; this closure is *not* invoked in round 1.
+        //    folded MLEs directly, so this closure is *not* invoked in round 1.
         let comb_fn: CombFn<F> = {
             let alpha_powers = alpha_powers.clone();
             let one = one.clone();
@@ -270,11 +274,13 @@ where
             .expect("sumcheck cannot have had 0 rounds")
             .clone();
 
-        let expected_len = ancillary
+        let active_len = ancillary
             .num_wit_bin_cols
             .saturating_mul(ancillary.bit_width);
 
         let mut mles = sumcheck_prover_state.mles;
+        debug_assert_eq!(mles.len(), add!(1, active_len));
+
         // Skip MLE 0 = eq_r (verifier recomputes it).
         let bit_slice_evals: Vec<F> = mles
             .drain(1..)
@@ -283,7 +289,7 @@ where
             })
             .collect::<Result<Vec<_>, _>>()?;
 
-        debug_assert_eq!(bit_slice_evals.len(), expected_len);
+        debug_assert_eq!(bit_slice_evals.len(), active_len);
 
         let mut transcription_buf: Vec<u8> = vec![0; F::Inner::NUM_BYTES];
         transcript.absorb_random_field_slice(&bit_slice_evals, &mut transcription_buf);
@@ -331,12 +337,14 @@ where
 
     /// Post-sumcheck half of the booleanity verifier.
     ///
-    /// Validates the length of `bit_slice_evals`, recomputes the expected
-    /// combination-function evaluation at the shared sumcheck point `r*`
-    /// using the received `bit_slice_evals`, and compares it against the
-    /// sumcheck's `expected_eval`. On success, absorbs `bit_slice_evals` into
-    /// the transcript (mirroring the prover's final absorption in
-    /// `finalize_prover`).
+    /// Validates the length of `bit_slice_evals`, recomputes the
+    /// booleanity residue at the shared sumcheck point $r^\star$, and
+    /// compares it against the sumcheck's `expected_eval`. On success,
+    /// absorbs `bit_slice_evals` into the transcript.
+    ///
+    /// The bit-decomposition consistency at $r^\star$ is **not** checked
+    /// here; the protocol layer squeezes $\alpha'$ and substitutes
+    /// the multipoint-eval inputs against `bit_slice_evals`.
     pub fn finalize_verifier(
         transcript: &mut impl Transcript,
         proof: BooleanityProof<F>,
@@ -379,72 +387,6 @@ where
         Ok(BoolVerifierSubclaim {
             bit_slice_evals: proof.bit_slice_evals,
         })
-    }
-
-    /// Verify the bit-slice claims at $r^\star$ against the projected
-    /// parent column evaluations (CPR `up_evals`) using the $\psi_a$
-    /// identity.
-    ///
-    /// For each witness binary-poly column $j$, checks
-    ///
-    /// $$
-    ///   \texttt{parent\_evals}[j] \;=\; \sum_{i=0}^{D-1} a^i \cdot
-    ///     \texttt{bit\_slice\_evals}[j \cdot D + i]
-    /// $$
-    ///
-    /// where $a$ is the random projection element used by $\psi_a$ to send
-    /// $F_q[X] \to F_q$. The left-hand side is the MLE evaluation at $r^\star$
-    /// of the projected parent column (i.e. `cpr_subclaim.up_evals[..]`
-    /// restricted to the witness binary-poly slice). The right-hand side is
-    /// the linear recombination of the prover-supplied bit-slice evals.
-    ///
-    /// With overwhelming probability over the random $a$, agreement forces
-    /// `bit_slice_evals` to be the true bit decomposition of the committed
-    /// parent column at $r^\star$.
-    pub fn verify_bit_decomposition_consistency(
-        bit_slice_evals: &[F],
-        parent_evals: &[F],
-        projecting_element: &F,
-        bits_per_col: usize,
-        field_cfg: &F::Config,
-    ) -> Result<(), BooleanityError<F>> {
-        let expected_len = parent_evals.len().saturating_mul(bits_per_col);
-        if bit_slice_evals.len() != expected_len {
-            return Err(BooleanityError::WrongBitSliceEvalsNumber {
-                expected: expected_len,
-                got: bit_slice_evals.len(),
-            });
-        }
-
-        if bits_per_col == 0 || parent_evals.is_empty() {
-            return Ok(());
-        }
-
-        let zero = F::zero_with_cfg(field_cfg);
-        let one = F::one_with_cfg(field_cfg);
-
-        let a_powers: Vec<F> = powers(projecting_element.clone(), one, bits_per_col);
-
-        for (col_idx, parent_eval) in parent_evals.iter().enumerate() {
-            let base = col_idx.saturating_mul(bits_per_col);
-            let mut recombined = zero.clone();
-            for (a_pow, bit_eval) in a_powers
-                .iter()
-                .zip(&bit_slice_evals[base..add!(base, bits_per_col)])
-            {
-                recombined += a_pow.clone() * bit_eval;
-            }
-
-            if &recombined != parent_eval {
-                return Err(BooleanityError::ConsistencyMismatch {
-                    col_idx,
-                    got: recombined,
-                    expected: parent_eval.clone(),
-                });
-            }
-        }
-
-        Ok(())
     }
 }
 
@@ -647,11 +589,6 @@ pub enum BooleanityError<F: PrimeField> {
     WrongBitSliceEvalsNumber { expected: usize, got: usize },
     #[error("booleanity claim value does not match: expected {expected}, got {got}")]
     ClaimValueDoesNotMatch { expected: F, got: F },
-    #[error(
-        "bit-decomposition consistency mismatch on witness binary-poly column {col_idx}: \
-         recombined Sum_i a^i * bit_slice = {got}, expected parent eval {expected}"
-    )]
-    ConsistencyMismatch { col_idx: usize, got: F, expected: F },
     #[error("error evaluating MLE: {0}")]
     MleEvaluationError(#[from] EvaluationError),
     #[error("arithmetic error: {0}")]
@@ -744,6 +681,7 @@ where
 
 #[cfg(test)]
 #[allow(
+    clippy::arithmetic_side_effects,
     clippy::cast_possible_truncation,
     clippy::cast_precision_loss,
     clippy::cast_sign_loss,
@@ -957,111 +895,6 @@ mod tests {
         );
     }
 
-    /// Honest `bit_slice_evals` recombine to the parent eval via $\psi_a$.
-    #[test]
-    fn consistency_check_happy_path() {
-        let zero = F::zero();
-        let one = F::one();
-        let two = one + one;
-        let three = two + one;
-        let a = three; // arbitrary nonzero projection element
-
-        // Two columns, D bit-slices each, populated with arbitrary field
-        // values. The "true" parent eval is the linear recombination via
-        // a^i, so we recompute it directly.
-        let n = 2usize;
-        let bit_slice_evals: Vec<F> = (0..n * D)
-            .map(|k| F::from(((k as u32) * 7 + 11) % 13))
-            .collect();
-
-        let mut parent_evals: Vec<F> = Vec::with_capacity(n);
-        for j in 0..n {
-            let mut acc = zero;
-            let mut a_pow = one;
-            for i in 0..D {
-                acc += a_pow * bit_slice_evals[j * D + i];
-                a_pow *= &a;
-            }
-            parent_evals.push(acc);
-        }
-
-        BooleanityChecker::<F>::verify_bit_decomposition_consistency(
-            &bit_slice_evals,
-            &parent_evals,
-            &a,
-            D,
-            &(),
-        )
-        .expect("honest recombination should match");
-    }
-
-    /// Tampered `bit_slice_evals[k]` triggers `ConsistencyMismatch` with
-    /// `col_idx = k / D`.
-    #[test]
-    fn consistency_check_tampered_bit_slice_rejected() {
-        let zero = F::zero();
-        let one = F::one();
-        let two = one + one;
-        let a = two + one; // arbitrary nonzero projection element
-
-        let n = 2usize;
-        let mut bit_slice_evals: Vec<F> = (0..n * D)
-            .map(|k| F::from(((k as u32) * 7 + 11) % 13))
-            .collect();
-
-        let mut parent_evals: Vec<F> = Vec::with_capacity(n);
-        for j in 0..n {
-            let mut acc = zero;
-            let mut a_pow = one;
-            for i in 0..D {
-                acc += a_pow * bit_slice_evals[j * D + i];
-                a_pow *= a;
-            }
-            parent_evals.push(acc);
-        }
-
-        let tamper_idx = D + 1; // column j = 1, bit i = 1
-        bit_slice_evals[tamper_idx] += &two;
-
-        let err = BooleanityChecker::<F>::verify_bit_decomposition_consistency(
-            &bit_slice_evals,
-            &parent_evals,
-            &a,
-            D,
-            &(),
-        )
-        .expect_err("tamper should be rejected");
-
-        assert!(
-            matches!(err, BooleanityError::ConsistencyMismatch { col_idx, .. } if col_idx == 1),
-            "expected ConsistencyMismatch on column 1, got {err:?}"
-        );
-    }
-
-    /// Length mismatch is reported as `WrongBitSliceEvalsNumber`.
-    #[test]
-    fn consistency_check_wrong_length_rejected() {
-        let one = F::one();
-        let a = one + one;
-
-        let parent_evals = vec![F::zero(); 2];
-        let bit_slice_evals = vec![F::zero(); 2 * D - 1];
-
-        let err = BooleanityChecker::<F>::verify_bit_decomposition_consistency(
-            &bit_slice_evals,
-            &parent_evals,
-            &a,
-            D,
-            &(),
-        )
-        .expect_err("length mismatch should be rejected");
-
-        assert!(
-            matches!(err, BooleanityError::WrongBitSliceEvalsNumber { .. }),
-            "expected WrongBitSliceEvalsNumber, got {err:?}"
-        );
-    }
-
     //
     // Round-1 fast path cross-validation.
     //
@@ -1081,7 +914,6 @@ mod tests {
         one: F,
     }
 
-    #[allow(clippy::arithmetic_side_effects)]
     fn cross_validation_inputs() -> FastPathHarness {
         // Three columns, eight rows, mixed bit patterns. nvars = 3 exercises
         // both round-1 (closed form) and rounds 2..num_vars (standard path).
@@ -1149,7 +981,6 @@ mod tests {
         mles
     }
 
-    #[allow(clippy::arithmetic_side_effects)]
     fn make_comb_fn(alpha_powers: Vec<F>, zero: F, one: F) -> CombFn<F> {
         Box::new(move |mle_values: &[F]| {
             let eq_r_val = &mle_values[0];

--- a/piop/src/lookup/booleanity.rs
+++ b/piop/src/lookup/booleanity.rs
@@ -3,8 +3,9 @@
 //! Proves that every coefficient of every witness binary-polynomial column is
 //! a bit $\in \\{0,1\\}$. The argument is structured as a single
 //! [`MultiDegreeSumcheckGroup`] of degree 3, batched alongside the existing
-//! CPR group with shared randomness, and discharges its bit-slice claims for
-//! free against the existing `lifted_evals` payload.
+//! CPR group with shared randomness, and verifies its bit-slice claims at
+//! the multi-degree sumcheck output point $r^\star$ against the projected
+//! parent column evaluations (CPR `up_evals`) using the $\psi_a$ identity.
 //!
 //! # Relation
 //!
@@ -27,19 +28,39 @@
 //!
 //! $$
 //! \sum_{b in {0,1}^\mu} eq(r, b) *
-//!   \sum_{j=0}^{N-1} \sum_{i=0}^{D-1} \delta^j * \gamma^i *
-//!     \widetilde{v_{j,i}}(b) * (\widetilde{v_{j,i}}(b) - 1)  =  0
+//!   \sum_{k=0}^{N*D-1} \alpha^k *
+//!     \widetilde{v_k}(b) * (\widetilde{v_k}(b) - 1)  =  0
 //! $$
 //!
-//! with batching challenges $\gamma$ (over the `D` bit-slices) and $\delta$
-//! (over the `N` witness binary-poly columns), and zerocheck point $r$.
-//! After the sumcheck reaches $r*$, the prover sends `bit_slice_evals` =
-//! $(\widetilde{v_{j,i}}(r*))$ to the verifier; these are then folded by
-//! `MultipointEval` into the standard evaluation point $r_0$ together with
-//! the CPR up/down evals. At $r_0$ the bit-slice MLE evaluations are exactly
-//! the coefficients of the polynomial-valued `lifted_evals` (by the
-//! MLE-commutes-with-coefficient-extraction identity), so the verifier
-//! discharges them for free.
+//! with a single batching challenge $\alpha$ over the flat
+//! $(j\text{-major}, i\text{-minor})$ index $k = j \cdot D + i$, and
+//! zerocheck point $r$. After the sumcheck reaches $r^\star$, the prover
+//! sends `bit_slice_evals` $= (\widetilde{v_{j,i}}(r^\star))$ to the
+//! verifier.
+//!
+//! # Bit-decomposition consistency check at $r^\star$
+//!
+//! The bit-slice claims at $r^\star$ are tied back to the committed parent
+//! columns via the $\psi_a$ identity at the MLE level: for every binary-poly
+//! column $u_j$,
+//!
+//! $$
+//!   \psi_a\bigl(\widetilde{u_j}(r^\star)\bigr)
+//!     = \sum_{i=0}^{D-1} a^i \cdot \widetilde{v_{j,i}}(r^\star).
+//! $$
+//!
+//! The left-hand side is already available to the verifier as
+//! `cpr_subclaim.up_evals[num_pub_bin + j]` (the projected MLE evaluation of
+//! the $j$-th witness binary-poly column at $r^\star$, coming out of the
+//! CPR group). The right-hand side is rebuilt from the prover-supplied
+//! `bit_slice_evals`. With overwhelming probability over the random $a$
+//! used by $\psi_a$, this linear pin-down forces the `bit_slice_evals` to
+//! be the true bit decomposition of $u_j$ at $r^\star$.
+//!
+//! Because the consistency check closes at $r^\star$, the bit-slice MLEs
+//! are **not** routed through `MultipointEval`: they participate only in
+//! the booleanity sumcheck group and then vanish from the rest of the
+//! protocol.
 
 use crate::{
     CombFn,
@@ -62,7 +83,7 @@ use zinc_transcript::{
     delegate_transcribable,
     traits::{ConstTranscribable, Transcript},
 };
-use zinc_utils::{add, inner_transparent_field::InnerTransparentField, mul, powers};
+use zinc_utils::{add, inner_transparent_field::InnerTransparentField, powers};
 
 //
 // Structs
@@ -73,8 +94,9 @@ pub struct BooleanityChecker<F: InnerTransparentField>(PhantomData<F>);
 
 /// Proof produced by the booleanity prover. Carries only the flat list of
 /// bit-slice MLE evaluations at the multi-degree sumcheck output point
-/// $r*$. The remaining open-eval consistency check at $r_0$ is discharged
-/// by the protocol-layer caller against `lifted_evals.coeffs`.
+/// $r*$. The bit-decomposition consistency at $r^\star$ is verified by
+/// the protocol-layer caller against the CPR `up_evals` of the witness
+/// binary-poly columns.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct BooleanityProof<F: PrimeField> {
     /// Flat list of `\widetilde{v_{j,i}}(r*)`, ordered `(j-major, i-minor)`.
@@ -99,12 +121,9 @@ pub struct BoolProverAncillary {
 /// Ancillary data produced by [`BooleanityChecker::prepare_verifier`] and
 /// consumed by [`BooleanityChecker::finalize_verifier`].
 pub struct BoolVerifierAncillary<F: PrimeField> {
-    /// Powers of the bit-slice batching challenge:
-    /// `[1, gamma, ..., gamma^{D-1}]`.
-    pub gamma_powers: Vec<F>,
-    /// Powers of the column batching challenge:
-    /// `[1, delta, ..., delta^{N-1}]`.
-    pub delta_powers: Vec<F>,
+    /// Powers of the single batching challenge over the flat
+    /// `(j-major, i-minor)` index: `[1, alpha, ..., alpha^{N*D - 1}]`.
+    pub alpha_powers: Vec<F>,
     /// The zerocheck point `r` sampled before the multi-degree sumcheck.
     pub zerocheck_point: Vec<F>,
     /// Number of witness binary-poly columns (`N`).
@@ -118,17 +137,15 @@ pub struct BoolVerifierAncillary<F: PrimeField> {
 /// Subclaim emitted by [`BooleanityChecker::finalize_verifier`].
 ///
 /// Carries the (now-validated against the sumcheck residue)
-/// `bit_slice_evals` at the shared multi-degree sumcheck point `r*`. The
-/// protocol-layer caller threads these as additional `up_evals` into
-/// [`crate::multipoint_eval::MultipointEval`], whose final consistency
-/// check at `r_0` is discharged against the coefficients of the existing
-/// `lifted_evals` polynomials.
+/// `bit_slice_evals` at the shared multi-degree sumcheck point `r*``.
+/// The protocol-layer caller passes these into
+/// [`BooleanityChecker::verify_bit_decomposition_consistency`] together
+/// with the CPR `up_evals` for the witness binary-poly columns to close
+/// the booleanity argument entirely inside step 4.
 #[derive(Clone, Debug)]
 pub struct BoolVerifierSubclaim<F: PrimeField> {
     /// Bit-slice MLE evaluations at `r*`, in `(j-major, i-minor)` order.
     pub bit_slice_evals: Vec<F>,
-    /// Shared evaluation point `r*` from the multi-degree sumcheck.
-    pub evaluation_point: Vec<F>,
 }
 
 //
@@ -158,18 +175,15 @@ where
         // 1. Zerocheck point r.
         let r: Vec<F> = transcript.get_field_challenges(num_vars, field_cfg);
 
-        // 2. Slice batching challenge gamma and its powers.
-        let gamma: F = transcript.get_field_challenge(field_cfg);
-        let gamma_powers: Vec<F> = powers(gamma, one.clone(), D);
+        // 2. Single batching challenge alpha over the flat (j-major, i-minor) index.
+        //    Powers vector has length N*D.
+        let alpha: F = transcript.get_field_challenge(field_cfg);
+        let alpha_powers: Vec<F> = powers(alpha, one.clone(), n.saturating_mul(D));
 
-        // 3. Column batching challenge delta and its powers.
-        let delta: F = transcript.get_field_challenge(field_cfg);
-        let delta_powers: Vec<F> = powers(delta, one.clone(), n);
-
-        // 4. Build eq(r, *) MLE.
+        // 3. Build eq(r, *) MLE.
         let eq_r = build_eq_x_r_inner(&r, field_cfg)?;
 
-        // 5. Build N*D bit-slice MLEs in canonical (j-major, i-minor) order.
+        // 4. Build N*D bit-slice MLEs in canonical (j-major, i-minor) order.
         let mut mles = Vec::with_capacity(add!(n.saturating_mul(D), 1));
         mles.push(eq_r);
         mles.extend(build_witness_bit_slice_mles::<F, D>(
@@ -177,12 +191,11 @@ where
             field_cfg,
         ));
 
-        // 6. Build comb_fn (degree 3 in the variables):
-        //   eq_r(b) * sum_{j,i} delta^j * gamma^i * v_{j,i}(b) * (v_{j,i}(b) - 1)
+        // 5. Build comb_fn (degree 3 in the variables):
+        //   eq_r(b) * sum_k alpha^k * v_k(b) * (v_k(b) - 1)
         let comb_fn: CombFn<F> = Box::new(move |mle_values: &[F]| {
             let eq_r_val = &mle_values[0];
-            let sum =
-                batched_booleanity_sum(&mle_values[1..], &delta_powers, &gamma_powers, &zero, &one);
+            let sum = batched_booleanity_sum(&mle_values[1..], &alpha_powers, &zero, &one);
             sum * eq_r_val
         });
 
@@ -270,14 +283,11 @@ where
 
         // Re-squeeze in the same order as the prover.
         let zerocheck_point: Vec<F> = transcript.get_field_challenges(num_vars, field_cfg);
-        let gamma: F = transcript.get_field_challenge(field_cfg);
-        let gamma_powers: Vec<F> = powers(gamma, one.clone(), bit_width);
-        let delta: F = transcript.get_field_challenge(field_cfg);
-        let delta_powers: Vec<F> = powers(delta, one, num_wit_bin_cols);
+        let alpha: F = transcript.get_field_challenge(field_cfg);
+        let alpha_powers: Vec<F> = powers(alpha, one, num_wit_bin_cols.saturating_mul(bit_width));
 
         Ok(BoolVerifierAncillary {
-            gamma_powers,
-            delta_powers,
+            alpha_powers,
             zerocheck_point,
             num_wit_bin_cols,
             bit_width,
@@ -290,14 +300,14 @@ where
     /// Validates the length of `bit_slice_evals`, recomputes the expected
     /// combination-function evaluation at the shared sumcheck point `r*`
     /// using the received `bit_slice_evals`, and compares it against the
-    /// sumcheck's `expected_evaluation`. On success, absorbs
-    /// `bit_slice_evals` into the transcript (mirroring the prover's
-    /// final absorption in `finalize_prover`).
+    /// sumcheck's `expected_eval`. On success, absorbs `bit_slice_evals` into
+    /// the transcript (mirroring the prover's final absorption in
+    /// `finalize_prover`).
     pub fn finalize_verifier(
         transcript: &mut impl Transcript,
         proof: BooleanityProof<F>,
         shared_point: Vec<F>,
-        expected_evaluation: &F,
+        expected_eval: &F,
         ancillary: BoolVerifierAncillary<F>,
         field_cfg: &F::Config,
     ) -> Result<BoolVerifierSubclaim<F>, BooleanityError<F>> {
@@ -318,19 +328,14 @@ where
         let eq_r_val = eq_eval(&shared_point, &ancillary.zerocheck_point, one.clone())?;
 
         // Recompute the comb_fn body at r* using the received bit-slice evals.
-        let sum = batched_booleanity_sum(
-            &proof.bit_slice_evals,
-            &ancillary.delta_powers,
-            &ancillary.gamma_powers,
-            &zero,
-            &one,
-        );
+        let sum =
+            batched_booleanity_sum(&proof.bit_slice_evals, &ancillary.alpha_powers, &zero, &one);
         let expected_claim_value = sum * eq_r_val;
 
-        if expected_claim_value != *expected_evaluation {
+        if expected_claim_value != *expected_eval {
             return Err(BooleanityError::ClaimValueDoesNotMatch {
                 expected: expected_claim_value,
-                got: expected_evaluation.clone(),
+                got: expected_eval.clone(),
             });
         }
 
@@ -339,8 +344,74 @@ where
 
         Ok(BoolVerifierSubclaim {
             bit_slice_evals: proof.bit_slice_evals,
-            evaluation_point: shared_point,
         })
+    }
+
+    /// Verify the bit-slice claims at $r^\star$ against the projected
+    /// parent column evaluations (CPR `up_evals`) using the $\psi_a$
+    /// identity.
+    ///
+    /// For each witness binary-poly column $j$, checks
+    ///
+    /// $$
+    ///   \texttt{parent\_evals}[j] \;=\; \sum_{i=0}^{D-1} a^i \cdot
+    ///     \texttt{bit\_slice\_evals}[j \cdot D + i]
+    /// $$
+    ///
+    /// where $a$ is the random projection element used by $\psi_a$ to send
+    /// $F_q[X] \to F_q$. The left-hand side is the MLE evaluation at $r^\star$
+    /// of the projected parent column (i.e. `cpr_subclaim.up_evals[..]`
+    /// restricted to the witness binary-poly slice). The right-hand side is
+    /// the linear recombination of the prover-supplied bit-slice evals.
+    ///
+    /// With overwhelming probability over the random $a$, agreement forces
+    /// `bit_slice_evals` to be the true bit decomposition of the committed
+    /// parent column at $r^\star$.
+    #[allow(clippy::arithmetic_side_effects)]
+    pub fn verify_bit_decomposition_consistency(
+        bit_slice_evals: &[F],
+        parent_evals: &[F],
+        projecting_element: &F,
+        bits_per_col: usize,
+        field_cfg: &F::Config,
+    ) -> Result<(), BooleanityError<F>> {
+        let expected_len = parent_evals.len().saturating_mul(bits_per_col);
+        if bit_slice_evals.len() != expected_len {
+            return Err(BooleanityError::WrongBitSliceEvalsNumber {
+                expected: expected_len,
+                got: bit_slice_evals.len(),
+            });
+        }
+
+        if bits_per_col == 0 || parent_evals.is_empty() {
+            return Ok(());
+        }
+
+        let zero = F::zero_with_cfg(field_cfg);
+        let one = F::one_with_cfg(field_cfg);
+
+        let a_powers: Vec<F> = powers(projecting_element.clone(), one, bits_per_col);
+
+        for (col_idx, parent_eval) in parent_evals.iter().enumerate() {
+            let base = col_idx.saturating_mul(bits_per_col);
+            let mut recombined = zero.clone();
+            for (a_pow, bit_eval) in a_powers
+                .iter()
+                .zip(&bit_slice_evals[base..base + bits_per_col])
+            {
+                recombined += a_pow.clone() * bit_eval;
+            }
+
+            if &recombined != parent_eval {
+                return Err(BooleanityError::ConsistencyMismatch {
+                    col_idx,
+                    got: recombined,
+                    expected: parent_eval.clone(),
+                });
+            }
+        }
+
+        Ok(())
     }
 }
 
@@ -357,6 +428,11 @@ pub enum BooleanityError<F: PrimeField> {
     WrongBitSliceEvalsNumber { expected: usize, got: usize },
     #[error("booleanity claim value does not match: expected {expected}, got {got}")]
     ClaimValueDoesNotMatch { expected: F, got: F },
+    #[error(
+        "bit-decomposition consistency mismatch on witness binary-poly column {col_idx}: \
+         recombined Sum_i a^i * bit_slice = {got}, expected parent eval {expected}"
+    )]
+    ConsistencyMismatch { col_idx: usize, got: F, expected: F },
     #[error("error evaluating MLE: {0}")]
     MleEvaluationError(#[from] EvaluationError),
     #[error("arithmetic error: {0}")]
@@ -370,36 +446,27 @@ pub enum BooleanityError<F: PrimeField> {
 /// Compute the booleanity residue
 ///
 /// $$
-/// sum_{j=0}^{N-1} sum_{i=0}^{D-1}
-///   \delta^j * \gamma^i * v_{j,i} * (v_{j,i} - 1)
+/// sum_{k=0}^{N*D - 1} \alpha^k * v_k * (v_k - 1)
 /// $$
 ///
-/// over a flat `(j-major, i-minor)` slice of bit-slice values
-/// (`N = delta_powers.len()`, `D = gamma_powers.len()`,
-/// `bit_slice_values.len() == N * D`).
+/// over a flat $(j\text{-major}, i\text{-minor})$ slice of bit-slice
+/// values with $k = j \cdot D + i$. `alpha_powers.len() ==
+/// bit_slice_values.len() == N * D`.
 ///
 /// This is the body of the booleanity sumcheck's combination function
 /// (without the leading `eq_r` factor).
 fn batched_booleanity_sum<F: PrimeField>(
     bit_slice_values: &[F],
-    delta_powers: &[F],
-    gamma_powers: &[F],
+    alpha_powers: &[F],
     zero: &F,
     one: &F,
 ) -> F {
-    let n = delta_powers.len();
-    let d = gamma_powers.len();
-    debug_assert_eq!(bit_slice_values.len(), mul!(n, d));
+    debug_assert_eq!(bit_slice_values.len(), alpha_powers.len());
 
     let mut sum = zero.clone();
-    for (j, delta_j) in delta_powers.iter().enumerate().take(n) {
-        let jd = mul!(j, d);
-        for i in 0..d {
-            let v = &bit_slice_values[add!(i, jd)];
-            let gamma_i = &gamma_powers[i];
-            let booleanity = (v.clone() - one) * v;
-            sum += booleanity * delta_j * gamma_i;
-        }
+    for (v, alpha_k) in bit_slice_values.iter().zip(alpha_powers.iter()) {
+        let booleanity = (v.clone() - one) * v;
+        sum += booleanity * alpha_k;
     }
     sum
 }
@@ -653,6 +720,114 @@ mod tests {
             },
             |err| matches!(err, BooleanityError::WrongBitSliceEvalsNumber { .. }),
             false,
+        );
+    }
+
+    /// Honest `bit_slice_evals` recombine to the parent eval via $\psi_a$.
+    #[test]
+    fn consistency_check_happy_path() {
+        let cfg = &();
+        let one = F::one_with_cfg(cfg);
+        let two = one + one;
+        let three = two + one;
+        let a = three; // arbitrary nonzero projection element
+
+        // Two columns, D bit-slices each, populated with arbitrary field
+        // values. The "true" parent eval is the linear recombination via
+        // a^i, so we recompute it directly.
+        let n = 2usize;
+        let bit_slice_evals: Vec<F> = (0..n * D)
+            .map(|k| F::from(((k as u32) * 7 + 11) % 13))
+            .collect();
+
+        let mut parent_evals: Vec<F> = Vec::with_capacity(n);
+        let zero = F::zero_with_cfg(cfg);
+        for j in 0..n {
+            let mut acc = zero;
+            let mut a_pow = one;
+            for i in 0..D {
+                acc += a_pow * bit_slice_evals[j * D + i];
+                a_pow *= &a;
+            }
+            parent_evals.push(acc);
+        }
+
+        BooleanityChecker::<F>::verify_bit_decomposition_consistency(
+            &bit_slice_evals,
+            &parent_evals,
+            &a,
+            D,
+            cfg,
+        )
+        .expect("honest recombination should match");
+    }
+
+    /// Tampered `bit_slice_evals[k]` triggers `ConsistencyMismatch` with
+    /// `col_idx = k / D`.
+    #[test]
+    fn consistency_check_tampered_bit_slice_rejected() {
+        let cfg = &();
+        let one = F::one_with_cfg(cfg);
+        let two = one + one;
+        let a = two + one; // 3
+
+        let n = 2usize;
+        let mut bit_slice_evals: Vec<F> = (0..n * D)
+            .map(|k| F::from(((k as u32) * 7 + 11) % 13))
+            .collect();
+
+        let zero = F::zero_with_cfg(cfg);
+        let mut parent_evals: Vec<F> = Vec::with_capacity(n);
+        for j in 0..n {
+            let mut acc = zero;
+            let mut a_pow = one;
+            for i in 0..D {
+                acc += a_pow * bit_slice_evals[j * D + i];
+                a_pow *= a;
+            }
+            parent_evals.push(acc);
+        }
+
+        let tamper_idx = D + 1; // column j = 1, bit i = 1
+        bit_slice_evals[tamper_idx] += &two;
+
+        let err = BooleanityChecker::<F>::verify_bit_decomposition_consistency(
+            &bit_slice_evals,
+            &parent_evals,
+            &a,
+            D,
+            cfg,
+        )
+        .expect_err("tamper should be rejected");
+
+        assert!(
+            matches!(err, BooleanityError::ConsistencyMismatch { col_idx, .. } if col_idx == 1),
+            "expected ConsistencyMismatch on column 1, got {err:?}"
+        );
+    }
+
+    /// Length mismatch is reported as `WrongBitSliceEvalsNumber`.
+    #[test]
+    fn consistency_check_wrong_length_rejected() {
+        let cfg = &();
+        let one = F::one_with_cfg(cfg);
+        let a = one + one;
+
+        let parent_evals = vec![F::zero_with_cfg(cfg); 2];
+        let bit_slice_evals = vec![F::zero_with_cfg(cfg); 2 * D - 1];
+
+        let err = BooleanityChecker::<F>::verify_bit_decomposition_consistency(
+            &bit_slice_evals,
+            &parent_evals,
+            &a,
+            D,
+            cfg,
+        )
+        .expect_err("length mismatch should be rejected");
+
+        assert!(
+            matches!(err, BooleanityError::WrongBitSliceEvalsNumber { .. }),
+            "expected WrongBitSliceEvalsNumber, got {err:?}"
         );
     }
 }

--- a/piop/src/lookup/booleanity.rs
+++ b/piop/src/lookup/booleanity.rs
@@ -493,7 +493,7 @@ struct BooleanityRound1FastPath<F: PrimeField, const D: usize> {
 impl<F, const D: usize> Round1FastPath<F> for BooleanityRound1FastPath<F, D>
 where
     F: InnerTransparentField + Send + Sync + 'static,
-    F::Inner: Clone + Send + Sync,
+    F::Inner: Zero + Clone + Send + Sync,
 {
     fn round_1_message(&self, config: &F::Config) -> Round1Output<F> {
         let zero = F::zero_with_cfg(config);
@@ -547,6 +547,26 @@ where
         r_1: &F,
         config: &F::Config,
     ) -> Vec<DenseMultilinearExtension<F::Inner>> {
+        // Edge case: when the sumcheck has only one round, the standard prover never
+        // performs the folding.
+        //
+        // The post-round-1 state expected by `finalize_prover` is the un-folded
+        // 1-variable MLE bundle (it then evaluates each MLE at `r_1`). Return that
+        // directly without applying the fold.
+        if self.num_vars <= 1 {
+            let r = [self.r_first_coord.clone()];
+            let eq_r = build_eq_x_r_inner(&r, config)
+                .expect("num_vars == 1 implies a single-coordinate r");
+            let mut out: Vec<DenseMultilinearExtension<F::Inner>> =
+                Vec::with_capacity(self.binary_cols.len().saturating_mul(D).saturating_add(1));
+            out.push(eq_r);
+            out.extend(build_witness_bit_slice_mles::<F, D>(
+                &self.binary_cols,
+                config,
+            ));
+            return out;
+        }
+
         let n_cols = self.binary_cols.len();
         let total_bit_slices = n_cols.saturating_mul(D);
         let new_num_vars = self.num_vars.saturating_sub(1);
@@ -680,7 +700,7 @@ fn batched_booleanity_sum<F: PrimeField>(
 /// This helper is the single source of truth for MLE ordering. Both the
 /// booleanity sumcheck group and the `MultipointEval` extension call it
 /// to guarantee identical ordering between prover and verifier.
-pub fn build_witness_bit_slice_mles<F, const D: usize>(
+fn build_witness_bit_slice_mles<F, const D: usize>(
     trace_bin_poly: &[DenseMultilinearExtension<BinaryPoly<D>>],
     field_cfg: &F::Config,
 ) -> Vec<DenseMultilinearExtension<F::Inner>>
@@ -854,6 +874,19 @@ mod tests {
             [true, false, false, true],
         ]);
         run_roundtrip(&[c0, c1], 2, |_| {}, |_| false, true);
+    }
+
+    /// Exercises the fast-path edge case where `eq_other_table = [1]`
+    // (empty product) and `fold_with_r1` produces 0-variable MLEs,
+    // after which the rounds-2..num_vars loop runs zero times.
+    #[test]
+    fn happy_path_num_vars_one() {
+        // Two columns, two rows each. Mixed bit patterns so the bit-slice
+        // MLEs are not all-zero (exercises every branch of the 4-way
+        // bit-fold table in `fold_with_r1`).
+        let c0 = build_col(vec![[true, false, true, false], [false, true, true, true]]);
+        let c1 = build_col(vec![[false, false, true, true], [true, true, false, false]]);
+        run_roundtrip(&[c0, c1], 1, |_| {}, |_| false, true);
     }
 
     #[test]

--- a/piop/src/sumcheck/multi_degree.rs
+++ b/piop/src/sumcheck/multi_degree.rs
@@ -39,12 +39,47 @@ use super::{
 // Types
 // ---------------------------------------------------------------------------
 
+/// Output of a [`Round1FastPath::round_1_message`] call.
+/// Carries the asserted sum and the round-1 polynomial tail (evaluations at `1,
+/// 2, ..., degree`, omitting the constant term) that the framework wraps into a
+/// regular [`SumcheckProverMsg`] and absorbs into the transcript.
+pub struct Round1Output<F> {
+    pub asserted_sum: F,
+    pub tail_evaluations: Vec<F>,
+}
+
+/// Opt-in hook on a [`MultiDegreeSumcheckGroup`] that bypasses
+/// [`SumcheckProverState::prove_round`] in the first round and replaces
+/// the full-size MLE fold by a closed-form half-size construction. Groups
+/// that don't supply it are run as usual.
+///
+/// Implementors must produce a round-1 message bit-identical to what the
+/// standard prover would emit and post-fold MLEs bit-identical to what
+/// `fix_variables_with_config(&[r_1], cfg)` would produce on the standard
+/// path.
+pub trait Round1FastPath<F: PrimeField>: Send + Sync {
+    /// Closed-form computation of the round-1 polynomial tail plus the
+    /// asserted sum `p_1(0) + p_1(1)`.
+    fn round_1_message(&self, config: &F::Config) -> Round1Output<F>;
+
+    /// Closed-form fold of the group MLEs by the verifier's first
+    /// challenge `r_1`. Returns the half-size MLEs in the same order
+    /// `prepare_sumcheck_group` would have produced for the standard
+    /// path.
+    fn fold_with_challenge(
+        self: Box<Self>,
+        challenge: &F,
+        config: &F::Config,
+    ) -> Vec<DenseMultilinearExtension<F::Inner>>;
+}
+
 /// A single degree group for the multi-degree sumcheck: (degree, mles,
 /// comb_fn).
 pub struct MultiDegreeSumcheckGroup<F: PrimeField> {
     degree: usize,
     poly: Vec<DenseMultilinearExtension<F::Inner>>,
     comb_fn: CombFn<F>,
+    round_1_fast_path: Option<Box<dyn Round1FastPath<F>>>,
 }
 
 impl<F: PrimeField> MultiDegreeSumcheckGroup<F> {
@@ -57,6 +92,21 @@ impl<F: PrimeField> MultiDegreeSumcheckGroup<F> {
             degree,
             poly,
             comb_fn,
+            round_1_fast_path: None,
+        }
+    }
+
+    pub fn new_with_fast_path(
+        degree: usize,
+        poly: Vec<DenseMultilinearExtension<F::Inner>>,
+        comb_fn: CombFn<F>,
+        round_1_fast: Box<dyn Round1FastPath<F>>,
+    ) -> Self {
+        Self {
+            degree,
+            poly,
+            comb_fn,
+            round_1_fast_path: Some(round_1_fast),
         }
     }
 }
@@ -255,7 +305,6 @@ impl<F: FromPrimitiveWithConfig> MultiDegreeSumcheck<F> {
     /// # Panics
     ///
     /// * Panics if `num_vars == 0` or `groups` is empty.
-    #[allow(clippy::type_complexity)]
     pub fn prove_as_subprotocol(
         transcript: &mut impl Transcript,
         groups: Vec<MultiDegreeSumcheckGroup<F>>,
@@ -280,33 +329,47 @@ impl<F: FromPrimitiveWithConfig> MultiDegreeSumcheck<F> {
         transcript.absorb_random_field(&nvars_field, &mut buf);
         transcript.absorb_random_field(&ngroups_field, &mut buf);
 
-        let mut verifier_msg = None;
         let mut group_messages: Vec<Vec<SumcheckProverMsg<F>>> = (0..num_groups)
             .map(|_| Vec::with_capacity(num_vars))
             .collect();
         let mut claimed_sums = Vec::with_capacity(num_groups);
 
-        let (mut prover_states, comb_fns): (Vec<_>, Vec<_>) = groups
-            .into_iter()
-            .map(|group| {
-                let degree_field = F::from_with_cfg(group.degree as u64, config);
-                transcript.absorb_random_field(&degree_field, &mut buf);
+        let mut prover_states: Vec<SumcheckProverState<F>> = Vec::with_capacity(num_groups);
+        let mut comb_fns: Vec<CombFn<F>> = Vec::with_capacity(num_groups);
+        let mut fast_paths: Vec<Option<Box<dyn Round1FastPath<F>>>> =
+            Vec::with_capacity(num_groups);
 
-                (
-                    SumcheckProverState::new(group.poly, num_vars, group.degree),
-                    group.comb_fn,
-                )
-            })
-            .unzip();
+        for group in groups {
+            let degree_field = F::from_with_cfg(group.degree as u64, config);
+            transcript.absorb_random_field(&degree_field, &mut buf);
 
-        for _ in 0..num_vars {
-            // Parallel: each group computes its round polynomial independently
+            prover_states.push(SumcheckProverState::new(group.poly, num_vars, group.degree));
+            comb_fns.push(group.comb_fn);
+            fast_paths.push(group.round_1_fast_path);
+        }
+
+        let mut verifier_msg = None;
+        for round in 1..=num_vars {
             let round_msgs: Vec<SumcheckProverMsg<F>> = cfg_iter_mut!(prover_states)
                 .zip(cfg_iter!(comb_fns))
-                .map(|(state, comb_fn)| state.prove_round(&verifier_msg, comb_fn, config))
+                .zip(cfg_iter!(fast_paths))
+                .map(|((state, comb_fn), fast_path)| {
+                    if round == 1
+                        && let Some(fast_path) = fast_path.as_ref()
+                    {
+                        // First round: per-group dispatch to fast path if available
+                        let out = fast_path.round_1_message(config);
+                        state.asserted_sum = Some(out.asserted_sum);
+                        state.round = 1;
+                        SumcheckProverMsg(NatEvaluatedPolyWithoutConstant::new(
+                            out.tail_evaluations,
+                        ))
+                    } else {
+                        state.prove_round(&verifier_msg, comb_fn, config)
+                    }
+                })
                 .collect();
 
-            // Sequential: absorb in deterministic order, sample one shared challenge
             for msg in &round_msgs {
                 transcript.absorb_random_field_slice(&msg.0.tail_evaluations, &mut buf);
             }
@@ -317,6 +380,21 @@ impl<F: FromPrimitiveWithConfig> MultiDegreeSumcheck<F> {
 
             let next_verifier_msg = transcript.get_field_challenge(config);
             transcript.absorb_random_field(&next_verifier_msg, &mut buf);
+
+            // For fast-path groups, install the post-fold MLEs and arm
+            // `skip_next_fold` so the standard prover does not refold them in
+            // the second round.
+            if round == 1 {
+                prover_states
+                    .iter_mut()
+                    .zip(fast_paths.iter_mut())
+                    .for_each(|(state, fp_slot)| {
+                        if let Some(fp) = fp_slot.take() {
+                            state.mles = fp.fold_with_challenge(&next_verifier_msg, config);
+                            state.skip_next_fold = true;
+                        }
+                    });
+            }
 
             verifier_msg = Some(next_verifier_msg);
         }

--- a/piop/src/sumcheck/prover.rs
+++ b/piop/src/sumcheck/prover.rs
@@ -62,10 +62,10 @@ pub struct ProverState<F: PrimeField> {
     pub round: usize,
     /// Claimed sum for the first round polynomial.
     pub asserted_sum: Option<F>,
-    /// When `true`, the next [`prove_round`] invocation pushes the verifier
-    /// challenge into `randomness` but skips the `fix_variables_with_config`
-    /// fold of `mles`. Used by round-1 fast paths (see that pre-fold the
-    /// MLEs as part of their setup.
+    /// When `true`, the next [`Self::prove_round`] invocation pushes the
+    /// verifier challenge into `randomness` but skips the
+    /// `fix_variables_with_config` fold of `mles`. Used by round-1 fast
+    /// paths (see that pre-fold the MLEs as part of their setup.
     /// The flag is reset to `false` after the skipped fold.
     pub skip_next_fold: bool,
 }

--- a/piop/src/sumcheck/prover.rs
+++ b/piop/src/sumcheck/prover.rs
@@ -64,10 +64,8 @@ pub struct ProverState<F: PrimeField> {
     pub asserted_sum: Option<F>,
     /// When `true`, the next [`prove_round`] invocation pushes the verifier
     /// challenge into `randomness` but skips the `fix_variables_with_config`
-    /// fold of `mles`. Used by round-1 fast paths (see
-    /// [`crate::sumcheck::multi_degree::Round1FastPath`]) that pre-fold the
-    /// MLEs as part of their setup, so the standard prover must not fold
-    /// them a second time.
+    /// fold of `mles`. Used by round-1 fast paths (see that pre-fold the
+    /// MLEs as part of their setup.
     /// The flag is reset to `false` after the skipped fold.
     pub skip_next_fold: bool,
 }
@@ -99,7 +97,8 @@ where
     /// Receive message from verifier, generate prover message, and proceed to
     /// next round.
     ///
-    /// Adapted Jolt's sumcheck implementation.
+    /// Adapted Jolt's sumcheck implementation, with some additions like round 1
+    /// fast path.
     #[allow(clippy::arithmetic_side_effects)]
     pub fn prove_round(
         &mut self,
@@ -114,8 +113,7 @@ where
             self.randomness.push(msg.clone());
 
             if self.skip_next_fold {
-                // A round-1 fast path already produced the post-fold MLEs;
-                // the standard fold would double-apply the challenge.
+                // A fast path already produced the post-fold MLEs
                 self.skip_next_fold = false;
             } else {
                 // fix the next variable at the verifier randomness for this round

--- a/piop/src/sumcheck/prover.rs
+++ b/piop/src/sumcheck/prover.rs
@@ -62,6 +62,14 @@ pub struct ProverState<F: PrimeField> {
     pub round: usize,
     /// Claimed sum for the first round polynomial.
     pub asserted_sum: Option<F>,
+    /// When `true`, the next [`prove_round`] invocation pushes the verifier
+    /// challenge into `randomness` but skips the `fix_variables_with_config`
+    /// fold of `mles`. Used by round-1 fast paths (see
+    /// [`crate::sumcheck::multi_degree::Round1FastPath`]) that pre-fold the
+    /// MLEs as part of their setup, so the standard prover must not fold
+    /// them a second time.
+    /// The flag is reset to `false` after the skipped fold.
+    pub skip_next_fold: bool,
 }
 
 impl<F: PrimeField> ProverState<F> {
@@ -79,6 +87,7 @@ impl<F: PrimeField> ProverState<F> {
             max_degree: degree,
             round: 0,
             asserted_sum: None,
+            skip_next_fold: false,
         }
     }
 }
@@ -104,13 +113,19 @@ where
             }
             self.randomness.push(msg.clone());
 
-            // fix the next variable at the verifier randomness for this round
-            let i = self.round;
-            let r = self.randomness[i - 1].clone();
+            if self.skip_next_fold {
+                // A round-1 fast path already produced the post-fold MLEs;
+                // the standard fold would double-apply the challenge.
+                self.skip_next_fold = false;
+            } else {
+                // fix the next variable at the verifier randomness for this round
+                let i = self.round;
+                let r = self.randomness[i - 1].clone();
 
-            cfg_iter_mut!(self.mles).for_each(|multiplicand| {
-                multiplicand.fix_variables_with_config(slice::from_ref(&r), config);
-            });
+                cfg_iter_mut!(self.mles).for_each(|multiplicand| {
+                    multiplicand.fix_variables_with_config(slice::from_ref(&r), config);
+                });
+            }
         } else if self.round > 0 {
             panic!("verifier message is empty");
         }

--- a/piop/src/sumcheck/tests.rs
+++ b/piop/src/sumcheck/tests.rs
@@ -456,6 +456,7 @@ fn prover_panics_if_round_exceeds_num_vars() {
         max_degree: 2,
         round: num_vars, // Set to the last valid round
         asserted_sum: None,
+        skip_next_fold: false,
     };
 
     let comb_fn = |_vals: &[F]| F::ZERO;

--- a/protocol/src/lib.rs
+++ b/protocol/src/lib.rs
@@ -10,12 +10,18 @@
 //!
 //! After the three compiler steps, the protocol continues with:
 //!
-//! - Combined CPR + Lookup multi-degree sumcheck (CPR group at degree
-//!   `max_deg+2`, one lookup group per table type; shared eval point `r*`)
-//! - Multi-point evaluation sumcheck (combines up/down evals at r* into a
-//!   single evaluation point r_0)
-//! - Lift-and-project (unprojected MLE evaluations at r_0)
-//! - Zip+ PCS open/verify at r_0
+//! - Combined CPR + Booleanity + Lookup multi-degree sumcheck (CPR group at
+//!   degree `max_deg+2`; optional booleanity group at degree 3 when the UAIR
+//!   has witness binary-poly columns; one lookup group per table type; shared
+//!   eval point `r*`)
+//! - $\alpha'$ bridge: squeeze a fresh challenge $\alpha'$ after the booleanity
+//!   `bit_slice_evals` are absorbed, and append one extra $\alpha'$-projected
+//!   MLE + up-eval to the multipoint-eval inputs per witness binary-poly column
+//!   (see `BooleanityChecker`)
+//! - Multi-point evaluation sumcheck (combines up/down evals at `r*` into a
+//!   single evaluation point `r_0`)
+//! - Lift-and-project (unprojected MLE evaluations at `r_0`)
+//! - Zip+ PCS open/verify at `r_0`
 
 pub mod fold;
 pub mod prover;
@@ -73,10 +79,10 @@ pub struct Proof<F: PrimeField> {
     pub ideal_check: IdealCheckProof<F>,
     /// Combined polynomial resolver proof (up_evals + down_evals).
     pub cpr_proof: CombinedPolyResolverProof<F>,
-    /// Multi-degree sumcheck proof (CPR group + future lookup groups).
+    /// Multi-degree sumcheck proof (CPR group + lookup groups).
     pub combined_sumcheck: MultiDegreeSumcheckProof<F>,
     /// Multi-point evaluation sumcheck proof (combines up_evals and
-    /// down_evals at r' into a single evaluation point r_0).
+    /// down_evals at `r*` into a single evaluation point `r_0`).
     pub multipoint_eval: MultipointEvalProof<F>,
     /// Witness-only polynomial MLE evaluations at r_0 in F_q[X]
     /// (after \phi_q, before \psi_a), ordered as

--- a/protocol/src/lib.rs
+++ b/protocol/src/lib.rs
@@ -51,7 +51,7 @@ use zinc_poly::{
 use zinc_primality::PrimalityTest;
 use zinc_transcript::traits::{ConstTranscribable, GenTranscribable, Transcribable, Transcript};
 use zinc_uair::{Uair, ideal::Ideal};
-use zinc_utils::{cfg_extend, cfg_into_iter, cfg_iter, named::Named};
+use zinc_utils::{cfg_extend, cfg_into_iter, cfg_iter, named::Named, powers};
 use zip_plus::{
     ZipError,
     code::LinearCode,
@@ -72,7 +72,7 @@ pub struct Proof<F: PrimeField> {
     /// Randomized ideal check proof.
     pub ideal_check: IdealCheckProof<F>,
     /// Combined polynomial resolver proof (up_evals + down_evals).
-    pub resolver: CombinedPolyResolverProof<F>,
+    pub cpr_proof: CombinedPolyResolverProof<F>,
     /// Multi-degree sumcheck proof (CPR group + future lookup groups).
     pub combined_sumcheck: MultiDegreeSumcheckProof<F>,
     /// Multi-point evaluation sumcheck proof (combines up_evals and
@@ -138,7 +138,7 @@ where
             commitments: (commit0, commit1, commit2),
             zip,
             ideal_check,
-            resolver,
+            cpr_proof: resolver,
             combined_sumcheck,
             multipoint_eval,
             witness_lifted_evals,
@@ -164,7 +164,7 @@ where
         buf = self.ideal_check.write_transcription_bytes_subset(buf);
 
         // resolver: u32 length prefix + data
-        buf = self.resolver.write_transcription_bytes_subset(buf);
+        buf = self.cpr_proof.write_transcription_bytes_subset(buf);
 
         // combined_sumcheck: u32 length prefix + data
         buf = self.combined_sumcheck.write_transcription_bytes_subset(buf);
@@ -214,7 +214,7 @@ where
             + IdealCheckProof::<F>::LENGTH_NUM_BYTES
             + self.ideal_check.get_num_bytes()
             + CombinedPolyResolverProof::<F>::LENGTH_NUM_BYTES
-            + self.resolver.get_num_bytes()
+            + self.cpr_proof.get_num_bytes()
             + MultiDegreeSumcheckProof::<F>::LENGTH_NUM_BYTES
             + self.combined_sumcheck.get_num_bytes()
             + MultipointEvalProof::<F>::LENGTH_NUM_BYTES
@@ -446,6 +446,43 @@ fn compute_lifted_evals<F: PrimeField, const D: usize>(
     }
 
     result
+}
+
+/// Compute the $\alpha'$ Schwartz-Zippel bridge scalars for the witness
+/// binary-poly columns:
+///
+/// $$
+///   c_j \;=\; \sum_{i=0}^{D-1} (\alpha')^{i} \cdot
+///     \text{bit\_slice\_evals}[j \cdot D + i].
+/// $$
+///
+/// One $c_j$ is produced per witness binary-poly column (in column-major
+/// order, matching `BooleanityProof::bit_slice_evals`). The result is
+/// appended to `MultipointEval`'s `up_evals` and bound to the committed
+/// witness column by the MP sumcheck + PCS chain at a fresh random
+/// $\alpha'$, replacing the previous (underconstrained for $D > 1$)
+/// $\psi_a$ linear pin-down.
+#[allow(clippy::arithmetic_side_effects)]
+fn alpha_prime_bridge_up_evals<F: PrimeField, const D: usize>(
+    bit_slice_evals: &[F],
+    num_wit_bin: usize,
+    alpha_prime: &F,
+    field_cfg: &F::Config,
+) -> Vec<F> {
+    debug_assert_eq!(bit_slice_evals.len(), num_wit_bin * D);
+    let one = F::one_with_cfg(field_cfg);
+    let alpha_powers: Vec<F> = powers(alpha_prime.clone(), one, D);
+    bit_slice_evals
+        .chunks_exact(D)
+        .map(|slice| {
+            slice
+                .iter()
+                .zip(&alpha_powers)
+                .fold(F::zero_with_cfg(field_cfg), |acc, (b, alpha_pow)| {
+                    acc + b.clone() * alpha_pow
+                })
+        })
+        .collect()
 }
 
 /// Project a DensePolynomial scalar to DynamicPolynomialF by projecting each
@@ -956,7 +993,7 @@ mod tests {
                 make_iprs(num_vars),
             ),
             default_project_ideal!(),
-            |proof| proof.resolver.up_evals.swap(0, 1),
+            |proof| proof.cpr_proof.up_evals.swap(0, 1),
             |res| {
                 assert!(matches!(
                     res.unwrap_err(),
@@ -979,7 +1016,7 @@ mod tests {
                 make_iprs(num_vars),
             ),
             default_project_ideal!(),
-            |proof| proof.resolver.down_evals.swap(0, 1),
+            |proof| proof.cpr_proof.down_evals.swap(0, 1),
             |res| {
                 assert!(matches!(
                     res.unwrap_err(),
@@ -1110,6 +1147,149 @@ mod tests {
                     ProtocolError::BooleanityProofMissing
                 ));
             },
+        );
+    }
+
+    /// Soundness regression: tamper $(\delta_0, \delta_1)$ on flat
+    /// positions $(0, 1)$ of `bit_slice_evals` (witness column 0) that
+    /// preserves both the booleanity residue at $r^\star$ and the OLD
+    /// $\psi_a$ linear pin-down $\delta_0 + a \delta_1 = 0$ at the
+    /// $\psi_a$ projecting element $a$ — caught by the $\alpha'$ bridge
+    /// via the MP + PCS chain.
+    ///
+    /// Closed form ($\alpha$ = booleanity batching challenge):
+    /// $$
+    ///   \delta_0 = -\frac{(2 b_0 - 1) - (\alpha / a)(2 b_1 - 1)}
+    ///                    {1 + \alpha / a^2}, \quad
+    ///   \delta_1 = -\delta_0 / a.
+    /// $$
+    /// $a$ and $\alpha$ are recovered by replaying steps 0..=3 and
+    /// driving the transcript through CPR + booleanity
+    /// `prepare_verifier`.
+    #[test]
+    #[allow(clippy::arithmetic_side_effects)]
+    fn test_big_linear_alpha_prime_bridge_catches_pin_down_preserving_tamper() {
+        use num_traits::Inv;
+        use zinc_piop::{
+            combined_poly_resolver::CombinedPolyResolver, lookup::booleanity::BooleanityChecker,
+        };
+        use zinc_uair::constraint_counter::count_constraints;
+
+        type Piop = ZincPlusPiop<TestZincTypesIprs, BigLinearUair<ZtInt>, F, D, QUARTER_D>;
+        type Ideal = IdealOrZero<DegreeOneIdeal<F>>;
+
+        let num_vars = 8;
+        let iprs = (
+            make_iprs(num_vars),
+            make_iprs(num_vars),
+            make_iprs(num_vars),
+        );
+        let pp = setup_pp::<TestZincTypesIprs>(num_vars, iprs);
+        let trace = BigLinearUair::<ZtInt>::generate_random_trace(num_vars, &mut rng());
+        let public_trace = trace.public(&BigLinearUair::<ZtInt>::signature());
+        let mut proof =
+            Piop::prove::<false, CHECKED>(&pp, &trace, num_vars, project_scalar_fn).expect("prove");
+
+        // Recover `a` and `\alpha` by replaying steps 0..=3 on a proof
+        // clone, then advancing the transcript through CPR + booleanity
+        // `prepare_verifier`.
+        let (cfg, a, alpha) = {
+            let mut v3 = Piop::step0_reconstruct_transcript::<Ideal>(
+                &pp,
+                proof.clone(),
+                &public_trace,
+                num_vars,
+            )
+            .and_then(|s| s.step1_prime_projection())
+            .and_then(|s| s.step2_ideal_check(default_project_ideal!()))
+            .and_then(|s| s.step3_eval_projection(project_scalar_fn))
+            .expect("steps 0..=3");
+
+            let cfg = *v3.field_cfg();
+            let a = v3.projecting_element_f().clone();
+            let nv = v3.num_vars();
+            let claimed_sums = v3.proof_combined_sumcheck().claimed_sums().to_vec();
+            let proof_cpr = v3.proof_cpr().clone();
+            let ic_subclaim = v3.ic_subclaim().clone();
+
+            let sig = v3.uair_signature().clone();
+            let num_wit_bin =
+                sig.total_cols().num_binary_poly_cols() - sig.public_cols().num_binary_poly_cols();
+            let transcript = v3.fs_transcript_mut();
+
+            CombinedPolyResolver::<F>::prepare_verifier::<BigLinearUair<ZtInt>>(
+                transcript,
+                &proof_cpr,
+                claimed_sums[0].clone(),
+                &ic_subclaim,
+                count_constraints::<BigLinearUair<ZtInt>>(),
+                nv,
+                &a,
+                &cfg,
+            )
+            .expect("CPR prepare_verifier");
+
+            let bool_anc = BooleanityChecker::<F>::prepare_verifier(
+                transcript,
+                &claimed_sums[1],
+                num_wit_bin,
+                D,
+                nv,
+                &cfg,
+            )
+            .expect("booleanity prepare_verifier");
+
+            (cfg, a, bool_anc.alpha_powers[1].clone())
+        };
+
+        // Build (\delta_0, \delta_1) from the closed form (see doc-comment).
+        let one = F::one_with_cfg(&cfg);
+        let zero = F::zero_with_cfg(&cfg);
+        let two = one.clone() + &one;
+
+        let a_inv: F = Inv::inv(a.clone()).expect("a != 0");
+        let alpha_over_a: F = alpha.clone() * &a_inv;
+        let alpha_over_a_sq: F = alpha_over_a.clone() * &a_inv;
+
+        let bp = proof
+            .booleanity_proof
+            .as_mut()
+            .expect("BigLinearUair has binary-poly witnesses");
+        let s0: F = two.clone() * &bp.bit_slice_evals[0] - &one; // 2 b_0 - 1
+        let s1: F = two * &bp.bit_slice_evals[1] - &one; // 2 b_1 - 1
+
+        let denom_inv: F = Inv::inv(one + &alpha_over_a_sq).expect("1 + α/a² != 0");
+        let delta_0: F = zero.clone() - (s0.clone() - alpha_over_a * &s1) * &denom_inv;
+        let delta_1: F = zero - a_inv * &delta_0;
+
+        // Sanity: tamper is non-trivial and preserves both OLD checks.
+        assert!(!F::is_zero(&delta_0), "tamper must be non-zero");
+        assert!(
+            F::is_zero(&(delta_0.clone() + a * &delta_1)),
+            "must preserve OLD ψ_a linear pin-down"
+        );
+        let residue = (delta_0.clone() * &s0 + delta_0.clone() * &delta_0)
+            + alpha * &(delta_1.clone() * &s1 + delta_1.clone() * &delta_1);
+        assert!(F::is_zero(&residue), "must preserve booleanity residue");
+
+        bp.bit_slice_evals[0] += delta_0;
+        bp.bit_slice_evals[1] += delta_1;
+
+        let err = Piop::verify::<_, CHECKED>(
+            &pp,
+            proof,
+            &public_trace,
+            num_vars,
+            project_scalar_fn,
+            default_project_ideal!(),
+        )
+        .expect_err("verifier must reject alpha-prime-tampered proof");
+        assert!(
+            matches!(
+                err,
+                ProtocolError::MultipointEval(_) | ProtocolError::PcsVerification(..)
+            ),
+            "expected MultipointEval / PCS-chain error, got: {err:?}"
         );
     }
 

--- a/protocol/src/lib.rs
+++ b/protocol/src/lib.rs
@@ -1020,12 +1020,10 @@ mod tests {
     // verifier errors.
     //
 
-    /// Swapping two entries of `booleanity_proof.bit_slice_evals` breaks
-    /// the recomputed booleanity residue at `r*`, which the verifier's
-    /// `finalize_verifier` catches against the sumcheck's
-    /// `expected_evaluation`. (With overwhelming probability over the
-    /// random transcript, two distinct bit-slice MLE evaluations at `r*`
-    /// produce different `v*(v-1)` residues.)
+    /// Perturbing one entry of `booleanity_proof.bit_slice_evals` by a
+    /// non-trivial additive constant breaks the recomputed booleanity
+    /// residue at `r*`, which the verifier's `finalize_verifier` catches
+    /// against the sumcheck's `expected_evaluation`.
     #[test]
     fn test_big_linear_tamper_booleanity_evals() {
         use zinc_piop::lookup::booleanity::BooleanityError;
@@ -1043,11 +1041,12 @@ mod tests {
                     .booleanity_proof
                     .as_mut()
                     .expect("BigLinearUair has binary-poly witnesses");
-                // Double one entry: x -> 2x. The booleanity residue at x is
-                // x*(x-1); at 2x it is 2x*(2x-1). For random F_q-valued x
-                // these differ with overwhelming probability.
-                let dup = bp.bit_slice_evals[0].clone();
-                bp.bit_slice_evals[0] += dup;
+                let two = {
+                    let cfg = bp.bit_slice_evals[0].cfg();
+                    let one = F::one_with_cfg(cfg);
+                    one.clone() + one
+                };
+                bp.bit_slice_evals[0] += two;
             },
             |res| {
                 assert!(matches!(

--- a/protocol/src/prover.rs
+++ b/protocol/src/prover.rs
@@ -5,7 +5,7 @@ use std::{borrow::Cow, collections::HashMap, fmt::Debug};
 use zinc_piop::{
     combined_poly_resolver::CombinedPolyResolver,
     ideal_check::IdealCheckProtocol,
-    lookup::booleanity::{self, BooleanityChecker, BooleanityProof},
+    lookup::booleanity::{BooleanityChecker, BooleanityProof},
     multipoint_eval::{MultipointEval, Proof as MultipointEvalProof},
     projections::{
         ColumnMajorTrace, ProjectedTrace, RowMajorTrace, evaluate_trace_to_column_mles,
@@ -535,6 +535,10 @@ impl_with_type_bounds!(ProverEvalProjected
     /// single sumcheck sharing one evaluation point `r*`. Produces
     /// `up_evals`/`down_evals` (CPR), `bit_slice_evals` (booleanity), and
     /// lookup auxiliary witnesses at `r*`.
+    ///
+    /// The booleanity bit-slice claims are checked at `r*` by the verifier
+    /// against the CPR `up_evals` for witness binary-poly columns using the
+    /// $\psi_a$ identity.
     pub fn step5_sumcheck(
         mut self,
     ) -> Result<ProverSumchecked<'a, Zt, U, F, D, FD>, ProtocolError<F, U::Ideal>> {
@@ -633,45 +637,17 @@ impl_with_type_bounds!(ProverEvalProjected
 impl_with_type_bounds!(ProverSumchecked
 {
     /// Step 6: Multi-point evaluation sumcheck. Combines `up_evals` and
-    /// `down_evals` at `r'` into a single evaluation point `r_0`.
+    /// `down_evals` at `r*` into a single evaluation point `r_0`.
     /// Only the sumcheck proof is sent; scalar evaluations at `r_0` are derived from the
-    /// polynomial-valued `lifted_evals` in Step 7. When the booleanity argument
-    /// is present, its bit-slice MLEs and `bit_slice_evals` are appended to
-    /// the `trace_mles` / `up_evals` passed to `MultipointEval`; the
-    /// corresponding `r_0`-side scalar claims are discharged for free by the
-    /// verifier against `lifted_evals.coeffs` in step 6.
+    /// polynomial-valued `lifted_evals` in Step 7.
     pub fn step6_multipoint_eval(
         mut self,
     ) -> Result<ProverMultipointEvaled<'a, Zt, U, F, D, FD>, ProtocolError<F, U::Ideal>> {
-        // Build extended trace_mles and up_evals: append witness bit-slice
-        // MLEs and their evaluations at r*, in the canonical order produced
-        // by `build_witness_bit_slice_mles` (j-major, i-minor).
-        let (extended_trace_mles, extended_up_evals) = if let Some(bp) = &self.booleanity_proof {
-            let trace_wit_bin_poly = {
-                let sig = &self.base.uair_signature;
-                let num_pub_bin = sig.public_cols().num_binary_poly_cols();
-                let num_total_bin = sig.total_cols().num_binary_poly_cols();
-                &self.base.original_trace.binary_poly[num_pub_bin..num_total_bin]
-            };
-
-            let mut trace_mles = self.projected_trace_f.clone();
-            trace_mles.extend(booleanity::build_witness_bit_slice_mles::<F, D>(
-                trace_wit_bin_poly,
-                &self.field_cfg,
-            ));
-
-            let mut up_evals = self.cpr_proof.up_evals.clone();
-            up_evals.extend_from_slice(&bp.bit_slice_evals);
-            (trace_mles, up_evals)
-        } else {
-            (self.projected_trace_f.clone(), self.cpr_proof.up_evals.clone())
-        };
-
         let (mp_proof, mp_prover_state) = MultipointEval::prove_as_subprotocol(
             &mut self.base.pcs_transcript.fs_transcript,
-            &extended_trace_mles,
+            &self.projected_trace_f,
             &self.cpr_eval_point,
-            &extended_up_evals,
+            &self.cpr_proof.up_evals,
             &self.cpr_proof.down_evals,
             self.base.uair_signature.shifts(),
             &self.field_cfg,

--- a/protocol/src/prover.rs
+++ b/protocol/src/prover.rs
@@ -14,15 +14,17 @@ use zinc_piop::{
     },
     sumcheck::multi_degree::MultiDegreeSumcheck,
 };
-use zinc_poly::univariate::dynamic::over_field::DynamicPolynomialF;
+use zinc_poly::{
+    mle::DenseMultilinearExtension, univariate::dynamic::over_field::DynamicPolynomialF,
+};
 use zinc_transcript::traits::{ConstTranscribable, Transcript};
 use zinc_uair::{
     Uair, UairSignature, UairTrace, constraint_counter::count_constraints,
     degree_counter::count_max_degree,
 };
 use zinc_utils::{
-    add, cfg_join, from_ref::FromRef, inner_transparent_field::InnerTransparentField,
-    mul_by_scalar::MulByScalar, projectable_to_field::ProjectableToField,
+    add, cfg_iter, cfg_join, from_ref::FromRef, inner_transparent_field::InnerTransparentField,
+    mul_by_scalar::MulByScalar, powers, projectable_to_field::ProjectableToField,
 };
 use zip_plus::{
     pcs::structs::{ZipPlus, ZipPlusHint, ZipPlusParams, ZipTypes},
@@ -175,6 +177,12 @@ pub struct ProverSumchecked<
     field_cfg: F::Config,
     projected_trace: ProjectedTrace<F>,
     ic_proof: IdealCheckProof<F>,
+    /// Trace MLEs at the original $\psi_a$ projecting element, as built
+    /// by `evaluate_trace_to_column_mles` in a previous step.
+    ///
+    /// Carried forward so that the next step can prepend them when assembling
+    /// the multipoint-eval inputs (and optionally append $\alpha'$-projected
+    /// witness-bin MLEs as the Schwartz-Zippel bridge).
     projected_trace_f: Vec<DenseMultilinearExtension<F::Inner>>,
 
     // New
@@ -183,6 +191,15 @@ pub struct ProverSumchecked<
     combined_sumcheck: MultiDegreeSumcheckProof<F>,
     lookup_proof: Option<BatchedLookupProof<F>>,
     booleanity_proof: Option<BooleanityProof<F>>,
+    /// Fresh challenge sampled after `bit_slice_evals` were absorbed by
+    /// booleanity's `finalize_prover`. Used by the next step to (a) build the
+    /// extra $\alpha'$-projected witness-bin trace MLEs and (b) compute
+    /// the per-column bridge scalars $c_j = \sum_i (\alpha')^i b_{j,i}$
+    /// appended to multipoint-eval's `up_evals`.
+    ///
+    /// `None` iff there are no witness binary-poly columns (no booleanity
+    /// argument).
+    alpha_prime_f: Option<F>,
 }
 
 /// After step 6 (multipoint eval).
@@ -536,9 +553,23 @@ impl_with_type_bounds!(ProverEvalProjected
     /// `up_evals`/`down_evals` (CPR), `bit_slice_evals` (booleanity), and
     /// lookup auxiliary witnesses at `r*`.
     ///
-    /// The booleanity bit-slice claims are checked at `r*` by the verifier
-    /// against the CPR `up_evals` for witness binary-poly columns using the
-    /// $\psi_a$ identity.
+    /// After booleanity's `finalize_prover` absorbs `bit_slice_evals` into
+    /// the transcript, this step squeezes a fresh challenge $\alpha'$ and
+    /// stores it on `ProverSumchecked`. The actual Schwartz-Zippel bridge
+    /// is installed in `step6_multipoint_eval`, which appends one extra
+    /// $\alpha'$-projected witness-bin column MLE (and matching up_eval
+    /// $c_j = \sum_i b_{j,i} (\alpha')^i$) per witness binary-poly column
+    /// to the multipoint-eval inputs. Shifts continue to reference the
+    /// original $\psi_a$-projected witness-bin slot, so `down_evals` are
+    /// untouched: shifted booleanity is inherited from un-shifted
+    /// booleanity (same committed column).
+    ///
+    /// The PCS chain (`step6_multipoint_eval` + lifted-evals + Zip+ open)
+    /// closes the bridge: at the random sumcheck output $r_0$,
+    /// $\overline{u_j}(\alpha') = \widetilde{g_j}(r_0)$ pins the appended
+    /// column's multilinear extension to the true $\alpha'$-projection
+    /// $g_j$ of the committed $u_j$, replacing the previous
+    /// underconstrained $\psi_a$ linear pin-down (sound only for $D=1$).
     pub fn step5_sumcheck(
         mut self,
     ) -> Result<ProverSumchecked<'a, Zt, U, F, D, FD>, ProtocolError<F, U::Ideal>> {
@@ -559,12 +590,10 @@ impl_with_type_bounds!(ProverEvalProjected
         let mut groups = vec![cpr_group];
 
         // Booleanity: prepare optional group over witness binary-poly cols.
-        let trace_wit_bin_poly = {
-            let sig = &self.base.uair_signature;
-            let num_pub_bin = sig.public_cols().num_binary_poly_cols();
-            let num_total_bin = sig.total_cols().num_binary_poly_cols();
-            &self.base.original_trace.binary_poly[num_pub_bin..num_total_bin]
-        };
+        let sig = &self.base.uair_signature;
+        let num_pub_bin = sig.public_cols().num_binary_poly_cols();
+        let num_total_bin = sig.total_cols().num_binary_poly_cols();
+        let trace_wit_bin_poly = &self.base.original_trace.binary_poly[num_pub_bin..num_total_bin];
 
         let bool_ancillary = if !trace_wit_bin_poly.is_empty() {
             let (bool_group, anc) = BooleanityChecker::prepare_sumcheck_group::<D>(
@@ -619,6 +648,19 @@ impl_with_type_bounds!(ProverEvalProjected
         // TODO: build BatchedLookupProof from collected lookup_proofs + lookup_metas
         let lookup_proof = None;
 
+        // Booleanity -> multipoint-eval `alpha_prime` bridge: squeeze
+        // \alpha' after `bit_slice_evals` were absorbed by `finalize_prover`.
+        // The challenge is consumed in `step6_multipoint_eval` to build the
+        // extra appended trace MLEs / up_evals (one per witness binary-poly
+        // column). `cpr_proof.up_evals` / `cpr_proof.down_evals` and
+        // `projected_trace_f` are carried through unmodified.
+        let alpha_prime_f: Option<F> = booleanity_proof.as_ref().map(|_| {
+            self.base
+                .pcs_transcript
+                .fs_transcript
+                .get_field_challenge(&self.field_cfg)
+        });
+
         Ok(ProverSumchecked {
             base: self.base,
             field_cfg: self.field_cfg,
@@ -630,6 +672,7 @@ impl_with_type_bounds!(ProverEvalProjected
             combined_sumcheck,
             lookup_proof,
             booleanity_proof,
+            alpha_prime_f,
         })
     }
 });
@@ -640,14 +683,64 @@ impl_with_type_bounds!(ProverSumchecked
     /// `down_evals` at `r*` into a single evaluation point `r_0`.
     /// Only the sumcheck proof is sent; scalar evaluations at `r_0` are derived from the
     /// polynomial-valued `lifted_evals` in Step 7.
+    ///
+    /// When the booleanity argument ran (witness binary-poly columns
+    /// present), the multipoint-eval inputs are *extended* with one extra
+    /// $\alpha'$-projected column MLE and one extra scalar up_eval
+    /// $c_j = \sum_i b_{j,i}\,(\alpha')^{i}$ per witness binary-poly column.
+    /// The appended columns are placed at indices
+    /// `[num_total_cols, num_total_cols + num_wit_bin)`; no `ShiftSpec`
+    /// references those indices, so `down_evals`/`shifts` are untouched and
+    /// shifted booleanity is inherited from the un-shifted column (which
+    /// continues to live at its original $\psi_a$-projected slot).
+    /// See the module-level `BooleanityChecker` docs for the soundness
+    /// argument (Schwartz-Zippel at $\alpha'$ + MP/PCS chain at $r_0$).
+    #[allow(clippy::arithmetic_side_effects)]
     pub fn step6_multipoint_eval(
         mut self,
     ) -> Result<ProverMultipointEvaled<'a, Zt, U, F, D, FD>, ProtocolError<F, U::Ideal>> {
+        let (trace_mles, up_evals) = if let Some(alpha_prime) = &self.alpha_prime_f {
+            let sig = &self.base.uair_signature;
+            let num_pub_bin = sig.public_cols().num_binary_poly_cols();
+            let num_total_bin = sig.total_cols().num_binary_poly_cols();
+            let num_wit_bin = num_total_bin.saturating_sub(num_pub_bin);
+
+            // Project the witness binary-poly columns at \alpha' directly from the
+            // committed BinaryPoly<D> data:
+            // More efficient that generic `evaluate_trace_to_column_mles` path.
+            let one = F::one_with_cfg(&self.field_cfg);
+            let alpha_powers: Vec<F> = powers(alpha_prime.clone(), one, D);
+            let bin_cols = &self.base.original_trace.binary_poly[num_pub_bin..num_total_bin];
+            let extra_trace_mles: Vec<DenseMultilinearExtension<F::Inner>> = cfg_iter!(bin_cols)
+                .map(|col| project_binary_col_at_field::<F, D>(col, &alpha_powers, &self.field_cfg))
+                .collect();
+            debug_assert_eq!(extra_trace_mles.len(), num_wit_bin);
+
+            let bp = self
+                .booleanity_proof
+                .as_ref()
+                .expect("booleanity_proof present iff alpha_prime_f is Some");
+            let extra_up_evals = alpha_prime_bridge_up_evals::<F, D>(
+                &bp.bit_slice_evals,
+                num_wit_bin,
+                alpha_prime,
+                &self.field_cfg,
+            );
+
+            let mut trace_mles = self.projected_trace_f;
+            trace_mles.extend(extra_trace_mles);
+            let mut up_evals = self.cpr_proof.up_evals.clone();
+            up_evals.extend(extra_up_evals);
+            (trace_mles, up_evals)
+        } else {
+            (self.projected_trace_f, self.cpr_proof.up_evals.clone())
+        };
+
         let (mp_proof, mp_prover_state) = MultipointEval::prove_as_subprotocol(
             &mut self.base.pcs_transcript.fs_transcript,
-            &self.projected_trace_f,
+            &trace_mles,
             &self.cpr_eval_point,
-            &self.cpr_proof.up_evals,
+            &up_evals,
             &self.cpr_proof.down_evals,
             self.base.uair_signature.shifts(),
             &self.field_cfg,
@@ -807,7 +900,7 @@ impl_with_type_bounds!(ProverPcsOpened
         Ok(Proof {
             commitments,
             ideal_check: self.ic_proof,
-            resolver: self.cpr_proof,
+            cpr_proof: self.cpr_proof,
             combined_sumcheck: self.combined_sumcheck,
             multipoint_eval: self.mp_proof,
             zip: zip_proof,
@@ -897,5 +990,47 @@ fn commit_optionally<Zt: ZipTypes, Lc: LinearCode<Zt>>(
     } else {
         let (hint, commitment) = ZipPlus::commit(pp, trace)?;
         Ok((Some(hint), commitment))
+    }
+}
+
+/// Project a single witness binary-poly column at a field element by
+/// evaluating each bit-packed cell $\sum_i \text{bit}_i \cdot X^i$ at
+/// $X = \alpha$.
+///
+/// Used to build the appended $\alpha'$-projected witness-binary-poly MLEs that
+/// participate in `MultipointEval` as the Schwartz-Zippel bridge from
+/// booleanity into the PCS chain.
+#[allow(clippy::arithmetic_side_effects)]
+fn project_binary_col_at_field<F, const D: usize>(
+    col: &DenseMultilinearExtension<BinaryPoly<D>>,
+    alpha_powers: &[F],
+    field_cfg: &F::Config,
+) -> DenseMultilinearExtension<F::Inner>
+where
+    F: PrimeField,
+    F::Inner: Clone + Send + Sync,
+{
+    debug_assert_eq!(alpha_powers.len(), D);
+    let zero = F::zero_with_cfg(field_cfg);
+
+    // Sequential row loop: per-row work is at most `D` conditional adds,
+    // The caller parallelizes the outer loop over witness binary-poly columns.
+    let evaluations: Vec<F::Inner> = col
+        .evaluations
+        .iter()
+        .map(|entry| {
+            let mut acc = zero.clone();
+            for (i, bit) in entry.iter().enumerate() {
+                if bit.into_inner() {
+                    acc += &alpha_powers[i];
+                }
+            }
+            acc.into_inner()
+        })
+        .collect();
+
+    DenseMultilinearExtension {
+        num_vars: col.num_vars,
+        evaluations,
     }
 }

--- a/protocol/src/prover.rs
+++ b/protocol/src/prover.rs
@@ -35,9 +35,8 @@ use zip_plus::{
 // Type-state structs
 //
 
-/// Persistent prover infrastructure carried across every step: the
-/// Fiat-Shamir transcript, PCS parameters/hints/commitments, and trace
-/// reference.
+/// Initial prover state, before commitment: the UAIR signature, the
+/// caller-provided original trace, and the folded witness trace.
 #[derive(Clone, Debug)]
 pub struct ProverFolded<
     'a,
@@ -54,9 +53,9 @@ pub struct ProverFolded<
     _phantom: PhantomData<(&'a u8, U, F)>,
 }
 
-/// Persistent prover infrastructure carried across every step: the
-/// Fiat-Shamir transcript, PCS parameters/hints/commitments, and trace
-/// reference.
+/// Persistent prover infrastructure carried across every subsequent
+/// step: the Fiat-Shamir transcript, PCS parameters/hints/commitments,
+/// and trace reference.
 /// Obtained after step 1 via [`step1_commit`](ProverFolded::step1_commit).
 #[derive(Clone, Debug)]
 pub struct ProverCommitted<
@@ -313,7 +312,7 @@ where
     F: PrimeField,
     F::Inner: ConstTranscribable,
 {
-    /// Step 1: Folding the trace.
+    /// Step 0: Folding the trace.
     #[allow(clippy::type_complexity)]
     pub fn step0_fold<'a>(
         trace: &'a UairTrace<'static, Zt::Int, Zt::Int, D, D>,
@@ -939,7 +938,7 @@ where
     /// Zinc+ full PIOP prover.
     ///
     /// Runs all protocol steps in sequence and returns the assembled proof.
-    /// For per-step control, start with [`Self::step1_commit`] and chain the
+    /// For per-step control, start with [`Self::step0_fold`] and chain the
     /// individual `stepN_*` methods.
     #[allow(clippy::too_many_arguments, clippy::type_complexity)]
     pub fn prove<const MLE_FIRST: bool, const CHECK_FOR_OVERFLOW: bool>(
@@ -1013,7 +1012,7 @@ where
     debug_assert_eq!(alpha_powers.len(), D);
     let zero = F::zero_with_cfg(field_cfg);
 
-    // Sequential row loop: per-row work is at most `D` conditional adds,
+    // Sequential row loop: per-row work is at most `D` conditional adds.
     // The caller parallelizes the outer loop over witness binary-poly columns.
     let evaluations: Vec<F::Inner> = col
         .evaluations

--- a/protocol/src/verifier.rs
+++ b/protocol/src/verifier.rs
@@ -4,7 +4,7 @@ use itertools::Itertools;
 use num_traits::Zero;
 use std::{collections::HashMap, io::Cursor};
 use zinc_piop::{
-    combined_poly_resolver::{self, CombinedPolyResolver},
+    combined_poly_resolver::CombinedPolyResolver,
     ideal_check::{self, IdealCheckProtocol},
     lookup::booleanity::{BooleanityChecker, BooleanityProof},
     multipoint_eval::{self, MultipointEval},
@@ -71,7 +71,7 @@ pub struct VerifierTranscriptReconstructed<
     // Proof leftovers
     proof_commitments: (ZipPlusCommitment, ZipPlusCommitment, ZipPlusCommitment),
     proof_ideal_check: IdealCheckProof<F>,
-    proof_resolver: CombinedPolyResolverProof<F>,
+    proof_cpr: CombinedPolyResolverProof<F>,
     proof_combined_sumcheck: MultiDegreeSumcheckProof<F>,
     proof_multipoint_eval: MultipointEvalProof<F>,
     proof_witness_lifted_evals: Vec<DynamicPolynomialF<F>>,
@@ -97,7 +97,7 @@ pub struct VerifierPrimeProjected<
     // Proof leftovers
     proof_commitments: (ZipPlusCommitment, ZipPlusCommitment, ZipPlusCommitment),
     proof_ideal_check: IdealCheckProof<F>,
-    proof_resolver: CombinedPolyResolverProof<F>,
+    proof_cpr: CombinedPolyResolverProof<F>,
     proof_combined_sumcheck: MultiDegreeSumcheckProof<F>,
     proof_multipoint_eval: MultipointEvalProof<F>,
     proof_witness_lifted_evals: Vec<DynamicPolynomialF<F>>,
@@ -123,7 +123,7 @@ pub struct VerifierIdealChecked<
 
     // Proof leftovers
     proof_commitments: (ZipPlusCommitment, ZipPlusCommitment, ZipPlusCommitment),
-    proof_resolver: CombinedPolyResolverProof<F>,
+    proof_cpr: CombinedPolyResolverProof<F>,
     proof_combined_sumcheck: MultiDegreeSumcheckProof<F>,
     proof_multipoint_eval: MultipointEvalProof<F>,
     proof_witness_lifted_evals: Vec<DynamicPolynomialF<F>>,
@@ -151,7 +151,7 @@ pub struct VerifierEvalProjected<
 
     // Proof leftovers
     proof_commitments: (ZipPlusCommitment, ZipPlusCommitment, ZipPlusCommitment),
-    proof_resolver: CombinedPolyResolverProof<F>,
+    proof_cpr: CombinedPolyResolverProof<F>,
     proof_combined_sumcheck: MultiDegreeSumcheckProof<F>,
     proof_multipoint_eval: MultipointEvalProof<F>,
     proof_witness_lifted_evals: Vec<DynamicPolynomialF<F>>,
@@ -173,7 +173,22 @@ pub struct VerifierSumchecked<
     base: VerifierBase<'a, Zt, D, FD>,
     field_cfg: F::Config,
     projecting_element_f: F,
-    cpr_subclaim: combined_poly_resolver::VerifierSubclaim<F>,
+    /// CPR subclaim's evaluation point ($r^\star$)
+    cpr_eval_point: Vec<F>,
+    cpr_up_evals: Vec<F>,
+    cpr_down_evals: Vec<F>,
+    /// `bit_slice_evals` carried over from booleanity's `finalize_verifier`,
+    /// to be collapsed into the appended `up_evals` entries
+    /// $c_j = \sum_i b_{j,i}\,(\alpha')^i$
+    ///
+    /// `None` iff there are  no witness binary-poly columns.
+    bool_bit_slice_evals: Option<Vec<F>>,
+    /// Fresh challenge sampled after `bit_slice_evals` were absorbed by
+    /// booleanity's `finalize_verifier`. Consumed in step 5 (bridge
+    /// scalars) and step 6 (appended $\alpha'$-projected open_evals).
+    ///
+    /// `None` iff there are no witness binary-poly columns.
+    alpha_prime_f: Option<F>,
 
     // Proof leftovers
     proof_commitments: (ZipPlusCommitment, ZipPlusCommitment, ZipPlusCommitment),
@@ -196,6 +211,8 @@ pub struct VerifierMultipointEvaled<
     base: VerifierBase<'a, Zt, D, FD>,
     field_cfg: F::Config,
     projecting_element_f: F,
+    // See VerifierSumchecked::alpha_prime_f
+    alpha_prime_f: Option<F>,
     mp_subclaim: multipoint_eval::Subclaim<F>,
 
     // Proof leftovers
@@ -303,7 +320,7 @@ where
             base,
             proof_commitments: proof.commitments,
             proof_ideal_check: proof.ideal_check,
-            proof_resolver: proof.resolver,
+            proof_cpr: proof.cpr_proof,
             proof_combined_sumcheck: proof.combined_sumcheck,
             proof_multipoint_eval: proof.multipoint_eval,
             proof_witness_lifted_evals: proof.witness_lifted_evals,
@@ -341,7 +358,7 @@ where
             field_cfg,
             proof_commitments: self.proof_commitments,
             proof_ideal_check: self.proof_ideal_check,
-            proof_resolver: self.proof_resolver,
+            proof_cpr: self.proof_cpr,
             proof_combined_sumcheck: self.proof_combined_sumcheck,
             proof_multipoint_eval: self.proof_multipoint_eval,
             proof_witness_lifted_evals: self.proof_witness_lifted_evals,
@@ -396,7 +413,7 @@ where
             field_cfg: self.field_cfg,
             ic_subclaim,
             proof_commitments: self.proof_commitments,
-            proof_resolver: self.proof_resolver,
+            proof_cpr: self.proof_cpr,
             proof_combined_sumcheck: self.proof_combined_sumcheck,
             proof_multipoint_eval: self.proof_multipoint_eval,
             proof_witness_lifted_evals: self.proof_witness_lifted_evals,
@@ -443,7 +460,7 @@ where
             projecting_element_f,
             projected_scalars_f,
             proof_commitments: self.proof_commitments,
-            proof_resolver: self.proof_resolver,
+            proof_cpr: self.proof_cpr,
             proof_combined_sumcheck: self.proof_combined_sumcheck,
             proof_multipoint_eval: self.proof_multipoint_eval,
             proof_witness_lifted_evals: self.proof_witness_lifted_evals,
@@ -485,7 +502,7 @@ where
         // CPR pre-sumcheck: squeezes folding challenge \alpha.
         let cpr_verifier_ancillary = CombinedPolyResolver::prepare_verifier::<U>(
             &mut self.base.pcs_transcript.fs_transcript,
-            &self.proof_resolver,
+            &self.proof_cpr,
             self.proof_combined_sumcheck.claimed_sums()[0].clone(),
             &self.ic_subclaim,
             num_constraints,
@@ -534,7 +551,7 @@ where
 
         let cpr_subclaim = CombinedPolyResolver::finalize_verifier::<U>(
             &mut self.base.pcs_transcript.fs_transcript,
-            self.proof_resolver,
+            self.proof_cpr,
             md_subclaims.point().to_vec(),
             md_subclaims.expected_evaluations()[0].clone(),
             cpr_verifier_ancillary,
@@ -542,7 +559,11 @@ where
             &self.field_cfg,
         )?;
 
-        if let Some(anc) = bool_verifier_ancillary {
+        // Booleanity -> multipoint-eval `alpha_prime` bridge.
+        // After `finalize_verifier` (residue check + transcript absorption of
+        // `bit_slice_evals`), squeeze `alpha_prime` and carry both forward to the
+        // next step.
+        let bool_bit_slice_evals: Option<Vec<F>> = if let Some(anc) = bool_verifier_ancillary {
             let booleanity_proof = self
                 .proof_booleanity
                 .take()
@@ -552,7 +573,8 @@ where
                 .get(1)
                 .ok_or(ProtocolError::BooleanityProofMissing)?;
 
-            // 4a: sumcheck residue check at r* against the bit-slice evals.
+            // Sumcheck residue check at r* against the bit-slice evals.
+            // Absorbs bit_slice_evals.
             let bool_subclaim = BooleanityChecker::<F>::finalize_verifier(
                 &mut self.base.pcs_transcript.fs_transcript,
                 booleanity_proof,
@@ -563,21 +585,20 @@ where
             )
             .map_err(ProtocolError::Booleanity)?;
 
-            // 4b: bit-decomposition consistency check at r* against the
-            // CPR up_evals of the witness binary-poly columns via the
-            // psi_a identity. Parent evals live at indices [num_pub_bin,
-            // num_total_bin) of `cpr_subclaim.up_evals`.
-            let num_wit_bin = num_total_bin.saturating_sub(num_pub_bin);
-            let parent_evals = &cpr_subclaim.up_evals[num_pub_bin..add!(num_pub_bin, num_wit_bin)];
-            BooleanityChecker::<F>::verify_bit_decomposition_consistency(
-                &bool_subclaim.bit_slice_evals,
-                parent_evals,
-                &self.projecting_element_f,
-                D,
-                &self.field_cfg,
-            )
-            .map_err(ProtocolError::Booleanity)?;
-        }
+            Some(bool_subclaim.bit_slice_evals)
+        } else {
+            None
+        };
+
+        // Squeeze alpha_prime in the same transcript order as the prover.
+        let alpha_prime_f: Option<F> = bool_bit_slice_evals.as_ref().map(|_| {
+            self.base
+                .pcs_transcript
+                .fs_transcript
+                .get_field_challenge(&self.field_cfg)
+        });
+
+        let cpr_eval_point = cpr_subclaim.evaluation_point;
 
         let _ = &self.proof_lookup_proof;
 
@@ -585,7 +606,11 @@ where
             base: self.base,
             field_cfg: self.field_cfg,
             projecting_element_f: self.projecting_element_f,
-            cpr_subclaim,
+            cpr_eval_point,
+            cpr_up_evals: cpr_subclaim.up_evals,
+            cpr_down_evals: cpr_subclaim.down_evals,
+            bool_bit_slice_evals,
+            alpha_prime_f,
             proof_commitments: self.proof_commitments,
             proof_multipoint_eval: self.proof_multipoint_eval,
             proof_witness_lifted_evals: self.proof_witness_lifted_evals,
@@ -605,16 +630,43 @@ where
     IdealOverF: Ideal,
 {
     /// Step 5: Multi-point evaluation sumcheck.
+    ///
+    /// When the booleanity argument ran, this step appends one extra
+    /// scalar up_eval $c_j = \sum_i b_{j,i}\,(\alpha')^i$ per witness
+    /// binary-poly column (derived from the in-flight `bit_slice_evals`).
+    /// These collapse the bit-slice claims at $r^\star$ into the
+    /// multipoint-eval consistency equation; the matching
+    /// $\alpha'$-projected `open_evals` are produced in step 6.
+    /// `down_evals` are passed through unchanged.
+    #[allow(clippy::arithmetic_side_effects)]
     pub fn step5_multipoint_eval<U: Uair>(
         mut self,
     ) -> Result<VerifierMultipointEvaled<'a, Zt, F, IdealOverF, D, FD>, ProtocolError<F, IdealOverF>>
     {
+        let up_evals: Vec<F> = if let (Some(bit_slice_evals), Some(alpha_prime)) =
+            (&self.bool_bit_slice_evals, &self.alpha_prime_f)
+        {
+            let sig = self.base.uair_signature.clone();
+            let num_pub_bin = sig.public_cols().num_binary_poly_cols();
+            let num_total_bin = sig.total_cols().num_binary_poly_cols();
+            let num_wit_bin = num_total_bin.saturating_sub(num_pub_bin);
+            let extra = alpha_prime_bridge_up_evals::<F, D>(
+                bit_slice_evals,
+                num_wit_bin,
+                alpha_prime,
+                &self.field_cfg,
+            );
+            self.cpr_up_evals.iter().cloned().chain(extra).collect()
+        } else {
+            self.cpr_up_evals.clone()
+        };
+
         let mp_subclaim = MultipointEval::verify_as_subprotocol(
             &mut self.base.pcs_transcript.fs_transcript,
             self.proof_multipoint_eval,
-            &self.cpr_subclaim.evaluation_point,
-            &self.cpr_subclaim.up_evals,
-            &self.cpr_subclaim.down_evals,
+            &self.cpr_eval_point,
+            &up_evals,
+            &self.cpr_down_evals,
             self.base.uair_signature.shifts(),
             self.base.num_vars,
             &self.field_cfg,
@@ -624,6 +676,7 @@ where
             base: self.base,
             field_cfg: self.field_cfg,
             projecting_element_f: self.projecting_element_f,
+            alpha_prime_f: self.alpha_prime_f,
             mp_subclaim,
             proof_commitments: self.proof_commitments,
             proof_witness_lifted_evals: self.proof_witness_lifted_evals,
@@ -654,6 +707,13 @@ where
 {
     /// Step 6: Recompute public lifted_evals, assemble full set, verify
     /// multipoint eval subclaim, and absorb all lifted_evals into transcript.
+    ///
+    /// All columns are projected at the original $\psi_a$
+    /// `projecting_element_f` (so shifts continue to be bound through the
+    /// $\psi_a$ chain). When the booleanity argument ran, additional
+    /// $\alpha'$-projected `open_evals` are appended for the witness
+    /// binary-poly columns; these match the appended `up_evals` from
+    /// step 5 and close the Schwartz-Zippel bridge to the bit-slice claims.
     pub fn step6_lifted_evals<U: Uair>(
         mut self,
     ) -> Result<
@@ -698,11 +758,28 @@ where
             .cloned()
             .collect();
 
-        let open_evals: Vec<F> = all_lifted_evals
+        // Project every column at the original \psi_a projecting element.
+        // Shifts continue to consume the \psi_a-projected open_evals.
+        let mut open_evals: Vec<F> = all_lifted_evals
             .iter()
             .map(|bar_u| bar_u.evaluate_at_point(&self.projecting_element_f))
             .collect::<Result<Vec<_>, _>>()
             .map_err(ProtocolError::LiftedEvalProjection)?;
+
+        // Append \alpha'-projected open_evals for the witness binary-poly
+        // columns. Their position matches the appended up_evals from
+        // step 5 (indices `[num_total_cols, num_total_cols + num_wit_bin)`
+        // in the extended MP column list). No ShiftSpec references these
+        // appended indices, so the shift_at_r0 selectors are unaffected.
+        if let Some(alpha_prime) = &self.alpha_prime_f {
+            for bar_u in &witness_lifted_evals[..num_wit_bin] {
+                open_evals.push(
+                    bar_u
+                        .evaluate_at_point(alpha_prime)
+                        .map_err(ProtocolError::LiftedEvalProjection)?,
+                );
+            }
+        }
 
         MultipointEval::verify_subclaim(
             &self.mp_subclaim,
@@ -948,5 +1025,60 @@ where
         .step6_lifted_evals::<U>()?
         .step7_pcs_verify::<U, CHECK_FOR_OVERFLOW>()?
         .finish::<F>()
+    }
+}
+
+/// Test-only accessors for internal state, needed for tampering tests.
+#[cfg(test)]
+pub mod test_helpers {
+    use super::*;
+
+    #[cfg(test)]
+    impl<'a, Zt: ZincTypes<D, FD>, const D: usize, const FD: usize> VerifierBase<'a, Zt, D, FD> {
+        #[cfg(test)]
+        pub fn fs_transcript_mut(&mut self) -> &mut Blake3Transcript {
+            &mut self.pcs_transcript.fs_transcript
+        }
+    }
+
+    #[cfg(test)]
+    impl<'a, Zt, U, F, IdealOverF, const D: usize, const FD: usize>
+        VerifierEvalProjected<'a, Zt, U, F, IdealOverF, D, FD>
+    where
+        Zt: ZincTypes<D, FD>,
+        F: PrimeField,
+        U: Uair,
+    {
+        pub fn projecting_element_f(&self) -> &F {
+            &self.projecting_element_f
+        }
+
+        pub fn field_cfg(&self) -> &F::Config {
+            &self.field_cfg
+        }
+
+        pub fn fs_transcript_mut(&mut self) -> &mut Blake3Transcript {
+            self.base.fs_transcript_mut()
+        }
+
+        pub fn proof_combined_sumcheck(&self) -> &MultiDegreeSumcheckProof<F> {
+            &self.proof_combined_sumcheck
+        }
+
+        pub fn ic_subclaim(&self) -> &ideal_check::VerifierSubclaim<F> {
+            &self.ic_subclaim
+        }
+
+        pub fn proof_cpr(&self) -> &CombinedPolyResolverProof<F> {
+            &self.proof_cpr
+        }
+
+        pub fn num_vars(&self) -> usize {
+            self.base.num_vars
+        }
+
+        pub fn uair_signature(&self) -> &UairSignature {
+            &self.base.uair_signature
+        }
     }
 }

--- a/protocol/src/verifier.rs
+++ b/protocol/src/verifier.rs
@@ -6,7 +6,7 @@ use std::{collections::HashMap, io::Cursor};
 use zinc_piop::{
     combined_poly_resolver::{self, CombinedPolyResolver},
     ideal_check::{self, IdealCheckProtocol},
-    lookup::booleanity::{BoolVerifierSubclaim, BooleanityChecker, BooleanityProof},
+    lookup::booleanity::{BooleanityChecker, BooleanityProof},
     multipoint_eval::{self, MultipointEval},
     projections::{
         ProjectedTrace, project_scalars, project_scalars_to_field, project_trace_coeffs_row_major,
@@ -174,7 +174,6 @@ pub struct VerifierSumchecked<
     field_cfg: F::Config,
     projecting_element_f: F,
     cpr_subclaim: combined_poly_resolver::VerifierSubclaim<F>,
-    bool_subclaim: Option<BoolVerifierSubclaim<F>>,
 
     // Proof leftovers
     proof_commitments: (ZipPlusCommitment, ZipPlusCommitment, ZipPlusCommitment),
@@ -198,10 +197,6 @@ pub struct VerifierMultipointEvaled<
     field_cfg: F::Config,
     projecting_element_f: F,
     mp_subclaim: multipoint_eval::Subclaim<F>,
-    /// Indicates the booleanity argument participated in the sumcheck,
-    /// so step 6 must append D coefficients per witness binary-poly col
-    /// to `open_evals`.
-    booleanity_present: bool,
 
     // Proof leftovers
     proof_commitments: (ZipPlusCommitment, ZipPlusCommitment, ZipPlusCommitment),
@@ -480,8 +475,7 @@ where
     U: Uair + 'static,
     IdealOverF: Ideal,
 {
-    /// Step 4: Sumcheck verification (CPR + optional booleanity + lookup
-    /// groups).
+    /// Step 4: Sumcheck verification (CPR + booleanity lookup).
     pub fn step4_sumcheck_verify(
         mut self,
     ) -> Result<VerifierSumchecked<'a, Zt, F, IdealOverF, D, FD>, ProtocolError<F, IdealOverF>>
@@ -506,9 +500,9 @@ where
         let sig = self.base.uair_signature.clone();
         let num_pub_bin = sig.public_cols().num_binary_poly_cols();
         let num_total_bin = sig.total_cols().num_binary_poly_cols();
-        let bool_present = num_total_bin > num_pub_bin;
+        let bin_wit_present = num_total_bin > num_pub_bin;
 
-        let bool_verifier_ancillary = if bool_present {
+        let bool_verifier_ancillary = if bin_wit_present {
             // booleanity is group index 1 (right after CPR)
             let bool_claimed_sum = self
                 .proof_combined_sumcheck
@@ -548,29 +542,42 @@ where
             &self.field_cfg,
         )?;
 
-        let bool_subclaim = if let Some(anc) = bool_verifier_ancillary {
+        if let Some(anc) = bool_verifier_ancillary {
             let booleanity_proof = self
                 .proof_booleanity
                 .take()
                 .ok_or(ProtocolError::BooleanityProofMissing)?;
-            let expected_evaluation = md_subclaims
+            let expected_eval = md_subclaims
                 .expected_evaluations()
                 .get(1)
                 .ok_or(ProtocolError::BooleanityProofMissing)?;
-            Some(
-                BooleanityChecker::<F>::finalize_verifier(
-                    &mut self.base.pcs_transcript.fs_transcript,
-                    booleanity_proof,
-                    md_subclaims.point().to_vec(),
-                    expected_evaluation,
-                    anc,
-                    &self.field_cfg,
-                )
-                .map_err(ProtocolError::Booleanity)?,
+
+            // 4a: sumcheck residue check at r* against the bit-slice evals.
+            let bool_subclaim = BooleanityChecker::<F>::finalize_verifier(
+                &mut self.base.pcs_transcript.fs_transcript,
+                booleanity_proof,
+                md_subclaims.point().to_vec(),
+                expected_eval,
+                anc,
+                &self.field_cfg,
             )
-        } else {
-            None
-        };
+            .map_err(ProtocolError::Booleanity)?;
+
+            // 4b: bit-decomposition consistency check at r* against the
+            // CPR up_evals of the witness binary-poly columns via the
+            // psi_a identity. Parent evals live at indices [num_pub_bin,
+            // num_total_bin) of `cpr_subclaim.up_evals`.
+            let num_wit_bin = num_total_bin.saturating_sub(num_pub_bin);
+            let parent_evals = &cpr_subclaim.up_evals[num_pub_bin..add!(num_pub_bin, num_wit_bin)];
+            BooleanityChecker::<F>::verify_bit_decomposition_consistency(
+                &bool_subclaim.bit_slice_evals,
+                parent_evals,
+                &self.projecting_element_f,
+                D,
+                &self.field_cfg,
+            )
+            .map_err(ProtocolError::Booleanity)?;
+        }
 
         let _ = &self.proof_lookup_proof;
 
@@ -579,7 +586,6 @@ where
             field_cfg: self.field_cfg,
             projecting_element_f: self.projecting_element_f,
             cpr_subclaim,
-            bool_subclaim,
             proof_commitments: self.proof_commitments,
             proof_multipoint_eval: self.proof_multipoint_eval,
             proof_witness_lifted_evals: self.proof_witness_lifted_evals,
@@ -603,24 +609,11 @@ where
         mut self,
     ) -> Result<VerifierMultipointEvaled<'a, Zt, F, IdealOverF, D, FD>, ProtocolError<F, IdealOverF>>
     {
-        // When the booleanity argument is present, the bit-slice claims
-        // produced by [`BooleanityChecker::finalize_verifier`] at `r*` are
-        // appended to `up_evals` and folded into the same `r_0` as the CPR
-        // claims. The corresponding scalar evaluations at `r_0` are
-        // discharged for free in step 6 against `lifted_evals.coeffs`.
-        let extended_up_evals: Vec<F> = if let Some(ref bs) = self.bool_subclaim {
-            let mut v = self.cpr_subclaim.up_evals;
-            v.extend_from_slice(&bs.bit_slice_evals);
-            v
-        } else {
-            self.cpr_subclaim.up_evals
-        };
-
         let mp_subclaim = MultipointEval::verify_as_subprotocol(
             &mut self.base.pcs_transcript.fs_transcript,
             self.proof_multipoint_eval,
             &self.cpr_subclaim.evaluation_point,
-            &extended_up_evals,
+            &self.cpr_subclaim.up_evals,
             &self.cpr_subclaim.down_evals,
             self.base.uair_signature.shifts(),
             self.base.num_vars,
@@ -632,7 +625,6 @@ where
             field_cfg: self.field_cfg,
             projecting_element_f: self.projecting_element_f,
             mp_subclaim,
-            booleanity_present: self.bool_subclaim.is_some(),
             proof_commitments: self.proof_commitments,
             proof_witness_lifted_evals: self.proof_witness_lifted_evals,
             proof_lookup_proof: self.proof_lookup_proof,
@@ -706,25 +698,11 @@ where
             .cloned()
             .collect();
 
-        let mut open_evals: Vec<F> = all_lifted_evals
+        let open_evals: Vec<F> = all_lifted_evals
             .iter()
             .map(|bar_u| bar_u.evaluate_at_point(&self.projecting_element_f))
             .collect::<Result<Vec<_>, _>>()
             .map_err(ProtocolError::LiftedEvalProjection)?;
-
-        // When the booleanity argument was active, the extended `up_evals`
-        // passed to MultipointEval included one entry per (witness bin-poly
-        // column, bit position). Their corresponding `open_evals` at r_0
-        // are precisely `lifted_evals[j].coeffs[i]` (already a scalar in
-        // F_q, not a polynomial).
-        if self.booleanity_present {
-            let zero = F::zero_with_cfg(&self.field_cfg);
-            for bar_u in all_lifted_evals.iter().skip(num_pub_bin).take(num_wit_bin) {
-                for i in 0..D {
-                    open_evals.push(bar_u.coeffs.get(i).cloned().unwrap_or_else(|| zero.clone()));
-                }
-            }
-        }
 
         MultipointEval::verify_subclaim(
             &self.mp_subclaim,

--- a/protocol/src/verifier.rs
+++ b/protocol/src/verifier.rs
@@ -179,9 +179,9 @@ pub struct VerifierSumchecked<
     cpr_down_evals: Vec<F>,
     /// `bit_slice_evals` carried over from booleanity's `finalize_verifier`,
     /// to be collapsed into the appended `up_evals` entries
-    /// $c_j = \sum_i b_{j,i}\,(\alpha')^i$
+    /// $c_j = \sum_i b_{j,i}\,(\alpha')^i$.
     ///
-    /// `None` iff there are  no witness binary-poly columns.
+    /// `None` iff there are no witness binary-poly columns.
     bool_bit_slice_evals: Option<Vec<F>>,
     /// Fresh challenge sampled after `bit_slice_evals` were absorbed by
     /// booleanity's `finalize_verifier`. Consumed in step 5 (bridge
@@ -492,7 +492,9 @@ where
     U: Uair + 'static,
     IdealOverF: Ideal,
 {
-    /// Step 4: Sumcheck verification (CPR + booleanity lookup).
+    /// Step 4: Sumcheck verification (CPR + optional booleanity +
+    /// future lookup groups), followed by the squeeze of the bridge
+    /// challenge $\alpha'$ when booleanity ran.
     pub fn step4_sumcheck_verify(
         mut self,
     ) -> Result<VerifierSumchecked<'a, Zt, F, IdealOverF, D, FD>, ProtocolError<F, IdealOverF>>
@@ -511,9 +513,11 @@ where
             &self.field_cfg,
         )?;
 
-        // Booleanity pre-sumcheck: squeezes r, \gamma, \delta in that order.
-        // Determined statically from the UAIR signature, so prover and
-        // verifier always agree on the presence flag.
+        // Booleanity pre-sumcheck: squeezes the zerocheck point `r`
+        // (num_vars field elements) and the batching challenge `alpha`,
+        // in that order.
+        // Presence is determined statically from the UAIR signature, so prover and
+        // verifier always agree on it.
         let sig = self.base.uair_signature.clone();
         let num_pub_bin = sig.public_cols().num_binary_poly_cols();
         let num_total_bin = sig.total_cols().num_binary_poly_cols();
@@ -992,7 +996,7 @@ where
     /// Zinc+ full PIOP verifier.
     ///
     /// Runs all verification steps in sequence and returns `Ok(())` on
-    /// success. For per-step control, starts with
+    /// success. For per-step control, start with
     /// [`Self::step0_reconstruct_transcript`] and chain the individual
     /// `stepN_*` methods.
     #[allow(clippy::too_many_arguments, clippy::type_complexity)]


### PR DESCRIPTION
Resolves #193

The following changes has been made:
* Optimized the way booleanity lookup is propagated to multi-point evaluation.
* Separate $(\gamma, \delta)$ challenges unified into $\alpha$ challenges of length $N*D$
* Multi-degree sumcheck now supports fast path for round 1 of folding, where prover message can be cheaply computed without using sumcheck combination function. Verifier is unaffected.
  * Implemented fast path for booleanity check.
* Also fixed a flaky booleanity test

Verifier and proof size largely aren't affected.
Prover benchmark changes:
| Bench prover  | vs pre-booleanity | vs non-optimized |
| --------------| ----------------- | ---------------- |
| `BigLinearPI` | +15%              | -15%             |
| `ShaProxy`    | +25%              | -20%             |