### PR TITLE
Wire bit-op virtuals through protocol constraint families

### DIFF
--- a/piop/src/ideal_check/combined_poly_builder.rs
+++ b/piop/src/ideal_check/combined_poly_builder.rs
@@ -13,7 +13,7 @@ use zinc_poly::{
     utils::{ArithErrors as PolyArithErrors, build_eq_x_r_vec},
 };
 use zinc_uair::{
-    BitOp, BitOpSpec, ColumnLayout, ConstraintBuilder, ShiftSpec, TraceRow, Uair, UairSignature,
+    ColumnLayout, ConstraintBuilder, ShiftSpec, TraceRow, Uair, UairSignature,
     ideal::ImpossibleIdeal,
 };
 use zinc_utils::{
@@ -87,9 +87,7 @@ where
 
             for spec in uair_sig.bit_op_specs() {
                 let source = &trace_matrix[row_idx][spec.source_col()];
-                down.push(apply_bit_op_to_poly::<F, DEGREE_PLUS_ONE>(
-                    source, spec, field_cfg,
-                ));
+                down.push(spec.op().transform::<F, DEGREE_PLUS_ONE>(source, field_cfg));
             }
 
             for spec in &shifts[bit_op_down_offset..] {
@@ -327,11 +325,8 @@ where
         .bit_op_specs()
         .iter()
         .map(|spec| {
-            apply_bit_op_to_poly::<F, DEGREE_PLUS_ONE>(
-                &up_evals[spec.source_col()],
-                spec,
-                field_cfg,
-            )
+            spec.op()
+                .transform::<F, DEGREE_PLUS_ONE>(&up_evals[spec.source_col()], field_cfg)
         })
         .collect();
 
@@ -388,17 +383,6 @@ fn push_shifted_down_entry<F: PrimeField>(
         down.push(trace_matrix[shifted_row_idx][spec.source_col()].clone());
     } else {
         down.push(DynamicPolynomialF::zero());
-    }
-}
-
-fn apply_bit_op_to_poly<F: PrimeField, const DEGREE_PLUS_ONE: usize>(
-    source: &DynamicPolynomialF<F>,
-    spec: &BitOpSpec,
-    field_cfg: &F::Config,
-) -> DynamicPolynomialF<F> {
-    match spec.op() {
-        BitOp::Rot(c) => source.rotate_right::<DEGREE_PLUS_ONE>(c, field_cfg),
-        BitOp::ShR(c) => source.shr::<DEGREE_PLUS_ONE>(c, field_cfg),
     }
 }
 

--- a/piop/src/projections.rs
+++ b/piop/src/projections.rs
@@ -8,7 +8,7 @@ use zinc_poly::{
     mle::DenseMultilinearExtension,
     univariate::dynamic::over_field::{DynamicPolyFInnerProduct, DynamicPolynomialF},
 };
-use zinc_uair::{BitOp, BitOpSpec, Uair, UairTrace, collect_scalars::collect_scalars};
+use zinc_uair::{BitOpSpec, Uair, UairTrace, collect_scalars::collect_scalars};
 use zinc_utils::{
     UNCHECKED, cfg_extend, cfg_into_iter, cfg_iter, cfg_iter_mut, inner_product::InnerProduct,
     powers,
@@ -357,10 +357,7 @@ pub fn build_bit_op_virtual_mle<F: PrimeField + 'static, const D: usize>(
     );
 
     let evaluate_with_bit_op = |cell: &DynamicPolynomialF<F>| -> F::Inner {
-        let transformed = match spec.op() {
-            BitOp::Rot(c) => cell.rotate_right::<D>(c, field_cfg),
-            BitOp::ShR(c) => cell.shr::<D>(c, field_cfg),
-        };
+        let transformed = spec.op().transform::<F, D>(cell, field_cfg);
         DynamicPolyFInnerProduct::inner_product::<UNCHECKED>(
             &transformed.coeffs,
             &projection_powers,
@@ -464,6 +461,7 @@ mod tests {
     use crypto_primitives::{
         Field, FromWithConfig, HasPrimeFieldConfig, crypto_bigint_monty::MontyField,
     };
+    use zinc_uair::BitOp;
 
     type F = MontyField<LIMBS>;
 

--- a/protocol/src/lib.rs
+++ b/protocol/src/lib.rs
@@ -783,8 +783,8 @@ mod tests {
     use zinc_primality::MillerRabin;
     use zinc_test_uair::{
         BigLinearUair, BigLinearUairWithPublicInput, BinaryDecompositionUair, GenerateRandomTrace,
-        ShaProxy, TestUairFqLargePrime, TestUairMixedShifts, TestUairNoMultiplication,
-        TestUairSimpleMultiplication,
+        ShaProxy, TestUairBitOpsFqFamily, TestUairFqLargePrime, TestUairMixedShifts,
+        TestUairNoMultiplication, TestUairSimpleMultiplication,
     };
     use zinc_uair::{
         constraint_counter::count_constraints, ideal::DegreeOneIdeal, ideal_collector::IdealOrZero,
@@ -1189,6 +1189,25 @@ mod tests {
         );
     }
 
+    /// End-to-end test: [`TestUairBitOpsFqFamily`] -- exercises bit-op virtual
+    /// columns through both the Q[X] and F_q[X] constraint families.
+    #[test]
+    fn test_e2e_bit_ops_with_fq_family() {
+        let num_vars = 8;
+        do_test::<TestZincTypesIprs, TestUairBitOpsFqFamily<ZtInt, ZtFmod>>(
+            num_vars,
+            (
+                make_iprs(num_vars),
+                make_iprs(num_vars),
+                make_iprs(num_vars),
+            ),
+            default_project_ideal!(),
+            |ideal, field_cfg| ideal.map(|i| DegreeOneIdeal::from_with_cfg(i, field_cfg)),
+            |_| {},
+            |res| res.unwrap(),
+        );
+    }
+
     /// End-to-end test: [`BigLinearUair`].
     ///
     /// Uses 16 binary_poly cols and 1 int col.
@@ -1335,6 +1354,79 @@ mod tests {
                     res.unwrap_err(),
                     ProtocolError::MultipointEval(MultipointEvalError::ClaimMismatch { .. })
                 ));
+            },
+        );
+    }
+
+    /// Regression for source-lift tampering on a bit-op UAIR in a
+    /// declared-prime family.
+    ///
+    /// [`TestUairBitOpsFqFamily`] constrains `ShR(w, 3)` through both Q[X]
+    /// and F_q[X]. Perturbing the F_q-family lifted eval of source column `w`
+    /// changes the committed-source opening and the verifier-derived bit-op
+    /// opening, so this is an end-to-end regression rather than an isolated
+    /// bit-op binding test.
+    #[test]
+    fn test_bit_ops_fq_family_tamper_source_lifted_evals() {
+        let num_vars = 8;
+        do_test::<TestZincTypesIprs, TestUairBitOpsFqFamily<ZtInt, ZtFmod>>(
+            num_vars,
+            (
+                make_iprs(num_vars),
+                make_iprs(num_vars),
+                make_iprs(num_vars),
+            ),
+            default_project_ideal!(),
+            |ideal, field_cfg| ideal.map(|i| DegreeOneIdeal::from_with_cfg(i, field_cfg)),
+            |proof| {
+                // Family 1 = declared prime q_1. Source column 0 is `w`, the
+                // source of the UAIR's single bit-op virtual `ShR(w, 3)`.
+                let cfg = *proof.cpr_proofs_fq[0].up_evals[0].cfg();
+                let one = F::one_with_cfg(&cfg);
+                let lifted = &mut proof.witness_lifted_evals[1][0];
+                if lifted.coeffs.is_empty() {
+                    lifted.coeffs.push(one);
+                } else {
+                    lifted.coeffs[0] += one;
+                }
+            },
+            |res| {
+                assert!(matches!(
+                    res.unwrap_err(),
+                    ProtocolError::MultipointEval(MultipointEvalError::ClaimMismatch { .. })
+                ));
+            },
+        );
+    }
+
+    /// Regression: a tampered F_q-family bit-op claim is rejected end-to-end.
+    ///
+    /// This perturbs the prover's claimed `ShR(w, 3)(r*)` value in the CPR
+    /// proof. That value is shared by CPR and multipoint-eval; in practice,
+    /// this mutation is caught by CPR's constraint reconstruction before the
+    /// final multipoint-eval check.
+    #[test]
+    fn test_bit_ops_fq_family_tamper_bit_op_eval() {
+        let num_vars = 8;
+        do_test::<TestZincTypesIprs, TestUairBitOpsFqFamily<ZtInt, ZtFmod>>(
+            num_vars,
+            (
+                make_iprs(num_vars),
+                make_iprs(num_vars),
+                make_iprs(num_vars),
+            ),
+            default_project_ideal!(),
+            |ideal, field_cfg| ideal.map(|i| DegreeOneIdeal::from_with_cfg(i, field_cfg)),
+            |proof| {
+                let bit_op_eval = &mut proof.cpr_proofs_fq[0].bit_op_evals[0];
+                let cfg = *bit_op_eval.cfg();
+                *bit_op_eval += F::one_with_cfg(&cfg);
+            },
+            |res| {
+                assert!(
+                    res.is_err(),
+                    "tampered F_q-family bit-op evaluation must be rejected"
+                );
             },
         );
     }

--- a/protocol/src/prover.rs
+++ b/protocol/src/prover.rs
@@ -8,8 +8,9 @@ use zinc_piop::{
     multipoint_eval::{MultipointEval, MultipointEvalFamilyInputs, Proof as MultipointEvalProof},
     projections::{
         ColumnMajorTrace, ProjectedScalars, ProjectedTrace, RowMajorTrace,
-        evaluate_trace_to_column_mles, project_scalars, project_scalars_to_field,
-        project_trace_coeffs_column_major, project_trace_coeffs_row_major,
+        build_bit_op_virtual_mle, evaluate_trace_to_column_mles, project_scalars,
+        project_scalars_to_field, project_trace_coeffs_column_major,
+        project_trace_coeffs_row_major,
     },
     sumcheck::multi_degree::{MultiDegreeSumcheck, MultiDegreeSumcheckGroup},
 };
@@ -230,6 +231,9 @@ pub struct ProverEvalProjected<
 
     // New
     projected_trace_f: Vec<DenseMultilinearExtension<F::Inner>>,
+    /// Q[X] family bit-op virtual MLEs, in `UairSignature::bit_op_specs()`
+    /// order.
+    bit_op_mles: Vec<DenseMultilinearExtension<F::Inner>>,
     projected_scalars_f: ProjectedScalars<U::Scalar, F>,
     /// Per-prime $\psi$-projected trace MLEs (one entry per declared prime
     /// in `UairSignature::primes()`). Built in step 4 from each
@@ -237,6 +241,9 @@ pub struct ProverEvalProjected<
     /// Consumed by per-prime CPR `prepare_sumcheck_group` in step 5.
     /// Empty for UAIRs with no declared fq primes.
     projected_trace_f_fq: Vec<Vec<DenseMultilinearExtension<F::Inner>>>,
+    /// Per-prime family bit-op virtual MLEs, one vector per declared prime,
+    /// each in `UairSignature::bit_op_specs()` order.
+    bit_op_mles_fq: Vec<Vec<DenseMultilinearExtension<F::Inner>>>,
     /// Per-prime $\psi$-projected scalars (one entry per declared prime).
     /// Built in step 4 from each `fq_staging[i].projected_scalars_fx`
     /// using `projecting_elements[i + 1]`. Consumed in step 5 by the
@@ -275,11 +282,15 @@ pub struct ProverSumchecked<
     /// the multipoint-eval inputs (and optionally append $\alpha'$-projected
     /// witness-bin MLEs as the Schwartz-Zippel bridge).
     projected_trace_f: Vec<DenseMultilinearExtension<F::Inner>>,
+    /// Q[X] family bit-op virtual MLEs, carried to multipoint eval.
+    bit_op_mles: Vec<DenseMultilinearExtension<F::Inner>>,
     /// Per-prime $\psi$-projected trace MLEs (one entry per declared
     /// prime). Threaded forward from step 4 by `step5_sumcheck` so that
     /// step 6's lockstep multipoint-eval can build per-prime MP families.
     /// Empty for UAIRs with no declared fq primes.
     projected_trace_f_fq: Vec<Vec<DenseMultilinearExtension<F::Inner>>>,
+    /// Per-prime bit-op virtual MLEs, carried to multipoint eval.
+    bit_op_mles_fq: Vec<Vec<DenseMultilinearExtension<F::Inner>>>,
 
     // New
     cpr_proof: CombinedPolyResolverProof<F>,
@@ -850,6 +861,19 @@ impl_with_type_bounds!(ProverIdealChecked
         let projected_trace_f =
             evaluate_trace_to_column_mles(&self.projected_trace, &projecting_elements[0]);
 
+        let bit_op_specs = self.base.uair_signature.bit_op_specs().to_vec();
+        let bit_op_mles = bit_op_specs
+            .iter()
+            .map(|spec| {
+                build_bit_op_virtual_mle::<F, D>(
+                    &self.projected_trace,
+                    spec,
+                    &projecting_elements[0],
+                    &self.field_cfg,
+                )
+            })
+            .collect();
+
         let projected_scalars_f =
             project_scalars_to_field(self.projected_scalars_fx, &projecting_elements[0])
                 .map_err(|(_s, _f, e)| ProtocolError::ScalarProjection(e))?;
@@ -864,6 +888,8 @@ impl_with_type_bounds!(ProverIdealChecked
         let mut projected_trace_fq: Vec<ProjectedTrace<F>> = Vec::with_capacity(n_fq);
         let mut projected_trace_f_fq: Vec<Vec<DenseMultilinearExtension<F::Inner>>> =
             Vec::with_capacity(n_fq);
+        let mut bit_op_mles_fq: Vec<Vec<DenseMultilinearExtension<F::Inner>>> =
+            Vec::with_capacity(n_fq);
         let mut projected_scalars_f_fq: Vec<ProjectedScalars<U::Scalar, F>> =
             Vec::with_capacity(n_fq);
         for (prime_idx, staging) in self.fq_staging.into_iter().enumerate() {
@@ -874,11 +900,23 @@ impl_with_type_bounds!(ProverIdealChecked
             } = staging;
             let trace_f_i =
                 evaluate_trace_to_column_mles(&projected_trace_i, &projecting_elements[family_idx]);
+            let bit_op_mles_i = bit_op_specs
+                .iter()
+                .map(|spec| {
+                    build_bit_op_virtual_mle::<F, D>(
+                        &projected_trace_i,
+                        spec,
+                        &projecting_elements[family_idx],
+                        &self.all_field_cfgs[family_idx],
+                    )
+                })
+                .collect();
             let scalars_f_i =
                 project_scalars_to_field(scalars_fx_i, &projecting_elements[family_idx])
                     .map_err(|(_s, _f, e)| ProtocolError::ScalarProjection(e))?;
             projected_trace_fq.push(projected_trace_i);
             projected_trace_f_fq.push(trace_f_i);
+            bit_op_mles_fq.push(bit_op_mles_i);
             projected_scalars_f_fq.push(scalars_f_i);
         }
 
@@ -893,8 +931,10 @@ impl_with_type_bounds!(ProverIdealChecked
             ic_eval_points: self.ic_eval_points,
             ic_proof_fq: self.ic_proof_fq,
             projected_trace_f,
+            bit_op_mles,
             projected_scalars_f,
             projected_trace_f_fq,
+            bit_op_mles_fq,
             projected_scalars_f_fq,
         })
     }
@@ -944,13 +984,9 @@ impl_with_type_bounds!(ProverEvalProjected
         );
 
         // ------------- Q[X] family groups -----------------
-        // TODO(#185): once protocol-level prover materializes bit-op virtual
-        // MLEs, pass them here. For now no UAIR on `main` declares
-        // `bit_op_specs`, so passing an empty vec keeps behaviour identical.
-        let bit_op_down_mles = Vec::new();
         let (q_cpr_group, q_cpr_ancillary) = CombinedPolyResolver::prepare_sumcheck_group::<U>(
             self.projected_trace_f.clone(),
-            bit_op_down_mles,
+            self.bit_op_mles.clone(),
             &self.ic_eval_points[0],
             &self.projected_scalars_f,
             /* family_idx = */ 0,
@@ -1005,7 +1041,7 @@ impl_with_type_bounds!(ProverEvalProjected
             let (cpr_group_i, cpr_ancillary_i) =
                 CombinedPolyResolver::prepare_sumcheck_group::<U>(
                     trace_f_i,
-                    Vec::new(),
+                    self.bit_op_mles_fq[prime_idx].clone(),
                     eval_point_i,
                     scalars_f_i,
                     family_idx,
@@ -1112,7 +1148,9 @@ impl_with_type_bounds!(ProverEvalProjected
             ic_proof: self.ic_proof,
             ic_proof_fq: self.ic_proof_fq,
             projected_trace_f: self.projected_trace_f,
+            bit_op_mles: self.bit_op_mles,
             projected_trace_f_fq: self.projected_trace_f_fq,
+            bit_op_mles_fq: self.bit_op_mles_fq,
             cpr_proof,
             cpr_eval_point: cpr_prover_state.evaluation_point,
             combined_sumcheck,
@@ -1255,10 +1293,10 @@ impl_with_type_bounds!(ProverSumchecked
         all_families.push(MultipointEvalFamilyInputs {
             field_cfg: &self.field_cfg,
             trace_mles: &projected_trace_f,
-            bit_op_mles: &[],
+            bit_op_mles: &self.bit_op_mles,
             eval_point: &self.cpr_eval_point,
             up_evals: &q_up_evals,
-            bit_op_evals: &[],
+            bit_op_evals: &self.cpr_proof.bit_op_evals,
             down_evals: &self.cpr_proof.down_evals,
         });
         for prime_idx in 0..n_fq {
@@ -1266,10 +1304,10 @@ impl_with_type_bounds!(ProverSumchecked
             all_families.push(MultipointEvalFamilyInputs {
                 field_cfg: &self.all_field_cfgs[family_idx],
                 trace_mles: &fq_trace_mles_padded[prime_idx],
-                bit_op_mles: &[],
+                bit_op_mles: &self.bit_op_mles_fq[prime_idx],
                 eval_point: &self.cpr_eval_points_fq[prime_idx],
                 up_evals: &fq_up_evals_padded[prime_idx],
-                bit_op_evals: &[],
+                bit_op_evals: &self.cpr_proofs_fq[prime_idx].bit_op_evals,
                 down_evals: &self.cpr_proofs_fq[prime_idx].down_evals,
             });
         }

--- a/protocol/src/verifier.rs
+++ b/protocol/src/verifier.rs
@@ -19,7 +19,7 @@ use zinc_transcript::{
     traits::{ConstTranscribable, Transcript},
 };
 use zinc_uair::{
-    Uair, UairSignature, UairTrace,
+    BitOp, Uair, UairSignature, UairTrace,
     constraint_counter::count_constraints,
     ideal::{Ideal, IdealCheck},
     ideal_collector::IdealOrZero,
@@ -258,6 +258,7 @@ pub struct VerifierSumchecked<
     /// CPR subclaim's evaluation point ($r^\star$)
     cpr_eval_point: Vec<F>,
     cpr_up_evals: Vec<F>,
+    cpr_bit_op_evals: Vec<F>,
     cpr_down_evals: Vec<F>,
     /// Per-prime CPR subclaim evaluation points (r*, lifted into
     /// each family's field). Length `n_fq`. Empty for UAIRs with no
@@ -265,6 +266,9 @@ pub struct VerifierSumchecked<
     cpr_eval_points_fq: Vec<Vec<F>>,
     /// Per-prime CPR subclaim `up_evals`. Length `n_fq`. Consumed in step 5.
     cpr_up_evals_fq: Vec<Vec<F>>,
+    /// Per-prime CPR subclaim `bit_op_evals`. Length `n_fq`. Consumed in step
+    /// 5.
+    cpr_bit_op_evals_fq: Vec<Vec<F>>,
     /// Per-prime CPR subclaim `down_evals`. Length `n_fq`. Consumed in step 5.
     cpr_down_evals_fq: Vec<Vec<F>>,
     /// `bit_slice_evals` carried over from booleanity's `finalize_verifier`,
@@ -897,6 +901,7 @@ where
         let n_fq = self.all_field_cfgs.len().saturating_sub(1);
         let mut cpr_eval_points_fq: Vec<Vec<F>> = Vec::with_capacity(n_fq);
         let mut cpr_up_evals_fq: Vec<Vec<F>> = Vec::with_capacity(n_fq);
+        let mut cpr_bit_op_evals_fq: Vec<Vec<F>> = Vec::with_capacity(n_fq);
         let mut cpr_down_evals_fq: Vec<Vec<F>> = Vec::with_capacity(n_fq);
         for (prime_idx, ((cpr_proof_i, cpr_ancillary_i), md_subclaims_i)) in self
             .proof_cpr_fq
@@ -919,6 +924,7 @@ where
             )?;
             cpr_eval_points_fq.push(cpr_subclaim_i.evaluation_point);
             cpr_up_evals_fq.push(cpr_subclaim_i.up_evals);
+            cpr_bit_op_evals_fq.push(cpr_subclaim_i.bit_op_evals);
             cpr_down_evals_fq.push(cpr_subclaim_i.down_evals);
         }
 
@@ -945,9 +951,11 @@ where
             projecting_elements: self.projecting_elements,
             cpr_eval_point,
             cpr_up_evals: cpr_subclaim.up_evals,
+            cpr_bit_op_evals: cpr_subclaim.bit_op_evals,
             cpr_down_evals: cpr_subclaim.down_evals,
             cpr_eval_points_fq,
             cpr_up_evals_fq,
+            cpr_bit_op_evals_fq,
             cpr_down_evals_fq,
             bool_bit_slice_evals,
             alpha_prime_f,
@@ -1053,13 +1061,15 @@ where
 
         let mut all_families: Vec<MultipointEvalFamilyInputs<'_, F>> =
             Vec::with_capacity(add!(n_fq, 1));
+        // The verifier-side MP precheck only consumes the claimed eval vectors;
+        // bit-op MLE bodies exist on the prover side only.
         all_families.push(MultipointEvalFamilyInputs {
             field_cfg: &self.field_cfg,
             trace_mles: &[],
             bit_op_mles: &[],
             eval_point: &self.cpr_eval_point,
             up_evals: &q_up_evals,
-            bit_op_evals: &[],
+            bit_op_evals: &self.cpr_bit_op_evals,
             down_evals: &self.cpr_down_evals,
         });
 
@@ -1071,7 +1081,7 @@ where
                 bit_op_mles: &[],
                 eval_point: &self.cpr_eval_points_fq[prime_idx],
                 up_evals,
-                bit_op_evals: &[],
+                bit_op_evals: &self.cpr_bit_op_evals_fq[prime_idx],
                 down_evals: &self.cpr_down_evals_fq[prime_idx],
             });
         }
@@ -1307,7 +1317,12 @@ where
         MultipointEval::verify_subclaim(
             &self.mp_subclaim,
             &q_open_evals,
-            &[],
+            &derive_bit_op_open_evals::<F, D>(
+                self.base.uair_signature.bit_op_specs(),
+                &q_all_lifted,
+                &self.projecting_elements[0],
+                &self.field_cfg,
+            )?,
             self.base.uair_signature.shifts(),
             &self.field_cfg,
         )?;
@@ -1340,7 +1355,12 @@ where
             MultipointEval::verify_subclaim(
                 &self.mp_subclaims_fq[prime_idx],
                 &open_evals_i,
-                &[],
+                &derive_bit_op_open_evals::<F, D>(
+                    self.base.uair_signature.bit_op_specs(),
+                    &all_lifted_i,
+                    &self.projecting_elements[family_idx],
+                    cfg_i,
+                )?,
                 self.base.uair_signature.shifts(),
                 cfg_i,
             )?;
@@ -1554,6 +1574,27 @@ impl<IdealOverF: Ideal> VerifierPcsVerified<IdealOverF> {
     pub fn finish<F: PrimeField>(self) -> Result<(), ProtocolError<F>> {
         Ok(())
     }
+}
+
+fn derive_bit_op_open_evals<F: PrimeField, const D: usize>(
+    specs: &[zinc_uair::BitOpSpec],
+    all_lifted: &[DynamicPolynomialF<F>],
+    projecting_element: &F,
+    field_cfg: &F::Config,
+) -> Result<Vec<F>, ProtocolError<F>> {
+    specs
+        .iter()
+        .map(|spec| {
+            let source = &all_lifted[spec.source_col()];
+            let transformed = match spec.op() {
+                BitOp::Rot(c) => source.rotate_right::<D>(c, field_cfg),
+                BitOp::ShR(c) => source.shr::<D>(c, field_cfg),
+            };
+            transformed
+                .evaluate_at_point(projecting_element)
+                .map_err(ProtocolError::LiftedEvalProjection)
+        })
+        .collect()
 }
 
 //

--- a/protocol/src/verifier.rs
+++ b/protocol/src/verifier.rs
@@ -19,7 +19,7 @@ use zinc_transcript::{
     traits::{ConstTranscribable, Transcript},
 };
 use zinc_uair::{
-    BitOp, Uair, UairSignature, UairTrace,
+    Uair, UairSignature, UairTrace,
     constraint_counter::count_constraints,
     ideal::{Ideal, IdealCheck},
     ideal_collector::IdealOrZero,
@@ -1586,10 +1586,7 @@ fn derive_bit_op_open_evals<F: PrimeField, const D: usize>(
         .iter()
         .map(|spec| {
             let source = &all_lifted[spec.source_col()];
-            let transformed = match spec.op() {
-                BitOp::Rot(c) => source.rotate_right::<D>(c, field_cfg),
-                BitOp::ShR(c) => source.shr::<D>(c, field_cfg),
-            };
+            let transformed = spec.op().transform::<F, D>(source, field_cfg);
             transformed
                 .evaluate_at_point(projecting_element)
                 .map_err(ProtocolError::LiftedEvalProjection)

--- a/test-uair/src/lib.rs
+++ b/test-uair/src/lib.rs
@@ -1014,6 +1014,80 @@ where
     }
 }
 
+/// UAIR combining bit-op virtual columns with both Q[X] and F_q[X]
+/// constraint families.
+///
+/// The single bit-op virtual column is `ShR(w, 3)`. Both families constrain it
+/// to match the committed expected column `s`, so the full protocol must carry
+/// the virtual bit-op column through each family, not just through ideal check.
+#[derive(Clone, Debug)]
+pub struct TestUairBitOpsFqFamily<R, P>(PhantomData<(R, P)>);
+
+impl<R, P> Uair for TestUairBitOpsFqFamily<R, P>
+where
+    R: ConstSemiring + 'static,
+    P: Semiring + From<u64> + 'static,
+{
+    type Ideal = DegreeOneIdeal<R>;
+    type FqIdeal = DegreeOneIdeal<R>;
+    type Scalar = DensePolynomial<R, 32>;
+    type Prime = P;
+
+    fn signature() -> UairSignature<Self::Prime> {
+        let total = TotalColumnLayout::new(2, 0, 0);
+        UairSignature::new(total, PublicColumnLayout::default(), vec![], vec![])
+            .with_bit_op_specs(vec![BitOpSpec::new(0, BitOp::ShR(3))])
+            .with_primes(vec![P::from(MERSENNE_61_PRIME)])
+    }
+
+    fn constrain_general<B, FromR, MulByScalar, IFromR, IFqFromR>(
+        b: &mut B,
+        up: TraceRow<B::Expr>,
+        down: TraceRow<B::Expr>,
+        _from_ref: FromR,
+        _mbs: MulByScalar,
+        ideal_from_ref: IFromR,
+        fq_ideal_from_ref: IFqFromR,
+    ) where
+        B: ConstraintBuilder,
+        IFromR: Fn(&Self::Ideal) -> B::Ideal,
+        IFqFromR: Fn(&Self::FqIdeal) -> B::FqIdeal,
+    {
+        let q_ideal = ideal_from_ref(&DegreeOneIdeal::new(R::ONE));
+        let fq_ideal = fq_ideal_from_ref(&DegreeOneIdeal::new(R::ONE));
+        let bit_op_matches_expected = down.binary_poly[0].clone() - &up.binary_poly[1];
+
+        b.assert_in_ideal(bit_op_matches_expected.clone(), &q_ideal);
+        b.assert_in_fq_ideal(0, bit_op_matches_expected, &fq_ideal);
+    }
+}
+
+impl<R, P> GenerateRandomTrace<32> for TestUairBitOpsFqFamily<R, P>
+where
+    R: ConstSemiring + 'static,
+    P: Semiring + From<u64> + 'static,
+{
+    type PolyCoeff = R;
+    type Int = R;
+
+    fn generate_random_trace<Rng: RngCore + ?Sized>(
+        num_vars: usize,
+        rng: &mut Rng,
+    ) -> UairTrace<'static, R, R, 32, 32> {
+        let n = 1usize << num_vars;
+        let w_u32: Vec<u32> = (0..n).map(|_| rng.next_u32()).collect();
+        let w_col: DenseMultilinearExtension<BinaryPoly<32>> =
+            w_u32.iter().map(|w| BinaryPoly::from(*w)).collect();
+        let s_shr_col: DenseMultilinearExtension<BinaryPoly<32>> =
+            w_u32.iter().map(|w| BinaryPoly::from(w >> 3)).collect();
+
+        UairTrace {
+            binary_poly: vec![w_col, s_shr_col].into(),
+            ..Default::default()
+        }
+    }
+}
+
 /// A UAIR exercising the Flavor-1 $F_{q}[X]$-constraint surface
 /// for **multiple large primes**.
 ///
@@ -1156,6 +1230,7 @@ mod tests {
         assert_uair_shape::<BigLinearUair<u32, u64>>(&[1; 17]);
         assert_uair_shape::<TestUairMixedShifts<Int<LIMBS>, u64>>(&[1, 1]);
         assert_uair_shape::<TestUairBitOpsMixedSplice<Int<LIMBS>, u64>>(&[1, 1, 1]);
+        assert_uair_shape::<TestUairBitOpsFqFamily<Int<LIMBS>, u64>>(&[1, 1]);
         // TestUairFqLargePrime: two F_{q_i}[X] linear constraints (one per
         // declared prime).
         assert_uair_shape::<TestUairFqLargePrime<Int<LIMBS>, u64>>(&[1, 1]);

--- a/uair/src/lib.rs
+++ b/uair/src/lib.rs
@@ -9,11 +9,13 @@ pub mod ideal;
 pub mod ideal_collector;
 pub mod lookup_types;
 
-use crypto_primitives::Semiring;
+use crypto_primitives::{PrimeField, Semiring};
 use std::borrow::Cow;
 use zinc_poly::{
     mle::DenseMultilinearExtension,
-    univariate::{binary::BinaryPoly, dense::DensePolynomial},
+    univariate::{
+        binary::BinaryPoly, dense::DensePolynomial, dynamic::over_field::DynamicPolynomialF,
+    },
 };
 use zinc_utils::{UNCHECKED, add, from_ref::FromRef, mul_by_scalar::MulByScalar, sub};
 
@@ -144,6 +146,18 @@ impl BitOp {
     pub fn count(&self) -> usize {
         match self {
             BitOp::Rot(c) | BitOp::ShR(c) => *c,
+        }
+    }
+
+    /// Apply the bit operation to a projected bit-polynomial cell.
+    pub fn transform<F: PrimeField, const D: usize>(
+        &self,
+        source: &DynamicPolynomialF<F>,
+        field_cfg: &F::Config,
+    ) -> DynamicPolynomialF<F> {
+        match self {
+            BitOp::Rot(c) => source.rotate_right::<D>(*c, field_cfg),
+            BitOp::ShR(c) => source.shr::<D>(*c, field_cfg),
         }
     }
 }


### PR DESCRIPTION
This is the next atomic follow-up after #191, #192, #194, #204, and #211 for #185, which blocks #91. It closes the executable protocol path for bit-op virtual columns across both Q[X] and F_q[X] constraint families.

## What changed

- Prover: materialize bit-op virtual MLEs from committed source columns for the Q[X] family and each declared F_q[X] family, using the matching projecting element and field config per family.
- Verifier: derive bit-op open evaluations from the public UAIR signature and the corresponding source lifted openings via the rotate/shift polynomial operations, then feed those derived values into multipoint-eval verification.
- Tests: add `TestUairBitOpsFqFamily`, which constrains `ShR(w, 3)` through both Q[X] and F_q[X], plus e2e and tamper regression coverage.

## Coverage note

The e2e tamper tests in this PR are intentionally framed as end-to-end regressions:

- `test_bit_ops_fq_family_tamper_source_lifted_evals` perturbs the source lifted eval, so it changes both the committed-source opening and the verifier-derived bit-op opening.
- `test_bit_ops_fq_family_tamper_bit_op_eval` perturbs the F_q-family bit-op CPR claim; that is caught by CPR constraint reconstruction before the final multipoint-eval check.

The isolated bit-op multipoint-eval binding coverage lives in #211 (`bit_op_virtual_opening_is_bound_in_subclaim`), and the CPR-level integrity for bit-op evals lives in #204. The honest e2e here exercises the new verifier derivation path because the prover and verifier compute the bit-op virtual through different routes that must agree.

## What is intentionally deferred

This completes the bit-op virtual-column protocol chain. Affine / linear-combination virtual columns for Ch/Maj-style shapes remain a separate follow-up part of #185, and SHA-256/ECDSA UAIR adoption follows in #91.

## Validation

Bit-op / F_q regression tests covered by `cargo test -p zinc-protocol`:

- `test_e2e_bit_ops_with_fq_family`
- `test_bit_ops_fq_family_tamper_source_lifted_evals`
- `test_bit_ops_fq_family_tamper_bit_op_eval`

Commands run locally:

```text
cargo test -p zinc-protocol
.githooks/pre-push
```