### PR TITLE
Adopt next iteration of crypto primitives

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ publish = false
 blake3 = "1.8"
 criterion = "0.7.0"
 crypto-bigint = { version = "= 0.7.0-rc.9", features = ["zeroize"] }
-crypto-primitives = { git = "https://github.com/NethermindEth/crypto-primitives.git", rev = "2cf39db8", features = ["std", "crypto_bigint", "rand"] }
+crypto-primitives = { git = "https://github.com/NethermindEth/crypto-primitives.git", rev = "234f101", features = ["std", "crypto_bigint", "rand"] }
 derive_more = { version = "2.1.1", features = ["full"] }
 itertools = "0.14"
 num-traits = "0.2"

--- a/piop/benches/combined_poly_resolver.rs
+++ b/piop/benches/combined_poly_resolver.rs
@@ -5,7 +5,7 @@ use criterion::{
     criterion_group, criterion_main, measurement::WallTime,
 };
 use crypto_primitives::{
-    ConstIntSemiring, Field, FromWithConfig, PrimeField, crypto_bigint_int::Int,
+    ConstIntSemiring, Field, FromWithConfig, HasPrimeFieldConfig, crypto_bigint_int::Int,
     crypto_bigint_monty::MontyField,
 };
 use rand::rng;
@@ -55,7 +55,7 @@ fn bench_no_mult<const INT_LIMBS: usize, const FIELD_LIMBS: usize>(
     let num_constraints = count_constraints::<TestUairNoMultiplication<Int<INT_LIMBS>>>();
     let max_degree = count_max_degree::<TestUairNoMultiplication<Int<INT_LIMBS>>>();
 
-    let prove_cpr = |field_cfg: &<F<FIELD_LIMBS> as PrimeField>::Config,
+    let prove_cpr = |field_cfg: &<F<FIELD_LIMBS> as HasPrimeFieldConfig>::Config,
                      trace: &UairTrace<_, _, _, _>,
                      transcript: &mut Blake3Transcript| {
         let projected_trace = project_trace_coeffs_row_major(trace, field_cfg);
@@ -239,7 +239,7 @@ fn bench_simple_mult<const INT_LIMBS: usize, const FIELD_LIMBS: usize>(
     let num_constraints = count_constraints::<TestUairSimpleMultiplication<Int<INT_LIMBS>>>();
     let max_degree = count_max_degree::<TestUairSimpleMultiplication<Int<INT_LIMBS>>>();
 
-    let prove_cpr = |field_cfg: &<F<FIELD_LIMBS> as PrimeField>::Config,
+    let prove_cpr = |field_cfg: &<F<FIELD_LIMBS> as HasPrimeFieldConfig>::Config,
                      trace: &UairTrace<_, _, _, _>,
                      transcript: &mut Blake3Transcript| {
         let projected_trace = project_trace_coeffs_row_major(trace, field_cfg);

--- a/piop/benches/combined_poly_resolver.rs
+++ b/piop/benches/combined_poly_resolver.rs
@@ -41,10 +41,10 @@ fn bench_no_mult<const INT_LIMBS: usize, const FIELD_LIMBS: usize>(
     group: &mut BenchmarkGroup<WallTime>,
     witness_size: usize,
 ) where
-    <F<FIELD_LIMBS> as Field>::Inner: ConstIntSemiring + ConstTranscribable,
+    <F<FIELD_LIMBS> as Field>::Integer: ConstIntSemiring + ConstTranscribable,
     TestUairNoMultiplication<Int<INT_LIMBS>>: Uair<Scalar = Witness<INT_LIMBS>, Ideal = DegreeOneIdeal<WitnessCoeff<INT_LIMBS>>>
         + GenerateRandomTrace<DEGREE_PLUS_ONE, PolyCoeff = Int<INT_LIMBS>, Int = Int<INT_LIMBS>>,
-    MillerRabin: PrimalityTest<<F<FIELD_LIMBS> as Field>::Inner>,
+    MillerRabin: PrimalityTest<<F<FIELD_LIMBS> as Field>::Integer>,
 {
     let mut rng = rng();
     let num_vars = zinc_utils::log2(witness_size) as usize;
@@ -225,10 +225,10 @@ fn bench_simple_mult<const INT_LIMBS: usize, const FIELD_LIMBS: usize>(
     group: &mut BenchmarkGroup<WallTime>,
     witness_size: usize,
 ) where
-    <F<FIELD_LIMBS> as Field>::Inner: ConstIntSemiring + ConstTranscribable,
+    <F<FIELD_LIMBS> as Field>::Integer: ConstIntSemiring + ConstTranscribable,
     TestUairSimpleMultiplication<Int<INT_LIMBS>>: Uair<Scalar = Witness<INT_LIMBS>>
         + GenerateRandomTrace<DEGREE_PLUS_ONE, PolyCoeff = Int<INT_LIMBS>, Int = Int<INT_LIMBS>>,
-    MillerRabin: PrimalityTest<<F<FIELD_LIMBS> as Field>::Inner>,
+    MillerRabin: PrimalityTest<<F<FIELD_LIMBS> as Field>::Integer>,
 {
     let mut rng = rng();
     let num_vars = zinc_utils::log2(witness_size) as usize;

--- a/piop/benches/ideal_check.rs
+++ b/piop/benches/ideal_check.rs
@@ -40,11 +40,11 @@ fn bench_no_mult<const INT_LIMBS: usize, const FIELD_LIMBS: usize>(
     group: &mut BenchmarkGroup<WallTime>,
     witness_size: usize,
 ) where
-    <F<FIELD_LIMBS> as Field>::Inner: ConstIntSemiring + ConstTranscribable,
+    <F<FIELD_LIMBS> as Field>::Integer: ConstIntSemiring + ConstTranscribable,
     TestUairNoMultiplication<Int<INT_LIMBS>>: Uair<Scalar = Witness<INT_LIMBS>, Ideal = DegreeOneIdeal<Int<INT_LIMBS>>>
         + GenerateRandomTrace<DEGREE_PLUS_ONE, PolyCoeff = Int<INT_LIMBS>, Int = Int<INT_LIMBS>>
         + IdealCheckProtocol,
-    MillerRabin: PrimalityTest<<F<FIELD_LIMBS> as Field>::Inner>,
+    MillerRabin: PrimalityTest<<F<FIELD_LIMBS> as Field>::Integer>,
 {
     let mut rng = rng();
     let num_vars = zinc_utils::log2(witness_size) as usize;
@@ -132,11 +132,11 @@ fn bench_simple_mult<const INT_LIMBS: usize, const FIELD_LIMBS: usize>(
     group: &mut BenchmarkGroup<WallTime>,
     witness_size: usize,
 ) where
-    <F<FIELD_LIMBS> as Field>::Inner: ConstIntSemiring + ConstTranscribable,
+    <F<FIELD_LIMBS> as Field>::Integer: ConstIntSemiring + ConstTranscribable,
     TestUairSimpleMultiplication<Int<INT_LIMBS>>: Uair<Scalar = Witness<INT_LIMBS>>
         + GenerateRandomTrace<DEGREE_PLUS_ONE, PolyCoeff = Int<INT_LIMBS>, Int = Int<INT_LIMBS>>
         + IdealCheckProtocol,
-    MillerRabin: PrimalityTest<<F<FIELD_LIMBS> as Field>::Inner>,
+    MillerRabin: PrimalityTest<<F<FIELD_LIMBS> as Field>::Integer>,
 {
     let mut rng = rng();
     let num_vars = zinc_utils::log2(witness_size) as usize;
@@ -226,8 +226,8 @@ fn bench_binary_decomposition<const FIELD_LIMBS: usize>(
     group: &mut BenchmarkGroup<WallTime>,
     witness_size: usize,
 ) where
-    <F<FIELD_LIMBS> as Field>::Inner: ConstIntSemiring + ConstTranscribable,
-    MillerRabin: PrimalityTest<<F<FIELD_LIMBS> as Field>::Inner>,
+    <F<FIELD_LIMBS> as Field>::Integer: ConstIntSemiring + ConstTranscribable,
+    MillerRabin: PrimalityTest<<F<FIELD_LIMBS> as Field>::Integer>,
 {
     let mut rng = rng();
     let num_vars = zinc_utils::log2(witness_size) as usize;
@@ -310,8 +310,8 @@ fn bench_big_linear_uair<const FIELD_LIMBS: usize>(
     group: &mut BenchmarkGroup<WallTime>,
     witness_size: usize,
 ) where
-    <F<FIELD_LIMBS> as Field>::Inner: ConstIntSemiring + ConstTranscribable,
-    MillerRabin: PrimalityTest<<F<FIELD_LIMBS> as Field>::Inner>,
+    <F<FIELD_LIMBS> as Field>::Integer: ConstIntSemiring + ConstTranscribable,
+    MillerRabin: PrimalityTest<<F<FIELD_LIMBS> as Field>::Integer>,
 {
     let mut rng = rng();
     let num_vars = zinc_utils::log2(witness_size) as usize;

--- a/piop/benches/ideal_check.rs
+++ b/piop/benches/ideal_check.rs
@@ -5,7 +5,7 @@ use criterion::{
     criterion_group, criterion_main, measurement::WallTime,
 };
 use crypto_primitives::{
-    ConstIntSemiring, Field, FromWithConfig, PrimeField, crypto_bigint_int::Int,
+    ConstIntSemiring, Field, FromWithConfig, HasPrimeFieldConfig, crypto_bigint_int::Int,
     crypto_bigint_monty::MontyField,
 };
 use rand::rng;
@@ -54,7 +54,7 @@ fn bench_no_mult<const INT_LIMBS: usize, const FIELD_LIMBS: usize>(
 
     let num_constraints = count_constraints::<TestUairNoMultiplication<Int<INT_LIMBS>>>();
 
-    let prove = |field_cfg: &<F<FIELD_LIMBS> as PrimeField>::Config,
+    let prove = |field_cfg: &<F<FIELD_LIMBS> as HasPrimeFieldConfig>::Config,
                  trace: &UairTrace<_, _, _, _>,
                  transcript: &mut Blake3Transcript|
      -> Proof<F<FIELD_LIMBS>> {
@@ -146,7 +146,7 @@ fn bench_simple_mult<const INT_LIMBS: usize, const FIELD_LIMBS: usize>(
 
     let num_constraints = count_constraints::<TestUairSimpleMultiplication<Int<INT_LIMBS>>>();
 
-    let prove = |field_cfg: &<F<FIELD_LIMBS> as PrimeField>::Config,
+    let prove = |field_cfg: &<F<FIELD_LIMBS> as HasPrimeFieldConfig>::Config,
                  trace: &UairTrace<_, _, _, _>,
                  transcript: &mut Blake3Transcript|
      -> Proof<F<FIELD_LIMBS>> {
@@ -240,7 +240,7 @@ fn bench_binary_decomposition<const FIELD_LIMBS: usize>(
 
     let num_constraints = count_constraints::<BinaryDecompositionUair<u32>>();
 
-    let prove = |field_cfg: &<F<FIELD_LIMBS> as PrimeField>::Config,
+    let prove = |field_cfg: &<F<FIELD_LIMBS> as HasPrimeFieldConfig>::Config,
                  trace: &UairTrace<_, _, _, _>,
                  transcript: &mut Blake3Transcript|
      -> Proof<F<FIELD_LIMBS>> {

--- a/piop/benches/sumcheck.rs
+++ b/piop/benches/sumcheck.rs
@@ -29,9 +29,8 @@ pub fn bench_simple_product<F, const LIMBS: usize>(
     witness_size: usize,
 ) where
     F: FromPrimitiveWithConfig + InnerTransparentField + FromRef<F> + 'static,
-    F::Inner: FromRef<F::Inner> + ConstTranscribable + ConstIntSemiring,
-    F::Modulus: FromRef<F::Modulus> + ConstTranscribable + ConstIntSemiring,
-    MillerRabin: PrimalityTest<F::Modulus>,
+    F::Integer: FromRef<F::Integer> + ConstTranscribable + ConstIntSemiring,
+    MillerRabin: PrimalityTest<F::Integer>,
     for<'a> &'a F: Mul<&'a F, Output = F>,
 {
     let mut rng = rng();
@@ -67,7 +66,7 @@ pub fn bench_simple_product<F, const LIMBS: usize>(
     let transcript = Blake3Transcript::new();
 
     let prove = |(a, b, c, mut transcript): (_, _, _, Blake3Transcript)| -> RFSumcheckProof<F, BinaryPoly<32>> {
-        let field_cfg = transcript.get_random_field_cfg::<F, <F as Field>::Modulus, MillerRabin>();
+        let field_cfg = transcript.get_random_field_cfg::<F, <F as Field>::Integer, MillerRabin>();
 
         let eq_r = build_eq_x_r_inner(&vec![F::from_with_cfg(2u32, &field_cfg); nvars], &field_cfg)
             .expect("Failed to build eq_r");
@@ -108,7 +107,7 @@ pub fn bench_simple_product<F, const LIMBS: usize>(
                 || (proof.clone(), transcript.clone()),
                 |(proof, mut transcript)| {
                     let field_cfg =
-                        transcript.get_random_field_cfg::<F, <F as Field>::Modulus, MillerRabin>();
+                        transcript.get_random_field_cfg::<F, <F as Field>::Integer, MillerRabin>();
 
                     let _ = black_box(
                         RFSumcheck::<F, _>::verify_as_subprotocol(

--- a/piop/src/combined_poly_resolver.rs
+++ b/piop/src/combined_poly_resolver.rs
@@ -87,8 +87,7 @@ impl<F: InnerTransparentField + FromPrimitiveWithConfig + Send + Sync> CombinedP
         field_cfg: &F::Config,
     ) -> Result<(MultiDegreeSumcheckGroup<F>, CprProverAncillary), CombinedPolyResolverError<F>>
     where
-        F::Inner: ConstTranscribable + Send + Sync + Zero + Default,
-        F::Modulus: ConstTranscribable,
+        F::Integer: ConstTranscribable + Send + Sync + Zero + Default,
         F: 'static,
         U::Scalar: 'static,
         U: Uair,
@@ -238,9 +237,8 @@ impl<F: InnerTransparentField + FromPrimitiveWithConfig + Send + Sync> CombinedP
         field_cfg: &F::Config,
     ) -> Result<(CprProof<F>, CprProverState<F>), CombinedPolyResolverError<F>>
     where
-        F::Inner: ConstTranscribable + Zero,
-        F::Modulus: ConstTranscribable,
         U: Uair,
+        F::Integer: ConstTranscribable + Zero,
     {
         // Sumcheck prover stops evaluating MLEs
         // at the second to last challenge
@@ -292,7 +290,7 @@ impl<F: InnerTransparentField + FromPrimitiveWithConfig + Send + Sync> CombinedP
         down_evals.extend_from_slice(&evals[up_end..bit_op_start]);
         down_evals.extend_from_slice(&evals[bit_op_end..]);
 
-        let mut transcription_buf: Vec<u8> = vec![0; F::Inner::NUM_BYTES];
+        let mut transcription_buf: Vec<u8> = vec![0; F::Integer::NUM_BYTES];
         transcript.absorb_random_field_slice(&up_evals, &mut transcription_buf);
         transcript.absorb_random_field_slice(&down_evals, &mut transcription_buf);
         transcript.absorb_random_field_slice(&bit_op_evals, &mut transcription_buf);
@@ -336,8 +334,7 @@ impl<F: InnerTransparentField + FromPrimitiveWithConfig + Send + Sync> CombinedP
         field_cfg: &F::Config,
     ) -> Result<CprVerifierAncillary<F>, CombinedPolyResolverError<F>>
     where
-        F::Inner: ConstTranscribable,
-        F::Modulus: ConstTranscribable,
+        F::Integer: ConstTranscribable,
         U: Uair,
     {
         let uair_sig = U::signature();
@@ -426,8 +423,7 @@ impl<F: InnerTransparentField + FromPrimitiveWithConfig + Send + Sync> CombinedP
         field_cfg: &F::Config,
     ) -> Result<VerifierSubclaim<F>, CombinedPolyResolverError<F>>
     where
-        F::Inner: ConstTranscribable,
-        F::Modulus: ConstTranscribable,
+        F::Integer: ConstTranscribable,
         U: Uair,
     {
         let uair_sig = U::signature();
@@ -482,7 +478,7 @@ impl<F: InnerTransparentField + FromPrimitiveWithConfig + Send + Sync> CombinedP
             });
         }
 
-        let mut transcription_buf: Vec<u8> = vec![0; F::Inner::NUM_BYTES];
+        let mut transcription_buf: Vec<u8> = vec![0; F::Integer::NUM_BYTES];
         transcript.absorb_random_field_slice(&proof.up_evals, &mut transcription_buf);
         transcript.absorb_random_field_slice(&proof.down_evals, &mut transcription_buf);
         transcript.absorb_random_field_slice(&proof.bit_op_evals, &mut transcription_buf);

--- a/piop/src/combined_poly_resolver/structs.rs
+++ b/piop/src/combined_poly_resolver/structs.rs
@@ -29,8 +29,7 @@ pub struct Proof<F: PrimeField> {
 
 impl<F: PrimeField> GenTranscribable for Proof<F>
 where
-    F::Inner: ConstTranscribable,
-    F::Modulus: ConstTranscribable,
+    F::Integer: ConstTranscribable,
 {
     fn read_transcription_bytes_exact(bytes: &[u8]) -> Self {
         let (up_evals, bytes) = Vec::<F>::read_transcription_bytes_subset(bytes);
@@ -54,8 +53,7 @@ where
 
 impl<F: PrimeField> Transcribable for Proof<F>
 where
-    F::Inner: ConstTranscribable,
-    F::Modulus: ConstTranscribable,
+    F::Integer: ConstTranscribable,
 {
     fn get_num_bytes(&self) -> usize {
         add!(

--- a/piop/src/ideal_check.rs
+++ b/piop/src/ideal_check.rs
@@ -62,8 +62,7 @@ pub trait IdealCheckProtocol: Uair {
     ) -> Result<(Proof<F>, ProverState<F>), IdealCheckError<F, Self::Ideal>>
     where
         F: InnerTransparentField,
-        F::Inner: ConstTranscribable,
-        F::Modulus: ConstTranscribable;
+        F::Integer: ConstTranscribable;
 
     /// Prover for any UAIR using combined polynomial construction.
     ///
@@ -91,8 +90,7 @@ pub trait IdealCheckProtocol: Uair {
     ) -> Result<(Proof<F>, ProverState<F>), IdealCheckError<F, Self::Ideal>>
     where
         F: InnerTransparentField,
-        F::Inner: ConstTranscribable,
-        F::Modulus: ConstTranscribable;
+        F::Integer: ConstTranscribable;
 
     /// The verifier part of the ideal-check subprotocol.
     ///
@@ -129,8 +127,7 @@ pub trait IdealCheckProtocol: Uair {
     ) -> Result<VerifierSubclaim<F>, IdealCheckError<F, IdealOverF>>
     where
         F: InnerTransparentField,
-        F::Inner: ConstTranscribable,
-        F::Modulus: ConstTranscribable,
+        F::Integer: ConstTranscribable,
         IdealOverF: Ideal + IdealCheck<DynamicPolynomialF<F>>,
         IdealOverFFromRef: Fn(&IdealOrZero<Self::Ideal>) -> IdealOverF;
 }
@@ -150,8 +147,7 @@ where
     ) -> Result<(Proof<F>, ProverState<F>), IdealCheckError<F, U::Ideal>>
     where
         F: InnerTransparentField,
-        F::Inner: ConstTranscribable,
-        F::Modulus: ConstTranscribable,
+        F::Integer: ConstTranscribable,
     {
         let evaluation_point = transcript.get_field_challenges(num_vars, field_cfg);
 
@@ -220,7 +216,7 @@ where
             }
         }
 
-        let mut transcription_buf: Vec<u8> = vec![0; F::Inner::NUM_BYTES];
+        let mut transcription_buf: Vec<u8> = vec![0; F::Integer::NUM_BYTES];
 
         combined_mle_values.iter().for_each(|combined_mle_value| {
             transcript
@@ -246,8 +242,7 @@ where
     ) -> Result<(Proof<F>, ProverState<F>), IdealCheckError<F, U::Ideal>>
     where
         F: InnerTransparentField,
-        F::Inner: ConstTranscribable,
-        F::Modulus: ConstTranscribable,
+        F::Integer: ConstTranscribable,
     {
         // Collect ideals to identify assert_zero constraints whose
         // combined polynomial is zero by construction (for honest provers).
@@ -278,7 +273,7 @@ where
             }
         };
 
-        let mut transcription_buf: Vec<u8> = vec![0; F::Inner::NUM_BYTES];
+        let mut transcription_buf: Vec<u8> = vec![0; F::Integer::NUM_BYTES];
 
         combined_mle_values.iter().for_each(|combined_mle_value| {
             transcript
@@ -303,12 +298,11 @@ where
     ) -> Result<VerifierSubclaim<F>, IdealCheckError<F, IdealOverF>>
     where
         F: InnerTransparentField,
-        F::Inner: ConstTranscribable,
-        F::Modulus: ConstTranscribable,
+        F::Integer: ConstTranscribable,
         IdealOverF: Ideal + IdealCheck<DynamicPolynomialF<F>>,
         IdealOverFFromRef: Fn(&IdealOrZero<U::Ideal>) -> IdealOverF,
     {
-        let mut transcription_buf: Vec<u8> = vec![0; F::Inner::NUM_BYTES];
+        let mut transcription_buf: Vec<u8> = vec![0; F::Integer::NUM_BYTES];
 
         let combined_mle_values = proof.combined_mle_values;
 

--- a/piop/src/ideal_check/structs.rs
+++ b/piop/src/ideal_check/structs.rs
@@ -10,8 +10,7 @@ pub struct Proof<F: PrimeField> {
 impl<F> GenTranscribable for Proof<F>
 where
     F: PrimeField,
-    F::Inner: ConstTranscribable,
-    F::Modulus: ConstTranscribable,
+    F::Integer: ConstTranscribable,
 {
     fn read_transcription_bytes_exact(bytes: &[u8]) -> Self {
         let combined_mle_values = DynamicPolyVecF::read_transcription_bytes_exact(bytes).0;
@@ -29,8 +28,7 @@ where
 impl<F> Transcribable for Proof<F>
 where
     F: PrimeField,
-    F::Inner: ConstTranscribable,
-    F::Modulus: ConstTranscribable,
+    F::Integer: ConstTranscribable,
 {
     fn get_num_bytes(&self) -> usize {
         DynamicPolyVecF::reinterpret(&self.combined_mle_values).get_num_bytes()

--- a/piop/src/lookup/booleanity.rs
+++ b/piop/src/lookup/booleanity.rs
@@ -113,7 +113,7 @@ pub struct BooleanityProof<F: PrimeField> {
 }
 
 delegate_transcribable!(BooleanityProof<F> { bit_slice_evals: Vec<F> }
-    where F: PrimeField, F::Inner: ConstTranscribable, F::Modulus: ConstTranscribable);
+    where F: PrimeField, F::Integer: ConstTranscribable);
 
 /// Ancillary data produced by [`BooleanityChecker::prepare_sumcheck_group`]
 /// and consumed by [`BooleanityChecker::finalize_prover`].
@@ -163,8 +163,7 @@ pub struct BoolVerifierSubclaim<F: PrimeField> {
 impl<F> BooleanityChecker<F>
 where
     F: InnerTransparentField + Send + Sync + 'static,
-    F::Inner: ConstTranscribable + Clone + Send + Sync + Zero + Default,
-    F::Modulus: ConstTranscribable,
+    F::Integer: ConstTranscribable + Clone + Send + Sync + Zero + Default,
 {
     /// Build the booleanity sumcheck group, to be appended to the
     /// multi-degree sumcheck.
@@ -293,7 +292,7 @@ where
 
         debug_assert_eq!(bit_slice_evals.len(), active_len);
 
-        let mut transcription_buf: Vec<u8> = vec![0; F::Inner::NUM_BYTES];
+        let mut transcription_buf: Vec<u8> = vec![0; F::Integer::NUM_BYTES];
         transcript.absorb_random_field_slice(&bit_slice_evals, &mut transcription_buf);
 
         Ok(BooleanityProof { bit_slice_evals })
@@ -385,7 +384,7 @@ where
             });
         }
 
-        let mut transcription_buf: Vec<u8> = vec![0; F::Inner::NUM_BYTES];
+        let mut transcription_buf: Vec<u8> = vec![0; F::Integer::NUM_BYTES];
         transcript.absorb_random_field_slice(&proof.bit_slice_evals, &mut transcription_buf);
 
         Ok(BoolVerifierSubclaim {
@@ -439,7 +438,7 @@ struct BooleanityRound1FastPath<F: PrimeField, const D: usize> {
 impl<F, const D: usize> Round1FastPath<F> for BooleanityRound1FastPath<F, D>
 where
     F: InnerTransparentField + Send + Sync + 'static,
-    F::Inner: Zero + Clone + Send + Sync,
+    F::Integer: Zero + Clone + Send + Sync,
 {
     fn round_1_message(&self, config: &F::Config) -> Round1Output<F> {
         let zero = F::zero_with_cfg(config);
@@ -648,7 +647,7 @@ fn build_witness_bit_slice_mles<F, const D: usize>(
 ) -> Vec<DenseMultilinearExtension<F::Inner>>
 where
     F: PrimeField,
-    F::Inner: Clone + Send + Sync,
+    F::Integer: Clone + Send + Sync,
 {
     let zero_inner = F::zero_with_cfg(field_cfg).into_inner();
     let one_inner = F::one_with_cfg(field_cfg).into_inner();

--- a/piop/src/multipoint_eval.rs
+++ b/piop/src/multipoint_eval.rs
@@ -65,7 +65,7 @@ pub struct Proof<F: PrimeField> {
 }
 
 delegate_transcribable!(Proof<F> { sumcheck_proof: SumcheckProof<F> }
-    where F: PrimeField, F::Inner: ConstTranscribable, F::Modulus: ConstTranscribable);
+    where F: PrimeField, F::Integer: ConstTranscribable);
 
 /// Prover state after the multi-point evaluation protocol.
 pub struct ProverState<F: PrimeField> {
@@ -105,8 +105,7 @@ pub struct MultipointEval<F>(PhantomData<F>);
 impl<F> MultipointEval<F>
 where
     F: InnerTransparentField + FromPrimitiveWithConfig + Send + Sync + 'static,
-    F::Inner: ConstTranscribable + Zero + Default + Send + Sync,
-    F::Modulus: ConstTranscribable,
+    F::Integer: ConstTranscribable + Zero + Default + Send + Sync,
 {
     /// Multi-point evaluation protocol prover.
     ///

--- a/piop/src/projections.rs
+++ b/piop/src/projections.rs
@@ -59,7 +59,11 @@ pub fn project_trace_coeffs_row_major<F, PolyCoeff, Int, const DB: usize, const 
     field_cfg: &F::Config,
 ) -> RowMajorTrace<F>
 where
-    F: for<'a> FromWithConfig<&'a PolyCoeff> + for<'a> FromWithConfig<&'a Int> + Send + Sync,
+    F: PrimeField
+        + for<'a> FromWithConfig<&'a PolyCoeff>
+        + for<'a> FromWithConfig<&'a Int>
+        + Send
+        + Sync,
     PolyCoeff: Clone + Send + Sync,
     Int: Clone + Send + Sync,
 {
@@ -150,7 +154,11 @@ pub fn project_trace_coeffs_column_major<F, PolyCoeff, Int, const DB: usize, con
     field_cfg: &F::Config,
 ) -> ColumnMajorTrace<F>
 where
-    F: for<'a> FromWithConfig<&'a PolyCoeff> + for<'a> FromWithConfig<&'a Int> + Send + Sync,
+    F: PrimeField
+        + for<'a> FromWithConfig<&'a PolyCoeff>
+        + for<'a> FromWithConfig<&'a Int>
+        + Send
+        + Sync,
     PolyCoeff: Clone + Send + Sync,
     Int: Clone + Send + Sync,
 {
@@ -453,11 +461,13 @@ pub fn project_scalars_to_field<R: Semiring + 'static, F: PrimeField>(
 mod tests {
     use super::*;
     use crate::test_utils::{LIMBS, test_config};
-    use crypto_primitives::{Field, FromWithConfig, crypto_bigint_monty::MontyField};
+    use crypto_primitives::{
+        Field, FromWithConfig, HasPrimeFieldConfig, crypto_bigint_monty::MontyField,
+    };
 
     type F = MontyField<LIMBS>;
 
-    fn f(value: u32, cfg: &<F as PrimeField>::Config) -> F {
+    fn f(value: u32, cfg: &<F as HasPrimeFieldConfig>::Config) -> F {
         F::from_with_cfg(value, cfg)
     }
 
@@ -468,7 +478,7 @@ mod tests {
     fn expected_inner(
         coeffs: &[F],
         projecting_element: &F,
-        cfg: &<F as PrimeField>::Config,
+        cfg: &<F as HasPrimeFieldConfig>::Config,
     ) -> <F as Field>::Inner {
         let zero = F::zero_with_cfg(cfg);
         let one = F::one_with_cfg(cfg);

--- a/piop/src/random_field_sumcheck.rs
+++ b/piop/src/random_field_sumcheck.rs
@@ -36,7 +36,9 @@ impl<F: PrimeField, R> RFProverState<F, R> {
     }
 }
 
-impl<F: FromPrimitiveWithConfig, R: Semiring + ProjectableToField<F>> RFSumcheck<F, R> {
+impl<F: PrimeField + FromPrimitiveWithConfig, R: Semiring + ProjectableToField<F>>
+    RFSumcheck<F, R>
+{
     /// Random field sumcheck prover.
     /// Samples a random field element, projects the input MLEs
     /// and performs the sumcheck proving algorithm.
@@ -73,8 +75,7 @@ impl<F: FromPrimitiveWithConfig, R: Semiring + ProjectableToField<F>> RFSumcheck
     ) -> (RFSumcheckProof<F, R>, RFProverState<F, R>)
     where
         F: InnerTransparentField,
-        F::Inner: ConstTranscribable + ConstIntSemiring + FromRef<F::Inner>,
-        F::Modulus: ConstTranscribable,
+        F::Integer: ConstTranscribable + ConstIntSemiring + FromRef<F::Integer>,
     {
         let projecting_element: F = transcript.get_field_challenge(field_cfg);
 
@@ -116,8 +117,7 @@ impl<F: FromPrimitiveWithConfig, R: Semiring + ProjectableToField<F>> RFSumcheck
         field_cfg: F::Config,
     ) -> Result<Subclaim<F>, RFSumcheckError<F>>
     where
-        F::Inner: ConstTranscribable + ConstIntSemiring,
-        F::Modulus: ConstTranscribable,
+        F::Integer: ConstTranscribable + ConstIntSemiring,
     {
         // Simulate getting the projecting element
         // Verifier does not use that element as it verifies only over RC,

--- a/piop/src/shift_predicate.rs
+++ b/piop/src/shift_predicate.rs
@@ -135,14 +135,16 @@ fn eval_shift_small<F: PrimeField>(x: &[F], y: &[F], c: usize, m: usize, zero: &
 mod tests {
     use super::*;
     use crate::test_utils::test_config;
-    use crypto_primitives::{Field, FromWithConfig, crypto_bigint_monty::MontyField};
+    use crypto_primitives::{
+        Field, FromWithConfig, HasPrimeFieldConfig, crypto_bigint_monty::MontyField,
+    };
     use rand::Rng;
     use zinc_poly::utils::{build_eq_x_r_inner, build_next_c_r_mle};
 
     type F = MontyField<4>;
 
     /// LE convention: to_bin(val, i) = bit i of val (LSB = index 0).
-    fn to_bin(val: usize, bit: usize, cfg: &<F as PrimeField>::Config) -> F {
+    fn to_bin(val: usize, bit: usize, cfg: &<F as HasPrimeFieldConfig>::Config) -> F {
         if (val >> bit) & 1 == 1 {
             F::one_with_cfg(cfg)
         } else {
@@ -151,13 +153,13 @@ mod tests {
     }
 
     /// Convert F::Inner back to F.
-    fn from_inner(inner: <F as Field>::Inner, cfg: &<F as PrimeField>::Config) -> F {
+    fn from_inner(inner: <F as Field>::Inner, cfg: &<F as HasPrimeFieldConfig>::Config) -> F {
         let mut f = F::zero_with_cfg(cfg);
         *f.inner_mut() = inner;
         f
     }
 
-    fn rand_field(rng: &mut impl Rng, cfg: &<F as PrimeField>::Config) -> F {
+    fn rand_field(rng: &mut impl Rng, cfg: &<F as HasPrimeFieldConfig>::Config) -> F {
         F::from_with_cfg(rng.random::<u32>(), cfg)
     }
 

--- a/piop/src/sumcheck.rs
+++ b/piop/src/sumcheck.rs
@@ -34,11 +34,10 @@ pub struct SumcheckProof<F> {
 
 impl<F: PrimeField> GenTranscribable for SumcheckProof<F>
 where
-    F::Inner: ConstTranscribable,
-    F::Modulus: ConstTranscribable,
+    F::Integer: ConstTranscribable,
 {
     fn read_transcription_bytes_exact(bytes: &[u8]) -> Self {
-        let mod_size = F::Modulus::NUM_BYTES;
+        let mod_size = F::Integer::NUM_BYTES;
         let cfg = zinc_transcript::read_field_cfg::<F>(&bytes[..mod_size]);
         let bytes = &bytes[mod_size..];
 
@@ -50,7 +49,7 @@ where
             let (len, rest) = u32::read_transcription_bytes_subset(bytes);
             let len = usize::try_from(len).expect("polynomial length must fit into usize");
             bytes = rest;
-            let end = mul!(len, F::Inner::NUM_BYTES);
+            let end = mul!(len, F::Integer::NUM_BYTES);
             let tail_evaluations = zinc_transcript::read_field_vec_with_cfg(&bytes[..end], &cfg);
             messages.push(ProverMsg(NatEvaluatedPolyWithoutConstant {
                 tail_evaluations,
@@ -58,8 +57,8 @@ where
             bytes = &bytes[end..];
         }
 
-        let claimed_sum = F::Inner::read_transcription_bytes_exact(bytes);
-        let claimed_sum = F::new_unchecked_with_cfg(claimed_sum, &cfg);
+        let claimed_sum = F::Integer::read_transcription_bytes_exact(bytes);
+        let claimed_sum = F::from_with_cfg(claimed_sum, &cfg);
         Self {
             messages,
             claimed_sum,
@@ -81,18 +80,17 @@ where
                 len.write_transcription_bytes_exact(&mut buf[0..u32::NUM_BYTES]);
                 &mut buf[u32::NUM_BYTES..]
             };
-            buf = zinc_transcript::append_field_vec_inner(buf, evals);
+            buf = zinc_transcript::append_field_vec_lifted(buf, evals);
         }
         self.claimed_sum
-            .inner()
+            .lift_to_integer()
             .write_transcription_bytes_exact(buf);
     }
 }
 
 impl<F: PrimeField> Transcribable for SumcheckProof<F>
 where
-    F::Inner: ConstTranscribable,
-    F::Modulus: ConstTranscribable,
+    F::Integer: ConstTranscribable,
 {
     #[allow(clippy::arithmetic_side_effects)]
     fn get_num_bytes(&self) -> usize {
@@ -102,15 +100,15 @@ where
             .iter()
             .map(|m| m.0.tail_evaluations.len())
             .sum();
-        F::Modulus::NUM_BYTES
+        F::Integer::NUM_BYTES
             + u32::NUM_BYTES // n_msgs
             + n_msgs * u32::NUM_BYTES // n_evals for each message
-            + total_evals * F::Inner::NUM_BYTES // evals
-            + F::Inner::NUM_BYTES // claimed_sum
+            + total_evals * F::Integer::NUM_BYTES // evals
+            + F::Integer::NUM_BYTES // claimed_sum
     }
 }
 
-impl<F: FromPrimitiveWithConfig> MLSumcheck<F> {
+impl<F: PrimeField + FromPrimitiveWithConfig> MLSumcheck<F> {
     /// Sumcheck prover main entry point.
     ///
     /// This function executes the Prover side of the Sumcheck protocol.
@@ -170,14 +168,13 @@ impl<F: FromPrimitiveWithConfig> MLSumcheck<F> {
     ) -> (SumcheckProof<F>, ProverState<F>)
     where
         F: InnerTransparentField,
-        F::Inner: ConstTranscribable + Zero,
-        F::Modulus: ConstTranscribable,
+        F::Integer: ConstTranscribable + Zero,
     {
         if nvars == 0 {
             panic!("Attempt to prove a constant")
         }
 
-        let mut buf = vec![0; F::Inner::NUM_BYTES];
+        let mut buf = vec![0; F::Integer::NUM_BYTES];
         let nvars_field = F::from_with_cfg(nvars as u64, config);
         let degree_field = F::from_with_cfg(degree as u64, config);
 
@@ -273,14 +270,13 @@ impl<F: FromPrimitiveWithConfig> MLSumcheck<F> {
         config: &F::Config,
     ) -> Result<Subclaim<F>, SumCheckError<F>>
     where
-        F::Inner: ConstTranscribable,
-        F::Modulus: ConstTranscribable,
+        F::Integer: ConstTranscribable,
     {
         if num_vars == 0 {
             panic!("Attempt to verify a sumcheck claim for 0 variables")
         }
 
-        let mut buf = vec![0; F::Inner::NUM_BYTES];
+        let mut buf = vec![0; F::Integer::NUM_BYTES];
 
         let (nvars_field, degree_field): (F, F) = {
             (

--- a/piop/src/sumcheck/multi_degree.rs
+++ b/piop/src/sumcheck/multi_degree.rs
@@ -135,11 +135,10 @@ impl<F> MultiDegreeSumcheckProof<F> {
 
 impl<F: PrimeField> GenTranscribable for MultiDegreeSumcheckProof<F>
 where
-    F::Inner: ConstTranscribable,
-    F::Modulus: ConstTranscribable,
+    F::Integer: ConstTranscribable,
 {
     fn read_transcription_bytes_exact(bytes: &[u8]) -> Self {
-        let mod_size = F::Modulus::NUM_BYTES;
+        let mod_size = F::Integer::NUM_BYTES;
         let cfg = zinc_transcript::read_field_cfg::<F>(&bytes[..mod_size]);
         let bytes = &bytes[mod_size..];
 
@@ -158,7 +157,7 @@ where
 
         let mut group_messages = Vec::with_capacity(num_groups);
         for &deg in &degrees {
-            let msg_bytes = mul!(deg, F::Inner::NUM_BYTES);
+            let msg_bytes = mul!(deg, F::Integer::NUM_BYTES);
             let mut msgs = Vec::with_capacity(num_vars);
             for _ in 0..num_vars {
                 let tail_evaluations =
@@ -173,10 +172,10 @@ where
 
         let mut claimed_sums = Vec::with_capacity(num_groups);
         for _ in 0..num_groups {
-            let cs = F::Inner::read_transcription_bytes_exact(&bytes[..F::Inner::NUM_BYTES]);
-            let cs = F::new_unchecked_with_cfg(cs, &cfg);
+            let cs = F::Integer::read_transcription_bytes_exact(&bytes[..F::Integer::NUM_BYTES]);
+            let cs = F::from_with_cfg(cs, &cfg);
             claimed_sums.push(cs);
-            bytes = &bytes[F::Inner::NUM_BYTES..];
+            bytes = &bytes[F::Integer::NUM_BYTES..];
         }
 
         Self {
@@ -208,22 +207,21 @@ where
 
         for group in &self.group_messages {
             for msg in group {
-                buf = zinc_transcript::append_field_vec_inner(buf, &msg.0.tail_evaluations);
+                buf = zinc_transcript::append_field_vec_lifted(buf, &msg.0.tail_evaluations);
             }
         }
 
         for cs in &self.claimed_sums {
-            cs.inner()
-                .write_transcription_bytes_exact(&mut buf[..F::Inner::NUM_BYTES]);
-            buf = &mut buf[F::Inner::NUM_BYTES..];
+            cs.lift_to_integer()
+                .write_transcription_bytes_exact(&mut buf[..F::Integer::NUM_BYTES]);
+            buf = &mut buf[F::Integer::NUM_BYTES..];
         }
     }
 }
 
 impl<F: PrimeField> Transcribable for MultiDegreeSumcheckProof<F>
 where
-    F::Inner: ConstTranscribable,
-    F::Modulus: ConstTranscribable,
+    F::Integer: ConstTranscribable,
 {
     fn get_num_bytes(&self) -> usize {
         let num_groups = self.group_messages.len();
@@ -232,10 +230,10 @@ where
         let total_evals: usize = self.degrees.iter().map(|&d| mul!(d, num_vars)).sum();
 
         // [field_cfg][num_groups][num_vars][deg₀..degₙ][evals...][claimed_sums]
-        let header = add!(F::Modulus::NUM_BYTES, add!(u32::NUM_BYTES, u32::NUM_BYTES));
+        let header = add!(F::Integer::NUM_BYTES, add!(u32::NUM_BYTES, u32::NUM_BYTES));
         let degrees = mul!(num_groups, u32::NUM_BYTES);
-        let eval_data = mul!(total_evals, F::Inner::NUM_BYTES);
-        let claimed = mul!(num_groups, F::Inner::NUM_BYTES);
+        let eval_data = mul!(total_evals, F::Integer::NUM_BYTES);
+        let claimed = mul!(num_groups, F::Integer::NUM_BYTES);
 
         add!(header, add!(degrees, add!(eval_data, claimed)))
     }
@@ -313,8 +311,7 @@ impl<F: FromPrimitiveWithConfig> MultiDegreeSumcheck<F> {
     ) -> (MultiDegreeSumcheckProof<F>, Vec<SumcheckProverState<F>>)
     where
         F: InnerTransparentField + Send + Sync,
-        F::Inner: ConstTranscribable + Zero,
-        F::Modulus: ConstTranscribable,
+        F::Integer: ConstTranscribable + Zero,
     {
         assert!(
             num_vars > 0,
@@ -323,7 +320,7 @@ impl<F: FromPrimitiveWithConfig> MultiDegreeSumcheck<F> {
         assert!(!groups.is_empty(), "need at least one degree group");
 
         let num_groups = groups.len();
-        let mut buf = vec![0; F::Inner::NUM_BYTES];
+        let mut buf = vec![0; F::Integer::NUM_BYTES];
         let nvars_field = F::from_with_cfg(num_vars as u64, config);
         let ngroups_field = F::from_with_cfg(num_groups as u64, config);
         transcript.absorb_random_field(&nvars_field, &mut buf);
@@ -471,8 +468,7 @@ impl<F: FromPrimitiveWithConfig> MultiDegreeSumcheck<F> {
     ) -> Result<MultiDegreeSubClaims<F>, SumCheckError<F>>
     where
         F: InnerTransparentField,
-        F::Inner: ConstTranscribable,
-        F::Modulus: ConstTranscribable,
+        F::Integer: ConstTranscribable,
     {
         assert!(
             num_vars > 0,
@@ -481,7 +477,7 @@ impl<F: FromPrimitiveWithConfig> MultiDegreeSumcheck<F> {
         let num_groups = proof.degrees.len();
         assert!(num_groups != 0, "need at least one degree group");
 
-        let mut buf = vec![0; F::Inner::NUM_BYTES];
+        let mut buf = vec![0; F::Integer::NUM_BYTES];
         let nvars_field = F::from_with_cfg(num_vars as u64, config);
         let ngroups_field = F::from_with_cfg(num_groups as u64, config);
         transcript.absorb_random_field(&nvars_field, &mut buf);

--- a/piop/src/sumcheck/prover.rs
+++ b/piop/src/sumcheck/prover.rs
@@ -38,14 +38,14 @@ impl<F> std::ops::DerefMut for NatEvaluatedPolyWithoutConstant<F> {
 }
 
 delegate_transcribable!(NatEvaluatedPolyWithoutConstant<F> { tail_evaluations: Vec<F> }
-    where F: PrimeField, F::Inner: ConstTranscribable, F::Modulus: ConstTranscribable);
+    where F: PrimeField, F::Integer: ConstTranscribable);
 
 #[repr(transparent)]
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct ProverMsg<F>(pub NatEvaluatedPolyWithoutConstant<F>);
 
 delegate_transcribable!(ProverMsg<F>(NatEvaluatedPolyWithoutConstant<F>)
-    where F: PrimeField, F::Inner: ConstTranscribable, F::Modulus: ConstTranscribable);
+    where F: PrimeField, F::Integer: ConstTranscribable);
 
 /// Sumcheck Prover State.
 pub struct ProverState<F: PrimeField> {

--- a/piop/src/sumcheck/tests.rs
+++ b/piop/src/sumcheck/tests.rs
@@ -278,13 +278,13 @@ fn sumcheck_with_zero_polynomial() {
 
     let poly_degree = 2;
     let num_mles = 2;
-    let zero_evals = vec![<F as Field>::Inner::ZERO; 1 << num_vars];
+    let zero_evals = vec![<F as Field>::Integer::ZERO; 1 << num_vars];
     let poly_mles: Vec<DenseMultilinearExtension<<F as Field>::Inner>> = (0..num_mles)
         .map(|_| {
             DenseMultilinearExtension::from_evaluations_vec(
                 num_vars,
                 zero_evals.clone(),
-                <F as Field>::Inner::ZERO,
+                <F as Field>::Integer::ZERO,
             )
         })
         .collect();
@@ -330,7 +330,7 @@ fn sumcheck_with_constant_polynomial() {
             DenseMultilinearExtension::from_evaluations_vec(
                 num_vars,
                 const_evals.clone(),
-                <F as Field>::Inner::ZERO,
+                <F as Field>::Integer::ZERO,
             )
         })
         .collect();

--- a/piop/src/sumcheck/verifier.rs
+++ b/piop/src/sumcheck/verifier.rs
@@ -58,14 +58,14 @@ pub struct Subclaim<F> {
     pub expected_evaluation: F,
 }
 
-impl<F: FromPrimitiveWithConfig> VerifierState<F> {
+impl<F: PrimeField + FromPrimitiveWithConfig> VerifierState<F> {
     /// Run verifier at current round, given prover message.
     ///
     /// Samples a Fiat-Shamir challenge from the transcript and delegates to
     /// [`Self::verify_round_with_challenge`]. Returns the sampled challenge.
     pub fn verify_round(&mut self, prover_msg: &ProverMsg<F>, transcript: &mut impl Transcript) -> F
     where
-        F::Inner: ConstTranscribable,
+        F::Integer: ConstTranscribable,
     {
         let challenge: F = transcript.get_field_challenge(&self.config);
         self.verify_round_with_challenge(prover_msg, challenge.clone());

--- a/poly/src/mle/dense.rs
+++ b/poly/src/mle/dense.rs
@@ -13,7 +13,7 @@ use crate::{
     EvaluationError,
     mle::{MultilinearExtension, MultilinearExtensionRand},
 };
-use crypto_primitives::{Matrix, PrimeField, Ring, Semiring};
+use crypto_primitives::{HasPrimeFieldConfig, Matrix, PrimeField, Ring, Semiring};
 use rand::{distr::StandardUniform, prelude::*};
 use rand_core::RngCore;
 use zinc_utils::{
@@ -243,7 +243,7 @@ where
     fn fix_variables_with_config(
         &mut self,
         partial_point: &[F],
-        config: &<F as PrimeField>::Config,
+        config: &<F as HasPrimeFieldConfig>::Config,
     ) {
         assert!(
             partial_point.len() <= self.num_vars,
@@ -281,7 +281,7 @@ where
     fn fixed_variables_with_config(
         &self,
         partial_point: &[F],
-        config: &<F as PrimeField>::Config,
+        config: &<F as HasPrimeFieldConfig>::Config,
     ) -> Self {
         let mut res = self.clone();
         res.fix_variables_with_config(partial_point, config);
@@ -291,7 +291,7 @@ where
     fn evaluate_with_config(
         mut self,
         point: &[F],
-        config: &<F as PrimeField>::Config,
+        config: &<F as HasPrimeFieldConfig>::Config,
     ) -> Result<F, EvaluationError> {
         if point.len() == self.num_vars {
             self.fix_variables_with_config(point, config);
@@ -525,7 +525,7 @@ mod tests {
 
     const LIMBS: usize = 4;
 
-    fn get_dyn_config(hex_modulus: &str) -> <MontyField<LIMBS> as PrimeField>::Config {
+    fn get_dyn_config(hex_modulus: &str) -> <MontyField<LIMBS> as HasPrimeFieldConfig>::Config {
         let modulus = Uint::new(
             crypto_bigint::Uint::from_str_radix_vartime(hex_modulus, 16)
                 .expect("Invalid modulus hex string"),
@@ -536,7 +536,7 @@ mod tests {
     const MODULUS: &str = "0076F668F4274572E39A3EA8285319B5";
     type F = MontyField<LIMBS>;
 
-    fn any_f(cfg: <F as PrimeField>::Config) -> impl Strategy<Value = F> + 'static {
+    fn any_f(cfg: <F as HasPrimeFieldConfig>::Config) -> impl Strategy<Value = F> + 'static {
         any::<u128>().prop_map(move |v| v.into_with_cfg(&cfg))
     }
 

--- a/poly/src/univariate/dense.rs
+++ b/poly/src/univariate/dense.rs
@@ -188,7 +188,9 @@ impl<R: Semiring + Zero + One, const DEGREE_PLUS_ONE: usize> One
     for DensePolynomial<R, DEGREE_PLUS_ONE>
 {
     fn one() -> Self {
-        Self::from(R::one())
+        let mut coeffs = array::from_fn(|_| R::zero());
+        coeffs[0] = R::one();
+        Self { coeffs }
     }
 }
 
@@ -573,17 +575,29 @@ where
     }
 }
 
-impl<R: Zero, const DEGREE_PLUS_ONE: usize> From<R> for DensePolynomial<R, DEGREE_PLUS_ONE> {
-    fn from(value: R) -> Self {
+impl<R: Zero + One, const DEGREE_PLUS_ONE: usize> From<bool>
+    for DensePolynomial<R, DEGREE_PLUS_ONE>
+{
+    fn from(value: bool) -> Self {
         let mut coeffs = array::from_fn(|_| R::zero());
-        coeffs[0] = value;
+        coeffs[0] = if value { R::one() } else { R::zero() };
         Self { coeffs }
     }
 }
 
+// impl<R: Zero, const DEGREE_PLUS_ONE: usize> From<R> for DensePolynomial<R,
+// DEGREE_PLUS_ONE> {     fn from(value: R) -> Self {
+//         let mut coeffs = array::from_fn(|_| R::zero());
+//         coeffs[0] = value;
+//         Self { coeffs }
+//     }
+// }
+
 impl<const DEGREE_PLUS_ONE: usize> FromRef<i64> for DensePolynomial<i128, DEGREE_PLUS_ONE> {
     fn from_ref(value: &i64) -> Self {
-        Self::from(i128::from(*value))
+        let mut coeffs = array::from_fn(|_| 0_i128);
+        coeffs[0] = i128::from(*value);
+        Self { coeffs }
     }
 }
 

--- a/poly/src/univariate/dense.rs
+++ b/poly/src/univariate/dense.rs
@@ -585,14 +585,6 @@ impl<R: Zero + One, const DEGREE_PLUS_ONE: usize> From<bool>
     }
 }
 
-// impl<R: Zero, const DEGREE_PLUS_ONE: usize> From<R> for DensePolynomial<R,
-// DEGREE_PLUS_ONE> {     fn from(value: R) -> Self {
-//         let mut coeffs = array::from_fn(|_| R::zero());
-//         coeffs[0] = value;
-//         Self { coeffs }
-//     }
-// }
-
 impl<const DEGREE_PLUS_ONE: usize> FromRef<i64> for DensePolynomial<i128, DEGREE_PLUS_ONE> {
     fn from_ref(value: &i64) -> Self {
         let mut coeffs = array::from_fn(|_| 0_i128);

--- a/poly/src/univariate/dynamic/over_field.rs
+++ b/poly/src/univariate/dynamic/over_field.rs
@@ -467,8 +467,7 @@ impl<F: PrimeField> DynamicPolyVecF<F> {
 impl<F> GenTranscribable for DynamicPolyVecF<F>
 where
     F: PrimeField,
-    F::Inner: ConstTranscribable,
-    F::Modulus: ConstTranscribable,
+    F::Integer: ConstTranscribable,
 {
     fn read_transcription_bytes_exact(bytes: &[u8]) -> Self {
         if bytes.is_empty() {
@@ -482,7 +481,7 @@ where
         };
         let mut bytes = &bytes[1..];
         let cfg_option = if modulus_present {
-            let mod_size = F::Modulus::NUM_BYTES;
+            let mod_size = F::Integer::NUM_BYTES;
             let cfg = zinc_transcript::read_field_cfg::<F>(&bytes[0..mod_size]);
             bytes = &bytes[mod_size..];
             Some(cfg)
@@ -494,7 +493,7 @@ where
             let (len, rest) = u32::read_transcription_bytes_subset(bytes);
             let len = usize::try_from(len).expect("polynomial length must fit into usize");
             bytes = rest;
-            let end = mul!(len, F::Inner::NUM_BYTES);
+            let end = mul!(len, F::Integer::NUM_BYTES);
             let coeffs = if let Some(ref cfg) = cfg_option {
                 zinc_transcript::read_field_vec_with_cfg(&bytes[..end], cfg)
             } else {
@@ -527,7 +526,7 @@ where
                 len.write_transcription_bytes_exact(&mut buf[0..u32::NUM_BYTES]);
                 &mut buf[u32::NUM_BYTES..]
             };
-            buf = zinc_transcript::append_field_vec_inner(buf, &poly.coeffs[0..len]);
+            buf = zinc_transcript::append_field_vec_lifted(buf, &poly.coeffs[0..len]);
         }
         assert!(buf.is_empty(), "Entire buffer should be used");
     }
@@ -536,8 +535,7 @@ where
 impl<F> Transcribable for DynamicPolyVecF<F>
 where
     F: PrimeField,
-    F::Inner: ConstTranscribable,
-    F::Modulus: ConstTranscribable,
+    F::Integer: ConstTranscribable,
 {
     fn get_num_bytes(&self) -> usize {
         if self.0.is_empty() {
@@ -546,7 +544,7 @@ where
         // 1 byte for the modulus presence flag
         let has_modulus = self.0.iter().any(|p| !p.coeffs.is_empty());
         let modulus_bytes = if has_modulus {
-            F::Modulus::NUM_BYTES
+            F::Integer::NUM_BYTES
         } else {
             0
         };
@@ -555,7 +553,7 @@ where
             .iter()
             .map(|poly| {
                 let len = poly.degree().map(|d| add!(d, 1)).unwrap_or(0);
-                add!(u32::NUM_BYTES, mul!(len, F::Inner::NUM_BYTES))
+                add!(u32::NUM_BYTES, mul!(len, F::Integer::NUM_BYTES))
             })
             .sum();
         add!(add!(1, modulus_bytes), poly_bytes)

--- a/poly/src/univariate/nat_evaluation.rs
+++ b/poly/src/univariate/nat_evaluation.rs
@@ -1,6 +1,6 @@
 use std::convert::identity;
 
-use crypto_primitives::{FromPrimitiveWithConfig, Semiring};
+use crypto_primitives::{FromPrimitiveWithConfig, PrimeField, Semiring};
 
 use crate::{EvaluatablePolynomial, EvaluationError, Polynomial};
 
@@ -22,7 +22,7 @@ impl<F: Clone> Polynomial<F> for NatEvaluatedPoly<F> {
     const DEGREE_BOUND: usize = usize::MAX;
 }
 
-impl<F: FromPrimitiveWithConfig> EvaluatablePolynomial<F, F> for NatEvaluatedPoly<F> {
+impl<F: PrimeField + FromPrimitiveWithConfig> EvaluatablePolynomial<F, F> for NatEvaluatedPoly<F> {
     type EvaluationPoint = F;
 
     /// Interpolate the *unique* univariate polynomial of degree *at most*

--- a/poly/src/utils.rs
+++ b/poly/src/utils.rs
@@ -291,7 +291,9 @@ pub fn next_mle_eval<R: Semiring>(u: &[R], v: &[R], zero: R, one: R) -> R {
 )]
 mod tests {
     use crypto_bigint::{U128, const_monty_params};
-    use crypto_primitives::{IntoWithConfig, crypto_bigint_const_monty::ConstMontyField};
+    use crypto_primitives::{
+        HasPrimeFieldConfig, IntoWithConfig, crypto_bigint_const_monty::ConstMontyField,
+    };
     use num_traits::{One, Zero};
     use proptest::{prelude::*, proptest};
 
@@ -405,7 +407,7 @@ mod tests {
         );
     }
 
-    fn any_f(cfg: <F as PrimeField>::Config) -> impl Strategy<Value = F> + 'static {
+    fn any_f(cfg: <F as HasPrimeFieldConfig>::Config) -> impl Strategy<Value = F> + 'static {
         any::<u128>().prop_map(move |v| v.into_with_cfg(&cfg))
     }
 

--- a/protocol/benches/e2e.rs
+++ b/protocol/benches/e2e.rs
@@ -6,7 +6,7 @@ use criterion::{
 };
 use crypto_bigint::U64;
 use crypto_primitives::{
-    ConstIntRing, ConstIntSemiring, Field, FixedSemiring, FromWithConfig, PrimeField,
+    ConstIntRing, ConstIntSemiring, Field, FixedSemiring, FromWithConfig, HasPrimeFieldConfig,
     crypto_bigint_int::Int, crypto_bigint_monty::MontyField, crypto_bigint_uint::Uint,
 };
 use rand::rng;
@@ -327,8 +327,10 @@ fn do_bench_e2e<Zt, U, IdealOverF>(
     num_vars: usize,
     pp: &Pp<Zt>,
     trace: &UairTrace<'static, Zt::Int, Zt::Int, D, D>,
-    project_scalar: impl Fn(&U::Scalar, &<F as PrimeField>::Config) -> DynamicPolynomialF<F> + Copy,
-    project_ideal: impl Fn(&IdealOrZero<U::Ideal>, &<F as PrimeField>::Config) -> IdealOverF + Copy,
+    project_scalar: impl Fn(&U::Scalar, &<F as HasPrimeFieldConfig>::Config) -> DynamicPolynomialF<F>
+    + Copy,
+    project_ideal: impl Fn(&IdealOrZero<U::Ideal>, &<F as HasPrimeFieldConfig>::Config) -> IdealOverF
+    + Copy,
 ) where
     Zt: ZincTypes<D, QUARTER_D>,
     Zt::Int: ProjectableToField<F>,
@@ -346,7 +348,7 @@ fn do_bench_e2e<Zt, U, IdealOverF>(
         + Sync
         + 'static,
     F: for<'a> FromWithConfig<&'a Zt::Int>,
-    <F as Field>::Modulus: ConstTranscribable + FromRef<Zt::Fmod>,
+    <F as Field>::Integer: ConstTranscribable + FromRef<Zt::Fmod>,
     U: Uair + 'static,
     IdealOverF: Ideal + IdealCheck<DynamicPolynomialF<F>>,
 {
@@ -417,8 +419,9 @@ fn do_bench_steps<Zt, U, IdealOverF>(
     num_vars: usize,
     pp: &Pp<Zt>,
     trace: &UairTrace<'static, Zt::Int, Zt::Int, D, D>,
-    project_scalar: fn(&U::Scalar, &<F as PrimeField>::Config) -> DynamicPolynomialF<F>,
-    project_ideal: impl Fn(&IdealOrZero<U::Ideal>, &<F as PrimeField>::Config) -> IdealOverF + Copy,
+    project_scalar: fn(&U::Scalar, &<F as HasPrimeFieldConfig>::Config) -> DynamicPolynomialF<F>,
+    project_ideal: impl Fn(&IdealOrZero<U::Ideal>, &<F as HasPrimeFieldConfig>::Config) -> IdealOverF
+    + Copy,
 ) where
     Zt: ZincTypes<D, QUARTER_D>,
     Zt::Int: ProjectableToField<F>,
@@ -436,7 +439,7 @@ fn do_bench_steps<Zt, U, IdealOverF>(
         + Sync
         + 'static,
     F: for<'a> FromWithConfig<&'a Zt::Int>,
-    <F as Field>::Modulus: ConstTranscribable + FromRef<Zt::Fmod>,
+    <F as Field>::Integer: ConstTranscribable + FromRef<Zt::Fmod>,
     U: Uair + 'static,
     IdealOverF: Ideal + IdealCheck<DynamicPolynomialF<F>>,
 {
@@ -659,7 +662,8 @@ where
 
     let pp = setup_pp(num_vars);
 
-    let proj_ideal = |ideal: &IdealOrZero<U::Ideal>, field_cfg: &<F as PrimeField>::Config| {
+    let proj_ideal = |ideal: &IdealOrZero<U::Ideal>,
+                      field_cfg: &<F as HasPrimeFieldConfig>::Config| {
         ideal.map(|i| DegreeOneIdeal::from_with_cfg(i, field_cfg))
     };
 
@@ -691,7 +695,8 @@ where
 
     let pp = setup_pp(num_vars);
 
-    let proj_ideal = |ideal: &IdealOrZero<U::Ideal>, field_cfg: &<F as PrimeField>::Config| {
+    let proj_ideal = |ideal: &IdealOrZero<U::Ideal>,
+                      field_cfg: &<F as HasPrimeFieldConfig>::Config| {
         ideal.map(|i| DegreeOneIdeal::from_with_cfg(i, field_cfg))
     };
 

--- a/protocol/src/lib.rs
+++ b/protocol/src/lib.rs
@@ -102,8 +102,7 @@ pub struct Proof<F: PrimeField> {
 impl<F> GenTranscribable for Proof<F>
 where
     F: PrimeField,
-    F::Inner: ConstTranscribable,
-    F::Modulus: ConstTranscribable,
+    F::Integer: ConstTranscribable,
 {
     fn read_transcription_bytes_exact(bytes: &[u8]) -> Self {
         let (commit0, bytes) = ZipPlusCommitment::read_transcription_bytes_subset(bytes);
@@ -204,8 +203,7 @@ where
 impl<F> Transcribable for Proof<F>
 where
     F: PrimeField,
-    F::Inner: ConstTranscribable,
-    F::Modulus: ConstTranscribable,
+    F::Integer: ConstTranscribable,
 {
     #[allow(clippy::arithmetic_side_effects)]
     fn get_num_bytes(&self) -> usize {
@@ -522,7 +520,8 @@ mod tests {
     use crate::fold::FoldBinaryTrace4x;
     use crypto_bigint::U64;
     use crypto_primitives::{
-        Field, crypto_bigint_int::Int, crypto_bigint_monty::MontyField, crypto_bigint_uint::Uint,
+        Field, HasPrimeFieldConfig, crypto_bigint_int::Int, crypto_bigint_monty::MontyField,
+        crypto_bigint_uint::Uint,
     };
     use rand::rng;
     use zinc_piop::{
@@ -734,7 +733,7 @@ mod tests {
         linear_codes: (Zt::BinaryLc, Zt::ArbitraryLc, Zt::IntLc),
         project_ideal: impl Fn(
             &IdealOrZero<U::Ideal>,
-            &<F as PrimeField>::Config,
+            &<F as HasPrimeFieldConfig>::Config,
         ) -> IdealOrZero<DegreeOneIdeal<F>>
         + Copy,
         tamper: impl Fn(&mut Proof<F>),
@@ -752,8 +751,7 @@ mod tests {
             + for<'a> FromWithConfig<&'a Zt::CombR>
             + for<'a> FromWithConfig<&'a Zt::Chal>
             + for<'a> FromWithConfig<&'a Zt::Pt>,
-        <F as Field>::Inner: FromRef<Zt::Fmod>,
-        <F as Field>::Modulus: FromRef<Zt::Fmod>,
+        <F as Field>::Integer: FromRef<Zt::Fmod>,
     {
         let mut rng = rng();
         let pp = setup_pp::<Zt>(num_vars, linear_codes);

--- a/protocol/src/prover.rs
+++ b/protocol/src/prover.rs
@@ -1,6 +1,5 @@
 use super::*;
 use crypto_primitives::{ConstIntSemiring, FromPrimitiveWithConfig, FromWithConfig};
-use num_traits::Zero;
 use std::{borrow::Cow, fmt::Debug};
 use zinc_piop::{
     combined_poly_resolver::CombinedPolyResolver,
@@ -296,9 +295,8 @@ macro_rules! impl_with_type_bounds {
                 + Send
                 + Sync
                 + 'static,
-            F::Inner:
-                ConstIntSemiring + ConstTranscribable + FromRef<Zt::Fmod> + Send + Sync + Zero + Default,
-            F::Modulus: ConstTranscribable + FromRef<Zt::Fmod>,
+            F::Integer:
+                ConstIntSemiring + ConstTranscribable + FromRef<Zt::Fmod> + Send + Sync,
         {
             $($code)*
         }
@@ -310,7 +308,7 @@ where
     Zt: ZincTypes<D, FD>,
     U: Uair,
     F: PrimeField,
-    F::Inner: ConstTranscribable,
+    F::Integer: ConstTranscribable,
 {
     /// Step 0: Folding the trace.
     #[allow(clippy::type_complexity)]
@@ -783,7 +781,7 @@ impl_with_type_bounds!(ProverMultipointEvaled
             &self.field_cfg,
         );
 
-        let mut transcription_buf: Vec<u8> = vec![0; F::Inner::NUM_BYTES];
+        let mut transcription_buf: Vec<u8> = vec![0; F::Integer::NUM_BYTES];
         for bar_u in &lifted_evals {
             self.base
                 .pcs_transcript
@@ -935,9 +933,7 @@ where
         + Send
         + Sync
         + 'static,
-    F::Inner:
-        ConstIntSemiring + ConstTranscribable + FromRef<Zt::Fmod> + Send + Sync + Zero + Default,
-    F::Modulus: ConstTranscribable + FromRef<Zt::Fmod>,
+    F::Integer: ConstIntSemiring + ConstTranscribable + FromRef<Zt::Fmod> + Send + Sync,
     U: Uair + 'static,
 {
     /// Zinc+ full PIOP prover.
@@ -1012,7 +1008,7 @@ fn project_binary_col_at_field<F, const D: usize>(
 ) -> DenseMultilinearExtension<F::Inner>
 where
     F: PrimeField,
-    F::Inner: Clone + Send + Sync,
+    F::Integer: Clone + Send + Sync,
 {
     debug_assert_eq!(alpha_powers.len(), D);
     let zero = F::zero_with_cfg(field_cfg);

--- a/protocol/src/verifier.rs
+++ b/protocol/src/verifier.rs
@@ -1,7 +1,6 @@
 use super::*;
 use crypto_primitives::{ConstIntSemiring, FromPrimitiveWithConfig, FromWithConfig};
 use itertools::Itertools;
-use num_traits::Zero;
 use std::io::Cursor;
 use zinc_piop::{
     combined_poly_resolver::CombinedPolyResolver,
@@ -261,7 +260,7 @@ where
     Zt: ZincTypes<D, FD>,
     U: Uair,
     F: PrimeField,
-    F::Inner: ConstTranscribable,
+    F::Integer: ConstTranscribable,
 {
     /// Step 0: Verifier entry point.
     /// Reconstruct Fiat-Shamir transcript from commitments and public data.
@@ -337,8 +336,7 @@ impl<'a, Zt, U, F, IdealOverF, const D: usize, const FD: usize>
 where
     Zt: ZincTypes<D, FD>,
     F: InnerTransparentField + FromPrimitiveWithConfig + FromRef<F> + Send + Sync + 'static,
-    F::Inner: ConstIntSemiring + ConstTranscribable + Send + Sync + Zero + Default,
-    F::Modulus: ConstTranscribable + FromRef<Zt::Fmod>,
+    F::Integer: ConstIntSemiring + ConstTranscribable + Send + Sync + FromRef<Zt::Fmod>,
     U: Uair,
     IdealOverF: Ideal,
 {
@@ -386,8 +384,7 @@ where
         + Send
         + Sync
         + 'static,
-    F::Inner: ConstIntSemiring + ConstTranscribable + Send + Sync + Zero + Default,
-    F::Modulus: ConstTranscribable + FromRef<Zt::Fmod>,
+    F::Integer: ConstIntSemiring + ConstTranscribable + Send + Sync + FromRef<Zt::Fmod>,
     U: Uair + 'static,
     IdealOverF: Ideal + IdealCheck<DynamicPolynomialF<F>>,
 {
@@ -435,8 +432,7 @@ where
         + Send
         + Sync
         + 'static,
-    F::Inner: ConstIntSemiring + ConstTranscribable + Send + Sync + Zero + Default,
-    F::Modulus: ConstTranscribable + FromRef<Zt::Fmod>,
+    F::Integer: ConstIntSemiring + ConstTranscribable + Send + Sync + FromRef<Zt::Fmod>,
     U: Uair + 'static,
     IdealOverF: Ideal,
 {
@@ -488,8 +484,7 @@ where
         + Send
         + Sync
         + 'static,
-    F::Inner: ConstIntSemiring + ConstTranscribable + Send + Sync + Zero + Default,
-    F::Modulus: ConstTranscribable + FromRef<Zt::Fmod>,
+    F::Integer: ConstIntSemiring + ConstTranscribable + Send + Sync + FromRef<Zt::Fmod>,
     U: Uair + 'static,
     IdealOverF: Ideal,
 {
@@ -630,8 +625,7 @@ impl<'a, Zt, F, IdealOverF, const D: usize, const FD: usize>
 where
     Zt: ZincTypes<D, FD>,
     F: InnerTransparentField + FromPrimitiveWithConfig + FromRef<F> + Send + Sync + 'static,
-    F::Inner: ConstIntSemiring + ConstTranscribable + Send + Sync + Zero + Default,
-    F::Modulus: ConstTranscribable + FromRef<Zt::Fmod>,
+    F::Integer: ConstIntSemiring + ConstTranscribable + Send + Sync + FromRef<Zt::Fmod>,
     IdealOverF: Ideal,
 {
     /// Step 5: Multi-point evaluation sumcheck.
@@ -706,8 +700,7 @@ where
         + Send
         + Sync
         + 'static,
-    F::Inner: ConstIntSemiring + ConstTranscribable + Send + Sync + Zero + Default,
-    F::Modulus: ConstTranscribable + FromRef<Zt::Fmod>,
+    F::Integer: ConstIntSemiring + ConstTranscribable + Send + Sync + FromRef<Zt::Fmod>,
     IdealOverF: Ideal,
 {
     /// Step 6: Recompute public lifted_evals, assemble full set, verify
@@ -793,7 +786,7 @@ where
             &self.field_cfg,
         )?;
 
-        let mut transcription_buf: Vec<u8> = vec![0; F::Inner::NUM_BYTES];
+        let mut transcription_buf: Vec<u8> = vec![0; F::Integer::NUM_BYTES];
         for bar_u in &all_lifted_evals {
             self.base
                 .pcs_transcript
@@ -832,8 +825,7 @@ where
         + Send
         + Sync
         + 'static,
-    F::Inner: ConstIntSemiring + ConstTranscribable + Send + Sync + Zero + Default,
-    F::Modulus: ConstTranscribable + FromRef<Zt::Fmod>,
+    F::Integer: ConstIntSemiring + ConstTranscribable + Send + Sync + FromRef<Zt::Fmod>,
     IdealOverF: Ideal,
 {
     /// Step 7: PCS verification at `r_0` (witness columns only).
@@ -990,8 +982,7 @@ where
         + Send
         + Sync
         + 'static,
-    F::Inner: ConstIntSemiring + ConstTranscribable + Send + Sync + Zero + Default,
-    F::Modulus: ConstTranscribable + FromRef<Zt::Fmod>,
+    F::Integer: ConstIntSemiring + ConstTranscribable + Send + Sync + FromRef<Zt::Fmod>,
     U: Uair + 'static,
 {
     /// Zinc+ full PIOP verifier.

--- a/transcript/src/lib.rs
+++ b/transcript/src/lib.rs
@@ -79,47 +79,47 @@ impl Transcript for Blake3Transcript {
 pub fn read_field_cfg<F>(bytes: &[u8]) -> F::Config
 where
     F: PrimeField,
-    F::Modulus: ConstTranscribable,
+    F::Integer: ConstTranscribable,
 {
-    let mod_size = F::Modulus::NUM_BYTES;
-    let modulus = F::Modulus::read_transcription_bytes_exact(&bytes[..mod_size]);
+    let mod_size = F::Integer::NUM_BYTES;
+    let modulus = F::Integer::read_transcription_bytes_exact(&bytes[..mod_size]);
     F::make_cfg(&modulus).expect("valid field modulus in proof transcription")
 }
 
 pub fn read_field_vec_with_cfg<F>(bytes: &[u8], field_cfg: &F::Config) -> Vec<F>
 where
     F: PrimeField,
-    F::Inner: ConstTranscribable,
+    F::Integer: ConstTranscribable,
 {
-    let inner_size = F::Inner::NUM_BYTES;
+    let int_size = F::Integer::NUM_BYTES;
     bytes
-        .chunks_exact(inner_size)
-        .map(F::Inner::read_transcription_bytes_exact)
-        .map(|inner| F::new_unchecked_with_cfg(inner, field_cfg))
+        .chunks_exact(int_size)
+        .map(F::Integer::read_transcription_bytes_exact)
+        .map(|int| F::from_with_cfg(int, field_cfg))
         .collect()
 }
 
-pub fn append_field_cfg<'a, F>(buf: &'a mut [u8], modulus: &F::Modulus) -> &'a mut [u8]
+pub fn append_field_cfg<'a, F>(buf: &'a mut [u8], modulus: &F::Integer) -> &'a mut [u8]
 where
     F: PrimeField,
-    F::Modulus: ConstTranscribable,
+    F::Integer: ConstTranscribable,
 {
-    let mod_size = F::Modulus::NUM_BYTES;
+    let mod_size = F::Integer::NUM_BYTES;
     let (buf, rest) = buf.split_at_mut(mod_size);
     modulus.write_transcription_bytes_exact(buf);
     rest
 }
 
-pub fn append_field_vec_inner<'a, F>(buf: &'a mut [u8], slice: &[F]) -> &'a mut [u8]
+pub fn append_field_vec_lifted<'a, F>(buf: &'a mut [u8], slice: &[F]) -> &'a mut [u8]
 where
     F: PrimeField,
-    F::Inner: ConstTranscribable,
+    F::Integer: ConstTranscribable,
 {
-    let inner_size = F::Inner::NUM_BYTES;
+    let int_size = F::Integer::NUM_BYTES;
     let mut offset = 0;
     for elem in slice {
-        let offset_end = add!(offset, inner_size);
-        elem.inner()
+        let offset_end = add!(offset, int_size);
+        elem.lift_to_integer()
             .write_transcription_bytes_exact(&mut buf[offset..offset_end]);
         offset = offset_end;
     }

--- a/transcript/src/traits.rs
+++ b/transcript/src/traits.rs
@@ -2,10 +2,10 @@
 // Transcribable and Transcript
 //
 
-use crypto_bigint::{BitOps, BoxedUint, Word};
+use crypto_bigint::Word;
 use crypto_primitives::{
-    ConstIntSemiring, PrimeField, WORD_FACTOR, boolean::Boolean, crypto_bigint_int::Int,
-    crypto_bigint_uint::Uint,
+    ConstIntSemiring, PrimeField, WORD_FACTOR, boolean::Boolean,
+    crypto_bigint_boxed_uint::BoxedUint, crypto_bigint_int::Int, crypto_bigint_uint::Uint,
 };
 use itertools::Itertools;
 use zinc_primality::PrimalityTest;
@@ -333,11 +333,10 @@ pub trait Transcript {
 
     fn get_field_challenge<F: PrimeField>(&mut self, cfg: &F::Config) -> F
     where
-        F::Inner: ConstTranscribable,
+        F::Integer: ConstTranscribable,
     {
         let random_inner = self.get_challenge();
-
-        F::new_with_cfg(random_inner, cfg)
+        F::from_with_cfg(random_inner, cfg)
     }
 
     /// Generates a pseudorandom transcribable values as challenges based on the
@@ -348,7 +347,7 @@ pub trait Transcript {
     //             alternative to `get_challenge`.
     fn get_field_challenges<F: PrimeField>(&mut self, n: usize, cfg: &F::Config) -> Vec<F>
     where
-        F::Inner: ConstTranscribable,
+        F::Integer: ConstTranscribable,
     {
         (0..n).map(|_| self.get_field_challenge(cfg)).collect()
     }
@@ -365,12 +364,12 @@ pub trait Transcript {
     where
         F: PrimeField,
         FMod: ConstTranscribable + ConstIntSemiring,
-        F::Modulus: FromRef<FMod>,
+        F::Integer: FromRef<FMod>,
         T: PrimalityTest<FMod>,
     {
         let prime = self.get_prime::<FMod, T>();
 
-        F::make_cfg(&F::Modulus::from_ref(&prime)).expect("prime is guaranteed to be prime")
+        F::make_cfg(&F::Integer::from_ref(&prime)).expect("prime is guaranteed to be prime")
     }
 
     /// Absorbs a byte slice into the hash sponge.
@@ -388,26 +387,18 @@ pub trait Transcript {
     /// Absorbs a field element into the transcript.
     /// Delegates to the field element's implementation of
     /// absorb_into_transcript.
-    // Note: Currently this only works for fields whose modulus and inner element
-    // have the same byte length
     fn absorb_random_field<F>(&mut self, v: &F, buf: &mut [u8])
     where
         F: PrimeField,
-        F::Inner: Transcribable,
-        F::Modulus: Transcribable,
+        F::Integer: Transcribable,
     {
-        debug_assert_eq!(F::Inner::LENGTH_NUM_BYTES, F::Modulus::LENGTH_NUM_BYTES);
-        debug_assert_eq!(
-            F::Inner::get_num_bytes(v.inner()),
-            F::Modulus::get_num_bytes(&v.modulus())
-        );
         self.absorb_inner(&[0x3]);
         v.modulus().write_transcription_bytes_exact(buf);
         self.absorb_inner(buf);
         self.absorb_inner(&[0x5]);
 
         self.absorb_inner(&[0x1]);
-        v.inner().write_transcription_bytes_exact(buf);
+        v.lift_to_integer().write_transcription_bytes_exact(buf);
         self.absorb_inner(buf);
         self.absorb_inner(&[0x3])
     }
@@ -418,8 +409,7 @@ pub trait Transcript {
     fn absorb_random_field_slice<F>(&mut self, v: &[F], buf: &mut [u8])
     where
         F: PrimeField,
-        F::Inner: Transcribable,
-        F::Modulus: Transcribable,
+        F::Integer: Transcribable,
     {
         v.iter().for_each(|x| self.absorb_random_field(x, buf));
     }
@@ -566,14 +556,13 @@ impl Transcribable for BoxedUint {
 impl<F> GenTranscribable for Vec<F>
 where
     F: PrimeField,
-    F::Inner: ConstTranscribable,
-    F::Modulus: ConstTranscribable,
+    F::Integer: ConstTranscribable,
 {
     fn read_transcription_bytes_exact(bytes: &[u8]) -> Self {
         if bytes.is_empty() {
             return Vec::new();
         }
-        let mod_size = F::Modulus::NUM_BYTES;
+        let mod_size = F::Integer::NUM_BYTES;
         let cfg = super::read_field_cfg::<F>(&bytes[..mod_size]);
         super::read_field_vec_with_cfg(&bytes[mod_size..], &cfg)
     }
@@ -583,7 +572,7 @@ where
             return;
         }
         let buf = super::append_field_cfg::<F>(buf, &self[0].modulus());
-        let buf = super::append_field_vec_inner(buf, self);
+        let buf = super::append_field_vec_lifted(buf, self);
         assert!(
             buf.is_empty(),
             "Buffer size mismatch for Vec<F> transcription"
@@ -594,14 +583,16 @@ where
 impl<F> Transcribable for Vec<F>
 where
     F: PrimeField,
-    F::Inner: ConstTranscribable,
-    F::Modulus: ConstTranscribable,
+    F::Integer: ConstTranscribable,
 {
     fn get_num_bytes(&self) -> usize {
         if self.is_empty() {
             0
         } else {
-            add!(F::Modulus::NUM_BYTES, mul!(self.len(), F::Inner::NUM_BYTES))
+            add!(
+                F::Integer::NUM_BYTES,
+                mul!(self.len(), F::Integer::NUM_BYTES)
+            )
         }
     }
 }

--- a/utils/src/field/boxed_monty.rs
+++ b/utils/src/field/boxed_monty.rs
@@ -1,11 +1,10 @@
-use crypto_bigint::BoxedUint;
-use crypto_primitives::{
-    FromWithConfig, IntoWithConfig, PrimeField, crypto_bigint_boxed_monty::BoxedMontyField,
-    crypto_bigint_uint::Uint,
-};
-
 use crate::{
     from_ref::FromRef, mul_by_scalar::MulByScalar, projectable_to_field::ProjectableToField,
+};
+use crypto_primitives::{
+    FromWithConfig, HasPrimeFieldConfig, IntoWithConfig,
+    crypto_bigint_boxed_monty::BoxedMontyField, crypto_bigint_boxed_uint::BoxedUint,
+    crypto_bigint_uint::Uint,
 };
 
 impl MulByScalar<&Self> for BoxedMontyField {
@@ -48,18 +47,20 @@ where
     clippy::cast_possible_wrap
 )]
 mod prop_tests {
-    use crypto_bigint::{BoxedUint, U256};
+    use crypto_bigint::U256;
     use crypto_primitives::{
-        FromWithConfig, IntoWithConfig, PrimeField, crypto_bigint_boxed_monty::BoxedMontyField,
+        FromWithConfig, HasPrimeFieldConfig, IntoWithConfig, PrimeField,
+        crypto_bigint_boxed_monty::BoxedMontyField, crypto_bigint_boxed_uint::BoxedUint,
     };
     use proptest::prelude::*;
+    use std::str::FromStr;
 
     const MODULUS: &str = "00dca94d8a1ecce3b6e8755d8999787d0524d8ca1ea755e7af84fb646fa31f27";
     type F = BoxedMontyField;
 
-    fn get_dyn_config(hex_modulus: &str) -> <BoxedMontyField as PrimeField>::Config {
+    fn get_dyn_config(hex_modulus: &str) -> <BoxedMontyField as HasPrimeFieldConfig>::Config {
         let modulus =
-            BoxedUint::from_str_radix_vartime(hex_modulus, 16).expect("Invalid modulus hex string");
+            BoxedUint::from_str(&format!("0x{hex_modulus}")).expect("Invalid modulus hex string");
         BoxedMontyField::make_cfg(&modulus).expect("Failed to create field config")
     }
 

--- a/utils/src/field/monty.rs
+++ b/utils/src/field/monty.rs
@@ -1,5 +1,5 @@
 use crypto_primitives::{
-    FromWithConfig, IntoWithConfig, PrimeField, crypto_bigint_monty::MontyField,
+    FromWithConfig, HasPrimeFieldConfig, IntoWithConfig, crypto_bigint_monty::MontyField,
     crypto_bigint_uint::Uint,
 };
 use std::ops::MulAssign;
@@ -66,7 +66,7 @@ impl<const LIMBS: usize> InnerTransparentField for MontyField<LIMBS> {
 mod prop_tests {
     use crypto_bigint::U256;
     use crypto_primitives::{
-        FromWithConfig, IntoWithConfig, PrimeField,
+        FromWithConfig, HasPrimeFieldConfig, IntoWithConfig, PrimeField,
         crypto_bigint_monty::{F256, MontyField},
         crypto_bigint_uint::Uint,
     };
@@ -78,7 +78,7 @@ mod prop_tests {
     const MODULUS: &str = "00dca94d8a1ecce3b6e8755d8999787d0524d8ca1ea755e7af84fb646fa31f27";
     type F = F256;
 
-    fn get_dyn_config(hex_modulus: &str) -> <MontyField<LIMBS> as PrimeField>::Config {
+    fn get_dyn_config(hex_modulus: &str) -> <MontyField<LIMBS> as HasPrimeFieldConfig>::Config {
         let modulus = Uint::new(
             crypto_bigint::Uint::<LIMBS>::from_str_radix_vartime(hex_modulus, 16).unwrap(),
         );

--- a/zip-plus/benches/zip_common.rs
+++ b/zip-plus/benches/zip_common.rs
@@ -45,7 +45,7 @@ pub fn do_bench<Zt: ZipTypes, Lc: LinearCode<Zt>, const CHECK_FOR_OVERFLOWS: boo
         + for<'a> FromWithConfig<&'a Zt::Chal>
         + for<'a> FromWithConfig<&'a Zt::Pt>
         + for<'a> MulByScalar<&'a F>,
-    <F as Field>::Inner: FromRef<Zt::Fmod> + Transcribable,
+    <F as Field>::Integer: FromRef<Zt::Fmod> + Transcribable,
     Zt::Eval: ProjectableToField<F>,
 {
     encode_rows::<Zt, Lc, 12>(group, make_linear_code);
@@ -244,7 +244,7 @@ pub fn prove<
         + for<'a> FromWithConfig<&'a Zt::Chal>
         + for<'a> FromWithConfig<&'a Zt::Pt>
         + for<'a> MulByScalar<&'a F>,
-    <F as Field>::Inner: FromRef<Zt::Fmod> + Transcribable,
+    <F as Field>::Integer: FromRef<Zt::Fmod> + Transcribable,
     Zt::Eval: ProjectableToField<F>,
 {
     let mut rng = ThreadRng::default();
@@ -332,7 +332,7 @@ pub fn verify<
         + for<'a> FromWithConfig<&'a Zt::Chal>
         + for<'a> FromWithConfig<&'a Zt::Pt>
         + for<'a> MulByScalar<&'a F>,
-    <F as Field>::Inner: FromRef<Zt::Fmod> + Transcribable,
+    <F as Field>::Integer: FromRef<Zt::Fmod> + Transcribable,
     Zt::Eval: ProjectableToField<F>,
 {
     let mut rng = ThreadRng::default();

--- a/zip-plus/src/code.rs
+++ b/zip-plus/src/code.rs
@@ -3,7 +3,7 @@ pub mod raa;
 pub mod raa_sign_flip;
 
 use crate::pcs::structs::ZipTypes;
-use crypto_primitives::FromPrimitiveWithConfig;
+use crypto_primitives::{FromPrimitiveWithConfig, PrimeField};
 use std::fmt::Debug;
 use zinc_utils::from_ref::FromRef;
 
@@ -68,5 +68,5 @@ pub trait LinearCode<Zt: ZipTypes>: Debug + Clone + Eq + Sync + Send {
     /// A vector of field elements representing the encoded row
     fn encode_f<F>(&self, row: &[F]) -> Vec<F>
     where
-        F: FromPrimitiveWithConfig + FromRef<F>;
+        F: PrimeField + FromPrimitiveWithConfig + FromRef<F>;
 }

--- a/zip-plus/src/code/iprs.rs
+++ b/zip-plus/src/code/iprs.rs
@@ -1,7 +1,7 @@
 mod pntt;
 
 use crate::{ZipError, code::LinearCode, pcs::structs::ZipTypes};
-use crypto_primitives::{FromPrimitiveWithConfig, FromWithConfig};
+use crypto_primitives::{FromPrimitiveWithConfig, FromWithConfig, PrimeField};
 use num_traits::{CheckedAdd, CheckedMul};
 use pntt::radix8::params::Config as PnttConfig;
 pub use pntt::radix8::params::{PnttConfigF65537, PnttInt, Radix8PnttParams};
@@ -90,7 +90,7 @@ where
     // that we are dealing with a field.
     fn encode_inner_f<F>(&self, row: &[F]) -> Vec<F>
     where
-        F: FromWithConfig<PnttInt> + FromRef<F>,
+        F: PrimeField + FromWithConfig<PnttInt> + FromRef<F>,
     {
         assert_eq!(
             row.len(),
@@ -151,7 +151,7 @@ where
 
     fn encode_f<F>(&self, row: &[F]) -> Vec<F>
     where
-        F: FromPrimitiveWithConfig + FromRef<F>,
+        F: PrimeField + FromPrimitiveWithConfig + FromRef<F>,
     {
         self.encode_inner_f(row)
     }

--- a/zip-plus/src/code/raa.rs
+++ b/zip-plus/src/code/raa.rs
@@ -1,5 +1,5 @@
 use crate::{code::LinearCode, pcs::structs::ZipTypes, utils::shuffle_seeded};
-use crypto_primitives::PrimeField;
+use crypto_primitives::{FromPrimitiveWithConfig, PrimeField};
 use num_traits::CheckedAdd;
 use std::{fmt::Debug, marker::PhantomData, ops::AddAssign};
 use zinc_poly::ConstCoeffBitWidth;
@@ -154,7 +154,7 @@ impl<Zt: ZipTypes, Config: RaaConfig, const REP: usize> LinearCode<Zt>
 
     fn encode_f<F>(&self, row: &[F]) -> Vec<F>
     where
-        F: PrimeField + FromRef<F>,
+        F: PrimeField + FromPrimitiveWithConfig + FromRef<F>,
     {
         self.encode_inner(row)
     }

--- a/zip-plus/src/code/raa_sign_flip.rs
+++ b/zip-plus/src/code/raa_sign_flip.rs
@@ -1,6 +1,6 @@
 use super::raa::*;
 use crate::{code::LinearCode, pcs::structs::ZipTypes, utils::shuffle_seeded};
-use crypto_primitives::{PrimeField, Ring};
+use crypto_primitives::{FromPrimitiveWithConfig, PrimeField, Ring};
 use num_traits::{CheckedAdd, CheckedNeg};
 use std::{
     fmt::Debug,
@@ -100,7 +100,7 @@ where
 
     fn encode_f<F>(&self, row: &[F]) -> Vec<F>
     where
-        F: PrimeField + FromRef<F>,
+        F: PrimeField + FromPrimitiveWithConfig + FromRef<F>,
     {
         self.encode_inner(row)
     }

--- a/zip-plus/src/pcs/phase_prove.rs
+++ b/zip-plus/src/pcs/phase_prove.rs
@@ -96,8 +96,7 @@ impl<Zt: ZipTypes, Lc: LinearCode<Zt>> ZipPlus<Zt, Lc> {
             + for<'a> FromWithConfig<&'a Zt::Pt>
             + for<'a> MulByScalar<&'a F>
             + FromRef<F>,
-        F::Inner: Transcribable,
-        F::Modulus: Transcribable,
+        F::Integer: Transcribable,
     {
         let point = point
             .iter()
@@ -129,8 +128,7 @@ impl<Zt: ZipTypes, Lc: LinearCode<Zt>> ZipPlus<Zt, Lc> {
             + for<'a> FromWithConfig<&'a Zt::CombR>
             + for<'a> MulByScalar<&'a F>
             + FromRef<F>,
-        F::Inner: Transcribable,
-        F::Modulus: Transcribable,
+        F::Integer: Transcribable,
     {
         let batch_size = polys.len();
         validate_input::<Zt, Lc, _>(
@@ -269,8 +267,7 @@ impl<Zt: ZipTypes, Lc: LinearCode<Zt>> ZipPlus<Zt, Lc> {
             + for<'a> FromWithConfig<&'a Zt::Pt>
             + for<'a> MulByScalar<&'a F>
             + FromRef<F>,
-        F::Inner: Transcribable,
-        F::Modulus: FromRef<Zt::Fmod> + Transcribable,
+        F::Integer: FromRef<Zt::Fmod> + Transcribable,
     {
         Self::prove::<F, CHECK_FOR_OVERFLOW>(
             transcript,

--- a/zip-plus/src/pcs/phase_verify.rs
+++ b/zip-plus/src/pcs/phase_verify.rs
@@ -7,7 +7,7 @@ use crate::{
     },
     pcs_transcript::PcsVerifierTranscript,
 };
-use crypto_primitives::{FromPrimitiveWithConfig, FromWithConfig};
+use crypto_primitives::{FromPrimitiveWithConfig, FromWithConfig, PrimeField};
 use itertools::Itertools;
 use num_traits::{ConstOne, ConstZero, Zero};
 #[cfg(feature = "parallel")]
@@ -106,13 +106,13 @@ impl<Zt: ZipTypes, Lc: LinearCode<Zt>> ZipPlus<Zt, Lc> {
         eval_f: &F,
     ) -> Result<(), ZipError>
     where
-        F: FromPrimitiveWithConfig
+        F: PrimeField
+            + FromPrimitiveWithConfig
             + FromRef<F>
             + for<'a> FromWithConfig<&'a Zt::CombR>
             + for<'a> FromWithConfig<&'a Zt::Chal>
             + for<'a> MulByScalar<&'a F>,
-        F::Inner: Transcribable,
-        F::Modulus: FromRef<Zt::Fmod> + Transcribable,
+        F::Integer: FromRef<Zt::Fmod> + Transcribable,
     {
         let per_poly_alphas = Self::sample_alphas(&mut transcript.fs_transcript, comm.batch_size);
         Self::verify_with_alphas::<F, CHECK_FOR_OVERFLOW>(
@@ -144,13 +144,13 @@ impl<Zt: ZipTypes, Lc: LinearCode<Zt>> ZipPlus<Zt, Lc> {
         per_poly_alphas: &[Vec<Zt::Chal>],
     ) -> Result<(), ZipError>
     where
-        F: FromPrimitiveWithConfig
+        F: PrimeField
+            + FromPrimitiveWithConfig
             + FromRef<F>
             + for<'a> FromWithConfig<&'a Zt::CombR>
             + for<'a> FromWithConfig<&'a Zt::Chal>
             + for<'a> MulByScalar<&'a F>,
-        F::Inner: Transcribable,
-        F::Modulus: FromRef<Zt::Fmod> + Transcribable,
+        F::Integer: FromRef<Zt::Fmod> + Transcribable,
     {
         let batch_size = comm.batch_size;
         validate_input::<Zt, Lc, _>(
@@ -323,8 +323,8 @@ mod tests {
     };
     use crypto_bigint::U64;
     use crypto_primitives::{
-        Field, FromWithConfig, IntSemiring, IntoWithConfig, PrimeField, crypto_bigint_int::Int,
-        crypto_bigint_monty::MontyField,
+        Field, FromWithConfig, HasPrimeFieldConfig, IntSemiring, IntoWithConfig, PrimeField,
+        crypto_bigint_int::Int, crypto_bigint_monty::MontyField,
     };
     use itertools::Itertools;
     use num_traits::{ConstOne, ConstZero, Zero};
@@ -443,7 +443,7 @@ mod tests {
             let original_f0: F = proof.clone().read_field_elements(1).unwrap().remove(0);
             // Skipping over LENGTH_NUM_BYTES prefix for b field elements, and the modulus
             // bytes, to flip a byte in the VALUE part of the first b element.
-            type Mod = <F as Field>::Modulus;
+            type Mod = <F as Field>::Integer;
             let offset = Mod::LENGTH_NUM_BYTES + Mod::NUM_BYTES;
             proof.stream.get_mut()[offset] ^= 0x01;
 
@@ -554,7 +554,7 @@ mod tests {
     fn verification_fails_with_invalid_point_size() {
         let num_vars = 10;
 
-        let make_invalid_point = |cfg: &<F as PrimeField>::Config| {
+        let make_invalid_point = |cfg: &<F as HasPrimeFieldConfig>::Config| {
             let mut invalid_point = vec![];
             for i in 0..=num_vars {
                 invalid_point.push(F::from_with_cfg(100 + i as i32, cfg));

--- a/zip-plus/src/pcs/test_utils.rs
+++ b/zip-plus/src/pcs/test_utils.rs
@@ -169,8 +169,7 @@ where
         + for<'a> FromWithConfig<&'a <TestZipTypes<N, K, M> as ZipTypes>::CombR>
         + for<'a> MulByScalar<&'a F>
         + FromRef<F>,
-    F::Inner: Transcribable,
-    F::Modulus: FromRef<<TestZipTypes<N, K, M> as ZipTypes>::Fmod> + Transcribable,
+    F::Integer: FromRef<<TestZipTypes<N, K, M> as ZipTypes>::Fmod> + Transcribable,
     <TestZipTypes<N, K, M> as ZipTypes>::Eval: ProjectableToField<F>,
 {
     setup_full_protocol_inner::<_, _, _, N>(num_vars, setup_test_params, || {
@@ -203,8 +202,7 @@ where
         + for<'a> MulByScalar<&'a F>
         + FromRef<F>
         + 'static,
-    F::Inner: Transcribable,
-    F::Modulus:
+    F::Integer:
         FromRef<<TestBinPolyZipTypes<K, M, DEGREE_PLUS_ONE> as ZipTypes>::Fmod> + Transcribable,
 {
     setup_full_protocol_inner::<_, _, _, N>(num_vars, setup_poly_test_params, || {
@@ -232,8 +230,7 @@ where
         + for<'a> FromWithConfig<&'a Zt::Pt>
         + for<'a> MulByScalar<&'a F>
         + FromRef<F>,
-    F::Inner: Transcribable,
-    F::Modulus: FromRef<Zt::Fmod> + Transcribable,
+    F::Integer: FromRef<Zt::Fmod> + Transcribable,
     Zt::Eval: ProjectableToField<F>,
 {
     let (pp, poly) = setup(num_vars);
@@ -263,7 +260,7 @@ pub fn get_field_cfg<Zt, F>(transcript: &mut impl Transcript) -> F::Config
 where
     Zt: ZipTypes,
     F: PrimeField,
-    F::Modulus: FromRef<Zt::Fmod>,
+    F::Integer: FromRef<Zt::Fmod>,
 {
     transcript.get_random_field_cfg::<F, Zt::Fmod, Zt::PrimeTest>()
 }

--- a/zip-plus/src/pcs_transcript.rs
+++ b/zip-plus/src/pcs_transcript.rs
@@ -99,17 +99,14 @@ impl PcsProverTranscript {
     pub fn write_field_elements<F>(&mut self, elems: &[F]) -> Result<(), ZipError>
     where
         F: PrimeField,
-        F::Inner: Transcribable,
-        F::Modulus: Transcribable,
+        F::Integer: Transcribable,
     {
         if !elems.is_empty() {
-            debug_assert_eq!(F::Inner::LENGTH_NUM_BYTES, F::Modulus::LENGTH_NUM_BYTES);
-            let num_bytes = F::Inner::get_num_bytes(elems[0].inner());
-            debug_assert_eq!(num_bytes, F::Modulus::get_num_bytes(&elems[0].modulus()));
+            let num_bytes = F::Integer::get_num_bytes(&elems[0].modulus());
             let num_bytes_arr = num_bytes
                 .to_le_bytes()
                 .into_iter()
-                .take(F::Inner::LENGTH_NUM_BYTES)
+                .take(F::Integer::LENGTH_NUM_BYTES)
                 .collect_vec();
             self.stream.write_all(&num_bytes_arr)?;
 
@@ -130,13 +127,12 @@ impl PcsProverTranscript {
     fn write_field_element_no_length<F>(&mut self, fe: &F, buf: &mut [u8]) -> Result<(), ZipError>
     where
         F: PrimeField,
-        F::Inner: Transcribable,
-        F::Modulus: Transcribable,
+        F::Integer: Transcribable,
     {
         self.fs_transcript.absorb_random_field(fe, buf);
         fe.modulus().write_transcription_bytes_exact(buf);
         self.stream.write_all(buf)?;
-        fe.inner().write_transcription_bytes_exact(buf);
+        fe.lift_to_integer().write_transcription_bytes_exact(buf);
         self.stream.write_all(buf)?;
         Ok(())
     }
@@ -242,15 +238,12 @@ impl PcsVerifierTranscript {
     pub fn read_field_elements<F>(&mut self, n: usize) -> Result<Vec<F>, ZipError>
     where
         F: PrimeField,
-        F::Inner: Transcribable,
-        F::Modulus: Transcribable,
+        F::Integer: Transcribable,
     {
         if n > 0 {
-            debug_assert_eq!(F::Inner::LENGTH_NUM_BYTES, F::Modulus::LENGTH_NUM_BYTES);
-            let mut buf = vec![0; F::Inner::LENGTH_NUM_BYTES];
+            let mut buf = vec![0; F::Integer::LENGTH_NUM_BYTES];
             self.stream.read_exact(&mut buf)?;
-            let num_bytes = F::Inner::read_num_bytes(&buf);
-            debug_assert_eq!(num_bytes, F::Modulus::read_num_bytes(&buf));
+            let num_bytes = F::Integer::read_num_bytes(&buf);
 
             let mut buf = vec![0; num_bytes];
             (0..n)
@@ -269,15 +262,14 @@ impl PcsVerifierTranscript {
     fn read_field_element_no_length<F>(&mut self, buf: &mut [u8]) -> Result<F, ZipError>
     where
         F: PrimeField,
-        F::Inner: Transcribable,
-        F::Modulus: Transcribable,
+        F::Integer: Transcribable,
     {
         self.stream.read_exact(buf)?;
-        let modulus = F::Modulus::read_transcription_bytes_exact(buf);
+        let modulus = F::Integer::read_transcription_bytes_exact(buf);
         self.stream.read_exact(buf)?;
-        let inner = F::Inner::read_transcription_bytes_exact(buf);
+        let int = F::Integer::read_transcription_bytes_exact(buf);
         let field_cfg = F::make_cfg(&modulus)?;
-        let fe = F::new_unchecked_with_cfg(inner, &field_cfg);
+        let fe = F::from_with_cfg(int, &field_cfg);
         self.fs_transcript.absorb_random_field(&fe, buf);
         Ok(fe)
     }


### PR DESCRIPTION
Adopt changed introduced in https://github.com/NethermindEth/crypto-primitives/pull/33.
This enables lifting field elements to integers - attempt to do that was done in #200.
Instead of writing `field.inner` to transcription, write `field.lift_to_integer`. This has no observable impact on UAIR benchmark performance.