### PR TITLE
Abstract away scalar projection HashMap

### DIFF
--- a/piop/src/combined_poly_resolver.rs
+++ b/piop/src/combined_poly_resolver.rs
@@ -12,6 +12,7 @@ use crate::{
         structs::{Proof as CprProof, ProverState as CprProverState},
     },
     ideal_check,
+    projections::ProjectedScalars,
     sumcheck::{
         SumCheckError, multi_degree::MultiDegreeSumcheckGroup,
         prover::ProverState as SumcheckProverState,
@@ -22,7 +23,7 @@ use itertools::Itertools;
 use num_traits::Zero;
 #[cfg(feature = "parallel")]
 use rayon::prelude::*;
-use std::{collections::HashMap, marker::PhantomData, slice};
+use std::{marker::PhantomData, slice};
 use thiserror::Error;
 use zinc_poly::{
     EvaluationError,
@@ -72,7 +73,7 @@ impl<F: InnerTransparentField + FromPrimitiveWithConfig + Send + Sync> CombinedP
         transcript: &mut impl Transcript,
         trace_matrix: Vec<DenseMultilinearExtension<F::Inner>>,
         evaluation_point: &[F],
-        projected_scalars: &HashMap<U::Scalar, F>,
+        projected_scalars: &ProjectedScalars<U::Scalar, F>,
         num_constraints: usize,
         num_vars: usize,
         max_degree: usize,
@@ -159,7 +160,6 @@ impl<F: InnerTransparentField + FromPrimitiveWithConfig + Send + Sync> CombinedP
             let project = |scalar: &U::Scalar| {
                 projected_scalars
                     .get(scalar)
-                    .cloned()
                     .expect("all scalars should have been projected at this point")
             };
 
@@ -359,7 +359,7 @@ impl<F: InnerTransparentField + FromPrimitiveWithConfig + Send + Sync> CombinedP
         shared_point: Vec<F>,
         expected_evaluation: F,
         ancillary: CprVerifierAncillary<F>,
-        projected_scalars: &HashMap<U::Scalar, F>,
+        projected_scalars: &ProjectedScalars<U::Scalar, F>,
         field_cfg: &F::Config,
     ) -> Result<VerifierSubclaim<F>, CombinedPolyResolverError<F>>
     where
@@ -384,7 +384,6 @@ impl<F: InnerTransparentField + FromPrimitiveWithConfig + Send + Sync> CombinedP
         let project = |scalar: &U::Scalar| {
             projected_scalars
                 .get(scalar)
-                .cloned()
                 .expect("all scalars should have been projected at this point")
         };
 

--- a/piop/src/ideal_check.rs
+++ b/piop/src/ideal_check.rs
@@ -5,11 +5,12 @@ mod structs;
 
 pub use structs::*;
 
-use crate::projections::{ColumnMajorTrace, RowMajorTrace, column_major_to_row_major};
+use crate::projections::{
+    ColumnMajorTrace, ProjectedScalars, RowMajorTrace, column_major_to_row_major,
+};
 use batched_ideal_check::*;
 use crypto_primitives::PrimeField;
 use num_traits::ConstZero;
-use std::collections::HashMap;
 use thiserror::Error;
 use zinc_poly::{
     EvaluationError, univariate::dynamic::over_field::DynamicPolynomialF,
@@ -54,7 +55,7 @@ pub trait IdealCheckProtocol: Uair {
     fn prove_mle_first<F>(
         transcript: &mut impl Transcript,
         trace_matrix: &ColumnMajorTrace<F>,
-        projected_scalars: &HashMap<Self::Scalar, DynamicPolynomialF<F>>,
+        projected_scalars: &ProjectedScalars<Self::Scalar, DynamicPolynomialF<F>>,
         num_constraints: usize,
         num_vars: usize,
         field_cfg: &F::Config,
@@ -83,7 +84,7 @@ pub trait IdealCheckProtocol: Uair {
     fn prove_combined<F>(
         transcript: &mut impl Transcript,
         trace_matrix: &RowMajorTrace<F>,
-        projected_scalars: &HashMap<Self::Scalar, DynamicPolynomialF<F>>,
+        projected_scalars: &ProjectedScalars<Self::Scalar, DynamicPolynomialF<F>>,
         num_constraints: usize,
         num_vars: usize,
         field_cfg: &F::Config,
@@ -142,7 +143,7 @@ where
     fn prove_mle_first<F>(
         transcript: &mut impl Transcript,
         trace_matrix: &ColumnMajorTrace<F>,
-        projected_scalars: &HashMap<U::Scalar, DynamicPolynomialF<F>>,
+        projected_scalars: &ProjectedScalars<U::Scalar, DynamicPolynomialF<F>>,
         num_constraints: usize,
         num_vars: usize,
         field_cfg: &F::Config,
@@ -237,7 +238,7 @@ where
     fn prove_combined<F>(
         transcript: &mut impl Transcript,
         trace_matrix: &RowMajorTrace<F>,
-        projected_scalars: &HashMap<U::Scalar, DynamicPolynomialF<F>>,
+        projected_scalars: &ProjectedScalars<U::Scalar, DynamicPolynomialF<F>>,
         num_constraints: usize,
         num_vars: usize,
         field_cfg: &F::Config,

--- a/piop/src/ideal_check/combined_poly_builder.rs
+++ b/piop/src/ideal_check/combined_poly_builder.rs
@@ -1,10 +1,9 @@
 #[cfg(feature = "parallel")]
 use rayon::prelude::*;
 
-use crate::projections::{ColumnMajorTrace, RowMajorTrace};
+use crate::projections::{ColumnMajorTrace, ProjectedScalars, RowMajorTrace};
 use crypto_primitives::PrimeField;
 use num_traits::Zero;
-use std::collections::HashMap;
 use zinc_poly::{
     EvaluationError,
     mle::{
@@ -32,7 +31,7 @@ use zinc_utils::{
 #[allow(clippy::arithmetic_side_effects)]
 pub fn evaluate_for_constraints<F, U>(
     trace_matrix: &RowMajorTrace<F>,
-    projected_scalars: &HashMap<U::Scalar, DynamicPolynomialF<F>>,
+    projected_scalars: &ProjectedScalars<U::Scalar, DynamicPolynomialF<F>>,
     num_constraints: usize,
     field_cfg: &F::Config,
     constraint_indices: &[usize],
@@ -159,7 +158,7 @@ fn evaluate_constraints_for_row<F, U>(
     up: &[DynamicPolynomialF<F>],
     down: &[DynamicPolynomialF<F>],
     num_constraints: usize,
-    projected_scalars: &HashMap<U::Scalar, DynamicPolynomialF<F>>,
+    projected_scalars: &ProjectedScalars<U::Scalar, DynamicPolynomialF<F>>,
     down_layout: &ColumnLayout,
 ) -> Vec<DynamicPolynomialF<F>>
 where
@@ -171,7 +170,6 @@ where
     let project = |x: &U::Scalar| {
         projected_scalars
             .get(x)
-            .cloned()
             .expect("all scalars should have been projected at this point")
     };
 
@@ -209,7 +207,7 @@ where
 #[allow(clippy::arithmetic_side_effects)]
 pub fn evaluate_combined_polynomials<F, U>(
     trace_matrix: &ColumnMajorTrace<F>,
-    projected_scalars: &HashMap<U::Scalar, DynamicPolynomialF<F>>,
+    projected_scalars: &ProjectedScalars<U::Scalar, DynamicPolynomialF<F>>,
     num_constraints: usize,
     evaluation_point: &[F],
     field_cfg: &F::Config,
@@ -292,7 +290,6 @@ where
     let project = |x: &U::Scalar| {
         projected_scalars
             .get(x)
-            .cloned()
             .expect("all scalars should have been projected at this point")
     };
 

--- a/piop/src/projections.rs
+++ b/piop/src/projections.rs
@@ -32,6 +32,22 @@ pub enum ProjectedTrace<F: PrimeField> {
     ColumnMajor(ColumnMajorTrace<F>),
 }
 
+#[derive(Clone, Debug)]
+pub struct ProjectedScalars<From: Semiring, To: Clone> {
+    inner: HashMap<From, To>,
+}
+
+impl<From: Semiring, To: Clone> ProjectedScalars<From, To> {
+    // TODO(alex): Maybe return results?
+    #[inline]
+    pub fn get(&self, scalar: &From) -> Option<To> {
+        // TODO(alex): Lookup key often is DensePolynomial<R, 32> which is relatively
+        //             expensive to hash. If this becomes a bottleneck we can consider
+        //             using e.g. a raw point cache or something.
+        self.inner.get(scalar).cloned()
+    }
+}
+
 /// Project a multi-typed trace onto F[X], returning a row-indexed (transposed)
 /// matrix. Result: `trace[row][col]` where columns are ordered as binary_poly,
 /// arbitrary_poly, int.
@@ -374,27 +390,29 @@ pub fn build_bit_op_virtual_mle<F: PrimeField + 'static, const D: usize>(
 /// Project scalars of a UAIR onto F[X].
 pub fn project_scalars<F: PrimeField, U: Uair>(
     project: impl Fn(&U::Scalar) -> DynamicPolynomialF<F>,
-) -> HashMap<U::Scalar, DynamicPolynomialF<F>> {
+) -> ProjectedScalars<U::Scalar, DynamicPolynomialF<F>> {
     let uair_scalars = collect_scalars::<U>();
 
     // TODO(Ilia): if there's a lot of scalars
     //             we should do this in parallel probably.
-    uair_scalars
+    let inner = uair_scalars
         .into_iter()
         .map(|scalar| {
             let mut dynamic_poly = project(&scalar);
             dynamic_poly.trim();
             (scalar, dynamic_poly)
         })
-        .collect()
+        .collect();
+
+    ProjectedScalars { inner }
 }
 
 /// Project scalars of a UAIR along F[X] -> F.
 #[allow(clippy::arithmetic_side_effects)]
 pub fn project_scalars_to_field<R: Semiring + 'static, F: PrimeField>(
-    scalars: HashMap<R, DynamicPolynomialF<F>>,
+    scalars: ProjectedScalars<R, DynamicPolynomialF<F>>,
     projecting_element: &F,
-) -> Result<HashMap<R, F>, (R, F, EvaluationError)> {
+) -> Result<ProjectedScalars<R, F>, (R, F, EvaluationError)> {
     // TODO(Ilia): Parallelising this might be good for big UAIRs.
     //             We'd conditionally route between sequential and parallel
     //             projection depending on how many scalars the UAIR has.
@@ -402,6 +420,7 @@ pub fn project_scalars_to_field<R: Semiring + 'static, F: PrimeField>(
     let zero = F::zero_with_cfg(projecting_element.cfg());
 
     let max_coeffs_len = scalars
+        .inner
         .values()
         .map(|poly| poly.degree().map_or(0, |d| d + 1))
         .max()
@@ -410,7 +429,8 @@ pub fn project_scalars_to_field<R: Semiring + 'static, F: PrimeField>(
 
     let projection_powers: Vec<F> = powers(projecting_element.clone(), one, max_coeffs_len);
 
-    Ok(scalars
+    let inner = scalars
+        .inner
         .into_iter()
         .map(|(scalar, value)| {
             let deg = value.degree().map_or(0, |d| d + 1);
@@ -424,7 +444,9 @@ pub fn project_scalars_to_field<R: Semiring + 'static, F: PrimeField>(
                 .expect("inner product cannot fail here"),
             )
         })
-        .collect())
+        .collect();
+
+    Ok(ProjectedScalars { inner })
 }
 
 #[cfg(test)]

--- a/piop/src/test_utils.rs
+++ b/piop/src/test_utils.rs
@@ -1,12 +1,10 @@
-use std::collections::HashMap;
-
 use crate::{
     ideal_check::{
         IdealCheckProtocol, Proof as IdealCheckProof, ProverState as IdealCheckProverState,
     },
     projections::{
-        ColumnMajorTrace, RowMajorTrace, project_scalars, project_trace_coeffs_column_major,
-        project_trace_coeffs_row_major,
+        ColumnMajorTrace, ProjectedScalars, RowMajorTrace, project_scalars,
+        project_trace_coeffs_column_major, project_trace_coeffs_row_major,
     },
 };
 use crypto_bigint::{Odd, modular::MontyParams};
@@ -39,7 +37,7 @@ pub fn run_ideal_check_prover_linear<U, const DEGREE_PLUS_ONE: usize>(
 ) -> (
     IdealCheckProof<F>,
     IdealCheckProverState<F>,
-    HashMap<U::Scalar, DynamicPolynomialF<F>>,
+    ProjectedScalars<U::Scalar, DynamicPolynomialF<F>>,
     ColumnMajorTrace<F>,
 )
 where
@@ -93,7 +91,7 @@ pub fn run_ideal_check_prover_combined<U, const DEGREE_PLUS_ONE: usize>(
 ) -> (
     IdealCheckProof<F>,
     IdealCheckProverState<F>,
-    HashMap<U::Scalar, DynamicPolynomialF<F>>,
+    ProjectedScalars<U::Scalar, DynamicPolynomialF<F>>,
     RowMajorTrace<F>,
 )
 where

--- a/protocol/src/prover.rs
+++ b/protocol/src/prover.rs
@@ -1,16 +1,16 @@
 use super::*;
 use crypto_primitives::{ConstIntSemiring, FromPrimitiveWithConfig, FromWithConfig};
 use num_traits::Zero;
-use std::{borrow::Cow, collections::HashMap, fmt::Debug};
+use std::{borrow::Cow, fmt::Debug};
 use zinc_piop::{
     combined_poly_resolver::CombinedPolyResolver,
     ideal_check::IdealCheckProtocol,
     lookup::booleanity::{BooleanityChecker, BooleanityProof},
     multipoint_eval::{MultipointEval, Proof as MultipointEvalProof},
     projections::{
-        ColumnMajorTrace, ProjectedTrace, RowMajorTrace, evaluate_trace_to_column_mles,
-        project_scalars, project_scalars_to_field, project_trace_coeffs_column_major,
-        project_trace_coeffs_row_major,
+        ColumnMajorTrace, ProjectedScalars, ProjectedTrace, RowMajorTrace,
+        evaluate_trace_to_column_mles, project_scalars, project_scalars_to_field,
+        project_trace_coeffs_column_major, project_trace_coeffs_row_major,
     },
     sumcheck::multi_degree::MultiDegreeSumcheck,
 };
@@ -100,7 +100,7 @@ pub struct ProverProjectedCombined<
     base: ProverCommitted<'a, Zt, U, F, D, FD>,
     field_cfg: F::Config,
     projected_trace: RowMajorTrace<F>,
-    projected_scalars_fx: HashMap<U::Scalar, DynamicPolynomialF<F>>,
+    projected_scalars_fx: ProjectedScalars<U::Scalar, DynamicPolynomialF<F>>,
 }
 
 /// After step 2 via [`step2_mle_first`](ProverCommitted::step2_mle_first)
@@ -117,7 +117,7 @@ pub struct ProverProjectedMleFirst<
     base: ProverCommitted<'a, Zt, U, F, D, FD>,
     field_cfg: F::Config,
     projected_trace: ColumnMajorTrace<F>,
-    projected_scalars_fx: HashMap<U::Scalar, DynamicPolynomialF<F>>,
+    projected_scalars_fx: ProjectedScalars<U::Scalar, DynamicPolynomialF<F>>,
 }
 
 /// After step 3 (ideal check).
@@ -133,7 +133,7 @@ pub struct ProverIdealChecked<
     base: ProverCommitted<'a, Zt, U, F, D, FD>,
     field_cfg: F::Config,
     projected_trace: ProjectedTrace<F>,
-    projected_scalars_fx: HashMap<U::Scalar, DynamicPolynomialF<F>>,
+    projected_scalars_fx: ProjectedScalars<U::Scalar, DynamicPolynomialF<F>>,
 
     // New
     ic_proof: IdealCheckProof<F>,
@@ -158,7 +158,7 @@ pub struct ProverEvalProjected<
 
     // New
     projected_trace_f: Vec<DenseMultilinearExtension<F::Inner>>,
-    projected_scalars_f: HashMap<U::Scalar, F>,
+    projected_scalars_f: ProjectedScalars<U::Scalar, F>,
 }
 
 /// After step 5 (sumcheck).
@@ -403,7 +403,7 @@ impl_with_type_bounds!(ProverCommitted
     fn project_common<S: Fn(&U::Scalar, &F::Config) -> DynamicPolynomialF<F>>(
         &mut self,
         project_scalar: S,
-    ) -> Result<(F::Config, HashMap<U::Scalar, DynamicPolynomialF<F>>), ProtocolError<F, U::Ideal>>
+    ) -> Result<(F::Config, ProjectedScalars<U::Scalar, DynamicPolynomialF<F>>), ProtocolError<F, U::Ideal>>
     {
         let field_cfg = self
             .pcs_transcript

--- a/protocol/src/verifier.rs
+++ b/protocol/src/verifier.rs
@@ -2,14 +2,15 @@ use super::*;
 use crypto_primitives::{ConstIntSemiring, FromPrimitiveWithConfig, FromWithConfig};
 use itertools::Itertools;
 use num_traits::Zero;
-use std::{collections::HashMap, io::Cursor};
+use std::io::Cursor;
 use zinc_piop::{
     combined_poly_resolver::CombinedPolyResolver,
     ideal_check::{self, IdealCheckProtocol},
     lookup::booleanity::{BooleanityChecker, BooleanityProof},
     multipoint_eval::{self, MultipointEval},
     projections::{
-        ProjectedTrace, project_scalars, project_scalars_to_field, project_trace_coeffs_row_major,
+        ProjectedScalars, ProjectedTrace, project_scalars, project_scalars_to_field,
+        project_trace_coeffs_row_major,
     },
     sumcheck::multi_degree::MultiDegreeSumcheck,
 };
@@ -147,7 +148,7 @@ pub struct VerifierEvalProjected<
     field_cfg: F::Config,
     ic_subclaim: ideal_check::VerifierSubclaim<F>,
     projecting_element_f: F,
-    projected_scalars_f: HashMap<U::Scalar, F>,
+    projected_scalars_f: ProjectedScalars<U::Scalar, F>,
 
     // Proof leftovers
     proof_commitments: (ZipPlusCommitment, ZipPlusCommitment, ZipPlusCommitment),


### PR DESCRIPTION
This is a small cleanup introducing typesafe wrapper around scalar projection that incapsulates underlying hashmap.
If needed, we can later add caching or change key resolution there (see #179), but for now this doesn't seem to be beneficial.