### PR TITLE
Batch bit-op virtual claims in multipoint eval

### DIFF
--- a/piop/benches/multipoint_eval.rs
+++ b/piop/benches/multipoint_eval.rs
@@ -87,8 +87,10 @@ fn bench_multipoint_eval(c: &mut Criterion, num_vars: usize, num_cols: usize) {
                         vec![MultipointEvalFamilyInputs {
                             field_cfg: &field_cfg,
                             trace_mles: &trace_mles,
+                            bit_op_mles: &[],
                             eval_point: &eval_point,
                             up_evals: &up_evals,
+                            bit_op_evals: &[],
                             down_evals: &down_evals,
                         }],
                         &shifts,
@@ -110,8 +112,10 @@ fn bench_multipoint_eval(c: &mut Criterion, num_vars: usize, num_cols: usize) {
         vec![MultipointEvalFamilyInputs {
             field_cfg: &field_cfg,
             trace_mles: &trace_mles,
+            bit_op_mles: &[],
             eval_point: &eval_point,
             up_evals: &up_evals,
+            bit_op_evals: &[],
             down_evals: &down_evals,
         }],
         &shifts,
@@ -139,8 +143,10 @@ fn bench_multipoint_eval(c: &mut Criterion, num_vars: usize, num_cols: usize) {
                     vec![MultipointEvalFamilyInputs {
                         field_cfg: &field_cfg,
                         trace_mles: &[],
+                        bit_op_mles: &[],
                         eval_point: &eval_point,
                         up_evals: &up_evals,
+                        bit_op_evals: &[],
                         down_evals: &down_evals,
                     }],
                     &shifts,
@@ -149,8 +155,14 @@ fn bench_multipoint_eval(c: &mut Criterion, num_vars: usize, num_cols: usize) {
                 )
                 .expect("verifier failed");
                 let subclaim = subclaims.pop().expect("single family");
-                MultipointEval::<F>::verify_subclaim(&subclaim, &open_evals, &shifts, &field_cfg)
-                    .expect("subclaim check failed");
+                MultipointEval::<F>::verify_subclaim(
+                    &subclaim,
+                    &open_evals,
+                    &[],
+                    &shifts,
+                    &field_cfg,
+                )
+                .expect("subclaim check failed");
             },
             BatchSize::SmallInput,
         );

--- a/piop/src/multipoint_eval.rs
+++ b/piop/src/multipoint_eval.rs
@@ -1,26 +1,32 @@
 //! Multi-point evaluation subprotocol.
 //!
-//! Reduces two sets of MLE evaluation claims at a shared point r' - the
-//! "up" evaluations `v_j(r')` and the "down" (shifted) evaluations
-//! `v_j^{down}(r')` - to a single set of standard MLE evaluation claims
-//! `v_j(r_0)` at a new random point `r_0` via one sumcheck.
+//! Reduces MLE evaluation claims at a shared point r' - the "up" evaluations
+//! `v_j(r')`, the "down" (shifted) evaluations `v_j^{down}(r')`, and optional
+//! bit-op virtual evaluations - to a single set of standard MLE evaluation
+//! claims at a new random point `r_0` via one sumcheck.
 //!
 //! The trace column MLEs are precombined into a single MLE
-//! `precombined(b) = \sum_j \gamma_j * v_j(b)` before entering the sumcheck, so
-//! the prover works with only 3 MLEs (`eq`, `next`, `precombined`) regardless
-//! of the number of columns. The sumcheck proves:
+//! `precombined(b) = \sum_j \gamma_j * v_j(b)
+//!                 + \sum_l \gamma_l^bit * bit_op_l(b)`
+//! before entering the sumcheck, so the prover works with only 3 MLE groups
+//! (`eq`, `next`, `precombined`) regardless of the number of columns. The
+//! sumcheck proves:
 //! ```text
-//! \sum_b [eq(b, r') * \sum_j \gamma_j * v_j(b)
+//! \sum_b [eq(b, r') * (\sum_j \gamma_j * v_j(b)
+//!                      + \sum_l \gamma_l^bit * bit_op_l(b))
 //!         + \sum_k \alpha_k * next_{c_k}(r', b) * v_{src_k}(b)]
-//!   = \sum_j \gamma_j * up_eval_j + \sum_k \alpha_k * down_eval_k
+//!   = \sum_j \gamma_j * up_eval_j
+//!     + \sum_l \gamma_l^bit * bit_op_eval_l
+//!     + \sum_k \alpha_k * down_eval_k
 //! ```
 //!
 //! where `\alpha_k` batch the per-shift evaluation kernels and `\gamma_j`
 //! batch across columns. After the sumcheck reduces to point `r_0`, the
-//! verifier calls [`MultipointEval::verify_subclaim`] with the `open_evals`
-//! (the F_q-valued MLE evaluations at `r_0`, typically derived from
-//! polynomial-valued `lifted_evals` via `\psi_a`) to check the final
-//! consistency equation.
+//! verifier calls [`MultipointEval::verify_subclaim`] with the committed-column
+//! `open_evals` and the verifier-derived `bit_op_open_evals` to check the
+//! final consistency equation. For bit-op virtuals, those open evaluations are
+//! derived from source lifted openings via Lemma 2.3 rather than trusted as
+//! independent witness openings.
 //!
 //! This corresponds to the T=2 case of Pi_{BMLE} in the paper. Following
 //! the paper, the prover sends only the polynomial-valued lifted evaluations
@@ -83,17 +89,24 @@ delegate_transcribable!(Proof<F> { sumcheck_proof: MultiDegreeSumcheckProof<F> }
 /// All families share the same `shifts` (UAIR-static), the same column
 /// counts, and the same `num_vars`. They differ only in (a) the field
 /// config they operate over and (b) the per-family field-projected
-/// `trace_mles`, `eval_point`, `up_evals`, and `down_evals`.
+/// `trace_mles`, bit-op virtual MLEs, `eval_point`, `up_evals`, and
+/// `down_evals`.
 pub struct MultipointEvalFamilyInputs<'a, F: PrimeField> {
     /// Field configuration for this family.
     pub field_cfg: &'a F::Config,
     /// Trace MLEs for this family (projected into this family's field).
     pub trace_mles: &'a [DenseMultilinearExtension<F::Inner>],
+    /// Bit-op virtual MLEs for this family (projected into this family's
+    /// field).
+    pub bit_op_mles: &'a [DenseMultilinearExtension<F::Inner>],
     /// Evaluation point $r^\star$ for this family.
     pub eval_point: &'a [F],
     /// `up_eval_j = v_j(r*)` for every column $j$, in this family's
     /// field.
     pub up_evals: &'a [F],
+    /// `bit_op_eval_l = bit_op_l(r*)` for every bit-op virtual column
+    /// $l$, in this family's field.
+    pub bit_op_evals: &'a [F],
     /// `down_eval_k = v_{src_k}^{<<c_k}(r*)` for every shift $k$, in
     /// this family's field.
     pub down_evals: &'a [F],
@@ -131,6 +144,9 @@ pub struct Subclaim<F: PrimeField> {
     /// Per-shift batching coefficients $\alpha_k$ sampled during the
     /// protocol (lifted into this family's field).
     pub alphas: Vec<F>,
+    /// Per-bit-op-virtual batching coefficients sampled during the
+    /// protocol (lifted into this family's field).
+    pub bit_op_gammas: Vec<F>,
     /// `eq(r_0, r^\star)` — the equality selector at the sumcheck output
     /// point.
     pub eq_at_r0: F,
@@ -154,26 +170,31 @@ where
     ///
     /// Drives one or more **families** of multi-point evaluation in lockstep,
     /// each family operating over its own field config. All families share
-    /// the same UAIR-static [`ShiftSpec`]s, the same number of columns, and
-    /// the same `num_vars`; they differ only in their per-family projected
+    /// the same UAIR-static [`ShiftSpec`]s, the same number of committed
+    /// columns, the same number of bit-op virtual columns, and the same
+    /// `num_vars`; they differ only in their per-family projected
     /// MLEs/scalars.
     ///
-    /// All protocol-level challenges $(\alpha_k, \gamma_j)$ are sampled once
-    /// as integers in $[0, q^*)$ via `q_star_cfg` and lifted into each
-    /// family's field via [`F::from_with_cfg`]. The inner sumcheck is
-    /// driven by [`MultiDegreeSumcheck`] (one degree-2 group per family),
-    /// so each round's challenge is likewise shared across families and
-    /// lifted per-family.
+    /// All protocol-level challenges $(\alpha_k, \gamma_j,
+    /// \gamma^\mathrm{bit}_l)$ are sampled once as integers in $[0, q^*)$
+    /// via `q_star_cfg` and lifted into each family's field via
+    /// [`F::from_with_cfg`]. The inner sumcheck is driven by
+    /// [`MultiDegreeSumcheck`] (one degree-2 group per family), so each
+    /// round's challenge is likewise shared across families and lifted
+    /// per-family.
     ///
     /// The single-family case (`families.len() == 1`) is the natural
     /// degenerate form; pass `q_star_cfg = families[0].field_cfg`.
     ///
     /// Per family, proves
     ///
-    /// $$\sum_b \Bigl[\, \mathrm{eq}(b, r^\star) \sum_j \gamma_j v_j(b) +
+    /// $$\sum_b \Bigl[\, \mathrm{eq}(b, r^\star) (
+    /// \sum_j \gamma_j v_j(b) + \sum_l \gamma^\mathrm{bit}_l w_l(b)) +
     /// \sum_k \alpha_k \cdot \mathrm{next}_{c_k}(r^\star, b) \cdot
     /// v_{\mathrm{src}_k}(b) \Bigr] = \sum_j \gamma_j \cdot
-    /// \mathrm{up\\_eval}_j + \sum_k \alpha_k \cdot \mathrm{down\\_eval}_k.$$
+    /// \mathrm{up\\_eval}_j + \sum_l \gamma^\mathrm{bit}_l \cdot
+    /// \mathrm{bit\\_op\\_eval}_l + \sum_k \alpha_k \cdot
+    /// \mathrm{down\\_eval}_k.$$
     ///
     /// Returns one `(Proof, ProverState)` per family in family order. The
     /// caller is responsible for computing and sending `lifted_evals` at
@@ -200,6 +221,7 @@ where
         let num_cols = families[0].trace_mles.len();
         let num_vars = families[0].eval_point.len();
         let num_down_cols = shifts.len();
+        let num_bit_op_cols = families[0].bit_op_evals.len();
 
         for b in &families {
             assert_eq!(
@@ -222,11 +244,21 @@ where
                 num_down_cols,
                 "down_evals length must match shifts length",
             );
+            assert_eq!(
+                b.bit_op_mles.len(),
+                num_bit_op_cols,
+                "all families must have the same number of bit-op MLEs",
+            );
+            assert_eq!(
+                b.bit_op_evals.len(),
+                num_bit_op_cols,
+                "all families must have the same number of bit-op evals",
+            );
         }
 
         // Step 1: Sample shared batching coefficients $\alpha_k$ and
-        // $\gamma_j$ as integers in $[0, q^*)$, then lift into each
-        // family's field.
+        // $\gamma_j$, then bit-op $\gamma^\mathrm{bit}_l$, as integers in
+        // $[0, q^*)$, then lift into each family's field.
         let shared_alpha_ints: Vec<F::Integer> = (0..num_down_cols)
             .map(|_| {
                 transcript
@@ -235,6 +267,13 @@ where
             })
             .collect();
         let shared_gamma_ints: Vec<F::Integer> = (0..num_cols)
+            .map(|_| {
+                transcript
+                    .get_field_challenge::<F>(q_star_cfg)
+                    .lift_to_integer()
+            })
+            .collect();
+        let shared_bit_op_gamma_ints: Vec<F::Integer> = (0..num_bit_op_cols)
             .map(|_| {
                 transcript
                     .get_field_challenge::<F>(q_star_cfg)
@@ -260,6 +299,15 @@ where
                     .collect()
             })
             .collect();
+        let per_family_bit_op_gammas: Vec<Vec<F>> = families
+            .iter()
+            .map(|b| {
+                shared_bit_op_gamma_ints
+                    .iter()
+                    .map(|v| F::from_with_cfg(v.clone(), b.field_cfg))
+                    .collect()
+            })
+            .collect();
 
         // Step 2: Build per-family sumcheck groups.
         //
@@ -276,6 +324,7 @@ where
             let cfg = family.field_cfg;
             let alphas_b = per_family_alphas[b_idx].clone();
             let gammas_b = &per_family_gammas[b_idx];
+            let bit_op_gammas_b = &per_family_bit_op_gammas[b_idx];
             let zero = F::zero_with_cfg(cfg);
             let zero_inner = zero.inner();
 
@@ -294,16 +343,27 @@ where
                 .into_iter()
                 .unzip();
 
-            // Precombine up cols with gammas: precombined[i] = \sum_j gamma_j trace[j][i].
+            // Precombine committed columns and bit-op virtual columns.
             let precombined = {
                 let evaluations: Vec<_> = cfg_into_iter!(0..1usize << num_vars)
                     .map(|i| {
-                        gammas_b
+                        let committed_acc =
+                            gammas_b
+                                .iter()
+                                .enumerate()
+                                .fold(zero.clone(), |acc, (j, gamma)| {
+                                    let eval_f = F::new_unchecked_with_cfg(
+                                        family.trace_mles[j].evaluations[i].clone(),
+                                        cfg,
+                                    );
+                                    acc + eval_f * gamma
+                                });
+                        bit_op_gammas_b
                             .iter()
                             .enumerate()
-                            .fold(zero.clone(), |acc, (j, gamma)| {
+                            .fold(committed_acc, |acc, (j, gamma)| {
                                 let eval_f = F::new_unchecked_with_cfg(
-                                    family.trace_mles[j].evaluations[i].clone(),
+                                    family.bit_op_mles[j].evaluations[i].clone(),
                                     cfg,
                                 );
                                 acc + eval_f * gamma
@@ -349,8 +409,10 @@ where
                 debug_expected_sums.push(compute_expected_sum(
                     family.up_evals,
                     family.down_evals,
+                    family.bit_op_evals,
                     gammas_b,
                     &alphas_b,
+                    bit_op_gammas_b,
                     zero,
                 ));
             }
@@ -424,6 +486,7 @@ where
 
         let num_cols = families[0].up_evals.len();
         let num_down_cols = shifts.len();
+        let num_bit_op_cols = families[0].bit_op_evals.len();
 
         // Sanity check
         for b in &families {
@@ -442,10 +505,16 @@ where
                 num_vars,
                 "all families must have the same num_vars",
             );
+            assert_eq!(
+                b.bit_op_evals.len(),
+                num_bit_op_cols,
+                "all families must have the same number of bit-op evals",
+            );
         }
 
-        // Step 1: Sample shared $\alpha_k$ and $\gamma_j$ in $[0, q^*)$
-        // (must match prover transcript order: alphas first, then gammas).
+        // Step 1: Sample shared $\alpha_k$, $\gamma_j$, and bit-op
+        // $\gamma^\mathrm{bit}_l$ in $[0, q^*)$ (must match prover
+        // transcript order: alphas, gammas, bit-op gammas).
         let shared_alpha_ints: Vec<F::Integer> = (0..num_down_cols)
             .map(|_| {
                 transcript
@@ -454,6 +523,13 @@ where
             })
             .collect();
         let shared_gamma_ints: Vec<F::Integer> = (0..num_cols)
+            .map(|_| {
+                transcript
+                    .get_field_challenge::<F>(q_star_cfg)
+                    .lift_to_integer()
+            })
+            .collect();
+        let shared_bit_op_gamma_ints: Vec<F::Integer> = (0..num_bit_op_cols)
             .map(|_| {
                 transcript
                     .get_field_challenge::<F>(q_star_cfg)
@@ -479,16 +555,27 @@ where
                     .collect()
             })
             .collect();
+        let per_family_bit_op_gammas: Vec<Vec<F>> = families
+            .iter()
+            .map(|b| {
+                shared_bit_op_gamma_ints
+                    .iter()
+                    .map(|v| F::from_with_cfg(v.clone(), b.field_cfg))
+                    .collect()
+            })
+            .collect();
 
         // Step 2: Per-family claimed-sum check (must equal the integer-
-        // shared expected sum derived from each family's up/down evals).
+        // shared expected sum derived from each family's up/down/bit-op evals).
         for (b_idx, (proof, family)) in proofs.iter().zip(families.iter()).enumerate() {
             let zero = F::zero_with_cfg(family.field_cfg);
             let expected = compute_expected_sum(
                 family.up_evals,
                 family.down_evals,
+                family.bit_op_evals,
                 &per_family_gammas[b_idx],
                 &per_family_alphas[b_idx],
+                &per_family_bit_op_gammas[b_idx],
                 zero,
             );
             let claimed = &proof.sumcheck_proof.claimed_sums()[0];
@@ -537,6 +624,7 @@ where
                     expected_evaluation,
                     gammas: per_family_gammas[b_idx].clone(),
                     alphas: per_family_alphas[b_idx].clone(),
+                    bit_op_gammas: per_family_bit_op_gammas[b_idx].clone(),
                     eq_at_r0,
                     shifts_at_r0,
                 })
@@ -557,15 +645,24 @@ where
     pub fn verify_subclaim(
         subclaim: &Subclaim<F>,
         open_evals: &[F],
+        bit_op_open_evals: &[F],
         shifts: &[ShiftSpec],
         field_cfg: &F::Config,
     ) -> Result<(), MultipointEvalError<F>> {
         let num_cols = subclaim.gammas.len();
+        let num_bit_op_cols = subclaim.bit_op_gammas.len();
 
         if open_evals.len() != num_cols {
             return Err(MultipointEvalError::WrongOpenEvalsNumber {
                 got: open_evals.len(),
                 expected: num_cols,
+            });
+        }
+
+        if bit_op_open_evals.len() != num_bit_op_cols {
+            return Err(MultipointEvalError::WrongBitOpOpenEvalsNumber {
+                got: bit_op_open_evals.len(),
+                expected: num_bit_op_cols,
             });
         }
 
@@ -578,6 +675,11 @@ where
             .fold(zero.clone(), |acc, (gamma, eval)| {
                 acc + gamma.clone() * eval
             });
+        let batched_up = subclaim
+            .bit_op_gammas
+            .iter()
+            .zip(bit_op_open_evals.iter())
+            .fold(batched_up, |acc, (gamma, eval)| acc + gamma.clone() * eval);
 
         // open_evals[j] = trace_col_j(r_0) for all committed (up) columns.
         // Shifted columns reuse the same opening: the shift is captured by
@@ -605,13 +707,17 @@ where
     }
 }
 
-/// `expected_sum = \sum_j \gamma_j * up_eval_j + \sum_k \alpha_k *
-/// down_eval_k`
+/// `expected_sum = \sum_j \gamma_j * up_eval_j
+///                + \sum_k \alpha_k * down_eval_k
+///                + \sum_l \gamma_l^bit * bit_op_eval_l`
+#[allow(clippy::too_many_arguments)]
 fn compute_expected_sum<F: PrimeField>(
     up_evals: &[F],
     down_evals: &[F],
+    bit_op_evals: &[F],
     gammas: &[F],
     alphas: &[F],
+    bit_op_gammas: &[F],
     zero: F,
 ) -> F {
     let up_sum = gammas
@@ -619,10 +725,15 @@ fn compute_expected_sum<F: PrimeField>(
         .zip(up_evals.iter())
         .fold(zero, |acc, (gamma, up)| acc + gamma.clone() * up);
 
-    alphas
+    let up_and_down = alphas
         .iter()
         .zip(down_evals.iter())
-        .fold(up_sum, |acc, (alpha, down)| acc + alpha.clone() * down)
+        .fold(up_sum, |acc, (alpha, down)| acc + alpha.clone() * down);
+
+    bit_op_gammas
+        .iter()
+        .zip(bit_op_evals.iter())
+        .fold(up_and_down, |acc, (gamma, eval)| acc + gamma.clone() * eval)
 }
 
 //
@@ -633,6 +744,8 @@ fn compute_expected_sum<F: PrimeField>(
 pub enum MultipointEvalError<F: PrimeField> {
     #[error("wrong number of open evaluations: got {got}, expected {expected}")]
     WrongOpenEvalsNumber { got: usize, expected: usize },
+    #[error("wrong number of bit-op open evaluations: got {got}, expected {expected}")]
+    WrongBitOpOpenEvalsNumber { got: usize, expected: usize },
     #[error("wrong sumcheck claimed sum: got {got}, expected {expected}")]
     WrongSumcheckSum { got: F, expected: F },
     #[error("multi-point eval claim mismatch: got {got}, expected {expected}")]
@@ -745,8 +858,10 @@ mod tests {
             vec![MultipointEvalFamilyInputs {
                 field_cfg: &(),
                 trace_mles,
+                bit_op_mles: &[],
                 eval_point: &public.eval_point,
                 up_evals: &public.up_evals,
+                bit_op_evals: &[],
                 down_evals: &public.down_evals,
             }],
             &public.shifts,
@@ -776,8 +891,10 @@ mod tests {
             vec![MultipointEvalFamilyInputs {
                 field_cfg: &(),
                 trace_mles: &[],
+                bit_op_mles: &[],
                 eval_point: &public.eval_point,
                 up_evals: &public.up_evals,
+                bit_op_evals: &[],
                 down_evals: &public.down_evals,
             }],
             &public.shifts,
@@ -787,7 +904,7 @@ mod tests {
         assert_eq!(subclaims.len(), 1, "single-family shape");
         let subclaim = subclaims.pop().expect("single family");
 
-        MultipointEval::<F>::verify_subclaim(&subclaim, &msg.open_evals, &public.shifts, &())?;
+        MultipointEval::<F>::verify_subclaim(&subclaim, &msg.open_evals, &[], &public.shifts, &())?;
 
         Ok(subclaim)
     }
@@ -854,6 +971,104 @@ mod tests {
         let shifts = vec![ShiftSpec::new(0, 2), ShiftSpec::new(0, 5)];
         let (public, msg) = honest_interaction(4, 3, &shifts);
         run_verifier(&public, &msg).unwrap();
+    }
+
+    #[test]
+    fn bit_op_virtual_opening_is_bound_in_subclaim() {
+        let shifts = vec![ShiftSpec::new(0, 1)];
+        let (trace_mles, public) = build_trace(3, 2, &shifts);
+
+        let bit_op_mles = vec![DenseMultilinearExtension::from_evaluations_vec(
+            public.num_vars,
+            trace_mles[0]
+                .evaluations
+                .iter()
+                .map(|eval| (F::new_unchecked_with_cfg(*eval, &()) + F::from(11_u32)).into_inner())
+                .collect(),
+            F::ZERO.into_inner(),
+        )];
+        let bit_op_evals: Vec<F> = bit_op_mles
+            .iter()
+            .map(|mle| {
+                mle.clone()
+                    .evaluate_with_config(&public.eval_point, &())
+                    .unwrap()
+            })
+            .collect();
+
+        let mut prover_transcript = make_transcript();
+        let mut prover_outputs = MultipointEval::<F>::prove_as_subprotocol(
+            &mut prover_transcript,
+            vec![MultipointEvalFamilyInputs {
+                field_cfg: &(),
+                trace_mles: &trace_mles,
+                bit_op_mles: &bit_op_mles,
+                eval_point: &public.eval_point,
+                up_evals: &public.up_evals,
+                bit_op_evals: &bit_op_evals,
+                down_evals: &public.down_evals,
+            }],
+            &public.shifts,
+            &(),
+        )
+        .expect("prover should succeed");
+        assert_eq!(prover_outputs.len(), 1, "single-family shape");
+        let (proof, prover_state) = prover_outputs.pop().expect("single family");
+
+        let r_0 = &prover_state.eval_point;
+        let open_evals: Vec<F> = trace_mles
+            .iter()
+            .map(|mle| mle.clone().evaluate_with_config(r_0, &()).unwrap())
+            .collect();
+        let bit_op_open_evals: Vec<F> = bit_op_mles
+            .iter()
+            .map(|mle| mle.clone().evaluate_with_config(r_0, &()).unwrap())
+            .collect();
+
+        let mut verifier_transcript = make_transcript();
+        let mut subclaims = MultipointEval::<F>::verify_as_subprotocol(
+            &mut verifier_transcript,
+            vec![proof],
+            vec![MultipointEvalFamilyInputs {
+                field_cfg: &(),
+                trace_mles: &[],
+                bit_op_mles: &[],
+                eval_point: &public.eval_point,
+                up_evals: &public.up_evals,
+                bit_op_evals: &bit_op_evals,
+                down_evals: &public.down_evals,
+            }],
+            &public.shifts,
+            public.num_vars,
+            &(),
+        )
+        .expect("verifier should accept sumcheck");
+        assert_eq!(subclaims.len(), 1, "single-family shape");
+        let subclaim = subclaims.pop().expect("single family");
+
+        MultipointEval::<F>::verify_subclaim(
+            &subclaim,
+            &open_evals,
+            &bit_op_open_evals,
+            &public.shifts,
+            &(),
+        )
+        .expect("correct bit-op opening should satisfy subclaim");
+
+        let mut bad_bit_op_open_evals = bit_op_open_evals;
+        bad_bit_op_open_evals[0] += F::ONE;
+        let err = MultipointEval::<F>::verify_subclaim(
+            &subclaim,
+            &open_evals,
+            &bad_bit_op_open_evals,
+            &public.shifts,
+            &(),
+        )
+        .unwrap_err();
+        assert!(
+            matches!(err, MultipointEvalError::ClaimMismatch { .. }),
+            "expected ClaimMismatch, got {err:?}",
+        );
     }
 
     // --- Failure: corrupted down_evals with mixed shifts ---

--- a/protocol/src/prover.rs
+++ b/protocol/src/prover.rs
@@ -1255,8 +1255,10 @@ impl_with_type_bounds!(ProverSumchecked
         all_families.push(MultipointEvalFamilyInputs {
             field_cfg: &self.field_cfg,
             trace_mles: &projected_trace_f,
+            bit_op_mles: &[],
             eval_point: &self.cpr_eval_point,
             up_evals: &q_up_evals,
+            bit_op_evals: &[],
             down_evals: &self.cpr_proof.down_evals,
         });
         for prime_idx in 0..n_fq {
@@ -1264,8 +1266,10 @@ impl_with_type_bounds!(ProverSumchecked
             all_families.push(MultipointEvalFamilyInputs {
                 field_cfg: &self.all_field_cfgs[family_idx],
                 trace_mles: &fq_trace_mles_padded[prime_idx],
+                bit_op_mles: &[],
                 eval_point: &self.cpr_eval_points_fq[prime_idx],
                 up_evals: &fq_up_evals_padded[prime_idx],
+                bit_op_evals: &[],
                 down_evals: &self.cpr_proofs_fq[prime_idx].down_evals,
             });
         }

--- a/protocol/src/verifier.rs
+++ b/protocol/src/verifier.rs
@@ -1056,8 +1056,10 @@ where
         all_families.push(MultipointEvalFamilyInputs {
             field_cfg: &self.field_cfg,
             trace_mles: &[],
+            bit_op_mles: &[],
             eval_point: &self.cpr_eval_point,
             up_evals: &q_up_evals,
+            bit_op_evals: &[],
             down_evals: &self.cpr_down_evals,
         });
 
@@ -1066,8 +1068,10 @@ where
             all_families.push(MultipointEvalFamilyInputs {
                 field_cfg: &self.all_field_cfgs[family_idx],
                 trace_mles: &[],
+                bit_op_mles: &[],
                 eval_point: &self.cpr_eval_points_fq[prime_idx],
                 up_evals,
+                bit_op_evals: &[],
                 down_evals: &self.cpr_down_evals_fq[prime_idx],
             });
         }
@@ -1303,6 +1307,7 @@ where
         MultipointEval::verify_subclaim(
             &self.mp_subclaim,
             &q_open_evals,
+            &[],
             self.base.uair_signature.shifts(),
             &self.field_cfg,
         )?;
@@ -1335,6 +1340,7 @@ where
             MultipointEval::verify_subclaim(
                 &self.mp_subclaims_fq[prime_idx],
                 &open_evals_i,
+                &[],
                 self.base.uair_signature.shifts(),
                 cfg_i,
             )?;


### PR DESCRIPTION
## What changed

This is the next atomic follow-up after #191, #192, #194, and #204 for #185, which blocks #91.

This PR extends the multipoint-eval subprotocol so bit-op virtual claims can be batched into the final consistency check:

- Adds separate bit-op batching challenges to the mp-eval subclaim.
- Lets the prover include bit-op virtual MLEs in the precombined MLE.
- Lets the verifier include CPR-provided bit-op evals in the expected sum.
- Extends the final subclaim check to fold verifier-derived bit-op open evals into the final check.
- Keeps current protocol and bench call sites as no-op empty bit-op slices until the next PR materializes and derives real bit-op openings.

## What is intentionally deferred

This PR does not yet materialize bit-op virtual MLEs in the full protocol prover, and it does not derive bit-op openings from lifted source openings in the protocol verifier. That is the next atomic PR. Existing UAIRs continue to use empty bit-op slots.

## Validation

- Red/green: cargo test -p zinc-piop bit_op_virtual_opening_is_bound_in_subclaim
- cargo test -p zinc-piop multipoint_eval
- cargo check -p zinc-protocol
- .githooks/pre-push