### PR TITLE
uair: add typed constraint tags to ideal collection

### DIFF
--- a/uair/src/ideal_collector.rs
+++ b/uair/src/ideal_collector.rs
@@ -1,7 +1,7 @@
 use zinc_utils::from_ref::FromRef;
 
 use crate::{
-    ConstraintBuilder, TraceRow, Uair,
+    ConstraintBuilder, ConstraintRing, TraceRow, Uair,
     dummy_semiring::DummySemiring,
     ideal::{Ideal, IdealCheck, IdealCheckError},
 };
@@ -10,6 +10,7 @@ use crate::{
 /// ideals used in a `Uair`.
 pub struct IdealCollector<I: Ideal> {
     pub ideals: Vec<IdealOrZero<I>>,
+    pub tags: Vec<ConstraintRing>,
 }
 
 impl<I: Ideal> IdealCollector<I> {
@@ -19,6 +20,7 @@ impl<I: Ideal> IdealCollector<I> {
     pub fn new(num_constraints: usize) -> Self {
         Self {
             ideals: Vec::with_capacity(num_constraints),
+            tags: Vec::with_capacity(num_constraints),
         }
     }
 }
@@ -48,10 +50,22 @@ where
 
     fn assert_in_ideal(&mut self, _expr: Self::Expr, ideal: &Self::Ideal) {
         self.ideals.push(ideal.clone());
+        self.tags.push(ConstraintRing::Z);
+    }
+
+    fn assert_in_ideal_typed(
+        &mut self,
+        _expr: Self::Expr,
+        ideal: &Self::Ideal,
+        ring: ConstraintRing,
+    ) {
+        self.ideals.push(ideal.clone());
+        self.tags.push(ring);
     }
 
     fn assert_zero(&mut self, _expr: Self::Expr) {
         self.ideals.push(IdealOrZero::zero());
+        self.tags.push(ConstraintRing::Z);
     }
 }
 
@@ -100,5 +114,70 @@ impl<I: Ideal> IdealCheck<DummySemiring> for IdealOrZero<I> {
     fn contains(&self, _value: &DummySemiring) -> Result<bool, IdealCheckError> {
         // Do nothing.
         Ok(true)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{
+        PublicColumnLayout, TotalColumnLayout,
+        ideal::ImpossibleIdeal,
+    };
+
+    #[derive(Clone)]
+    struct TypedCollectorUair;
+
+    impl Uair for TypedCollectorUair {
+        type Ideal = ImpossibleIdeal;
+        type Scalar = DummySemiring;
+
+        fn signature() -> crate::UairSignature {
+            crate::UairSignature::new(
+                TotalColumnLayout::new(0, 0, 0),
+                PublicColumnLayout::new(0, 0, 0),
+                vec![],
+                vec![],
+            )
+        }
+
+        fn constrain_general<B, FromR, MulByScalar, IFromR>(
+            b: &mut B,
+            _up: TraceRow<B::Expr>,
+            _down: TraceRow<B::Expr>,
+            from_ref: FromR,
+            _mbs: MulByScalar,
+            ideal_from_ref: IFromR,
+        ) where
+            B: ConstraintBuilder,
+            FromR: Fn(&Self::Scalar) -> B::Expr,
+            MulByScalar: Fn(&B::Expr, &Self::Scalar) -> Option<B::Expr>,
+            IFromR: Fn(&Self::Ideal) -> B::Ideal,
+        {
+            b.assert_in_ideal_typed(
+                from_ref(&DummySemiring),
+                &ideal_from_ref(&ImpossibleIdeal),
+                ConstraintRing::Fp,
+            );
+            b.assert_zero(from_ref(&DummySemiring));
+            b.assert_in_ideal(
+                from_ref(&DummySemiring),
+                &ideal_from_ref(&ImpossibleIdeal),
+            );
+        }
+    }
+
+    #[test]
+    fn collect_ideals_records_parallel_tags() {
+        let collector = collect_ideals::<TypedCollectorUair>(3);
+
+        assert_eq!(collector.ideals.len(), 3);
+        assert_eq!(
+            collector.tags,
+            vec![ConstraintRing::Fp, ConstraintRing::Z, ConstraintRing::Z]
+        );
+        assert!(matches!(collector.ideals[0], IdealOrZero::NonZero(_)));
+        assert!(collector.ideals[1].is_zero_ideal());
+        assert!(matches!(collector.ideals[2], IdealOrZero::NonZero(_)));
     }
 }

--- a/uair/src/lib.rs
+++ b/uair/src/lib.rs
@@ -21,6 +21,13 @@ use crate::ideal::{Ideal, IdealCheck};
 
 pub use lookup_types::{LookupColumnSpec, LookupTableType};
 
+/// Per-constraint ring tag for typed constraint collection.
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
+pub enum ConstraintRing {
+    Z,
+    Fp,
+}
+
 /// The abstract interface to constraint building logic.
 /// In essence it allows to create constraints modulo ideals.
 pub trait ConstraintBuilder {
@@ -35,9 +42,33 @@ pub trait ConstraintBuilder {
     /// Add a constraint saying that `expr` belongs to the ideal `ideal`.
     fn assert_in_ideal(&mut self, expr: Self::Expr, ideal: &Self::Ideal);
 
+    /// Add a constraint tagged for a specific ring in the typed-constraint
+    /// flow. Builders that do not care about tags can keep the existing
+    /// semantics by falling back to `assert_in_ideal`.
+    fn assert_in_ideal_typed(
+        &mut self,
+        expr: Self::Expr,
+        ideal: &Self::Ideal,
+        _ring: ConstraintRing,
+    ) {
+        self.assert_in_ideal(expr, ideal);
+    }
+
     /// Add a constraint saying that `expr` is equal to zero which is
     /// the same as saying that `expr` belongs to the zero ideal.
     fn assert_zero(&mut self, expr: Self::Expr);
+
+    /// Builders may override this to skip work for inactive typed rings.
+    #[inline(always)]
+    fn is_active_for(&self, _ring: ConstraintRing) -> bool {
+        true
+    }
+
+    /// Builders may override this to skip zero-ideal constraints.
+    #[inline(always)]
+    fn is_active_for_zero_ideal(&self) -> bool {
+        true
+    }
 }
 
 /// Specifies a shifted column
@@ -610,6 +641,23 @@ pub trait Uair: Clone {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::{dummy_semiring::DummySemiring, ideal::ImpossibleIdeal};
+
+    #[derive(Default)]
+    struct TypedFallbackBuilder {
+        non_zero_constraints: usize,
+    }
+
+    impl ConstraintBuilder for TypedFallbackBuilder {
+        type Expr = DummySemiring;
+        type Ideal = ImpossibleIdeal;
+
+        fn assert_in_ideal(&mut self, _expr: Self::Expr, _ideal: &Self::Ideal) {
+            self.non_zero_constraints += 1;
+        }
+
+        fn assert_zero(&mut self, _expr: Self::Expr) {}
+    }
 
     fn signature_with_mixed_shifts() -> UairSignature {
         UairSignature::new(
@@ -669,5 +717,23 @@ mod tests {
     fn bit_op_specs_reject_count_at_cell_width() {
         let _ = signature_with_mixed_shifts()
             .with_bit_op_specs(8, vec![BitOpSpec::new(0, BitOp::Rot(8))]);
+    }
+
+    #[test]
+    fn typed_assertion_defaults_to_plain_assert_in_ideal() {
+        let mut builder = TypedFallbackBuilder::default();
+
+        builder.assert_in_ideal_typed(DummySemiring, &ImpossibleIdeal, ConstraintRing::Fp);
+
+        assert_eq!(builder.non_zero_constraints, 1);
+    }
+
+    #[test]
+    fn skip_hints_default_to_active() {
+        let builder = TypedFallbackBuilder::default();
+
+        assert!(builder.is_active_for(ConstraintRing::Z));
+        assert!(builder.is_active_for(ConstraintRing::Fp));
+        assert!(builder.is_active_for_zero_ideal());
     }
 }


### PR DESCRIPTION
This PR adds the first typed-constraint plumbing slice for #186.

It keeps the change at the UAIR boundary. The patch introduces `ConstraintRing`, adds a defaulted `assert_in_ideal_typed(...)` entrypoint on `ConstraintBuilder`, and records per-constraint tags in `IdealCollector`.

I split this out because the full dual-prime work spans `uair`, `piop`, and `protocol`, while this metadata plumbing is the smallest reusable piece and the easiest part to review independently. Existing builders keep their current behavior because the new typed entrypoint falls back to `assert_in_ideal(...)` by default.

This PR does not change `piop` routing or prover/verifier branching yet.

Validation:
`cargo test -p zinc-uair`
`cargo test -p zinc-uair --all-features`
`cargo check -p zinc-piop`
`cargo check -p zinc-protocol`
