### PR TITLE
Add optional proof-of-work grinding plumbing

### DIFF
--- a/protocol/Cargo.toml
+++ b/protocol/Cargo.toml
@@ -16,6 +16,7 @@ parallel = [
     "zinc-poly/parallel",
     "zinc-uair/parallel",
     "zinc-utils/parallel",
+    "zip-plus/parallel",
 ]
 simd = ["zinc-poly/simd", "zinc-piop/simd", "zip-plus/simd"]
 unchecked = []

--- a/transcript/Cargo.toml
+++ b/transcript/Cargo.toml
@@ -9,16 +9,19 @@ license.workspace = true
 [lib]
 bench = false
 
+[features]
+parallel = ["dep:rayon"]
+
 [dependencies]
 blake3 = { workspace = true }
 crypto-bigint = { workspace = true }
 crypto-primitives = { workspace = true }
-thiserror = { workspace = true}
 itertools = { workspace = true }
 num-traits = { workspace = true }
+rayon = { workspace = true, optional = true }
+thiserror = { workspace = true }
 zinc-primality = { workspace = true }
 zinc-utils = { workspace = true }
 
 [lints]
 workspace = true
-

--- a/transcript/src/lib.rs
+++ b/transcript/src/lib.rs
@@ -1,3 +1,4 @@
+pub mod pow;
 pub mod traits;
 
 use crate::traits::{ConstTranscribable, GenTranscribable, Transcript};
@@ -38,6 +39,21 @@ impl Blake3Transcript {
         let mut hasher = blake3::Hasher::new();
         hasher.update(DOMAIN_SEPARATOR);
         Self { hasher }
+    }
+
+    fn derive_seed(&self, context: &'static str) -> [u8; 32] {
+        let transcript_digest = self.hasher.finalize();
+        blake3::derive_key(context, transcript_digest.as_bytes())
+    }
+
+    /// Derives the proof-of-work seed from the current transcript prefix
+    /// without changing the transcript state.
+    ///
+    /// The operation has a fixed BLAKE3 derive-key context. Keeping it
+    /// non-mutating makes the subsequent nonce message the only transcript
+    /// state change made by grinding.
+    pub fn derive_pow_seed(&self) -> [u8; 32] {
+        self.derive_seed(crate::pow::POW_SEED_CONTEXT)
     }
 
     /// Generates a specified number of pseudorandom bytes based on the current
@@ -113,3 +129,35 @@ where
 #[derive(Clone, Debug, PartialEq, Error)]
 #[error("{1}")]
 pub struct TranscriptError(pub ErrorKind, pub String);
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn seed_derivation_is_stable_domain_separated_and_non_mutating() {
+        let mut transcript = Blake3Transcript::new();
+        transcript.absorb_bytes(b"shared prefix");
+        let mut untouched = transcript.clone();
+
+        let seed = transcript.derive_pow_seed();
+        assert_eq!(seed, transcript.derive_pow_seed());
+        assert_ne!(
+            seed,
+            transcript.derive_seed("zinc-plus/test/seed-b/v1"),
+            "different operations must not share derived seeds"
+        );
+        let mut different_prefix = transcript.clone();
+        different_prefix.absorb_bytes(b"different suffix");
+        assert_ne!(
+            seed,
+            different_prefix.derive_pow_seed(),
+            "the proof-of-work seed must bind the transcript prefix"
+        );
+        assert_eq!(
+            transcript.get_challenge::<u64>(),
+            untouched.get_challenge::<u64>(),
+            "deriving a seed must not consume or absorb a challenge"
+        );
+    }
+}

--- a/transcript/src/pow.rs
+++ b/transcript/src/pow.rs
@@ -1,0 +1,182 @@
+//! Pure proof-of-work search and checking primitives.
+//!
+//! Protocol code is responsible for deriving a seed from the transcript
+//! prefix and for absorbing the resulting nonce before the protected
+//! challenge. This module deliberately does not mutate a transcript.
+
+#[cfg(feature = "parallel")]
+use rayon::prelude::*;
+use zinc_utils::add;
+
+/// Domain used to derive the proof-of-work seed from a Fiat-Shamir transcript.
+pub const POW_SEED_CONTEXT: &str = "zinc-plus/fiat-shamir/query-pow-seed/v1";
+
+/// Highest protocol-level grinding difficulty accepted by Zinc+.
+///
+/// This keeps an accidentally enabled configuration within a practical
+/// `u64` nonce-search budget.
+pub const MAX_GRINDING_BITS: u32 = 32;
+
+/// Bound the deterministic search chunk selected from the configured
+/// difficulty. Small difficulties avoid oversized speculative work; larger
+/// difficulties amortize Rayon scheduling across a wider range.
+const MIN_SEARCH_CHUNK_LOG2: u32 = 12;
+const MAX_SEARCH_CHUNK_LOG2: u32 = 24;
+
+/// Keep cheap predicate calls from being dominated by Rayon scheduling.
+#[cfg(feature = "parallel")]
+const MIN_SEARCH_LEN: usize = 1 << 8;
+
+fn search_chunk_len(bits: u32) -> u32 {
+    let log2 = bits
+        .saturating_div(2)
+        .saturating_add(8)
+        .clamp(MIN_SEARCH_CHUNK_LOG2, MAX_SEARCH_CHUNK_LOG2);
+    1u32.checked_shl(log2)
+        .expect("PoW search chunk exponent is bounded below 32")
+}
+
+/// Hashes the fixed 64-byte message `seed || nonce_le || zero_padding` with
+/// BLAKE3 and returns the first eight digest bytes as a big-endian integer.
+/// A valid witness therefore has zeroes in the conventional leading bits of
+/// the BLAKE3 digest.
+///
+/// The 24 zero bytes make the work message exactly one BLAKE3 block and are
+/// part of the protocol encoding.
+#[must_use]
+pub fn pow_hash(seed: &[u8; 32], nonce: u64) -> u64 {
+    let mut input = [0u8; blake3::BLOCK_LEN];
+    input[..32].copy_from_slice(seed);
+    input[32..40].copy_from_slice(&nonce.to_le_bytes());
+    let digest = blake3::hash(&input);
+    u64::from_be_bytes(
+        digest.as_bytes()[..8]
+            .try_into()
+            .expect("BLAKE3 digest is 32 bytes"),
+    )
+}
+
+/// Returns whether `nonce` supplies at least `bits` bits of work for `seed`.
+///
+/// `bits == 0` accepts every nonce. Values above 64 reject every nonce.
+#[must_use]
+pub fn check_pow(seed: &[u8; 32], nonce: u64, bits: u32) -> bool {
+    pow_hash(seed, nonce).leading_zeros() >= bits
+}
+
+/// Finds the smallest nonce satisfying [`check_pow`].
+///
+/// Expected work is approximately `2^bits` BLAKE3 evaluations. The result is
+/// deterministic with and without the `parallel` feature.
+///
+/// # Panics
+/// Panics when `bits >= 64`, which is not a feasible search configuration.
+#[must_use]
+pub fn find_pow_nonce(seed: &[u8; 32], bits: u32) -> u64 {
+    assert!(bits < 64, "grinding bit count must be less than 64");
+    if bits == 0 {
+        return 0;
+    }
+    let chunk_len = search_chunk_len(bits);
+    let mut chunk_start = 0u64;
+    loop {
+        if let Some(nonce) = search_chunk(seed, chunk_start, chunk_len, bits) {
+            return nonce;
+        }
+        chunk_start = add!(
+            chunk_start,
+            u64::from(chunk_len),
+            "PoW nonce search exhausted the u64 nonce space"
+        );
+    }
+}
+
+#[cfg(feature = "parallel")]
+fn search_chunk(seed: &[u8; 32], start: u64, len: u32, bits: u32) -> Option<u64> {
+    (0..len)
+        .into_par_iter()
+        .with_min_len(MIN_SEARCH_LEN)
+        .map(|offset| add!(start, u64::from(offset)))
+        .find_first(|nonce| check_pow(seed, *nonce, bits))
+}
+
+#[cfg(not(feature = "parallel"))]
+fn search_chunk(seed: &[u8; 32], start: u64, len: u32, bits: u32) -> Option<u64> {
+    (0..len)
+        .map(|offset| add!(start, u64::from(offset)))
+        .find(|nonce| check_pow(seed, *nonce, bits))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn test_seed() -> [u8; 32] {
+        *blake3::hash(b"zinc-plus PoW test seed").as_bytes()
+    }
+
+    #[test]
+    fn hash_wire_vectors_are_stable() {
+        assert_eq!(pow_hash(&[0u8; 32], 0), 0x4d00_6976_636a_8696);
+        assert_eq!(pow_hash(&[0u8; 32], 1), 0xbb4f_adcb_0b8f_eab0);
+        assert_eq!(pow_hash(&[0x42u8; 32], 42), 0xe8d7_1fdd_a38e_84f3);
+    }
+
+    #[test]
+    fn search_chunks_scale_with_difficulty_and_remain_bounded() {
+        assert_eq!(search_chunk_len(1), 1 << 12);
+        assert_eq!(search_chunk_len(12), 1 << 14);
+        assert_eq!(search_chunk_len(16), 1 << 16);
+        assert_eq!(search_chunk_len(20), 1 << 18);
+        assert_eq!(search_chunk_len(24), 1 << 20);
+        assert_eq!(search_chunk_len(32), 1 << 24);
+        assert_eq!(search_chunk_len(u32::MAX), 1 << 24);
+    }
+
+    #[test]
+    fn find_then_check_roundtrip() {
+        let seed = test_seed();
+        for bits in [0, 1, 4, 8] {
+            let nonce = find_pow_nonce(&seed, bits);
+            assert!(check_pow(&seed, nonce, bits));
+        }
+    }
+
+    #[test]
+    fn found_nonce_is_minimal_and_deterministic() {
+        let seed = test_seed();
+        let nonce = find_pow_nonce(&seed, 8);
+        assert_eq!(nonce, 66, "the deterministic proof nonce changed");
+        assert_eq!(nonce, find_pow_nonce(&seed, 8));
+        assert!((0..nonce).all(|smaller| !check_pow(&seed, smaller, 8)));
+    }
+
+    #[test]
+    fn search_advances_past_an_empty_chunk() {
+        const BITS: u32 = 12;
+
+        let chunk_len = search_chunk_len(BITS);
+        let seed = (0u64..100)
+            .map(|counter| *blake3::hash(&counter.to_le_bytes()).as_bytes())
+            .find(|seed| search_chunk(seed, 0, chunk_len, BITS).is_none())
+            .expect("a deterministic seed with no solution in its first chunk");
+
+        let nonce = find_pow_nonce(&seed, BITS);
+        assert!(nonce >= u64::from(chunk_len));
+        assert!(check_pow(&seed, nonce, BITS));
+    }
+
+    #[test]
+    fn zero_and_out_of_range_bits_are_explicit() {
+        let seed = test_seed();
+        assert_eq!(find_pow_nonce(&seed, 0), 0);
+        assert!(check_pow(&seed, 0, 0));
+        assert!(!check_pow(&seed, 0, 65));
+    }
+
+    #[test]
+    #[should_panic(expected = "less than 64")]
+    fn search_rejects_64_bits() {
+        let _ = find_pow_nonce(&test_seed(), 64);
+    }
+}

--- a/zip-plus/Cargo.toml
+++ b/zip-plus/Cargo.toml
@@ -14,6 +14,7 @@ parallel = [
     "dep:rayon",
     "zinc-utils/parallel",
     "zinc-poly/parallel",
+    "zinc-transcript/parallel",
     "ark-ff/parallel",
     "ark-poly/parallel",
 ]

--- a/zip-plus/src/lib.rs
+++ b/zip-plus/src/lib.rs
@@ -20,6 +20,8 @@ pub enum ZipError {
     Serialization(String),
     #[error("Transcript failure: {0}")]
     Transcript(#[from] TranscriptError),
+    #[error("Proof-of-work grinding check failed: {0}")]
+    Grinding(String),
     #[error("Error during polynomial evaluation: {0}")]
     PolynomialEvaluationError(zinc_poly::EvaluationError),
     #[error("Error during inner product computation: {0}")]

--- a/zip-plus/src/pcs/phase_commit.rs
+++ b/zip-plus/src/pcs/phase_commit.rs
@@ -789,6 +789,11 @@ mod tests {
             // b vectors: per poly, num_rows field elements
             let b_phase_size = batch_size * (pp.num_rows * size_of_f);
             let combined_row_size = pp.linear_code.row_len() * size_of_zt_m;
+            let grinding_size = if Zt::GRINDING_BITS == 0 {
+                0
+            } else {
+                size_of::<u64>()
+            };
 
             // Column openings: per opening, column values from all cw_matrices + one Merkle
             // proof
@@ -798,7 +803,7 @@ mod tests {
             let column_opening_phase_size =
                 Zt::NUM_COLUMN_OPENINGS * (column_values_size + single_merkle_proof_size);
 
-            b_phase_size + combined_row_size + column_opening_phase_size
+            b_phase_size + combined_row_size + grinding_size + column_opening_phase_size
         }
 
         type F = MontyField<K>;

--- a/zip-plus/src/pcs/phase_prove.rs
+++ b/zip-plus/src/pcs/phase_prove.rs
@@ -45,7 +45,9 @@ impl<Zt: ZipTypes, Lc: LinearCode<Zt>> ZipPlus<Zt, Lc> {
     ///    `row_len`) = `sum_i(sum_j(s_j * w'_ij))`, accumulated across all
     ///    polynomials
     /// 6. Writes `combined_row` to the transcript.
-    /// 7. Opens `NUM_COLUMN_OPENINGS` Merkle columns: for each, squeezes a
+    /// 7. Performs `GRINDING_BITS` of proof-of-work (a no-op when zero), then
+    ///    writes and absorbs the nonce.
+    /// 8. Opens `NUM_COLUMN_OPENINGS` Merkle columns: for each, squeezes a
     ///    column index, writes per-polynomial column values (Cw entries), and
     ///    appends the Merkle proof.
     ///
@@ -56,6 +58,7 @@ impl<Zt: ZipTypes, Lc: LinearCode<Zt>> ZipPlus<Zt, Lc> {
     /// [b written as F elements]
     /// [coeffs s sampled (or hardcoded [1])]
     /// [combined_row written as CombR]
+    /// [grinding nonce written as u64, only when GRINDING_BITS > 0]
     /// [column openings: idx, per-poly column values, merkle proof] × NUM_COLUMN_OPENINGS
     /// ```
     ///
@@ -97,6 +100,13 @@ impl<Zt: ZipTypes, Lc: LinearCode<Zt>> ZipPlus<Zt, Lc> {
         C::Integer: ConstTranscribable,
         Zt::CombR: MulByScalar<Zt::Chal>,
     {
+        const {
+            assert!(
+                Zt::GRINDING_BITS <= zinc_transcript::pow::MAX_GRINDING_BITS,
+                "GRINDING_BITS exceeds the supported maximum"
+            )
+        }
+
         let point = point
             .iter()
             .map(|v| field_cfg.project(v))
@@ -252,6 +262,7 @@ impl<Zt: ZipTypes, Lc: LinearCode<Zt>> ZipPlus<Zt, Lc> {
         };
 
         transcript.write_const_many(&combined_row)?;
+        transcript.grind(Zt::GRINDING_BITS)?;
         for _ in 0..Zt::NUM_COLUMN_OPENINGS {
             let column_idx = transcript.squeeze_challenge_idx(pp.linear_code.codeword_len());
             Self::open_merkle_trees_for_column(transcript, commit_hint, column_idx)?;

--- a/zip-plus/src/pcs/phase_verify.rs
+++ b/zip-plus/src/pcs/phase_verify.rs
@@ -70,8 +70,9 @@ impl<Zt: ZipTypes, Lc: LinearCode<Zt>> ZipPlus<Zt, Lc> {
     /// 5. Re-derives combination coefficients `s` (or `[1]` when `num_rows ==
     ///    1`).
     /// 6. Reads combined row `w` (CombR, length `row_len`) and encodes it.
-    /// 7. **Check 2**: asserts `<w, q_1> == <s, b>`.
-    /// 8. For each of `NUM_COLUMN_OPENINGS`: a. Squeezes column index, reads
+    /// 7. Checks and absorbs the optional proof-of-work nonce.
+    /// 8. **Check 2**: asserts `<w, q_1> == <s, b>`.
+    /// 9. For each of `NUM_COLUMN_OPENINGS`: a. Squeezes column index, reads
     ///    per-poly column values + Merkle proof. b. **Check 3**:
     ///    `verify_column_testing_batched`. c. **Check 4**:
     ///    `proof.verify(comm.root, column_values, col)`.
@@ -110,6 +111,13 @@ impl<Zt: ZipTypes, Lc: LinearCode<Zt>> ZipPlus<Zt, Lc> {
             + ProjectElementWithConfig<Zt::Chal>,
         C::Integer: ConstTranscribable,
     {
+        const {
+            assert!(
+                Zt::GRINDING_BITS <= zinc_transcript::pow::MAX_GRINDING_BITS,
+                "GRINDING_BITS exceeds the supported maximum"
+            )
+        }
+
         let per_poly_alphas = Self::sample_alphas(&mut transcript.fs_transcript, comm.batch_size);
         Self::verify_with_alphas::<C, CHECK_FOR_OVERFLOW>(
             transcript,
@@ -181,6 +189,7 @@ impl<Zt: ZipTypes, Lc: LinearCode<Zt>> ZipPlus<Zt, Lc> {
         };
 
         let combined_row: Vec<Zt::CombR> = transcript.read_const_many(row_len)?;
+        transcript.check_grinding(Zt::GRINDING_BITS)?;
         let encoded_combined_row: Vec<Zt::CombR> = vp.linear_code.encode_wide(&combined_row);
 
         // Check 2: <w, q_1> == <s, b>
@@ -335,7 +344,10 @@ mod tests {
         mle::{DenseMultilinearExtension, MultilinearExtensionRand},
         univariate::binary::BinaryPoly,
     };
-    use zinc_transcript::traits::{ConstTranscribable, Transcript};
+    use zinc_transcript::{
+        pow::check_pow,
+        traits::{ConstTranscribable, Transcript},
+    };
     use zinc_utils::CHECKED;
 
     const INT_LIMBS: usize = U64::LIMBS;
@@ -359,6 +371,111 @@ mod tests {
 
     type TestZip = ZipPlus<Zt, C>;
     type TestPolyZip = ZipPlus<PolyZt, PolyC>;
+
+    type GrindZt = GrindZipTypes<N, K, M>;
+    type GrindC = IprsCode<GrindZt, TestIprsConfig, REP_FACTOR, CHECKED>;
+    type GrindZip = ZipPlus<GrindZt, GrindC>;
+
+    #[test]
+    fn grinding_enabled_proof_roundtrips() {
+        let num_vars = 10;
+        let (pp, comm, point_f, eval_f, mut transcript) =
+            setup_full_grinding_protocol::<Cfg, N, K, M>(num_vars);
+        let field_cfg = get_field_cfg::<GrindZt, Cfg>(&mut transcript.fs_transcript);
+
+        let result = GrindZip::verify::<_, CHECKED>(
+            &mut transcript,
+            &pp,
+            &comm,
+            &field_cfg,
+            &point_f,
+            &eval_f,
+        );
+        assert!(result.is_ok(), "grinding proof failed: {result:?}");
+        transcript
+            .check_eof()
+            .expect("grinding proof should be fully consumed");
+    }
+
+    #[test]
+    fn grinding_adds_one_nonce_without_reducing_queries() {
+        let num_vars = 10;
+        assert_eq!(
+            GrindZt::NUM_COLUMN_OPENINGS,
+            Zt::NUM_COLUMN_OPENINGS,
+            "the plumbing test must not take unproved query-reduction credit"
+        );
+
+        let (_, _, _, _, baseline) = setup_full_protocol::<Cfg, N, K, M>(num_vars);
+        let (_, _, _, _, grinded) = setup_full_grinding_protocol::<Cfg, N, K, M>(num_vars);
+        assert_eq!(
+            grinded.stream.get_ref().len(),
+            baseline.stream.get_ref().len() + size_of::<u64>(),
+            "enabled grinding must add exactly one fixed-width nonce"
+        );
+    }
+
+    #[test]
+    fn grinding_enabled_proof_rejects_a_proven_invalid_nonce() {
+        let num_vars = 10;
+        let (pp, poly) = setup_grind_test_params::<N, K, M>(num_vars);
+        let (hint, comm) = GrindZip::commit_single(&pp, &poly).expect("commit should succeed");
+        let point: Vec<Int<N>> = (0..num_vars).map(|i| Int::from(i as i32 + 2)).collect();
+
+        let mut prover = PcsProverTranscript::new_from_commitment(&comm);
+        let field_cfg = get_field_cfg::<GrindZt, Cfg>(&mut prover.fs_transcript);
+        let eval_f = GrindZip::prove_single::<Cfg, CHECKED>(
+            &mut prover,
+            &pp,
+            &poly,
+            &point,
+            &hint,
+            &field_cfg,
+        )
+        .expect("prove should succeed");
+        let point_f: Vec<F> = point.iter().map(|v| field_cfg.project(v)).collect();
+
+        // Replay the public verifier prefix exactly up to, but not including,
+        // the nonce. This gives the seed against which the tampered nonce is
+        // proven invalid instead of relying on a probabilistic byte flip.
+        let mut prefix = prover.clone().into_verification_transcript();
+        prefix.fs_transcript.absorb_bytes(&comm.root);
+        let prefix_field_cfg = get_field_cfg::<GrindZt, Cfg>(&mut prefix.fs_transcript);
+        let _alphas = GrindZip::sample_alphas(&mut prefix.fs_transcript, comm.batch_size);
+        let _b = prefix
+            .read_field_elements(&prefix_field_cfg, pp.num_rows)
+            .expect("b read should succeed");
+        if pp.num_rows > 1 {
+            let _: Vec<<GrindZt as ZipTypes>::Chal> =
+                prefix.fs_transcript.get_challenges(pp.num_rows);
+        }
+        let _combined_row: Vec<<GrindZt as ZipTypes>::CombR> = prefix
+            .read_const_many(pp.linear_code.row_len())
+            .expect("combined row read should succeed");
+        let seed = prefix.fs_transcript.derive_pow_seed();
+        let nonce_offset = usize::try_from(prefix.stream.position()).expect("offset fits usize");
+        let bad_nonce = (0u64..)
+            .find(|nonce| !check_pow(&seed, *nonce, GrindZt::GRINDING_BITS))
+            .expect("an invalid nonce exists");
+
+        let mut tampered = prover.into_verification_transcript();
+        tampered.stream.get_mut()[nonce_offset..nonce_offset + size_of::<u64>()]
+            .copy_from_slice(&bad_nonce.to_le_bytes());
+        tampered.fs_transcript.absorb_bytes(&comm.root);
+        let verify_field_cfg = get_field_cfg::<GrindZt, Cfg>(&mut tampered.fs_transcript);
+        let result = GrindZip::verify::<_, CHECKED>(
+            &mut tampered,
+            &pp,
+            &comm,
+            &verify_field_cfg,
+            &point_f,
+            &eval_f,
+        );
+        assert!(
+            matches!(result, Err(ZipError::Grinding(_))),
+            "expected the dedicated grinding error, got {result:?}"
+        );
+    }
 
     #[test]
     fn successful_verification_of_valid_proof() {

--- a/zip-plus/src/pcs/structs.rs
+++ b/zip-plus/src/pcs/structs.rs
@@ -11,8 +11,17 @@ use zinc_transcript::traits::{ConstTranscribable, GenTranscribable};
 use zinc_utils::{from_ref::FromRef, inner_product::InnerProduct, named::Named};
 
 pub trait ZipTypes: Clone + Debug + Send + Sync {
-    /// For IPRS codes, 2^{-security_parameter} = rate^{num_openings / 3}
+    /// Number of columns opened by the verifier.
     const NUM_COLUMN_OPENINGS: usize;
+
+    /// Proof-of-work bits applied immediately before the column-query
+    /// challenges. Zero disables grinding and adds no proof bytes.
+    ///
+    /// This mechanism does not by itself justify reducing
+    /// [`Self::NUM_COLUMN_OPENINGS`]. Crediting these bits requires a protocol
+    /// soundness argument that isolates the protected query term.
+    /// Values above [`zinc_transcript::pow::MAX_GRINDING_BITS`] are rejected.
+    const GRINDING_BITS: u32 = 0;
 
     /// Semiring of witness/polynomial evaluations on boolean hypercube
     type Eval: ConstCoeffBitWidth + Default + Named + Clone + Debug + Send + Sync;

--- a/zip-plus/src/pcs/test_utils.rs
+++ b/zip-plus/src/pcs/test_utils.rs
@@ -61,6 +61,27 @@ impl<const N: usize, const K: usize, const M: usize> ZipTypes for TestZipTypes<N
     type ArrCombRDotChal = MBSInnerProduct;
 }
 
+/// Dedicated test configuration for the optional grinding path. Ordinary test
+/// and production configurations retain the default of zero grinding bits.
+#[derive(Debug, Clone)]
+pub struct GrindZipTypes<const N: usize, const K: usize, const M: usize> {}
+impl<const N: usize, const K: usize, const M: usize> ZipTypes for GrindZipTypes<N, K, M> {
+    // Grinding plumbing is tested without taking any query-reduction credit.
+    const NUM_COLUMN_OPENINGS: usize = 100;
+    const GRINDING_BITS: u32 = if cfg!(miri) { 2 } else { 8 };
+    type Eval = Int<N>;
+    type Cw = Int<K>;
+    type Fmod = Uint<K>;
+    type PrimeTest = MillerRabin;
+    type Chal = Int<N>;
+    type Pt = Int<N>;
+    type CombR = Int<M>;
+    type Comb = Self::CombR;
+    type EvalDotChal = ScalarProduct;
+    type CombDotChal = ScalarProduct;
+    type ArrCombRDotChal = MBSInnerProduct;
+}
+
 #[derive(Debug, Clone)]
 pub struct TestBinPolyZipTypes<const K: usize, const M: usize, const DEGREE_PLUS_ONE: usize> {}
 impl<const K: usize, const M: usize, const DEGREE_PLUS_ONE: usize> ZipTypes
@@ -96,6 +117,22 @@ pub fn setup_test_params<const N: usize, const K: usize, const M: usize>(
         IprsCode<TestZipTypes<N, K, M>, TestIprsConfig, REP_FACTOR, CHECKED>,
     >,
     DenseMultilinearExtension<<TestZipTypes<N, K, M> as ZipTypes>::Eval>,
+) {
+    setup_test_params_inner(
+        num_vars,
+        IprsCode::new(IPRS_ROW_LEN, IPRS_DEPTH).unwrap(),
+        |poly_size| (1..=poly_size as i32).map(Int::from).collect(),
+    )
+}
+
+pub fn setup_grind_test_params<const N: usize, const K: usize, const M: usize>(
+    num_vars: usize,
+) -> (
+    ZipPlusParams<
+        GrindZipTypes<N, K, M>,
+        IprsCode<GrindZipTypes<N, K, M>, TestIprsConfig, REP_FACTOR, CHECKED>,
+    >,
+    DenseMultilinearExtension<<GrindZipTypes<N, K, M> as ZipTypes>::Eval>,
 ) {
     setup_test_params_inner(
         num_vars,
@@ -171,6 +208,30 @@ where
     C::Integer: ConstTranscribable + FromRef<<TestZipTypes<N, K, M> as ZipTypes>::Fmod>,
 {
     setup_full_protocol_inner::<_, _, C, N>(num_vars, setup_test_params, || {
+        (0..num_vars).map(|i| Int::from(i as i32 + 2)).collect()
+    })
+}
+
+pub fn setup_full_grinding_protocol<C, const N: usize, const K: usize, const M: usize>(
+    num_vars: usize,
+) -> (
+    ZipPlusParams<
+        GrindZipTypes<N, K, M>,
+        IprsCode<GrindZipTypes<N, K, M>, TestIprsConfig, REP_FACTOR, CHECKED>,
+    >,
+    ZipPlusCommitment,
+    Vec<C::Element>,
+    C::Element,
+    PcsVerifierTranscript,
+)
+where
+    C: BaseFieldConfig
+        + ProjectElementWithConfig<<GrindZipTypes<N, K, M> as ZipTypes>::Pt>
+        + ProjectElementWithConfig<<GrindZipTypes<N, K, M> as ZipTypes>::CombR>
+        + Sync,
+    C::Integer: ConstTranscribable + FromRef<<GrindZipTypes<N, K, M> as ZipTypes>::Fmod>,
+{
+    setup_full_protocol_inner::<_, _, C, N>(num_vars, setup_grind_test_params, || {
         (0..num_vars).map(|i| Int::from(i as i32 + 2)).collect()
     })
 }

--- a/zip-plus/src/pcs_transcript.rs
+++ b/zip-plus/src/pcs_transcript.rs
@@ -1,4 +1,4 @@
-use crate::{merkle::MerkleProof, pcs::structs::ZipPlusCommitment};
+use crate::{ZipError, merkle::MerkleProof, pcs::structs::ZipPlusCommitment};
 use crypto_primitives::BaseFieldConfig;
 use itertools::Itertools;
 use std::{
@@ -7,6 +7,7 @@ use std::{
 };
 use zinc_transcript::{
     Blake3Transcript, TranscriptError,
+    pow::{MAX_GRINDING_BITS, check_pow, find_pow_nonce},
     traits::{ConstTranscribable, Transcribable, Transcript},
 };
 use zinc_utils::{add, mul, rem};
@@ -97,6 +98,28 @@ impl PcsProverTranscript {
     }
 
     common_methods!();
+
+    /// Performs proof-of-work immediately before a protected Fiat-Shamir
+    /// challenge. The seed is derived from the pre-nonce transcript prefix;
+    /// writing the nonce is the sole transcript mutation in this operation.
+    ///
+    /// This is a no-op when `bits == 0` and rejects infeasible configurations
+    /// before deriving a seed or touching the proof stream.
+    pub fn grind(&mut self, bits: u32) -> Result<(), ZipError> {
+        if bits == 0 {
+            return Ok(());
+        }
+        if bits > MAX_GRINDING_BITS {
+            return Err(ZipError::InvalidPcsParam(format!(
+                "grinding bits must not exceed {MAX_GRINDING_BITS}, got {bits}"
+            )));
+        }
+
+        let seed = self.fs_transcript.derive_pow_seed();
+        let nonce = find_pow_nonce(&seed, bits);
+        self.write(&nonce)?;
+        Ok(())
+    }
 
     /// Writes field elements to the proof stream and absorbs them into the
     /// transcript, as raw (inner-representation) bytes.
@@ -227,6 +250,31 @@ pub struct PcsVerifierTranscript {
 
 impl PcsVerifierTranscript {
     common_methods!();
+
+    /// Reads and checks a proof-of-work nonce before the protected challenge.
+    /// The seed is derived before `read` absorbs the nonce, mirroring
+    /// [`PcsProverTranscript::grind`]. An invalid nonce still remains absorbed,
+    /// but callers must abort verification on the returned error.
+    pub fn check_grinding(&mut self, bits: u32) -> Result<(), ZipError> {
+        if bits == 0 {
+            return Ok(());
+        }
+        if bits > MAX_GRINDING_BITS {
+            return Err(ZipError::InvalidPcsParam(format!(
+                "grinding bits must not exceed {MAX_GRINDING_BITS}, got {bits}"
+            )));
+        }
+
+        let seed = self.fs_transcript.derive_pow_seed();
+        let nonce: u64 = self.read()?;
+        if check_pow(&seed, nonce, bits) {
+            Ok(())
+        } else {
+            Err(ZipError::Grinding(format!(
+                "nonce {nonce} does not provide {bits} bits of work"
+            )))
+        }
+    }
 
     /// Returns an error unless the whole proof stream has been consumed.
     ///
@@ -518,6 +566,159 @@ mod tests {
         verifier
             .check_eof()
             .expect("stream should be fully consumed");
+    }
+
+    #[test]
+    fn grinding_roundtrip_uses_the_pre_nonce_seed_and_stays_in_sync() {
+        const BITS: u32 = 8;
+
+        let comm = ZipPlusCommitment::default();
+        let prefix = [11u64, 22, 33];
+        let mut prover = PcsProverTranscript::new_from_commitment(&comm);
+        prover
+            .write_const_many(&prefix)
+            .expect("prefix write should succeed");
+        let expected_seed = prover.fs_transcript.derive_pow_seed();
+        let expected_nonce = find_pow_nonce(&expected_seed, BITS);
+        let mut one_write = prover.clone();
+        one_write
+            .write(&expected_nonce)
+            .expect("manual nonce write should succeed");
+        prover.grind(BITS).expect("grinding should succeed");
+        assert_eq!(
+            prover.stream, one_write.stream,
+            "grinding must serialize exactly one ordinary nonce message"
+        );
+        let prover_challenge = prover.squeeze_challenge_idx(CAP);
+        assert_eq!(
+            prover_challenge,
+            one_write.squeeze_challenge_idx(CAP),
+            "grinding must absorb the nonce exactly once"
+        );
+
+        let mut verifier = prover.into_verification_transcript();
+        verifier.fs_transcript.absorb_bytes(&comm.root);
+        let read_prefix: Vec<u64> = verifier
+            .read_const_many(prefix.len())
+            .expect("prefix read should succeed");
+        assert_eq!(read_prefix, prefix);
+        assert_eq!(
+            verifier.fs_transcript.derive_pow_seed(),
+            expected_seed,
+            "verifier must derive the PoW seed before reading the nonce"
+        );
+
+        verifier
+            .check_grinding(BITS)
+            .expect("valid nonce should verify");
+        let verifier_challenge = verifier.squeeze_challenge_idx(CAP);
+        assert_eq!(prover_challenge, verifier_challenge);
+        verifier
+            .check_eof()
+            .expect("stream should be fully consumed");
+    }
+
+    #[test]
+    fn zero_bit_grinding_is_an_exact_no_op() {
+        let comm = ZipPlusCommitment::default();
+        let mut baseline = PcsProverTranscript::new_from_commitment(&comm);
+        let mut zero_work = baseline.clone();
+
+        zero_work
+            .grind(0)
+            .expect("zero-bit grinding should succeed");
+        assert_eq!(zero_work.stream, baseline.stream, "zero bits wrote a nonce");
+        assert_eq!(
+            zero_work.squeeze_challenge_idx(CAP),
+            baseline.squeeze_challenge_idx(CAP),
+            "zero bits changed the Fiat-Shamir state"
+        );
+
+        let mut verifier = zero_work.into_verification_transcript();
+        verifier.fs_transcript.absorb_bytes(&comm.root);
+        let mut verifier_baseline = verifier.clone();
+        verifier
+            .check_grinding(0)
+            .expect("zero-bit check should succeed");
+        assert_eq!(verifier.stream.position(), 0, "zero bits read proof bytes");
+        assert_eq!(
+            verifier.squeeze_challenge_idx(CAP),
+            verifier_baseline.squeeze_challenge_idx(CAP),
+            "zero-bit verification changed the Fiat-Shamir state"
+        );
+    }
+
+    #[test]
+    fn invalid_grinding_configuration_fails_before_mutating_state() {
+        let comm = ZipPlusCommitment::default();
+        let mut prover = PcsProverTranscript::new_from_commitment(&comm);
+        let mut untouched_prover = prover.clone();
+        assert!(matches!(
+            prover.grind(MAX_GRINDING_BITS + 1),
+            Err(ZipError::InvalidPcsParam(_))
+        ));
+        assert_eq!(prover.stream, untouched_prover.stream);
+        assert_eq!(
+            prover.squeeze_challenge_idx(CAP),
+            untouched_prover.squeeze_challenge_idx(CAP)
+        );
+
+        let mut verifier =
+            PcsProverTranscript::new_from_commitment(&comm).into_verification_transcript();
+        verifier.fs_transcript.absorb_bytes(&comm.root);
+        let mut untouched_verifier = verifier.clone();
+        assert!(matches!(
+            verifier.check_grinding(MAX_GRINDING_BITS + 1),
+            Err(ZipError::InvalidPcsParam(_))
+        ));
+        assert_eq!(
+            verifier.stream.position(),
+            untouched_verifier.stream.position()
+        );
+        assert_eq!(
+            verifier.squeeze_challenge_idx(CAP),
+            untouched_verifier.squeeze_challenge_idx(CAP)
+        );
+    }
+
+    #[test]
+    fn missing_and_invalid_grinding_nonces_are_distinguished() {
+        const BITS: u32 = 8;
+
+        let comm = ZipPlusCommitment::default();
+        let mut missing =
+            PcsProverTranscript::new_from_commitment(&comm).into_verification_transcript();
+        missing.fs_transcript.absorb_bytes(&comm.root);
+        assert!(matches!(
+            missing.check_grinding(BITS),
+            Err(ZipError::Transcript(TranscriptError(
+                ErrorKind::UnexpectedEof,
+                _
+            )))
+        ));
+
+        let mut prover = PcsProverTranscript::new_from_commitment(&comm);
+        prover
+            .write_const_many(&[7u64, 8, 9])
+            .expect("prefix write should succeed");
+        let seed = prover.fs_transcript.derive_pow_seed();
+        prover.grind(BITS).expect("grinding should succeed");
+
+        let bad_nonce = (0u64..)
+            .find(|nonce| !check_pow(&seed, *nonce, BITS))
+            .expect("an invalid nonce exists");
+        let nonce_offset = prover.stream.get_ref().len() - size_of::<u64>();
+        prover.stream.get_mut()[nonce_offset..].copy_from_slice(&bad_nonce.to_le_bytes());
+
+        let mut invalid = prover.into_verification_transcript();
+        invalid.fs_transcript.absorb_bytes(&comm.root);
+        let _: Vec<u64> = invalid
+            .read_const_many(3)
+            .expect("prefix read should succeed");
+        assert!(matches!(
+            invalid.check_grinding(BITS),
+            Err(ZipError::Grinding(_))
+        ));
     }
 
     /// Trailing bytes are bytes that never entered the transcript, so they


### PR DESCRIPTION
Goes towards #149.

Reworked on top of #231. The previous combined-row binding commit was dropped because transcript reads and writes are now absorbed unconditionally.

This adds optional proof-of-work immediately before the Zip+ column-opening challenges:

* Added pure BLAKE3 nonce search and verification. The seed is domain-separated and derived non-mutatingly from the current Fiat-Shamir transcript; the work message is `seed || nonce_le || 0^24`.
* The prover and verifier derive the seed after `combined_row` and before the nonce enters the transcript. The prover then searches and writes the nonce; the verifier reads and checks it. Normal transcript IO is therefore the nonce's only absorption.
* Search returns the smallest valid nonce deterministically in both sequential and parallel builds. Protocol configurations are capped at 32 grinding bits.
* Added `ZipTypes::GRINDING_BITS`, defaulting to `0`. No production or benchmark configuration enables it, so the existing proof format and challenge schedule are unchanged by default.

This PR does not reduce `NUM_COLUMN_OPENINGS` or claim soundness credit for grinding. That requires a reviewed protocol argument isolating the protected query term. The enabled test configuration retains all 100 openings and adds exactly one `u64` nonce.

Tests cover stable hash vectors, sequential/parallel determinism, search rollover, the zero-bit no-op, invalid configurations, missing and invalid nonces, proof-size accounting, end-to-end verification, and nonce tampering. The full `.githooks/pre-push` check passes.
