### PR TITLE
Adopt next iteration of crypto primitives, take 2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ publish = false
 blake3 = "1.8"
 criterion = "0.7.0"
 crypto-bigint = { version = "= 0.7.0-rc.9", features = ["zeroize"] }
-crypto-primitives = { git = "https://github.com/NethermindEth/crypto-primitives.git", rev = "234f101", features = ["std", "crypto_bigint", "rand"] }
+crypto-primitives = { git = "https://github.com/NethermindEth/crypto-primitives.git", rev = "30a8c38", features = ["std", "crypto_bigint", "rand"] }
 derive_more = { version = "2.1.1", features = ["full"] }
 itertools = "0.14"
 num-traits = "0.2"

--- a/piop/src/sumcheck.rs
+++ b/piop/src/sumcheck.rs
@@ -66,7 +66,7 @@ where
     }
 
     fn write_transcription_bytes_exact(&self, mut buf: &mut [u8]) {
-        buf = zinc_transcript::append_field_cfg::<F>(buf, &self.claimed_sum.modulus());
+        buf = zinc_transcript::append_field_cfg::<F>(buf, &F::modulus(self.claimed_sum.cfg()));
         buf = {
             let len =
                 u32::try_from(self.messages.len()).expect("messages length must fit into u32");

--- a/piop/src/sumcheck/multi_degree.rs
+++ b/piop/src/sumcheck/multi_degree.rs
@@ -186,7 +186,7 @@ where
     }
 
     fn write_transcription_bytes_exact(&self, mut buf: &mut [u8]) {
-        buf = zinc_transcript::append_field_cfg::<F>(buf, &self.claimed_sums[0].modulus());
+        buf = zinc_transcript::append_field_cfg::<F>(buf, &F::modulus(self.claimed_sums[0].cfg()));
 
         let num_groups =
             u32::try_from(self.group_messages.len()).expect("num groups must fit into u32");

--- a/poly/src/univariate/dynamic/over_field.rs
+++ b/poly/src/univariate/dynamic/over_field.rs
@@ -513,7 +513,7 @@ where
         }
         if let Some(element) = self.0.iter().find_map(|poly| poly.coeffs.first()) {
             buf[0] = 1; // Indicate that modulus is present
-            buf = zinc_transcript::append_field_cfg::<F>(&mut buf[1..], &element.modulus());
+            buf = zinc_transcript::append_field_cfg::<F>(&mut buf[1..], &F::modulus(element.cfg()));
         } else {
             buf[0] = 0;
             buf = &mut buf[1..];

--- a/transcript/src/traits.rs
+++ b/transcript/src/traits.rs
@@ -393,7 +393,7 @@ pub trait Transcript {
         F::Integer: Transcribable,
     {
         self.absorb_inner(&[0x3]);
-        v.modulus().write_transcription_bytes_exact(buf);
+        F::modulus(v.cfg()).write_transcription_bytes_exact(buf);
         self.absorb_inner(buf);
         self.absorb_inner(&[0x5]);
 
@@ -571,7 +571,7 @@ where
         if self.is_empty() {
             return;
         }
-        let buf = super::append_field_cfg::<F>(buf, &self[0].modulus());
+        let buf = super::append_field_cfg::<F>(buf, &F::modulus(self[0].cfg()));
         let buf = super::append_field_vec_lifted(buf, self);
         assert!(
             buf.is_empty(),

--- a/uair/src/ideal/rotation.rs
+++ b/uair/src/ideal/rotation.rs
@@ -63,12 +63,11 @@ impl<F: PrimeField, const W: usize> IdealCheck<DynamicPolynomialF<F>>
                 if !value.coeffs.is_empty() {
                     // We could technically do the conversion here, but this is not expected
                     // to happen and likely signifies a bug.
-                    let coeffs_modulus = value.coeffs[0].modulus();
-                    if coeffs_modulus != generating_root.modulus() {
+                    let coeffs_modulus = F::modulus(value.coeffs[0].cfg());
+                    let root_modulus = F::modulus(generating_root.cfg());
+                    if coeffs_modulus != root_modulus {
                         return Err(IdealCheckError(format!(
-                            "Coefficient modulus {:?} doesn not match generating root modulus {:?}",
-                            coeffs_modulus,
-                            generating_root.modulus()
+                            "Coefficient modulus {coeffs_modulus} doesn not match generating root modulus {root_modulus}",
                         )));
                     }
                 }

--- a/zip-plus/src/pcs/phase_verify.rs
+++ b/zip-plus/src/pcs/phase_verify.rs
@@ -449,7 +449,7 @@ mod tests {
 
             // Sanity check that we didn't mess up the tampering
             let tampered_f0: F = proof.clone().read_field_elements(1).unwrap().remove(0);
-            assert_eq!(original_f0.modulus(), tampered_f0.modulus());
+            assert_eq!(F::modulus(original_f0.cfg()), F::modulus(tampered_f0.cfg()));
             assert_ne!(original_f0, tampered_f0);
 
             proof
@@ -850,7 +850,7 @@ mod tests {
         // New transcript starts with b field elements: [1-byte prefix][modulus|value
         // per elem]. Flip a byte inside the first b element's VALUE to corrupt
         // eval consistency.
-        let num_bytes_f_mod = eval_f.modulus().get_num_bytes();
+        let num_bytes_f_mod = F::modulus(eval_f.cfg()).get_num_bytes();
         let num_bytes_f_val = eval_f.inner().get_num_bytes();
         let flip_at = 1 + num_bytes_f_mod + num_bytes_f_val / 4;
 

--- a/zip-plus/src/pcs_transcript.rs
+++ b/zip-plus/src/pcs_transcript.rs
@@ -102,7 +102,7 @@ impl PcsProverTranscript {
         F::Integer: Transcribable,
     {
         if !elems.is_empty() {
-            let num_bytes = F::Integer::get_num_bytes(&elems[0].modulus());
+            let num_bytes = F::Integer::get_num_bytes(&F::modulus(elems[0].cfg()));
             let num_bytes_arr = num_bytes
                 .to_le_bytes()
                 .into_iter()
@@ -130,7 +130,7 @@ impl PcsProverTranscript {
         F::Integer: Transcribable,
     {
         self.fs_transcript.absorb_random_field(fe, buf);
-        fe.modulus().write_transcription_bytes_exact(buf);
+        F::modulus(fe.cfg()).write_transcription_bytes_exact(buf);
         self.stream.write_all(buf)?;
         fe.lift_to_integer().write_transcription_bytes_exact(buf);
         self.stream.write_all(buf)?;


### PR DESCRIPTION
Adopt changed introduced in https://github.com/NethermindEth/crypto-primitives/pull/34.
This enables querying field modulus without full element, using just a field configuration.