### PR TITLE
Delayed Modular Reduction for Fast Polynomial Evaluations

### DIFF
--- a/piop/src/combined_poly_resolver.rs
+++ b/piop/src/combined_poly_resolver.rs
@@ -125,7 +125,7 @@ where
                             continue;
                         }
                         if let Some(w) = &weights[i] {
-                            acc += w.clone();
+                            acc += w;
                         }
                     }
                     acc.into_inner()

--- a/piop/src/ideal_check/combined_poly_builder.rs
+++ b/piop/src/ideal_check/combined_poly_builder.rs
@@ -6,7 +6,7 @@ use crate::{
     scalar_proj_cache::ScalarProjCache,
 };
 use crypto_primitives::PrimeField;
-use num_traits::{ConstZero, Zero};
+use num_traits::Zero;
 use std::cell::RefCell;
 use zinc_poly::{
     EvaluationError,

--- a/piop/src/lookup/booleanity.rs
+++ b/piop/src/lookup/booleanity.rs
@@ -13,7 +13,9 @@
 //! `max_degree + 3`. For SHA-style UAIRs (max_degree ≥ 6) with hundreds
 //! of bit-slice MLEs, this is a 2–2.5× saving on step 4 alone.
 
-use crypto_primitives::{FromPrimitiveWithConfig, PrimeField, semiring::boolean::Boolean};
+use crypto_primitives::{
+    FromPrimitiveWithConfig, PrimeField, crypto_bigint_uint::Uint, semiring::boolean::Boolean,
+};
 use num_traits::Zero;
 #[cfg(feature = "parallel")]
 use rayon::prelude::*;
@@ -31,7 +33,10 @@ use zinc_uair::{
     VirtualBoolSpec,
 };
 use zinc_utils::{
-    cfg_into_iter, cfg_iter, inner_transparent_field::InnerTransparentField, powers,
+    cfg_into_iter, cfg_iter,
+    delayed_reduction::{DelayedModularReduction, MontgomeryLimbs},
+    inner_transparent_field::InnerTransparentField,
+    powers,
 };
 
 /// Build the F::Inner-valued shifted bit-slice MLEs for each
@@ -88,15 +93,11 @@ where
 /// sumcheck point `r*`. Equivalent to
 /// `build_shifted_bit_slice_mles(...).iter().map(evaluate_at(r*))`,
 /// but skips materializing the `num_shifted_specs · D` F::Inner-valued
-/// MLE buffers (~`num_shifted · D · n` F::Inner allocations). Builds
-/// the size-`n` `eq(r*, ·)` table once and accumulates per-bit sums
-/// directly from the `BinaryPoly<D>` trace columns in a single pass
-/// per spec (t outer, bits inner — avoids `iter().nth(bit_idx)`'s
-/// linear cost on custom binary-poly iterators).
+/// MLE buffers (~`num_shifted · D · n` F::Inner allocations).
 ///
-/// Used when the prover doesn't otherwise need the materialized bit-
-/// slice MLEs (i.e. when no `VirtualBoolSpec` is registered — the
-/// `VirtualBinaryPolySpec` path reads source binary_polys directly).
+/// The hot per-bit sums are accumulated with delayed modular reduction:
+/// each bit accumulator is a small `Uint<5>` integer and is reduced
+/// once at the end of the spec scan.
 #[allow(clippy::arithmetic_side_effects)]
 pub fn compute_shifted_bit_slice_evals_streaming<F, const D: usize>(
     trace_witness_binary_poly: &[DenseMultilinearExtension<BinaryPoly<D>>],
@@ -105,39 +106,42 @@ pub fn compute_shifted_bit_slice_evals_streaming<F, const D: usize>(
     field_cfg: &F::Config,
 ) -> Result<Vec<F>, ArithErrors>
 where
-    F: PrimeField + Send + Sync,
+    F: PrimeField + MontgomeryLimbs + Send + Sync,
     F::Config: Sync,
 {
     if shifted_specs.is_empty() {
         return Ok(Vec::new());
     }
-    // Single shared eq table — one O(n) pass + O(n) memory across all
-    // (spec, bit) sums.
     let eq_table = build_eq_x_r_vec(point, field_cfg)?;
+    let reduction_params = F::barrett_reduction_params(field_cfg);
 
-    let zero = F::zero_with_cfg(field_cfg);
     let out: Vec<F> = cfg_iter!(shifted_specs)
         .flat_map(|spec| {
             let col = &trace_witness_binary_poly[spec.witness_col_idx];
             let shift = spec.shift_amount;
             let n = col.evaluations.len();
-            // Per-bit accumulators, one F-element each.
-            let mut accs: Vec<F> = vec![zero.clone(); D];
+            let mut accs: Vec<Uint<5>> = vec![Uint::zero(); D];
             for t in 0..n {
                 let src_t = t.checked_add(shift).filter(|&v| v < n);
                 if let Some(s) = src_t {
                     let bp = &col.evaluations[s];
                     let eq_t = &eq_table[t];
-                    // Walk bits in their stored order; the iterator
-                    // visits each coefficient once in O(D).
                     for (bit_idx, coeff) in bp.iter().enumerate() {
                         if coeff.into_inner() {
-                            accs[bit_idx] += eq_t;
+                            <Uint<5> as DelayedModularReduction<F>>::add(&mut accs[bit_idx], eq_t);
                         }
                     }
                 }
             }
-            accs
+            accs.into_iter()
+                .map(|acc| {
+                    <Uint<5> as DelayedModularReduction<F>>::reduce(
+                        acc,
+                        field_cfg,
+                        &reduction_params,
+                    )
+                })
+                .collect::<Vec<_>>()
         })
         .collect();
     Ok(out)
@@ -1193,6 +1197,39 @@ mod tests {
             num_vars,
             evaluations,
         }
+    }
+
+    #[test]
+    fn shifted_bit_slice_streaming_matches_materialized_mles() {
+        let cfg = test_cfg();
+        let col = col_from_u8s(&[0b0000_0001, 0b0000_1010, 0b1010_0000, 0b1111_0000]);
+        let specs = [
+            ShiftedBitSliceSpec::new(0, 1),
+            ShiftedBitSliceSpec::new(0, 2),
+        ];
+        let point = vec![
+            F::from_with_cfg(3u64, &cfg),
+            F::from_with_cfg(5u64, &cfg),
+        ];
+
+        let materialized = build_shifted_bit_slice_mles::<F, 8>(
+            std::slice::from_ref(&col),
+            &specs,
+            &cfg,
+        )
+        .into_iter()
+        .map(|mle| mle.evaluate_with_config(&point, &cfg))
+        .collect::<Result<Vec<_>, _>>()
+        .unwrap();
+        let streaming = compute_shifted_bit_slice_evals_streaming::<F, 8>(
+            std::slice::from_ref(&col),
+            &specs,
+            &point,
+            &cfg,
+        )
+        .unwrap();
+
+        assert_eq!(streaming, materialized);
     }
 
     #[test]

--- a/piop/src/lookup/booleanity.rs
+++ b/piop/src/lookup/booleanity.rs
@@ -132,7 +132,7 @@ where
                     // visits each coefficient once in O(D).
                     for (bit_idx, coeff) in bp.iter().enumerate() {
                         if coeff.into_inner() {
-                            accs[bit_idx] = accs[bit_idx].clone() + eq_t.clone();
+                            accs[bit_idx] += eq_t;
                         }
                     }
                 }

--- a/protocol/benches/e2e.rs
+++ b/protocol/benches/e2e.rs
@@ -317,8 +317,7 @@ where
 
 const DEGREE_PLUS_ONE: usize = 32;
 const INT_LIMBS: usize = U64::LIMBS;
-// `fixed-prime` branch: 256-bit field modulus (4 × u64 limbs) so that the
-// fixed secp256k1 base prime fits in `Fmod = Uint<FIELD_LIMBS>`.
+// 256-bit field modulus (4 × u64 limbs).
 const FIELD_LIMBS: usize = U64::LIMBS * 4;
 
 type F = MontyField<FIELD_LIMBS>;

--- a/protocol/src/lib.rs
+++ b/protocol/src/lib.rs
@@ -24,7 +24,10 @@ pub mod verifier;
 #[cfg(feature = "parallel")]
 use rayon::prelude::*;
 
-use crypto_primitives::{ConstIntRing, ConstIntSemiring, FromWithConfig, PrimeField, Semiring};
+use crypto_primitives::{
+    ConstIntRing, ConstIntSemiring, FromWithConfig, PrimeField, Semiring,
+    crypto_bigint_uint::Uint,
+};
 use std::{fmt::Debug, marker::PhantomData};
 use thiserror::Error;
 use zinc_piop::{
@@ -47,7 +50,11 @@ use zinc_poly::{
 use zinc_primality::PrimalityTest;
 use zinc_transcript::traits::{ConstTranscribable, GenTranscribable, Transcribable, Transcript};
 use zinc_uair::{Uair, ideal::Ideal};
-use zinc_utils::{cfg_extend, cfg_into_iter, cfg_iter, named::Named};
+use zinc_utils::{
+    cfg_extend, cfg_into_iter, cfg_iter,
+    delayed_reduction::{DelayedModularReduction, MontgomeryLimbs},
+    named::Named,
+};
 use zip_plus::{
     ZipError,
     code::LinearCode,
@@ -505,12 +512,16 @@ fn absorb_public_columns<T: ConstTranscribable>(
 /// Binary columns exploit the 0/1 structure for conditional additions only.
 /// The `eq(point, *)` table is built once and reused across all columns.
 #[allow(clippy::arithmetic_side_effects)]
-fn compute_lifted_evals<F: PrimeField, const D: usize>(
+fn compute_lifted_evals<F, const D: usize>(
     point: &[F],
     trace_bin_poly: &[DenseMultilinearExtension<BinaryPoly<D>>],
     projected_trace: &ProjectedTrace<F>,
     field_cfg: &F::Config,
-) -> Vec<DynamicPolynomialF<F>> {
+) -> Vec<DynamicPolynomialF<F>>
+where
+    F: PrimeField + MontgomeryLimbs + Send + Sync,
+    F::Config: Sync,
+{
     compute_lifted_evals_capped::<F, D>(point, trace_bin_poly, projected_trace, field_cfg, None)
 }
 
@@ -524,46 +535,48 @@ fn compute_lifted_evals<F: PrimeField, const D: usize>(
 /// section here is wasted work. Pass `Some(num_total_arb_cols)` to stop
 /// the non-binary iter right after arbitrary cols.
 #[allow(clippy::arithmetic_side_effects)]
-pub fn compute_lifted_evals_capped<F: PrimeField, const D: usize>(
+pub fn compute_lifted_evals_capped<F, const D: usize>(
     point: &[F],
     trace_bin_poly: &[DenseMultilinearExtension<BinaryPoly<D>>],
     projected_trace: &ProjectedTrace<F>,
     field_cfg: &F::Config,
     non_binary_cap: Option<usize>,
-) -> Vec<DynamicPolynomialF<F>> {
+) -> Vec<DynamicPolynomialF<F>>
+where
+    F: PrimeField + MontgomeryLimbs + Send + Sync,
+    F::Config: Sync,
+{
     let eq_table = zinc_poly::utils::build_eq_x_r_vec(point, field_cfg)
         .expect("compute_lifted_evals: eq table build failed");
+    let reduction_params = F::barrett_reduction_params(field_cfg);
 
     let n_bin = trace_bin_poly.len();
     let zero = F::zero_with_cfg(field_cfg);
 
-    // Binary columns: exploit 0/1 structure for conditional additions.
-    // Pack each entry's up-to-64 boolean coefficients into a u64 so we
-    // can (a) skip entries that are identically zero, and (b) walk only
-    // the SET bits via `trailing_zeros` + Brian Kernighan's clear-lowest
-    // instead of branching on every slot.
-    debug_assert!(D <= 64, "compute_lifted_evals: bitmask packing assumes D <= 64");
+    // Binary columns: exploit 0/1 structure for conditional additions,
+    // accumulating with delayed modular reduction and reducing once per
+    // coefficient.
     let mut result: Vec<DynamicPolynomialF<F>> = cfg_iter!(trace_bin_poly)
         .map(|col| {
-            let mut coeffs = vec![zero.clone(); D];
+            let mut coeffs = vec![Uint::<5>::default(); D];
             for (b, entry) in col.iter().enumerate() {
-                let mut bits: u64 = 0;
+                let eq_b = &eq_table[b];
                 for (l, coeff) in entry.iter().enumerate().take(D) {
                     if coeff.into_inner() {
-                        bits |= 1u64 << l;
+                        <Uint<5> as DelayedModularReduction<F>>::add(&mut coeffs[l], eq_b);
                     }
                 }
-                if bits == 0 {
-                    continue;
-                }
-                let eq_b = &eq_table[b];
-                let mut remaining = bits;
-                while remaining != 0 {
-                    let l = remaining.trailing_zeros() as usize;
-                    coeffs[l] += eq_b;
-                    remaining &= remaining - 1;
-                }
             }
+            let coeffs: Vec<F> = coeffs
+                .into_iter()
+                .map(|acc| {
+                    <Uint<5> as DelayedModularReduction<F>>::reduce(
+                        acc,
+                        field_cfg,
+                        &reduction_params,
+                    )
+                })
+                .collect();
             DynamicPolynomialF::new_trimmed(coeffs)
         })
         .collect();
@@ -779,7 +792,8 @@ mod tests {
     use super::*;
     use crypto_bigint::U64;
     use crypto_primitives::{
-        Field, crypto_bigint_int::Int, crypto_bigint_monty::MontyField, crypto_bigint_uint::Uint,
+        Field, FromWithConfig, boolean::Boolean, crypto_bigint_int::Int,
+        crypto_bigint_monty::MontyField, crypto_bigint_uint::Uint,
     };
     use rand::rng;
     use zinc_piop::{
@@ -813,8 +827,7 @@ mod tests {
     };
 
     const INT_LIMBS: usize = U64::LIMBS;
-    // `fixed-prime` branch: 256-bit field modulus (4 × u64 limbs) so the
-    // hardcoded secp256k1 base prime fits in `Fmod = Uint<FIELD_LIMBS>`.
+    // 256-bit field modulus (4 × u64 limbs).
     const FIELD_LIMBS: usize = U64::LIMBS * 4;
     const DEGREE_PLUS_ONE: usize = 32;
 
@@ -850,6 +863,67 @@ mod tests {
     };
 
     type F = MontyField<FIELD_LIMBS>;
+
+    #[test]
+    fn lifted_binary_eval_matches_definition() {
+        let field_cfg = fixed_prime::secp256k1_field_cfg::<F, Uint<FIELD_LIMBS>>();
+        let point = vec![
+            F::from_with_cfg(7u64, &field_cfg),
+            F::from_with_cfg(11u64, &field_cfg),
+        ];
+        let trace_bin_poly: Vec<DenseMultilinearExtension<BinaryPoly<8>>> = [
+            [0b0000_0001, 0b0000_1010, 0b1010_0000, 0b1111_0000],
+            [0b1111_1111, 0b0101_0101, 0b0011_0011, 0b0000_0000],
+        ]
+        .into_iter()
+        .map(|patterns| {
+            let evaluations: Vec<BinaryPoly<8>> = patterns
+                .into_iter()
+                .map(|p| {
+                    let coeffs: [Boolean; 8] =
+                        std::array::from_fn(|i| Boolean::new((p >> i) & 1 != 0));
+                    BinaryPoly::<8>::new(coeffs)
+                })
+                .collect();
+            DenseMultilinearExtension {
+                num_vars: evaluations.len().next_power_of_two().trailing_zeros() as usize,
+                evaluations,
+            }
+        })
+        .collect();
+        let projected_trace = ProjectedTrace::RowMajor(vec![
+            vec![
+                DynamicPolynomialF::new_trimmed(vec![F::zero_with_cfg(&field_cfg)]),
+                DynamicPolynomialF::new_trimmed(vec![F::zero_with_cfg(&field_cfg)]),
+            ];
+            4
+        ]);
+
+        let eq_table = zinc_poly::utils::build_eq_x_r_vec(&point, &field_cfg).unwrap();
+        let expected: Vec<_> = trace_bin_poly
+            .iter()
+            .map(|col| {
+                let mut coeffs = vec![F::zero_with_cfg(&field_cfg); 8];
+                for (row_idx, entry) in col.iter().enumerate() {
+                    for (bit_idx, coeff) in entry.iter().enumerate() {
+                        if coeff.into_inner() {
+                            coeffs[bit_idx] += &eq_table[row_idx];
+                        }
+                    }
+                }
+                DynamicPolynomialF::new_trimmed(coeffs)
+            })
+            .collect();
+        let lifted = compute_lifted_evals_capped::<F, 8>(
+            &point,
+            &trace_bin_poly,
+            &projected_trace,
+            &field_cfg,
+            None,
+        );
+
+        assert_eq!(lifted, expected);
+    }
 
     #[derive(Debug, Clone)]
     pub struct BinPolyZipTypes {}
@@ -1034,7 +1108,7 @@ mod tests {
         check_verification: impl Fn(Result<(), ProtocolError<F, IdealOrZero<DegreeOneIdeal<F>>>>),
     ) where
         Zt: ZincTypes<DEGREE_PLUS_ONE>,
-        Zt::Int: num_traits::Zero,
+        Zt::Int: ProjectableToField<F> + num_traits::Zero,
         <Zt::BinaryZt as ZipTypes>::Cw: ProjectableToField<F>,
         <Zt::ArbitraryZt as ZipTypes>::Eval: ProjectableToField<F>,
         <Zt::ArbitraryZt as ZipTypes>::Cw: ProjectableToField<F>,

--- a/protocol/src/prover.rs
+++ b/protocol/src/prover.rs
@@ -255,6 +255,7 @@ macro_rules! impl_with_type_bounds {
             <Zt::ArbitraryZt as ZipTypes>::Eval: ProjectableToField<F>,
             U: Uair + 'static,
             F: InnerTransparentField
+                + MontgomeryLimbs
                 + FromPrimitiveWithConfig
                 + for<'b> FromWithConfig<&'b Zt::Int>
                 + for<'b> FromWithConfig<&'b <Zt::BinaryZt as ZipTypes>::CombR>
@@ -975,6 +976,7 @@ where
     Zt::Int: ProjectableToField<F>,
     <Zt::ArbitraryZt as ZipTypes>::Eval: ProjectableToField<F>,
     F: InnerTransparentField
+        + MontgomeryLimbs
         + FromPrimitiveWithConfig
         + for<'a> FromWithConfig<&'a Zt::Int>
         + for<'a> FromWithConfig<&'a <Zt::BinaryZt as ZipTypes>::CombR>
@@ -1127,6 +1129,7 @@ where
     BinaryPoly<HALF_D>: ProjectableToField<F>,
     U: Uair + 'static,
     F: InnerTransparentField
+        + MontgomeryLimbs
         + FromPrimitiveWithConfig
         + for<'a> FromWithConfig<&'a ZtF::Int>
         + for<'a> FromWithConfig<&'a <ZtF::BinaryZt as ZipTypes>::CombR>
@@ -1643,6 +1646,7 @@ where
     BinaryPoly<QUARTER_D>: ProjectableToField<F>,
     U: Uair<Scalar = zinc_poly::univariate::dense::DensePolynomial<Int<INT_LIMBS>, D>> + 'static,
     F: InnerTransparentField
+        + MontgomeryLimbs
         + FromPrimitiveWithConfig
         + for<'a> FromWithConfig<&'a Int<INT_LIMBS>>
         + for<'a> FromWithConfig<&'a Int<INT_QUARTER_LIMBS>>
@@ -1708,6 +1712,7 @@ where
     BinaryPoly<QUARTER_D>: ProjectableToField<F>,
     U: Uair<Scalar = zinc_poly::univariate::dense::DensePolynomial<Int<INT_LIMBS>, D>> + 'static,
     F: InnerTransparentField
+        + MontgomeryLimbs
         + FromPrimitiveWithConfig
         + for<'a> FromWithConfig<&'a Int<INT_LIMBS>>
         + for<'a> FromWithConfig<&'a Int<INT_QUARTER_LIMBS>>
@@ -1779,6 +1784,7 @@ where
     BinaryPoly<QUARTER_D>: ProjectableToField<F>,
     U: Uair<Scalar = zinc_poly::univariate::dense::DensePolynomial<Int<INT_LIMBS>, D>> + 'static,
     F: InnerTransparentField
+        + MontgomeryLimbs
         + FromPrimitiveWithConfig
         + for<'a> FromWithConfig<&'a Int<INT_LIMBS>>
         + for<'a> FromWithConfig<&'a Int<INT_QUARTER_LIMBS>>
@@ -1846,6 +1852,7 @@ where
     BinaryPoly<QUARTER_D>: ProjectableToField<F>,
     U: Uair<Scalar = zinc_poly::univariate::dense::DensePolynomial<Int<INT_LIMBS>, D>> + 'static,
     F: InnerTransparentField
+        + MontgomeryLimbs
         + FromPrimitiveWithConfig
         + for<'a> FromWithConfig<&'a Int<INT_LIMBS>>
         + for<'a> FromWithConfig<&'a Int<INT_QUARTER_LIMBS>>

--- a/protocol/src/prover.rs
+++ b/protocol/src/prover.rs
@@ -2072,12 +2072,16 @@ where
         .iter()
         .map(|&idx| projected_trace_f[int_offset + idx].clone())
         .collect();
-    let shifted_bit_slice_mles = build_shifted_bit_slice_mles::<F, D>(
-        &trace.binary_poly[num_pub_bin..],
-        uair_signature.shifted_bit_slice_specs(),
-        &field_cfg,
-    );
     let virtual_specs = uair_signature.virtual_booleanity_cols();
+    let shifted_bit_slice_mles = if virtual_specs.is_empty() {
+        Vec::new()
+    } else {
+        build_shifted_bit_slice_mles::<F, D>(
+            &trace.binary_poly[num_pub_bin..],
+            uair_signature.shifted_bit_slice_specs(),
+            &field_cfg,
+        )
+    };
     let virtual_mles = if virtual_specs.is_empty() {
         Vec::new()
     } else {
@@ -2148,11 +2152,21 @@ where
         cpr_ancillary,
         &field_cfg,
     )?;
-    let shifted_bit_slice_evals: Vec<F> = shifted_bit_slice_mles
-        .into_iter()
-        .map(|mle| mle.evaluate_with_config(&cpr_prover_state.evaluation_point, &field_cfg))
-        .collect::<Result<Vec<_>, _>>()
-        .map_err(ProtocolError::ShiftedBitSliceEval)?;
+    let shifted_bit_slice_evals: Vec<F> = if shifted_bit_slice_mles.is_empty() {
+        compute_shifted_bit_slice_evals_streaming::<F, D>(
+            &trace.binary_poly[num_pub_bin..],
+            uair_signature.shifted_bit_slice_specs(),
+            &cpr_prover_state.evaluation_point,
+            &field_cfg,
+        )
+        .map_err(|e| ProtocolError::Booleanity(e.into()))?
+    } else {
+        shifted_bit_slice_mles
+            .into_iter()
+            .map(|mle| mle.evaluate_with_config(&cpr_prover_state.evaluation_point, &field_cfg))
+            .collect::<Result<Vec<_>, _>>()
+            .map_err(ProtocolError::ShiftedBitSliceEval)?
+    };
     cpr_proof.shifted_bit_slice_evals = shifted_bit_slice_evals;
     if let Some(ba) = bool_ancillary_opt {
         let bool_state = md_states.remove(0);

--- a/protocol/src/verifier.rs
+++ b/protocol/src/verifier.rs
@@ -34,8 +34,9 @@ use zinc_uair::{
     ideal_collector::IdealOrZero,
 };
 use zinc_utils::{
-    add, cfg_join, from_ref::FromRef, inner_transparent_field::InnerTransparentField,
-    mul_by_scalar::MulByScalar, projectable_to_field::ProjectableToField,
+    add, cfg_join, delayed_reduction::MontgomeryLimbs, from_ref::FromRef,
+    inner_transparent_field::InnerTransparentField, mul_by_scalar::MulByScalar,
+    projectable_to_field::ProjectableToField,
 };
 use zip_plus::{
     pcs::structs::{ZipPlus, ZipPlusParams, ZipTypes},
@@ -756,6 +757,7 @@ where
     Zt::Int: ProjectableToField<F>,
     <Zt::ArbitraryZt as ZipTypes>::Eval: ProjectableToField<F>,
     F: InnerTransparentField
+        + MontgomeryLimbs
         + FromPrimitiveWithConfig
         + for<'b> FromWithConfig<&'b Zt::Int>
         + for<'b> FromWithConfig<&'b Zt::Chal>
@@ -992,6 +994,7 @@ where
     <Zt::ArbitraryZt as ZipTypes>::Cw: ProjectableToField<F>,
     <Zt::IntZt as ZipTypes>::Cw: ProjectableToField<F>,
     F: InnerTransparentField
+        + MontgomeryLimbs
         + FromPrimitiveWithConfig
         + for<'a> FromWithConfig<&'a Zt::Int>
         + for<'a> FromWithConfig<&'a <Zt::BinaryZt as ZipTypes>::CombR>
@@ -1098,6 +1101,7 @@ where
     <ZtF::IntZt as ZipTypes>::Cw: ProjectableToField<F>,
     U: Uair + 'static,
     F: InnerTransparentField
+        + MontgomeryLimbs
         + FromPrimitiveWithConfig
         + for<'b> FromWithConfig<&'b ZtF::Int>
         + for<'b> FromWithConfig<&'b <ZtF::BinaryZt as ZipTypes>::CombR>
@@ -1672,6 +1676,7 @@ where
     <ZtF::IntZt as ZipTypes>::Cw: ProjectableToField<F>,
     U: Uair<Scalar = zinc_poly::univariate::dense::DensePolynomial<Int<INT_LIMBS>, D>> + 'static,
     F: InnerTransparentField
+        + MontgomeryLimbs
         + FromPrimitiveWithConfig
         + for<'b> FromWithConfig<&'b Int<INT_LIMBS>>
         + for<'b> FromWithConfig<&'b Int<INT_QUARTER_LIMBS>>
@@ -1746,6 +1751,7 @@ where
     <ZtF::IntZt as ZipTypes>::Cw: ProjectableToField<F>,
     U: Uair<Scalar = zinc_poly::univariate::dense::DensePolynomial<Int<INT_LIMBS>, D>> + 'static,
     F: InnerTransparentField
+        + MontgomeryLimbs
         + FromPrimitiveWithConfig
         + for<'b> FromWithConfig<&'b Int<INT_LIMBS>>
         + for<'b> FromWithConfig<&'b Int<INT_QUARTER_LIMBS>>
@@ -1821,6 +1827,7 @@ where
     <ZtF::IntZt as ZipTypes>::Cw: ProjectableToField<F>,
     U: Uair<Scalar = zinc_poly::univariate::dense::DensePolynomial<Int<INT_LIMBS>, D>> + 'static,
     F: InnerTransparentField
+        + MontgomeryLimbs
         + FromPrimitiveWithConfig
         + for<'b> FromWithConfig<&'b Int<INT_LIMBS>>
         + for<'b> FromWithConfig<&'b Int<INT_QUARTER_LIMBS>>

--- a/test-uair/src/sha_ecdsa.rs
+++ b/test-uair/src/sha_ecdsa.rs
@@ -80,15 +80,17 @@ use zinc_uair::{
 
 use crate::{
     GenerateRandomTrace,
-    ecdsa::{self, FINAL_ROW as ECDSA_FINAL_ROW, NUM_SHAMIR_ROUNDS},
+    ecdsa,
     ecdsa_doubling::{EC_FP_INT_LIMBS, EcdsaFpRing},
     sha256::{self, Sha256CompressionSliceUair, Sha256Ideal},
 };
+#[cfg(test)]
+use crate::ecdsa::FINAL_ROW as ECDSA_FINAL_ROW;
 
 use crypto_primitives::crypto_bigint_int::Int;
 
 // Re-export for convenience.
-pub use crate::ecdsa::FINAL_ROW;
+pub use crate::ecdsa::{FINAL_ROW, NUM_SHAMIR_ROUNDS};
 
 // ---------------------------------------------------------------------------
 // Column layout for the merged trace.

--- a/utils/src/delayed_reduction.rs
+++ b/utils/src/delayed_reduction.rs
@@ -1,0 +1,418 @@
+//! Delayed modular reduction helpers for fixed 4-limb Montgomery fields.
+//!
+//! This module is intentionally narrow: it supports summing Montgomery-form
+//! field elements into a 5-limb accumulator, then reducing once with Barrett
+//! reduction. The limb routines are adapted from Spartan2's MIT-licensed
+//! `big_num` helpers.
+
+use crypto_bigint::modular::ConstMontyParams;
+use crypto_primitives::{
+    PrimeField, crypto_bigint_const_monty::ConstMontyField, crypto_bigint_monty::MontyField,
+    crypto_bigint_uint::Uint,
+};
+use num_traits::Zero;
+
+/// Barrett reduction parameters modulo a 4-limb prime.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct BarrettReductionParams {
+    /// The 4-limb prime modulus in little-endian limb order.
+    pub modulus: [u64; 4],
+
+    /// `floor(2^512 / MODULUS)`, stored in little-endian limb order.
+    pub mu: [u64; 5],
+}
+
+impl BarrettReductionParams {
+    #[inline(always)]
+    pub const fn new(modulus: [u64; 4]) -> Self {
+        Self {
+            modulus,
+            mu: compute_barrett_mu(modulus),
+        }
+    }
+}
+
+/// Field types that expose reduced Montgomery-form limbs.
+pub trait MontgomeryLimbs: PrimeField<Inner = Uint<4>> + Sized {
+    /// Construct a field element from reduced Montgomery-form limbs.
+    fn from_montgomery_limbs(limbs: [u64; 4], cfg: &Self::Config) -> Self;
+
+    /// Borrow the field element's Montgomery-form limbs.
+    fn montgomery_limbs(&self) -> &[u64; 4];
+
+    /// Return Barrett reduction parameters for this field configuration.
+    fn barrett_reduction_params(cfg: &Self::Config) -> BarrettReductionParams;
+}
+
+/// Accumulator trait for delayed modular reduction.
+pub trait DelayedModularReduction<F>: Zero + Clone + Send + Sync
+where
+    F: PrimeField,
+{
+    fn add(&mut self, value: &F);
+    fn reduce(self, cfg: &F::Config, params: &BarrettReductionParams) -> F;
+}
+
+impl<F> DelayedModularReduction<F> for Uint<5>
+where
+    F: MontgomeryLimbs + Send + Sync,
+{
+    #[inline(always)]
+    fn add(&mut self, value: &F) {
+        let acc = self.as_mut_words();
+        let rhs = value.montgomery_limbs();
+        let mut carry = 0u64;
+        let mut i = 0;
+        while i < 4 {
+            let (sum, c0) = acc[i].overflowing_add(rhs[i]);
+            let (sum, c1) = sum.overflowing_add(carry);
+            acc[i] = sum;
+            carry = (c0 as u64) + (c1 as u64);
+            i += 1;
+        }
+
+        let old_hi = acc[4];
+        acc[4] = acc[4].wrapping_add(carry);
+        debug_assert!(
+            acc[4] >= old_hi,
+            "Uint<5> delayed accumulator overflowed high limb"
+        );
+    }
+
+    #[inline(always)]
+    fn reduce(self, cfg: &F::Config, params: &BarrettReductionParams) -> F {
+        let acc = self.as_words();
+        F::from_montgomery_limbs(barrett_reduce_5(acc, params), cfg)
+    }
+}
+
+impl<Mod> MontgomeryLimbs for ConstMontyField<Mod, 4>
+where
+    Mod: ConstMontyParams<4>,
+{
+    #[inline(always)]
+    fn from_montgomery_limbs(limbs: [u64; 4], _cfg: &Self::Config) -> Self {
+        Self::new_unchecked(Uint::<4>::from_words(limbs))
+    }
+
+    #[inline(always)]
+    fn montgomery_limbs(&self) -> &[u64; 4] {
+        self.inner().as_words()
+    }
+
+    #[inline(always)]
+    fn barrett_reduction_params(_cfg: &Self::Config) -> BarrettReductionParams {
+        BarrettReductionParams::new(Uint::<4>::new(*Mod::PARAMS.modulus().as_ref()).to_words())
+    }
+}
+
+impl MontgomeryLimbs for MontyField<4> {
+    #[inline(always)]
+    fn from_montgomery_limbs(limbs: [u64; 4], cfg: &Self::Config) -> Self {
+        Self::new_unchecked_with_cfg(Uint::<4>::from_words(limbs), cfg)
+    }
+
+    #[inline(always)]
+    fn montgomery_limbs(&self) -> &[u64; 4] {
+        self.inner().as_words()
+    }
+
+    #[inline(always)]
+    fn barrett_reduction_params(cfg: &Self::Config) -> BarrettReductionParams {
+        BarrettReductionParams::new(Uint::<4>::new(cfg.modulus().get()).to_words())
+    }
+}
+
+/// Barrett reduction for a 5-limb value modulo a 4-limb modulus.
+///
+/// This uses the 5-limb remainder path, which is required for moduli near
+/// `2^256` such as the secp256k1 base prime.
+#[inline(always)]
+pub fn barrett_reduce_5(c: &[u64; 5], params: &BarrettReductionParams) -> [u64; 4] {
+    let q1 = [c[3], c[4]];
+    let q2 = mul_2x5_to_7(&q1, &params.mu);
+    let q3 = [q2[5], q2[6]];
+
+    let r1 = *c;
+    let r2 = mul_2x4_lo5(&q3, &params.modulus);
+    let mut r = sub::<5>(&r1, &r2);
+
+    if r[4] != 0 || gte::<4>(&[r[0], r[1], r[2], r[3]], &params.modulus) {
+        r = sub_5_4(&r, &params.modulus);
+    }
+
+    debug_assert!(
+        r[4] == 0 && !gte::<4>(&[r[0], r[1], r[2], r[3]], &params.modulus),
+        "Barrett reduction produced non-canonical result"
+    );
+
+    [r[0], r[1], r[2], r[3]]
+}
+
+#[inline(always)]
+fn mul_2x5_to_7(a: &[u64; 2], b: &[u64; 5]) -> [u64; 7] {
+    let mut result = [0u64; 7];
+    for i in 0..2 {
+        let mut carry = 0u128;
+        for j in 0..5 {
+            let prod = (a[i] as u128) * (b[j] as u128) + (result[i + j] as u128) + carry;
+            result[i + j] = prod as u64;
+            carry = prod >> 64;
+        }
+        result[i + 5] = carry as u64;
+    }
+    result
+}
+
+#[inline(always)]
+fn mul_2x4_lo5(a: &[u64; 2], b: &[u64; 4]) -> [u64; 5] {
+    let mut result = [0u64; 5];
+
+    let mut carry = 0u128;
+    for j in 0..4 {
+        let prod = (a[0] as u128) * (b[j] as u128) + carry;
+        result[j] = prod as u64;
+        carry = prod >> 64;
+    }
+    result[4] = carry as u64;
+
+    carry = 0;
+    for j in 0..4 {
+        let prod = (a[1] as u128) * (b[j] as u128) + (result[1 + j] as u128) + carry;
+        result[1 + j] = prod as u64;
+        carry = prod >> 64;
+    }
+
+    result
+}
+
+#[inline(always)]
+const fn gte<const N: usize>(a: &[u64; N], b: &[u64; N]) -> bool {
+    let mut i = N;
+    while i > 0 {
+        i -= 1;
+        if a[i] > b[i] {
+            return true;
+        }
+        if a[i] < b[i] {
+            return false;
+        }
+    }
+    true
+}
+
+#[inline(always)]
+const fn sub<const N: usize>(a: &[u64; N], b: &[u64; N]) -> [u64; N] {
+    let mut result = [0u64; N];
+    let mut borrow = 0u64;
+    let mut i = 0;
+    while i < N {
+        let (diff, b1) = a[i].overflowing_sub(b[i]);
+        let (diff2, b2) = diff.overflowing_sub(borrow);
+        result[i] = diff2;
+        borrow = (b1 as u64) + (b2 as u64);
+        i += 1;
+    }
+    result
+}
+
+#[inline(always)]
+const fn sub_5_4(a: &[u64; 5], b: &[u64; 4]) -> [u64; 5] {
+    let mut result = [0u64; 5];
+    let mut borrow = 0u64;
+    let mut i = 0;
+    while i < 4 {
+        let (diff, b1) = a[i].overflowing_sub(b[i]);
+        let (diff2, b2) = diff.overflowing_sub(borrow);
+        result[i] = diff2;
+        borrow = (b1 as u64) + (b2 as u64);
+        i += 1;
+    }
+    let (diff, _) = a[4].overflowing_sub(borrow);
+    result[4] = diff;
+    result
+}
+
+#[inline(always)]
+const fn shl<const N: usize>(a: &[u64; N]) -> [u64; N] {
+    let mut result = [0u64; N];
+    let mut carry = 0u64;
+    let mut i = 0;
+    while i < N {
+        let new_carry = a[i] >> 63;
+        result[i] = (a[i] << 1) | carry;
+        carry = new_carry;
+        i += 1;
+    }
+    result
+}
+
+#[inline(always)]
+const fn shr<const N: usize>(a: &[u64; N]) -> [u64; N] {
+    let mut result = [0u64; N];
+    let mut carry = 0u64;
+    let mut i = N;
+    while i > 0 {
+        i -= 1;
+        let new_carry = a[i] << 63;
+        result[i] = (a[i] >> 1) | carry;
+        carry = new_carry;
+    }
+    result
+}
+
+#[inline(always)]
+const fn clz<const N: usize>(a: &[u64; N]) -> u32 {
+    let mut i = N;
+    let mut count = 0u32;
+    while i > 0 {
+        i -= 1;
+        if a[i] != 0 {
+            return count + a[i].leading_zeros();
+        }
+        count += 64;
+    }
+    count
+}
+
+pub const fn compute_barrett_mu(p: [u64; 4]) -> [u64; 5] {
+    let mut dividend: [u64; 9] = [0, 0, 0, 0, 0, 0, 0, 0, 1];
+    let divisor: [u64; 9] = [p[0], p[1], p[2], p[3], 0, 0, 0, 0, 0];
+    let mut quotient: [u64; 5] = [0; 5];
+
+    let dividend_clz = clz::<9>(&dividend);
+    let divisor_clz = clz::<9>(&divisor);
+    if divisor_clz <= dividend_clz {
+        return quotient;
+    }
+
+    let shift_bits = divisor_clz - dividend_clz;
+    let mut shifted_divisor = divisor;
+    let whole_limbs = (shift_bits / 64) as usize;
+    let rem_bits = shift_bits % 64;
+
+    if whole_limbs > 0 {
+        let mut i = 8;
+        while i >= whole_limbs {
+            shifted_divisor[i] = shifted_divisor[i - whole_limbs];
+            if i == whole_limbs {
+                break;
+            }
+            i -= 1;
+        }
+        let mut j = 0;
+        while j < whole_limbs {
+            shifted_divisor[j] = 0;
+            j += 1;
+        }
+    }
+
+    let mut i = 0;
+    while i < rem_bits {
+        shifted_divisor = shl::<9>(&shifted_divisor);
+        i += 1;
+    }
+
+    let mut bit_pos = shift_bits;
+    loop {
+        if gte::<9>(&dividend, &shifted_divisor) {
+            dividend = sub::<9>(&dividend, &shifted_divisor);
+            let limb_idx = (bit_pos / 64) as usize;
+            let bit_idx = bit_pos % 64;
+            if limb_idx < 5 {
+                quotient[limb_idx] |= 1u64 << bit_idx;
+            }
+        }
+
+        if bit_pos == 0 {
+            break;
+        }
+        bit_pos -= 1;
+        shifted_divisor = shr::<9>(&shifted_divisor);
+    }
+
+    quotient
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crypto_primitives::{FromWithConfig, crypto_bigint_monty::MontyField};
+
+    type F = MontyField<4>;
+
+    fn secp256k1_cfg() -> <F as PrimeField>::Config {
+        let modulus = Uint::<4>::from_words([
+            0xFFFF_FFFE_FFFF_FC2F,
+            0xFFFF_FFFF_FFFF_FFFF,
+            0xFFFF_FFFF_FFFF_FFFF,
+            0xFFFF_FFFF_FFFF_FFFF,
+        ]);
+        F::make_cfg(&modulus).expect("secp256k1 base field prime is valid")
+    }
+
+    #[test]
+    fn secp256k1_barrett_params_match_expected_modulus() {
+        let cfg = secp256k1_cfg();
+        assert_eq!(
+            F::barrett_reduction_params(&cfg).modulus,
+            [
+                0xFFFF_FFFE_FFFF_FC2F,
+                0xFFFF_FFFF_FFFF_FFFF,
+                0xFFFF_FFFF_FFFF_FFFF,
+                0xFFFF_FFFF_FFFF_FFFF,
+            ],
+        );
+    }
+
+    #[test]
+    fn delayed_sum_matches_field_addition() {
+        let cfg = secp256k1_cfg();
+        let reduction_params = F::barrett_reduction_params(&cfg);
+        let values: Vec<F> = (0..512)
+            .map(|i| F::from_with_cfg(i as u64 + 1, &cfg))
+            .collect();
+
+        let mut expected = F::zero_with_cfg(&cfg);
+        for value in &values {
+            expected += value;
+        }
+
+        let mut acc = Uint::<5>::zero();
+        for value in &values {
+            <Uint<5> as DelayedModularReduction<F>>::add(&mut acc, value);
+        }
+
+        assert_eq!(
+            <Uint<5> as DelayedModularReduction<F>>::reduce(acc, &cfg, &reduction_params),
+            expected
+        );
+    }
+
+    #[test]
+    fn barrett_reduce_5_matches_uint_remainder_for_bounded_sum() {
+        let cfg = secp256k1_cfg();
+        let reduction_params = F::barrett_reduction_params(&cfg);
+        let mut acc = Uint::<5>::zero();
+        let max = -F::from_with_cfg(1u64, &cfg);
+        for _ in 0..512 {
+            <Uint<5> as DelayedModularReduction<F>>::add(&mut acc, &max);
+        }
+
+        let wide = acc;
+        let modulus = Uint::<5>::from_words([
+            reduction_params.modulus[0],
+            reduction_params.modulus[1],
+            reduction_params.modulus[2],
+            reduction_params.modulus[3],
+            0,
+        ]);
+        let expected = (wide % &modulus)
+            .checked_resize::<4>()
+            .expect("remainder fits in four limbs");
+
+        let acc = acc.as_words();
+        let reduced = barrett_reduce_5(acc, &reduction_params);
+        assert_eq!(Uint::<4>::from_words(reduced), expected);
+    }
+}

--- a/utils/src/field/const_monty.rs
+++ b/utils/src/field/const_monty.rs
@@ -31,7 +31,7 @@ macro_rules! impl_from_primitive_ref {
         )*
     };
 }
-impl_from_primitive_ref!(u8, u16, u32, u64, u128);
+impl_from_primitive_ref!(u8, u16, u32, u64, u128, i8, i16, i32, i64, i128);
 
 impl<Mod: ConstMontyParams<LIMBS>, const LIMBS: usize> FromRef<Uint<LIMBS>>
     for ConstMontyForm<Mod, LIMBS>
@@ -49,14 +49,23 @@ impl<Mod: ConstMontyParams<LIMBS>, const LIMBS: usize> FromRef<Self>
     }
 }
 
-impl<Mod: ConstMontyParams<LIMBS>, const LIMBS: usize, const LIMBS2: usize>
-    ProjectableToField<ConstMontyField<Mod, LIMBS>> for Int<LIMBS2>
+impl<Mod: ConstMontyParams<LIMBS>, const LIMBS: usize, const LIMBS2: usize> FromRef<Int<LIMBS2>>
+    for ConstMontyField<Mod, LIMBS>
+{
+    fn from_ref(value: &Int<LIMBS2>) -> Self {
+        value.into()
+    }
+}
+
+impl<T, Mod: ConstMontyParams<LIMBS>, const LIMBS: usize>
+    ProjectableToField<ConstMontyField<Mod, LIMBS>> for T
+where
+    ConstMontyField<Mod, LIMBS>: FromRef<T>,
 {
     fn prepare_projection(
         _sampled_value: &ConstMontyField<Mod, LIMBS>,
     ) -> impl Fn(&Self) -> ConstMontyField<Mod, LIMBS> + Send + Sync + 'static {
-        // No need to read anything
-        |value: &Int<LIMBS2>| value.into()
+        |value: &T| ConstMontyField::<Mod, LIMBS>::from_ref(value)
     }
 }
 

--- a/utils/src/lib.rs
+++ b/utils/src/lib.rs
@@ -1,3 +1,4 @@
+pub mod delayed_reduction;
 pub mod field;
 pub mod from_ref;
 pub mod inner_product;


### PR DESCRIPTION
This PR speeds up binary polynomial evaluation under the scalarization challenge by using delayed modular reduction for the hot equality-weight accumulations.

Delayed modular reduction means we do not reduce modulo the field prime after every field addition. Instead, we accumulate several field elements in a wider integer representation that is large enough to hold the unreduced sum, then reduce the accumulator back into the field once at the end.

For a binary column with row bits c_{b,i}, evaluation has the shape:

Σ_b eq_r(b) · (Σ_i c_{b,i} α^i)

Equivalently:

Σ_i α^i · (Σ_b eq_r(b) c_{b,i})

This PR accelerates the inner coefficient sums:

Σ_b eq_r(b) c_{b,i}

Those sums are just conditional additions of cached eq_r(b) values for set bits. Instead of performing a modular reduction after each selected addition, we accumulate the Montgomery limbs in a 5-limb Uint<5> delayed-reduction accumulator and perform one Barrett reduction at the end.