### PR TITLE
perf(piop): avoid clones in virtual bit-op evals

### DIFF
--- a/piop/src/combined_poly_resolver.rs
+++ b/piop/src/combined_poly_resolver.rs
@@ -125,7 +125,7 @@ where
                             continue;
                         }
                         if let Some(w) = &weights[i] {
-                            acc += w.clone();
+                            acc += w;
                         }
                     }
                     acc.into_inner()

--- a/piop/src/ideal_check/combined_poly_builder.rs
+++ b/piop/src/ideal_check/combined_poly_builder.rs
@@ -6,7 +6,7 @@ use crate::{
     scalar_proj_cache::ScalarProjCache,
 };
 use crypto_primitives::PrimeField;
-use num_traits::{ConstZero, Zero};
+use num_traits::Zero;
 use std::cell::RefCell;
 use zinc_poly::{
     EvaluationError,

--- a/piop/src/lookup/booleanity.rs
+++ b/piop/src/lookup/booleanity.rs
@@ -132,7 +132,7 @@ where
                     // visits each coefficient once in O(D).
                     for (bit_idx, coeff) in bp.iter().enumerate() {
                         if coeff.into_inner() {
-                            accs[bit_idx] = accs[bit_idx].clone() + eq_t.clone();
+                            accs[bit_idx] += eq_t;
                         }
                     }
                 }

--- a/test-uair/src/sha_ecdsa.rs
+++ b/test-uair/src/sha_ecdsa.rs
@@ -80,15 +80,17 @@ use zinc_uair::{
 
 use crate::{
     GenerateRandomTrace,
-    ecdsa::{self, FINAL_ROW as ECDSA_FINAL_ROW, NUM_SHAMIR_ROUNDS},
+    ecdsa,
     ecdsa_doubling::{EC_FP_INT_LIMBS, EcdsaFpRing},
     sha256::{self, Sha256CompressionSliceUair, Sha256Ideal},
 };
+#[cfg(test)]
+use crate::ecdsa::FINAL_ROW as ECDSA_FINAL_ROW;
 
 use crypto_primitives::crypto_bigint_int::Int;
 
 // Re-export for convenience.
-pub use crate::ecdsa::FINAL_ROW;
+pub use crate::ecdsa::{FINAL_ROW, NUM_SHAMIR_ROUNDS};
 
 // ---------------------------------------------------------------------------
 // Column layout for the merged trace.

--- a/test-uair/src/sha_ecdsa.rs
+++ b/test-uair/src/sha_ecdsa.rs
@@ -80,17 +80,15 @@ use zinc_uair::{
 
 use crate::{
     GenerateRandomTrace,
-    ecdsa,
+    ecdsa::{self, FINAL_ROW as ECDSA_FINAL_ROW, NUM_SHAMIR_ROUNDS},
     ecdsa_doubling::{EC_FP_INT_LIMBS, EcdsaFpRing},
     sha256::{self, Sha256CompressionSliceUair, Sha256Ideal},
 };
-#[cfg(test)]
-use crate::ecdsa::FINAL_ROW as ECDSA_FINAL_ROW;
 
 use crypto_primitives::crypto_bigint_int::Int;
 
 // Re-export for convenience.
-pub use crate::ecdsa::{FINAL_ROW, NUM_SHAMIR_ROUNDS};
+pub use crate::ecdsa::FINAL_ROW;
 
 // ---------------------------------------------------------------------------
 // Column layout for the merged trace.


### PR DESCRIPTION
Use borrowed/in-place field addition while accumulating rotated and shifted binary polynomial evaluations. These paths run once per relevant set bit across each virtual bit-op or shifted bit-slice column, so avoiding clones removes a large amount of temporary field-element copying without changing the immediate-reduction semantics.