### PR TITLE
Bump primitives dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,8 +54,11 @@ cast_possible_truncation = "deny"
 cast_possible_wrap = "deny"
 cast_precision_loss = "deny"
 cast_sign_loss = "deny"
+clone_on_copy = "warn"
 needless_return = "deny"
 panicking_overflow_checks = "deny"
+redundant_clone = "deny"
+unnecessary_to_owned = "deny"
 unwrap_used = "deny"
 
 [profile.release]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,14 +24,14 @@ publish = false
 
 blake3 = "1.8"
 criterion = "0.7.0"
-crypto-bigint = { version = "= 0.7.0-rc.9", features = ["zeroize"] }
-crypto-primitives = { git = "https://github.com/NethermindEth/crypto-primitives.git", rev = "aa65fab", features = ["std", "crypto_bigint", "rand"] }
+crypto-bigint = { version = "= 0.7.5", features = ["zeroize"] }
+crypto-primitives = { git = "https://github.com/NethermindEth/crypto-primitives.git", rev = "59a19d5", features = ["std", "crypto_bigint", "rand"] }
 derive_more = { version = "2.1.1", features = ["full"] }
 itertools = "0.14"
 num-traits = "0.2"
 proptest = "1.9.0"
-rand = "0.9"
-rand_core = "0.9"
+rand = "0.10"
+rand_core = "0.10"
 rayon = { version = "1.10" }
 thiserror = "2.0"
 zinc-piop = { path = "piop/" }

--- a/piop/benches/multipoint_eval.rs
+++ b/piop/benches/multipoint_eval.rs
@@ -6,7 +6,7 @@ use criterion::{BatchSize, BenchmarkId, Criterion, criterion_group, criterion_ma
 use crypto_primitives::{
     FromWithConfig, crypto_bigint_monty::MontyField, crypto_bigint_uint::Uint,
 };
-use rand::{Rng, rng};
+use rand::prelude::*;
 use zinc_piop::multipoint_eval::{MultipointEval, MultipointEvalFamilyInputs};
 
 use zinc_poly::mle::{DenseMultilinearExtension, MultilinearExtensionWithConfig};
@@ -18,7 +18,7 @@ const FIELD_LIMBS: usize = 4;
 type F = MontyField<FIELD_LIMBS>;
 
 fn bench_multipoint_eval(c: &mut Criterion, num_vars: usize, num_cols: usize) {
-    let mut rng = rng();
+    let mut rng = rand::rng();
     let n = 1usize << num_vars;
     let params = format!("nvars={}/cols={}", num_vars, num_cols);
 

--- a/piop/benches/sumcheck.rs
+++ b/piop/benches/sumcheck.rs
@@ -11,7 +11,7 @@ use crypto_primitives::{
     ConstIntSemiring, Field, FromPrimitiveWithConfig, crypto_bigint_monty::MontyField,
 };
 use num_traits::Zero;
-use rand::{Rng, rng};
+use rand::prelude::*;
 use zinc_piop::random_field_sumcheck::{RFSumcheck, RFSumcheckProof};
 use zinc_poly::{
     mle::DenseMultilinearExtension, univariate::binary::BinaryPoly, utils::build_eq_x_r_inner,
@@ -33,7 +33,7 @@ pub fn bench_simple_product<F, const LIMBS: usize>(
     MillerRabin: PrimalityTest<F::Integer>,
     for<'a> &'a F: Mul<&'a F, Output = F>,
 {
-    let mut rng = rng();
+    let mut rng = rand::rng();
     let a: Vec<u32> = (0..witness_size).map(|_| rng.random()).collect();
     let b: Vec<u32> = (0..witness_size).map(|_| rng.random()).collect();
     let c: Vec<u32> = (0..witness_size).map(|_| rng.random()).collect();

--- a/piop/src/ideal_check.rs
+++ b/piop/src/ideal_check.rs
@@ -354,7 +354,7 @@ pub enum IdealCheckError<F: PrimeField> {
     EqPolyConstructionError(#[from] PolyArithErrors),
 }
 
-#[allow(clippy::arithmetic_side_effects)]
+#[allow(clippy::arithmetic_side_effects, clippy::redundant_clone)]
 #[cfg(test)]
 mod tests {
     use crate::test_utils::{

--- a/piop/src/lookup/booleanity.rs
+++ b/piop/src/lookup/booleanity.rs
@@ -203,7 +203,7 @@ where
         let comb_fn: CombFn<F> = {
             let alpha_powers = alpha_powers.clone();
             let one = one.clone();
-            let zero = zero.clone();
+            let zero = zero;
             Box::new(move |mle_values: &[F]| {
                 let eq_r_val = &mle_values[0];
                 let sum = batched_booleanity_sum(&mle_values[1..], &alpha_powers, &zero, &one);
@@ -215,7 +215,7 @@ where
         //    `build_eq_x_r_inner` rejects empty inputs, so handle num_vars == 1
         //    explicitly by emitting the empty-product table `[1]`.
         let eq_other_table: Vec<F::Inner> = if num_vars <= 1 {
-            vec![one.clone().into_inner()]
+            vec![one.into_inner()]
         } else {
             build_eq_x_r_inner(&r[1..], field_cfg)?.evaluations
         };

--- a/piop/src/random_field_sumcheck.rs
+++ b/piop/src/random_field_sumcheck.rs
@@ -147,7 +147,7 @@ impl<F: PrimeField> From<SumCheckError<F>> for RFSumcheckError<F> {
 mod tests {
     use crypto_primitives::{Field, FromWithConfig, crypto_bigint_monty::MontyField};
     use num_traits::Zero;
-    use rand::{Rng, rng};
+    use rand::prelude::*;
     use zinc_poly::{
         mle::DenseMultilinearExtension, univariate::binary::BinaryPoly, utils::build_eq_x_r_inner,
     };
@@ -163,7 +163,7 @@ mod tests {
     #[test]
     fn test_simple_product_random_field_sumcheck() {
         let witness_size = 1 << 3;
-        let mut rng = rng();
+        let mut rng = rand::rng();
         let a: Vec<u32> = (0..witness_size).map(|_| rng.random()).collect();
         let b: Vec<u32> = (0..witness_size).map(|_| rng.random()).collect();
         let c: Vec<u32> = (0..witness_size).map(|_| rng.random()).collect();

--- a/piop/src/shift_predicate.rs
+++ b/piop/src/shift_predicate.rs
@@ -138,7 +138,7 @@ mod tests {
     use crypto_primitives::{
         Field, FromWithConfig, HasPrimeFieldConfig, crypto_bigint_monty::MontyField,
     };
-    use rand::Rng;
+    use rand::prelude::*;
     use zinc_poly::utils::{build_eq_x_r_inner, build_next_c_r_mle};
 
     type F = MontyField<4>;

--- a/piop/src/sumcheck/multi_degree.rs
+++ b/piop/src/sumcheck/multi_degree.rs
@@ -635,6 +635,13 @@ impl<F: FromPrimitiveWithConfig> MultiDegreeSumcheck<F> {
 // ---------------------------------------------------------------------------
 
 #[cfg(test)]
+#[allow(
+    clippy::arithmetic_side_effects,
+    clippy::cast_possible_truncation,
+    clippy::cast_possible_wrap,
+    clippy::cast_sign_loss,
+    clippy::redundant_clone
+)]
 mod tests {
     use super::*;
     use crypto_bigint::{U128, const_monty_params};

--- a/piop/src/sumcheck/tests.rs
+++ b/piop/src/sumcheck/tests.rs
@@ -3,7 +3,7 @@ mod utils;
 use crypto_bigint::{U128, const_monty_params};
 use crypto_primitives::{Field, crypto_bigint_const_monty::ConstMontyField};
 use num_traits::{ConstOne, ConstZero, Zero};
-use rand::RngCore;
+use rand::prelude::*;
 use zinc_poly::mle::{DenseMultilinearExtension, MultilinearExtensionWithConfig};
 use zinc_transcript::{Blake3Transcript, traits::Transcript};
 use zinc_utils::inner_transparent_field::InnerTransparentField;
@@ -19,9 +19,9 @@ const_monty_params!(Params, U128, "00000000b933426489189cb5b47d567f");
 
 type F = ConstMontyField<Params, { U128::LIMBS }>;
 
-fn generate_sumcheck_proof<Rn: RngCore>(
+fn generate_sumcheck_proof(
     num_vars: usize,
-    mut rng: &mut Rn,
+    mut rng: &mut impl Rng,
 ) -> (usize, SumcheckProof<F>) {
     let mut transcript = Blake3Transcript::default();
 

--- a/piop/src/sumcheck/tests.rs
+++ b/piop/src/sumcheck/tests.rs
@@ -19,10 +19,7 @@ const_monty_params!(Params, U128, "00000000b933426489189cb5b47d567f");
 
 type F = ConstMontyField<Params, { U128::LIMBS }>;
 
-fn generate_sumcheck_proof(
-    num_vars: usize,
-    mut rng: &mut impl Rng,
-) -> (usize, SumcheckProof<F>) {
+fn generate_sumcheck_proof(num_vars: usize, mut rng: &mut impl Rng) -> (usize, SumcheckProof<F>) {
     let mut transcript = Blake3Transcript::default();
 
     let ((poly_mles, poly_degree), products, _) =

--- a/piop/src/sumcheck/tests/utils.rs
+++ b/piop/src/sumcheck/tests/utils.rs
@@ -3,15 +3,15 @@ use std::ops::Range;
 use crypto_bigint::Random;
 use crypto_primitives::PrimeField;
 use itertools::Itertools;
-use rand::{Rng, RngCore};
+use rand::prelude::*;
 use zinc_poly::{mle::DenseMultilinearExtension, utils::ArithErrors};
 
 #[allow(clippy::arithmetic_side_effects, clippy::type_complexity)]
-pub(crate) fn rand_poly<F: PrimeField + Random, Rn: RngCore>(
+pub(crate) fn rand_poly<F: PrimeField + Random, G: Rng>(
     nv: usize,
     num_multiplicands_range: Range<usize>,
     num_products: usize,
-    rng: &mut Rn,
+    rng: &mut G,
     config: &F::Config,
 ) -> Result<
     (
@@ -31,7 +31,7 @@ pub(crate) fn rand_poly<F: PrimeField + Random, Rn: RngCore>(
         degree = num_multiplicands.max(degree);
         let (product, product_sum) = random_mle_list(nv, num_multiplicands, rng, config.clone());
 
-        let coefficient = F::try_random(rng).expect("sampling coefficient failed");
+        let coefficient = F::try_random_from_rng(rng).expect("sampling coefficient failed");
         mles.extend(product);
         sum += &(product_sum * &coefficient);
 
@@ -81,10 +81,10 @@ pub fn rand_poly_comb_fn<F: PrimeField>(
 /// Returns
 /// - the list of polynomials,
 /// - its sum of polynomial evaluations over the boolean hypercube.
-pub fn random_mle_list<F: PrimeField + Random, Rn: RngCore>(
+pub fn random_mle_list<F: PrimeField + Random, G: Rng>(
     nv: usize,
     degree: usize,
-    rng: &mut Rn,
+    rng: &mut G,
     config: F::Config,
 ) -> (Vec<DenseMultilinearExtension<F>>, F) {
     let mut multiplicands = (0..degree)
@@ -96,7 +96,7 @@ pub fn random_mle_list<F: PrimeField + Random, Rn: RngCore>(
         let mut product = F::one_with_cfg(&config);
 
         for e in multiplicands.iter_mut() {
-            let val = F::try_random(rng).expect("sampling random value failed");
+            let val = F::try_random_from_rng(rng).expect("sampling random value failed");
             e.push(val.clone());
             product *= &val;
         }

--- a/piop/src/test_utils.rs
+++ b/piop/src/test_utils.rs
@@ -7,7 +7,7 @@ use crate::{
         project_trace_coeffs_column_major, project_trace_coeffs_row_major,
     },
 };
-use crypto_bigint::{Odd, modular::MontyParams};
+use crypto_bigint::{Odd, modular::FixedMontyParams};
 use crypto_primitives::{FromWithConfig, crypto_bigint_int::Int, crypto_bigint_monty::MontyField};
 use zinc_poly::univariate::{dense::DensePolynomial, dynamic::over_field::DynamicPolynomialF};
 use zinc_test_uair::GenerateRandomTrace;
@@ -16,12 +16,12 @@ use zinc_uair::{Uair, UairTrace, constraint_counter::count_constraints};
 
 pub const LIMBS: usize = 4;
 
-pub fn test_config() -> MontyParams<LIMBS> {
+pub fn test_config() -> FixedMontyParams<LIMBS> {
     let modulus = crypto_bigint::Uint::<LIMBS>::from_be_hex(
         "0000000000000000000000000000000000860995AE68FC80E1B1BD1E39D54B33",
     );
     let modulus = Odd::new(modulus).expect("modulus should be odd");
-    MontyParams::new(modulus)
+    FixedMontyParams::new(modulus)
 }
 
 type F = MontyField<4>;

--- a/poly/benches/mle_evaluation.rs
+++ b/poly/benches/mle_evaluation.rs
@@ -6,30 +6,30 @@ use std::hint::black_box;
 use criterion::{
     AxisScale, BenchmarkId, Criterion, PlotConfiguration, criterion_group, criterion_main,
 };
-use crypto_bigint::{Odd, modular::MontyParams};
+use crypto_bigint::{Odd, modular::FixedMontyParams};
 use crypto_primitives::{FromWithConfig, PrimeField, crypto_bigint_monty::F256};
 use itertools::Itertools;
 use num_traits::ConstZero;
-use rand::{Rng, rng};
+use rand::prelude::*;
 use zinc_poly::mle::{DenseMultilinearExtension, MultilinearExtensionWithConfig};
 
 const LIMBS: usize = 4;
 
 type F = F256;
 
-fn bench_config() -> MontyParams<LIMBS> {
+fn bench_config() -> FixedMontyParams<LIMBS> {
     let modulus = crypto_bigint::Uint::<LIMBS>::from_be_hex(
         "0000000000000000000000000000000000860995AE68FC80E1B1BD1E39D54B33",
     );
     let modulus = Odd::new(modulus).expect("modulus should be odd");
-    MontyParams::new(modulus)
+    FixedMontyParams::new(modulus)
 }
 
 #[allow(clippy::arithmetic_side_effects)]
 fn bench_dense_mle_evaluation(
     group: &mut criterion::BenchmarkGroup<criterion::measurement::WallTime>,
 ) {
-    let mut rng = rng();
+    let mut rng = rand::rng();
     for i in 0..20 {
         let v = DenseMultilinearExtension::from_evaluations_vec(
             i,

--- a/poly/benches/nat_evaluation.rs
+++ b/poly/benches/nat_evaluation.rs
@@ -6,7 +6,7 @@ use std::hint::black_box;
 use criterion::{
     AxisScale, BenchmarkId, Criterion, PlotConfiguration, criterion_group, criterion_main,
 };
-use crypto_bigint::{Odd, modular::MontyParams};
+use crypto_bigint::{Odd, modular::FixedMontyParams};
 use crypto_primitives::{FromWithConfig, crypto_bigint_monty::F256};
 use itertools::Itertools;
 use zinc_poly::{EvaluatablePolynomial, univariate::nat_evaluation::NatEvaluatedPoly};
@@ -15,12 +15,12 @@ const LIMBS: usize = 4;
 
 type F = F256;
 
-fn bench_config() -> MontyParams<LIMBS> {
+fn bench_config() -> FixedMontyParams<LIMBS> {
     let modulus = crypto_bigint::Uint::<LIMBS>::from_be_hex(
         "0000000000000000000000000000000000860995AE68FC80E1B1BD1E39D54B33",
     );
     let modulus = Odd::new(modulus).expect("modulus should be odd");
-    MontyParams::new(modulus)
+    FixedMontyParams::new(modulus)
 }
 
 #[allow(clippy::arithmetic_side_effects)]

--- a/poly/src/mle.rs
+++ b/poly/src/mle.rs
@@ -65,5 +65,5 @@ pub trait MultilinearExtensionWithConfig<F: PrimeField> {
 pub trait MultilinearExtensionRand<T> {
     /// Outputs an `l`-variate multilinear extension where value of evaluations
     /// are sampled uniformly at random.
-    fn rand<R: RngCore + ?Sized>(num_vars: usize, rng: &mut R) -> Self;
+    fn rand<R: Rng + ?Sized>(num_vars: usize, rng: &mut R) -> Self;
 }

--- a/poly/src/mle/dense.rs
+++ b/poly/src/mle/dense.rs
@@ -15,7 +15,6 @@ use crate::{
 };
 use crypto_primitives::{HasPrimeFieldConfig, Matrix, PrimeField, Ring, Semiring};
 use rand::{distr::StandardUniform, prelude::*};
-use rand_core::RngCore;
 use zinc_utils::{
     CHECKED, add, cfg_into_iter, inner_transparent_field::InnerTransparentField,
     mul_by_scalar::MulByScalar, projectable_to_field::ProjectableToField, sub,
@@ -365,7 +364,7 @@ where
     R: Send + Clone + Default,
     StandardUniform: Distribution<R>,
 {
-    fn rand<Rng: RngCore + ?Sized>(num_vars: usize, rng: &mut Rng) -> Self {
+    fn rand<G: Rng + ?Sized>(num_vars: usize, rng: &mut G) -> Self {
         (0..1 << num_vars).map(|_| rng.random::<R>()).collect()
     }
 }

--- a/poly/src/mle/dense.rs
+++ b/poly/src/mle/dense.rs
@@ -511,7 +511,8 @@ where
     clippy::arithmetic_side_effects,
     clippy::cast_possible_truncation,
     clippy::cast_possible_wrap,
-    clippy::cast_sign_loss
+    clippy::cast_sign_loss,
+    clippy::redundant_clone
 )]
 mod tests {
     use super::*;

--- a/poly/src/univariate/dynamic/over_field.rs
+++ b/poly/src/univariate/dynamic/over_field.rs
@@ -563,22 +563,22 @@ where
 #[cfg(test)]
 #[allow(clippy::arithmetic_side_effects)]
 mod tests {
-    use crypto_bigint::{Odd, modular::MontyParams};
+    use crypto_bigint::{Odd, modular::FixedMontyParams};
     use crypto_primitives::{FromWithConfig, crypto_bigint_monty::F256};
     use proptest::prelude::*;
-    use rand::Rng;
+    use rand::prelude::*;
 
     use super::*;
 
     const LIMBS: usize = 4;
     type F = F256;
 
-    fn test_config() -> MontyParams<LIMBS> {
+    fn test_config() -> FixedMontyParams<LIMBS> {
         let modulus = crypto_bigint::Uint::<LIMBS>::from_be_hex(
             "0000000000000000000000000000000000860995AE68FC80E1B1BD1E39D54B33",
         );
         let modulus = Odd::new(modulus).expect("modulus should be odd");
-        MontyParams::new(modulus)
+        FixedMontyParams::new(modulus)
     }
 
     #[test]

--- a/poly/src/univariate/dynamic/over_field.rs
+++ b/poly/src/univariate/dynamic/over_field.rs
@@ -370,7 +370,7 @@ impl<F: PrimeField> Euclid for DynamicPolynomialF<F> {
         let zero = F::zero_with_cfg(cfg);
 
         if dividend_deg < divisor_deg {
-            return (zero_poly.clone(), self.clone());
+            return (zero_poly, self.clone());
         }
 
         // Copy dividend as working remainder
@@ -712,7 +712,7 @@ mod tests {
         z -= y.clone();
         assert_eq!(z, res);
 
-        let mut z = x.clone();
+        let mut z = x;
         z -= &y;
         assert_eq!(z, res);
 
@@ -741,7 +741,7 @@ mod tests {
         z -= y.clone();
         assert_eq!(z, res);
 
-        let mut z = x.clone();
+        let mut z = x;
         z -= &y;
         assert_eq!(z, res);
     }
@@ -773,7 +773,7 @@ mod tests {
         );
         assert_eq!(DynamicPolynomialF::ZERO * &x, DynamicPolynomialF::ZERO);
 
-        let mut y = x.clone();
+        let mut y = x;
 
         y *= DynamicPolynomialF::ZERO;
 
@@ -1050,7 +1050,7 @@ mod tests {
             let product = &quotient * &divisor;
             let reconstructed = product + &remainder;
 
-            let mut dividend_trimmed = dividend.clone();
+            let mut dividend_trimmed = dividend;
             let mut reconstructed_trimmed = reconstructed;
             dividend_trimmed.trim();
             reconstructed_trimmed.trim();
@@ -1072,7 +1072,7 @@ mod tests {
             remainder_trimmed.trim();
             quotient_trimmed.trim();
 
-            let mut q_trimmed = q.clone();
+            let mut q_trimmed = q;
             q_trimmed.trim();
 
             prop_assert_eq!(remainder_trimmed, DynamicPolynomialF::ZERO);

--- a/poly/src/univariate/dynamic/over_fixed_semiring.rs
+++ b/poly/src/univariate/dynamic/over_fixed_semiring.rs
@@ -460,7 +460,7 @@ mod tests {
         z -= y.clone();
         assert_eq!(z, res);
 
-        let mut z = x.clone();
+        let mut z = x;
         z -= &y;
         assert_eq!(z, res);
 
@@ -489,7 +489,7 @@ mod tests {
         z -= y.clone();
         assert_eq!(z, res);
 
-        let mut z = x.clone();
+        let mut z = x;
         z -= &y;
         assert_eq!(z, res);
     }
@@ -519,7 +519,7 @@ mod tests {
         );
         assert_eq!(DynamicPolynomialFS::ZERO * &x, DynamicPolynomialFS::ZERO);
 
-        let mut y = x.clone();
+        let mut y = x;
 
         y *= DynamicPolynomialFS::ZERO;
 

--- a/poly/src/univariate/nat_evaluation.rs
+++ b/poly/src/univariate/nat_evaluation.rs
@@ -183,7 +183,7 @@ where
 
 #[cfg(test)]
 mod tests {
-    use crypto_bigint::{Odd, modular::MontyParams};
+    use crypto_bigint::{Odd, modular::FixedMontyParams};
     use crypto_primitives::{FromWithConfig, crypto_bigint_monty::F256};
     use itertools::Itertools;
 
@@ -192,12 +192,12 @@ mod tests {
     const LIMBS: usize = 4;
     type F = F256;
 
-    fn test_config() -> MontyParams<LIMBS> {
+    fn test_config() -> FixedMontyParams<LIMBS> {
         let modulus = crypto_bigint::Uint::<LIMBS>::from_be_hex(
             "0000000000000000000000000000000000860995AE68FC80E1B1BD1E39D54B33",
         );
         let modulus = Odd::new(modulus).expect("modulus should be odd");
-        MontyParams::new(modulus)
+        FixedMontyParams::new(modulus)
     }
 
     #[test]

--- a/primality/Cargo.toml
+++ b/primality/Cargo.toml
@@ -11,7 +11,7 @@ bench = false
 
 [dependencies]
 crypto-bigint = { workspace = true }
-crypto-primes = { version = "= 0.7.0-pre.3" }
+crypto-primes = { version = "0.7" }
 crypto-primitives = { workspace = true }
 
 [lints]

--- a/protocol/src/fold.rs
+++ b/protocol/src/fold.rs
@@ -253,7 +253,7 @@ fn mle_eval_msb_first<F: PrimeField>(values: Vec<F>, gammas: &[F], one: &F) -> F
 #[cfg(test)]
 mod tests {
     use super::*;
-    use rand::{Rng, rng};
+    use rand::prelude::*;
     use zinc_transcript::traits::GenTranscribable;
 
     /// Build two MLEs (`BinaryRefPoly<D>` and `BinaryU64Poly<D>`) carrying the
@@ -337,7 +337,7 @@ mod tests {
         }
 
         // 4-entry input: enumerate all 16^4 = 65536 patterns is too much; sample.
-        let mut rng = rng();
+        let mut rng = rand::rng();
         for _ in 0..32 {
             let bits_list: Vec<u64> = (0..4).map(|_| rng.random::<u64>() & 0xF).collect();
             assert_split_matches::<4, 2>(bits_list);
@@ -346,7 +346,7 @@ mod tests {
 
     #[test]
     fn split_ref_and_u64_match_random() {
-        let mut rng = rng();
+        let mut rng = rand::rng();
 
         for n_log in 0..=3 {
             let n = 1usize << n_log;

--- a/test-uair/src/generate_trace.rs
+++ b/test-uair/src/generate_trace.rs
@@ -1,4 +1,4 @@
-use rand::RngCore;
+use rand::Rng;
 use zinc_uair::{Uair, UairTrace};
 
 /// A trait for UAIRs for generating random trace (for both public and witness
@@ -8,8 +8,8 @@ pub trait GenerateRandomTrace<const DEGREE_PLUS_ONE: usize>: Uair {
     type Int: Clone;
 
     #[allow(clippy::type_complexity)]
-    fn generate_random_trace<Rng: RngCore + ?Sized>(
+    fn generate_random_trace<G: Rng + ?Sized>(
         num_vars: usize,
-        rng: &mut Rng,
+        rng: &mut G,
     ) -> UairTrace<'static, Self::PolyCoeff, Self::Int, DEGREE_PLUS_ONE, DEGREE_PLUS_ONE>;
 }

--- a/test-uair/src/lib.rs
+++ b/test-uair/src/lib.rs
@@ -73,9 +73,9 @@ where
     type PolyCoeff = R;
     type Int = R;
 
-    fn generate_random_trace<Rng: RngCore + ?Sized>(
+    fn generate_random_trace<G: Rng + ?Sized>(
         num_vars: usize,
-        rng: &mut Rng,
+        rng: &mut G,
     ) -> UairTrace<'static, R, R, 32, 32> {
         let mut a: Vec<DynamicPolynomialFS<R>> =
             vec![DynamicPolynomialFS::new(vec![R::from(rng.random::<i8>())])];
@@ -185,9 +185,9 @@ where
     type PolyCoeff = R;
     type Int = R;
 
-    fn generate_random_trace<Rng: rand::RngCore + ?Sized>(
+    fn generate_random_trace<G: Rng + ?Sized>(
         num_vars: usize,
-        rng: &mut Rng,
+        rng: &mut G,
     ) -> UairTrace<'static, R, R, 32, 32> {
         let a: DenseMultilinearExtension<DensePolynomial<R, 32>> =
             DenseMultilinearExtension::rand(num_vars, rng)
@@ -320,9 +320,9 @@ where
     type PolyCoeff = R;
     type Int = R;
 
-    fn generate_random_trace<Rng: rand::RngCore + ?Sized>(
+    fn generate_random_trace<G: Rng + ?Sized>(
         num_vars: usize,
-        rng: &mut Rng,
+        rng: &mut G,
     ) -> UairTrace<'static, R, R, 32, 32> {
         let int_col_u32: DenseMultilinearExtension<u32> =
             DenseMultilinearExtension::rand(num_vars, rng);
@@ -412,14 +412,14 @@ where
     type PolyCoeff = R;
     type Int = R;
 
-    fn generate_random_trace<Rng: rand::RngCore + ?Sized>(
+    fn generate_random_trace<G: Rng + ?Sized>(
         num_vars: usize,
-        rng: &mut Rng,
+        rng: &mut G,
     ) -> UairTrace<'static, R, R, 32, 32> {
         /// Generate a random binary polynomial with the given number of 1-bits.
         fn random_binary_poly_with_popcount(
             popcount: u32,
-            rng: &mut (impl rand::RngCore + ?Sized),
+            rng: &mut (impl rand::Rng + ?Sized),
         ) -> BinaryPoly<32> {
             let mut positions: [u8; 32] =
                 core::array::from_fn(|i| u8::try_from(i).expect("can't fail"));
@@ -533,9 +533,9 @@ where
     type PolyCoeff = <BigLinearUair<R, P> as GenerateRandomTrace<32>>::PolyCoeff;
     type Int = <BigLinearUair<R, P> as GenerateRandomTrace<32>>::Int;
 
-    fn generate_random_trace<Rng: RngCore + ?Sized>(
+    fn generate_random_trace<G: Rng + ?Sized>(
         num_vars: usize,
-        rng: &mut Rng,
+        rng: &mut G,
     ) -> UairTrace<'static, Self::PolyCoeff, Self::Int, 32, 32> {
         BigLinearUair::<R, P>::generate_random_trace(num_vars, rng)
     }
@@ -655,14 +655,14 @@ where
     type Int = R;
 
     #[allow(clippy::needless_range_loop)]
-    fn generate_random_trace<Rng: rand::RngCore + ?Sized>(
+    fn generate_random_trace<G: Rng + ?Sized>(
         num_vars: usize,
-        rng: &mut Rng,
+        rng: &mut G,
     ) -> UairTrace<'static, R, R, 32, 32> {
         /// Generate a random binary polynomial with the given number of 1-bits.
         fn random_binary_poly_with_popcount(
             popcount: u32,
-            rng: &mut (impl rand::RngCore + ?Sized),
+            rng: &mut (impl rand::Rng + ?Sized),
         ) -> BinaryPoly<32> {
             let mut positions: [u8; 32] =
                 core::array::from_fn(|i| u8::try_from(i).expect("can't fail"));
@@ -865,9 +865,9 @@ where
     type Int = R;
 
     // Witness: random b, derive a from a[i+1] = a[i] + b[i], set c[i] = b[i+2].
-    fn generate_random_trace<Rng: rand::RngCore + ?Sized>(
+    fn generate_random_trace<G: Rng + ?Sized>(
         num_vars: usize,
-        rng: &mut Rng,
+        rng: &mut G,
     ) -> UairTrace<'static, R, R, 32, 32> {
         let n = 1 << num_vars;
 
@@ -968,9 +968,9 @@ where
     type PolyCoeff = R;
     type Int = R;
 
-    fn generate_random_trace<Rng: RngCore + ?Sized>(
+    fn generate_random_trace<G: Rng + ?Sized>(
         num_vars: usize,
-        rng: &mut Rng,
+        rng: &mut G,
     ) -> UairTrace<'static, R, R, 32, 32> {
         let n = 1usize << num_vars;
 
@@ -1070,9 +1070,9 @@ where
     type PolyCoeff = R;
     type Int = R;
 
-    fn generate_random_trace<Rng: RngCore + ?Sized>(
+    fn generate_random_trace<G: Rng + ?Sized>(
         num_vars: usize,
-        rng: &mut Rng,
+        rng: &mut G,
     ) -> UairTrace<'static, R, R, 32, 32> {
         let n = 1usize << num_vars;
         let w_u32: Vec<u32> = (0..n).map(|_| rng.next_u32()).collect();
@@ -1173,9 +1173,9 @@ where
     type PolyCoeff = R;
     type Int = R;
 
-    fn generate_random_trace<Rng: rand::RngCore + ?Sized>(
+    fn generate_random_trace<G: Rng + ?Sized>(
         num_vars: usize,
-        rng: &mut Rng,
+        rng: &mut G,
     ) -> UairTrace<'static, R, R, 32, 32> {
         // Build the witness column: random polynomials whose constant term
         // is forced to zero (so `phi_q(a)(0) = 0` regardless of `q`).

--- a/zip-plus/benches/zip_common.rs
+++ b/zip-plus/benches/zip_common.rs
@@ -174,7 +174,7 @@ where
     let leaves = (0..num_leaves)
         .map(|_| rng.random::<<Zt as ZipTypes>::Cw>())
         .collect_vec();
-    let matrix: DenseRowMatrix<_> = vec![leaves.clone()].into();
+    let matrix: DenseRowMatrix<_> = vec![leaves].into();
     let rows = matrix.to_rows_slices();
 
     group.bench_function(
@@ -281,7 +281,7 @@ pub fn prove<
         let mut t = transcript.clone();
         do_prove!(&mut t);
         CombinedProof {
-            comm: commitment.clone(),
+            comm: commitment,
             proof_transcript: t.stream.into_inner(),
         }
     };

--- a/zip-plus/src/merkle.rs
+++ b/zip-plus/src/merkle.rs
@@ -438,16 +438,15 @@ mod tests {
     use super::*;
     use crypto_bigint::Random;
     use crypto_primitives::crypto_bigint_int::Int;
-    use rand::rng;
 
     #[test]
     #[cfg_attr(miri, ignore)] // long running
     fn test_merkle_proof() {
         const N: usize = 3;
         let leaves_len = 1024;
-        let mut rng = rng();
+        let mut rng = rand::rng();
         let leaves_data = (0..leaves_len)
-            .map(|_| Int::random(&mut rng))
+            .map(|_| Int::random_from_rng(&mut rng))
             .collect::<Vec<Int<N>>>();
 
         let merkle_tree = MerkleTree::new(&[leaves_data.as_slice()]);

--- a/zip-plus/src/pcs/phase_commit.rs
+++ b/zip-plus/src/pcs/phase_commit.rs
@@ -199,7 +199,7 @@ mod tests {
     };
     use itertools::Itertools;
     use num_traits::Zero;
-    use rand::{Rng, rng};
+    use rand::prelude::*;
     use std::sync::LazyLock;
     use zinc_poly::{mle::DenseMultilinearExtension, univariate::binary::BinaryPoly};
     use zinc_utils::CHECKED;
@@ -785,7 +785,7 @@ mod tests {
 
         type F = MontyField<K>;
 
-        let mut rng = rng();
+        let mut rng = rand::rng();
         let num_vars = 10;
         let poly_size: usize = 1 << num_vars;
         let param = TestZip::setup(poly_size, C.clone());
@@ -795,7 +795,7 @@ mod tests {
         let mle =
             DenseMultilinearExtension::from_evaluations_slice(num_vars, &evaluations, Zero::zero());
         let point: Vec<_> = (0..num_vars)
-            .map(|_| <Zt as ZipTypes>::Pt::random(&mut rng))
+            .map(|_| <Zt as ZipTypes>::Pt::random_from_rng(&mut rng))
             .collect();
 
         let (hint, comm) = TestZip::commit_single(&param, &mle).unwrap();

--- a/zip-plus/src/pcs/phase_prove.rs
+++ b/zip-plus/src/pcs/phase_prove.rs
@@ -193,7 +193,7 @@ impl<Zt: ZipTypes, Lc: LinearCode<Zt>> ZipPlus<Zt, Lc> {
         transcript.write_field_elements(&b)?;
         // Compute eval = <q_0, b> (inner product in field), <q_2, b> in paper
         // It is safe to use inner_product_unchecked because we're in a field.
-        let eval = MBSInnerProduct::inner_product::<UNCHECKED>(&q_0, &b, zero_f.clone())?;
+        let eval = MBSInnerProduct::inner_product::<UNCHECKED>(&q_0, &b, zero_f)?;
 
         // Matrix-vector product over the flat poly_comb_r layout:
         // Each poly is a row-major (num_rows x row_len) matrix, and coeffs is the

--- a/zip-plus/src/pcs/phase_verify.rs
+++ b/zip-plus/src/pcs/phase_verify.rs
@@ -195,7 +195,7 @@ impl<Zt: ZipTypes, Lc: LinearCode<Zt>> ZipPlus<Zt, Lc> {
         // MontyField's FromWithConfig does this; BoxedMontyField's does not and will
         // panic.
         let lhs = MBSInnerProduct::inner_product_field(&combined_row, &q_1, zero_f.clone())?;
-        let rhs = MBSInnerProduct::inner_product_field(&coeffs, &b, zero_f.clone())?;
+        let rhs = MBSInnerProduct::inner_product_field(&coeffs, &b, zero_f)?;
 
         if lhs != rhs {
             return Err(ZipError::InvalidPcsOpen("Coherence failure".into()));


### PR DESCRIPTION
* Bump `crypto-primitives`, `rand` and `crypto-bigint` dependencies
* Disallow Clippy `redundant_clone` and `unnecessary_to_owned`; warn on `clone_on_copy`

Updated relevant code.