### PR TITLE
Switch crypto-primitives to be rev-based dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ publish = false
 blake3 = "1.8"
 criterion = "0.7.0"
 crypto-bigint = { version = "= 0.7.0-rc.9", features = ["zeroize"] }
-crypto-primitives = { git = "https://github.com/NethermindEth/crypto-primitives.git", branch = "main", features = ["std", "crypto_bigint", "rand"] }
+crypto-primitives = { git = "https://github.com/NethermindEth/crypto-primitives.git", rev = "2cf39db8", features = ["std", "crypto_bigint", "rand"] }
 derive_more = { version = "2.1.1", features = ["full"] }
 itertools = "0.14"
 num-traits = "0.2"


### PR DESCRIPTION
Since we're planning to introduce several backward-incompatible changes to https://github.com/NethermindEth/crypto-primitives, switch the dependency tracking to be based off of a specific commit hash rather than on latest `main`.