### PR TITLE
Plumb bit-op virtuals through CPR

### DIFF
--- a/piop/benches/combined_poly_resolver.rs
+++ b/piop/benches/combined_poly_resolver.rs
@@ -95,6 +95,7 @@ fn bench_no_mult<const INT_LIMBS: usize, const FIELD_LIMBS: usize>(
             CombinedPolyResolver::prepare_sumcheck_group::<TestUairNoMultiplication<_>>(
                 transcript,
                 trace_f,
+                Vec::new(),
                 &ic_prover_state.evaluation_point,
                 &scalars_f,
                 num_constraints,
@@ -111,13 +112,14 @@ fn bench_no_mult<const INT_LIMBS: usize, const FIELD_LIMBS: usize>(
             field_cfg,
         );
 
-        let (cpr_proof, cpr_state) = CombinedPolyResolver::finalize_prover(
-            transcript,
-            md_states.into_iter().next().expect("one CPR group"),
-            cpr_ancillary,
-            field_cfg,
-        )
-        .expect("CPR finalize failed");
+        let (cpr_proof, cpr_state) =
+            CombinedPolyResolver::finalize_prover::<TestUairNoMultiplication<_>>(
+                transcript,
+                md_states.into_iter().next().expect("one CPR group"),
+                cpr_ancillary,
+                field_cfg,
+            )
+            .expect("CPR finalize failed");
 
         (
             ic_proof,
@@ -280,6 +282,7 @@ fn bench_simple_mult<const INT_LIMBS: usize, const FIELD_LIMBS: usize>(
         >(
             transcript,
             trace_f,
+            Vec::new(),
             &ic_prover_state.evaluation_point,
             &scalars_f,
             num_constraints,
@@ -296,13 +299,14 @@ fn bench_simple_mult<const INT_LIMBS: usize, const FIELD_LIMBS: usize>(
             field_cfg,
         );
 
-        let (cpr_proof, cpr_state) = CombinedPolyResolver::finalize_prover(
-            transcript,
-            md_states.into_iter().next().expect("one CPR group"),
-            cpr_ancillary,
-            field_cfg,
-        )
-        .expect("CPR finalize failed");
+        let (cpr_proof, cpr_state) =
+            CombinedPolyResolver::finalize_prover::<TestUairSimpleMultiplication<Int<INT_LIMBS>>>(
+                transcript,
+                md_states.into_iter().next().expect("one CPR group"),
+                cpr_ancillary,
+                field_cfg,
+            )
+            .expect("CPR finalize failed");
 
         (
             ic_proof,

--- a/piop/src/combined_poly_resolver.rs
+++ b/piop/src/combined_poly_resolver.rs
@@ -61,6 +61,12 @@ impl<F: InnerTransparentField + FromPrimitiveWithConfig + Send + Sync> CombinedP
     /// # Parameters
     /// - `transcript`: FS-transcript.
     /// - `trace_matrix`: The trace that have been projected to F.
+    /// - `bit_op_down_mles`: MLEs of the bit-op virtual columns, projected to
+    ///   `F::Inner`, in `UairSignature::bit_op_specs()` order. The caller is
+    ///   responsible for applying the bit-op (ROTR / SHR) entry-wise on the
+    ///   *unprojected* binary_poly source column *before* projection — see
+    ///   Lemma 2.3 of the Zinc+ paper. The length must equal the signature's
+    ///   `bit_op_specs().len()`.
     /// - `evaluation_point`: The evaluation point for the claims.
     /// - `projected_scalars`: The UAIR scalars projected to `F`.
     /// - `num_constraints`: The number of constraint polynomials in the UAIR
@@ -72,6 +78,7 @@ impl<F: InnerTransparentField + FromPrimitiveWithConfig + Send + Sync> CombinedP
     pub fn prepare_sumcheck_group<U>(
         transcript: &mut impl Transcript,
         trace_matrix: Vec<DenseMultilinearExtension<F::Inner>>,
+        bit_op_down_mles: Vec<DenseMultilinearExtension<F::Inner>>,
         evaluation_point: &[F],
         projected_scalars: &ProjectedScalars<U::Scalar, F>,
         num_constraints: usize,
@@ -100,9 +107,16 @@ impl<F: InnerTransparentField + FromPrimitiveWithConfig + Send + Sync> CombinedP
         // TODO consider working with pointers since down cols are virtual cols until
         // folded in sumcheck - virtual MLE trait needed in sumcheck.
         let uair_sig = U::signature();
+
+        assert_eq!(
+            bit_op_down_mles.len(),
+            uair_sig.bit_op_specs().len(),
+            "bit_op_down_mles count must match UairSignature::bit_op_specs().len()",
+        );
+
         let zero_inner = zero.clone().into_inner();
         let n = 1usize << num_vars;
-        let down: Vec<DenseMultilinearExtension<F::Inner>> = cfg_iter!(uair_sig.shifts())
+        let shift_mles: Vec<DenseMultilinearExtension<F::Inner>> = cfg_iter!(uair_sig.shifts())
             .map(|spec| {
                 let mut evals = trace_matrix[spec.source_col()][spec.shift_amount()..].to_vec();
                 evals.resize(n, zero_inner.clone());
@@ -112,6 +126,28 @@ impl<F: InnerTransparentField + FromPrimitiveWithConfig + Send + Sync> CombinedP
                 }
             })
             .collect();
+
+        // Down-row layout (see UairSignature::with_bit_op_specs):
+        //
+        //     [shifted_binary..., bit_op_binary...,
+        //      shifted_arbitrary..., shifted_int...]
+        //
+        // Shifts are sorted by source_col, so binary-source shifts come first.
+        // We splice the bit-op MLEs in between the binary and non-binary
+        // shift groups so that the resulting `down` vector is consistent with
+        // the down ColumnLayout (binary_poly_cols + arbitrary_poly_cols +
+        // int_cols).
+        let bit_op_down_offset = uair_sig.bit_op_down_offset();
+        let num_shift_down = shift_mles.len();
+        let num_bit_op_specs = bit_op_down_mles.len();
+        let mut down: Vec<DenseMultilinearExtension<F::Inner>> =
+            Vec::with_capacity(num_shift_down + num_bit_op_specs);
+        let mut shift_iter = shift_mles.into_iter();
+        for _ in 0..bit_op_down_offset {
+            down.push(shift_iter.next().expect("offset within shift_mles range"));
+        }
+        down.extend(bit_op_down_mles);
+        down.extend(shift_iter);
 
         let eq_r = build_eq_x_r_inner(evaluation_point, field_cfg)?;
         // To get the constraints on the last row ignored
@@ -179,7 +215,7 @@ impl<F: InnerTransparentField + FromPrimitiveWithConfig + Send + Sync> CombinedP
             MultiDegreeSumcheckGroup::new(max_degree + 2, mles, comb_fn),
             CprProverAncillary {
                 num_cols,
-                num_down_cols,
+                num_down_cols: num_shift_down,
                 num_vars,
             },
         ))
@@ -195,7 +231,7 @@ impl<F: InnerTransparentField + FromPrimitiveWithConfig + Send + Sync> CombinedP
     ///   counts and `num_vars` needed to split the flat eval vector.
     /// - `field_cfg`: Field configuration.
     #[allow(clippy::arithmetic_side_effects)]
-    pub fn finalize_prover(
+    pub fn finalize_prover<U>(
         transcript: &mut impl Transcript,
         sumcheck_prover_state: SumcheckProverState<F>,
         ancillary: CprProverAncillary,
@@ -204,6 +240,7 @@ impl<F: InnerTransparentField + FromPrimitiveWithConfig + Send + Sync> CombinedP
     where
         F::Inner: ConstTranscribable + Zero,
         F::Modulus: ConstTranscribable,
+        U: Uair,
     {
         // Sumcheck prover stops evaluating MLEs
         // at the second to last challenge
@@ -230,17 +267,40 @@ impl<F: InnerTransparentField + FromPrimitiveWithConfig + Send + Sync> CombinedP
             })
             .try_collect()?;
 
-        debug_assert_eq!(evals.len(), ancillary.num_cols + ancillary.num_down_cols);
-        let mut transcription_buf: Vec<u8> = vec![0; F::Inner::NUM_BYTES];
-        transcript.absorb_random_field_slice(&evals, &mut transcription_buf);
-        let (up_evals, down_evals) = (
-            evals[0..ancillary.num_cols].to_vec(),
-            evals[ancillary.num_cols..].to_vec(),
+        let uair_sig = U::signature();
+        let num_bit_op_specs = uair_sig.bit_op_specs().len();
+        let bit_op_down_offset = uair_sig.bit_op_down_offset();
+
+        debug_assert_eq!(
+            evals.len(),
+            ancillary.num_cols + ancillary.num_down_cols + num_bit_op_specs,
         );
+
+        // The post-sumcheck evals are laid out as
+        //   [up_evals..., shifted_binary..., bit_op_evals..., shifted_non_binary...]
+        // matching the order in which `prepare_sumcheck_group` packed them
+        // into the MLE vector. We split them into three on-wire vectors:
+        // `up_evals`, `down_evals` (shifts only, in their UAIR-signature
+        // order), and `bit_op_evals` (in `bit_op_specs()` order).
+        let up_end = ancillary.num_cols;
+        let bit_op_start = up_end + bit_op_down_offset;
+        let bit_op_end = bit_op_start + num_bit_op_specs;
+
+        let up_evals = evals[..up_end].to_vec();
+        let bit_op_evals = evals[bit_op_start..bit_op_end].to_vec();
+        let mut down_evals = Vec::with_capacity(ancillary.num_down_cols);
+        down_evals.extend_from_slice(&evals[up_end..bit_op_start]);
+        down_evals.extend_from_slice(&evals[bit_op_end..]);
+
+        let mut transcription_buf: Vec<u8> = vec![0; F::Inner::NUM_BYTES];
+        transcript.absorb_random_field_slice(&up_evals, &mut transcription_buf);
+        transcript.absorb_random_field_slice(&down_evals, &mut transcription_buf);
+        transcript.absorb_random_field_slice(&bit_op_evals, &mut transcription_buf);
         Ok((
             CprProof {
                 up_evals,
                 down_evals,
+                bit_op_evals,
             },
             CprProverState {
                 evaluation_point: sumcheck_prover_state.randomness,
@@ -281,8 +341,11 @@ impl<F: InnerTransparentField + FromPrimitiveWithConfig + Send + Sync> CombinedP
         U: Uair,
     {
         let uair_sig = U::signature();
-        proof
-            .validate_evaluation_sizes(uair_sig.total_cols().cols(), uair_sig.down_cols().cols())?;
+        proof.validate_evaluation_sizes(
+            uair_sig.total_cols().cols(),
+            uair_sig.shifts().len(),
+            uair_sig.bit_op_specs().len(),
+        )?;
 
         let zero = F::zero_with_cfg(field_cfg);
         let one = F::one_with_cfg(field_cfg);
@@ -387,13 +450,24 @@ impl<F: InnerTransparentField + FromPrimitiveWithConfig + Send + Sync> CombinedP
                 .expect("all scalars should have been projected at this point")
         };
 
+        // Build the full down-row eval vec by splicing bit-op evals into the
+        // binary_poly slot, matching the down ColumnLayout enforced by
+        // `UairSignature::with_bit_op_specs`:
+        //   [shifted_binary..., bit_op_evals..., shifted_arbitrary..., shifted_int...]
+        let bit_op_down_offset = uair_sig.bit_op_down_offset();
+        let mut full_down_evals =
+            Vec::with_capacity(add!(proof.down_evals.len(), proof.bit_op_evals.len()));
+        full_down_evals.extend_from_slice(&proof.down_evals[..bit_op_down_offset]);
+        full_down_evals.extend_from_slice(&proof.bit_op_evals);
+        full_down_evals.extend_from_slice(&proof.down_evals[bit_op_down_offset..]);
+
         U::constrain_general(
             &mut folder,
             TraceRow::from_slice_with_layout(
                 &proof.up_evals,
                 uair_sig.total_cols().as_column_layout(),
             ),
-            TraceRow::from_slice_with_layout(&proof.down_evals, down_layout),
+            TraceRow::from_slice_with_layout(&full_down_evals, down_layout),
             project,
             |x, y| Some(project(y) * x),
             ImpossibleIdeal::from_ref,
@@ -411,10 +485,12 @@ impl<F: InnerTransparentField + FromPrimitiveWithConfig + Send + Sync> CombinedP
         let mut transcription_buf: Vec<u8> = vec![0; F::Inner::NUM_BYTES];
         transcript.absorb_random_field_slice(&proof.up_evals, &mut transcription_buf);
         transcript.absorb_random_field_slice(&proof.down_evals, &mut transcription_buf);
+        transcript.absorb_random_field_slice(&proof.bit_op_evals, &mut transcription_buf);
 
         Ok(VerifierSubclaim {
             up_evals: proof.up_evals,
             down_evals: proof.down_evals,
+            bit_op_evals: proof.bit_op_evals,
             evaluation_point: shared_point,
         })
     }
@@ -432,6 +508,8 @@ pub enum CombinedPolyResolverError<F: PrimeField> {
     WrongUpEvalsNumber { got: usize, expected: usize },
     #[error("wrong shifted trace columns evaluations number: got {got}, expected {expected}")]
     WrongDownEvalsNumber { got: usize, expected: usize },
+    #[error("wrong bit-op virtual columns evaluations number: got {got}, expected {expected}")]
+    WrongBitOpEvalsNumber { got: usize, expected: usize },
     #[error("sumcheck verification failed: {0}")]
     SumcheckError(SumCheckError<F>),
     #[error("wrong sumcheck claimed sum: received {got}, expected {expected}")]
@@ -541,6 +619,7 @@ mod tests {
                 &ProjectedTrace::RowMajor(projected_trace),
                 &projecting_element,
             ),
+            Vec::new(),
             &ic_prover_state.evaluation_point,
             &projected_scalars,
             num_constraints,
@@ -557,7 +636,7 @@ mod tests {
             &test_config(),
         );
 
-        let (proof, _) = CombinedPolyResolver::finalize_prover(
+        let (proof, _) = CombinedPolyResolver::finalize_prover::<U>(
             &mut prover_transcript,
             states.into_iter().next().unwrap(),
             cpr_ancillary,

--- a/piop/src/combined_poly_resolver/structs.rs
+++ b/piop/src/combined_poly_resolver/structs.rs
@@ -8,13 +8,23 @@ use crate::combined_poly_resolver::CombinedPolyResolverError;
 ///
 /// Note: the sumcheck proof now lives at the protocol
 /// level as part of `MultiDegreeSumcheckProof`.
+///
+/// `bit_op_evals` is the prover's claim about the bit-op virtual columns'
+/// MLE evaluations at the shared CPR point. These are *not* trusted by
+/// themselves: they are bound back to the source columns' lifted openings at
+/// the multi-point evaluation endpoint via Lemma 2.3.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Proof<F: PrimeField> {
     /// The evaluation of the projected trace columns MLEs at the shared point.
     pub up_evals: Vec<F>,
     /// The evaluations of the shifted projected trace columns MLEs at the
-    /// shared point.
+    /// shared point. Carries *only* the row-shift virtual columns —
+    /// bit-op virtuals are sent separately in `bit_op_evals` to avoid
+    /// overloading shift semantics on the wire.
     pub down_evals: Vec<F>,
+    /// The evaluations of the bit-op virtual columns (ROTR / SHR) at the
+    /// shared point, in `UairSignature::bit_op_specs()` order.
+    pub bit_op_evals: Vec<F>,
 }
 
 impl<F: PrimeField> GenTranscribable for Proof<F>
@@ -25,16 +35,19 @@ where
     fn read_transcription_bytes_exact(bytes: &[u8]) -> Self {
         let (up_evals, bytes) = Vec::<F>::read_transcription_bytes_subset(bytes);
         let (down_evals, bytes) = Vec::<F>::read_transcription_bytes_subset(bytes);
+        let (bit_op_evals, bytes) = Vec::<F>::read_transcription_bytes_subset(bytes);
         assert!(bytes.is_empty(), "All bytes should be consumed");
         Self {
             up_evals,
             down_evals,
+            bit_op_evals,
         }
     }
 
     fn write_transcription_bytes_exact(&self, buf: &mut [u8]) {
         let buf = self.up_evals.write_transcription_bytes_subset(buf);
         let buf = self.down_evals.write_transcription_bytes_subset(buf);
+        let buf = self.bit_op_evals.write_transcription_bytes_subset(buf);
         assert!(buf.is_empty(), "Entire buffer should be used");
     }
 }
@@ -46,21 +59,25 @@ where
 {
     fn get_num_bytes(&self) -> usize {
         add!(
-            2 * u32::NUM_BYTES,
+            3 * u32::NUM_BYTES,
             add!(
                 self.up_evals.get_num_bytes(),
-                self.down_evals.get_num_bytes()
+                add!(
+                    self.down_evals.get_num_bytes(),
+                    self.bit_op_evals.get_num_bytes()
+                )
             )
         )
     }
 }
 
 impl<F: PrimeField> Proof<F> {
-    /// Check if `up_evals` and `down_evals` vectors have the expected lengths.
+    /// Check that the proof's evaluation vectors have the expected lengths.
     pub fn validate_evaluation_sizes(
         &self,
         num_cols: usize,
         num_down_cols: usize,
+        num_bit_op_specs: usize,
     ) -> Result<(), CombinedPolyResolverError<F>> {
         if self.up_evals.len() != num_cols {
             return Err(CombinedPolyResolverError::WrongUpEvalsNumber {
@@ -76,6 +93,13 @@ impl<F: PrimeField> Proof<F> {
             });
         }
 
+        if self.bit_op_evals.len() != num_bit_op_specs {
+            return Err(CombinedPolyResolverError::WrongBitOpEvalsNumber {
+                got: self.bit_op_evals.len(),
+                expected: num_bit_op_specs,
+            });
+        }
+
         Ok(())
     }
 }
@@ -87,11 +111,11 @@ pub struct ProverState<F: PrimeField> {
 
 /// Ancillary data produced by `prepare_sumcheck_group` and consumed by
 /// `finalize_prover`. Holds everything needed to extract `up_evals` /
-/// `down_evals` after the shared sumcheck completes.
+/// `down_evals` / `bit_op_evals` after the shared sumcheck completes.
 pub struct CprProverAncillary {
     /// Number of trace (up) columns — used to split the flat evals vec.
     pub num_cols: usize,
-    /// Number of shifted (down) columns.
+    /// Number of shift-virtual (down) columns.
     pub num_down_cols: usize,
     /// Number of variables — used to index the last challenge.
     pub num_vars: usize,
@@ -110,14 +134,21 @@ pub struct CprVerifierAncillary<F: PrimeField> {
 }
 
 /// The claim that is left to be proven after the combined polynomial resolver
-/// verifier has succeeded. It is several evaluation claims about the trace
-/// columns and the shifted trace columns at the same evaluation point.
+/// verifier has succeeded. It is a list of evaluation claims at a common
+/// evaluation point, covering committed trace columns, row-shift virtual
+/// columns, and bit-op virtual columns. Bit-op evals are kept separate so the
+/// downstream `MultipointEval` can bind them back to the source columns'
+/// lifted openings (per Lemma 2.3 of the Zinc+ paper) rather than treating
+/// them as standalone trusted evaluations.
 #[derive(Clone, Debug)]
 pub struct VerifierSubclaim<F: PrimeField> {
     /// Evaluation point for the claims.
     pub evaluation_point: Vec<F>,
     /// Evaluation claims about the trace columns.
     pub up_evals: Vec<F>,
-    /// Evaluation claims about the shifted trace columns.
+    /// Evaluation claims about the row-shift virtual columns.
     pub down_evals: Vec<F>,
+    /// Evaluation claims about the bit-op virtual columns, in
+    /// `UairSignature::bit_op_specs()` order.
+    pub bit_op_evals: Vec<F>,
 }

--- a/protocol/src/prover.rs
+++ b/protocol/src/prover.rs
@@ -575,9 +575,14 @@ impl_with_type_bounds!(ProverEvalProjected
         let num_constraints = count_constraints::<U>();
         let max_degree = count_max_degree::<U>();
 
+        // TODO(#185): once protocol-level prover materializes bit-op virtual
+        // MLEs, pass them here. For now no UAIR on `main` declares
+        // `bit_op_specs`, so passing an empty vec keeps behaviour identical.
+        let bit_op_down_mles = Vec::new();
         let (cpr_group, cpr_ancillary) = CombinedPolyResolver::prepare_sumcheck_group::<U>(
             &mut self.base.pcs_transcript.fs_transcript,
             self.projected_trace_f.clone(),
+            bit_op_down_mles,
             &self.ic_eval_point,
             &self.projected_scalars_f,
             num_constraints,
@@ -622,7 +627,7 @@ impl_with_type_bounds!(ProverEvalProjected
 
         let mut md_iter = md_states.into_iter();
 
-        let (cpr_proof, cpr_prover_state) = CombinedPolyResolver::finalize_prover(
+        let (cpr_proof, cpr_prover_state) = CombinedPolyResolver::finalize_prover::<U>(
             &mut self.base.pcs_transcript.fs_transcript,
             md_iter.next().expect("CPR group always present"),
             cpr_ancillary,

--- a/uair/src/lib.rs
+++ b/uair/src/lib.rs
@@ -423,6 +423,20 @@ impl UairSignature {
         &self.bit_op_specs
     }
 
+    /// Number of row-shift virtual columns that precede bit-op virtuals in the
+    /// down-row ordering.
+    ///
+    /// The full down-row order is:
+    /// `[shifted_binary_poly..., bit_op_binary_poly...,
+    /// shifted_arbitrary_poly..., shifted_int...]`.
+    pub fn bit_op_down_offset(&self) -> usize {
+        let binary_poly_end = self.total_cols.num_binary_poly_cols();
+        self.shifts
+            .iter()
+            .take_while(|spec| spec.source_col() < binary_poly_end)
+            .count()
+    }
+
     /// Column-type layout of the down row (shifted virtuals + bit-op virtuals).
     pub fn down_cols(&self) -> &VirtualColumnLayout {
         &self.down_cols
@@ -632,6 +646,7 @@ mod tests {
         assert_eq!(sig.down_cols().num_binary_poly_cols(), 3);
         assert_eq!(sig.down_cols().num_arbitrary_poly_cols(), 1);
         assert_eq!(sig.down_cols().num_int_cols(), 1);
+        assert_eq!(sig.bit_op_down_offset(), 1);
     }
 
     #[test]
@@ -642,6 +657,7 @@ mod tests {
         assert_eq!(sig.down_cols().num_binary_poly_cols(), 1);
         assert_eq!(sig.down_cols().num_arbitrary_poly_cols(), 1);
         assert_eq!(sig.down_cols().num_int_cols(), 1);
+        assert_eq!(sig.bit_op_down_offset(), 1);
     }
 
     #[test]


### PR DESCRIPTION
## What changed

This is the next small follow-up after #191, #192, and #194 for #185, which blocks #91.

It extends the combined polynomial resolver (CPR) path to carry bit-op virtual column evaluations separately from row-shift down evaluations:

- Adds `bit_op_evals` to the CPR proof and verifier subclaim.
- Adds `bit_op_down_mles` input to `CombinedPolyResolver::prepare_sumcheck_group`.
- Splices bit-op MLEs into the CPR sumcheck down-row layout as:
  `[shifted_binary..., bit_op_binary..., shifted_arbitrary..., shifted_int...]`.
- Keeps the wire format explicit: row-shift evals remain in `down_evals`, bit-op virtual evals travel in `bit_op_evals`.
- Updates current no-bit-op protocol and benchmark callers with `Vec::new()` placeholders.

## What is intentionally deferred

This PR does not bind `bit_op_evals` to source openings yet. That remains for the next atomic PR in the multipoint-eval/protocol verifier layer. The CPR proof values introduced here are therefore plumbing only until that follow-up lands.

## Validation

- `cargo test -p zinc-piop combined_poly_resolver`
- `cargo check -p zinc-protocol`
- `.githooks/pre-push`