### PR TITLE
Bind unshifted affine virtuals to source columns

### DIFF
--- a/piop/src/lookup/booleanity.rs
+++ b/piop/src/lookup/booleanity.rs
@@ -66,6 +66,15 @@
 //! By Schwartz–Zippel on the indeterminate $X$, if `bit_slice_evals` are
 //! not the true bit-decomposition then equality fails with probability
 //! $\le (D-1)/|F|$, so the verifier rejects.
+//!
+//! For an unshifted affine virtual, the protocol collapses its bit-slice
+//! claims at the same $\alpha'$ and compares the result directly with the
+//! declared affine combination of source-column collapses at $r^\star$.
+//! Public source collapses are recomputed from the public trace; witness source
+//! collapses are the committed-column values bound through the MP/PCS chain
+//! above. Shifted affine terms require a separate row-shift opening and are
+//! rejected when affine specs are attached to the UAIR signature until that
+//! binding is implemented.
 
 use crate::{
     CombFn,
@@ -114,7 +123,7 @@ type BooleanityZerocheckSetup<F> = (Vec<F>, Vec<F>, CombFn<F>);
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct BooleanityProof<F> {
     /// Flat list of `\widetilde{v_{j,i}}(r*)`, ordered `(j-major, i-minor)`.
-    /// Length = `num_wit_bin_cols * D`.
+    /// Length is `num_cols * D` for the corresponding Booleanity group.
     pub bit_slice_evals: Vec<F>,
 }
 

--- a/protocol/src/lib.rs
+++ b/protocol/src/lib.rs
@@ -11,13 +11,16 @@
 //! After the three compiler steps, the protocol continues with:
 //!
 //! - Combined CPR + Booleanity + Lookup multi-degree sumcheck (CPR group at
-//!   degree `max_deg+2`; optional booleanity group at degree 3 when the UAIR
-//!   has witness binary-poly columns; one lookup group per table type; shared
-//!   eval point `r*`)
+//!   degree `max_deg+2`; optional degree-3 booleanity groups for committed
+//!   witness binary columns and affine virtual targets; one lookup group per
+//!   table type; shared eval point `r*`)
 //! - $\alpha'$ bridge: squeeze a fresh challenge $\alpha'$ after the booleanity
 //!   `bit_slice_evals` are absorbed, and append one extra $\alpha'$-projected
 //!   MLE + up-eval to the multipoint-eval inputs per witness binary-poly column
 //!   (see `BooleanityChecker`)
+//! - Affine virtual bridge: collapse each unshifted virtual at the same
+//!   `alpha'` and compare it directly with the affine combination of its
+//!   public/committed source projections at `r*`
 //! - Multi-point evaluation sumcheck (combines up/down evals at `r*` into a
 //!   single evaluation point `r_0`)
 //! - Lift-and-project (unprojected MLE evaluations at `r_0`)
@@ -130,6 +133,9 @@ pub struct Proof<F> {
     /// has no witness binary-poly columns (the argument is omitted from
     /// the multi-degree sumcheck in that case).
     pub booleanity_proof: Option<BooleanityProof<F>>,
+    /// Affine-virtual booleanity argument proof. `None` when the UAIR has no
+    /// affine virtual specs.
+    pub affine_booleanity_proof: Option<BooleanityProof<F>>,
     /// Per-prime $F_{q_i}[X]$ ideal-check proofs, one per declared
     /// prime in [`zinc_uair::UairSignature::primes`], in the same order.
     /// Empty for UAIRs with $Q[X]$-only constraints.
@@ -159,6 +165,43 @@ pub struct Proof<F> {
     /// If no $F_q[X]$ constraints are present, this will be `None` to indicate
     /// $q'' := q_0$ and this is identical to `witness_lifted_evals`.
     pub witness_lifted_evals_pp: Option<Vec<DynamicPolynomial<F>>>,
+}
+
+fn read_optional_booleanity_proof<F>(bytes: &[u8]) -> (Option<BooleanityProof<F>>, &[u8])
+where
+    F: ConstTranscribable,
+{
+    let (presence, bytes) = u32::read_transcription_bytes_subset(bytes);
+    if presence == 0 {
+        (None, bytes)
+    } else {
+        let (proof, bytes) = BooleanityProof::read_transcription_bytes_subset(bytes);
+        (Some(proof), bytes)
+    }
+}
+
+fn write_optional_booleanity_proof<'a, F>(
+    proof: &Option<BooleanityProof<F>>,
+    mut buf: &'a mut [u8],
+) -> &'a mut [u8]
+where
+    F: ConstTranscribable,
+{
+    buf = u32::from(proof.is_some()).write_transcription_bytes_subset(buf);
+    if let Some(proof) = proof {
+        buf = proof.write_transcription_bytes_subset(buf);
+    }
+    buf
+}
+
+#[allow(clippy::arithmetic_side_effects)]
+fn optional_booleanity_proof_num_bytes<F>(proof: &Option<BooleanityProof<F>>) -> usize
+where
+    F: ConstTranscribable,
+{
+    proof.as_ref().map_or(0, |proof| {
+        BooleanityProof::<F>::LENGTH_NUM_BYTES + proof.get_num_bytes()
+    })
 }
 
 impl<F> GenTranscribable for Proof<F>
@@ -195,15 +238,8 @@ where
             bytes = rest;
         }
 
-        // booleanity_proof: presence flag (u32: 0 = absent, 1 = present)
-        // followed by the proof body (length-prefixed) when present.
-        let (presence, bytes) = u32::read_transcription_bytes_subset(bytes);
-        let (booleanity_proof, bytes) = if presence != 0 {
-            let (p, rest) = BooleanityProof::<F>::read_transcription_bytes_subset(bytes);
-            (Some(p), rest)
-        } else {
-            (None, bytes)
-        };
+        let (booleanity_proof, bytes) = read_optional_booleanity_proof(bytes);
+        let (affine_booleanity_proof, bytes) = read_optional_booleanity_proof(bytes);
 
         // ideal_checks_fq: u32 count, then that many length-prefixed
         // IdealCheckProof entries (one per declared prime).
@@ -273,6 +309,7 @@ where
             witness_lifted_evals,
             lookup_proof: None,
             booleanity_proof,
+            affine_booleanity_proof,
             ideal_checks_fq,
             cpr_proofs_fq,
             combined_sumchecks_fq,
@@ -316,13 +353,8 @@ where
             buf = DynamicPolyVec::reinterpret(wlf).write_transcription_bytes_subset(buf);
         }
 
-        // booleanity_proof: u32 presence flag, then (optionally) the body
-        // with its own length prefix.
-        let presence = u32::from(self.booleanity_proof.is_some());
-        buf = presence.write_transcription_bytes_subset(buf);
-        if let Some(ref bp) = self.booleanity_proof {
-            buf = bp.write_transcription_bytes_subset(buf);
-        }
+        buf = write_optional_booleanity_proof(&self.booleanity_proof, buf);
+        buf = write_optional_booleanity_proof(&self.affine_booleanity_proof, buf);
 
         // ideal_checks_fq: u32 count + that many length-prefixed entries.
         let n_fq = u32::try_from(self.ideal_checks_fq.len())
@@ -376,10 +408,9 @@ where
 {
     #[allow(clippy::arithmetic_side_effects)]
     fn get_num_bytes(&self) -> usize {
-        let booleanity_bytes = match &self.booleanity_proof {
-            Some(bp) => BooleanityProof::<F>::LENGTH_NUM_BYTES + bp.get_num_bytes(),
-            None => 0,
-        };
+        let booleanity_bytes = optional_booleanity_proof_num_bytes(&self.booleanity_proof);
+        let affine_booleanity_bytes =
+            optional_booleanity_proof_num_bytes(&self.affine_booleanity_proof);
         let ideal_checks_fq_bytes: usize = self
             .ideal_checks_fq
             .iter()
@@ -432,9 +463,12 @@ where
             // witness_lifted_evals: count + sum of (length-prefix + body) per family
             + u32::NUM_BYTES
             + witness_lifted_evals_bytes
-            // booleanity presence flag + optional payload
+            // committed-column booleanity presence flag + optional payload
             + u32::NUM_BYTES
             + booleanity_bytes
+            // affine-virtual booleanity presence flag + optional payload
+            + u32::NUM_BYTES
+            + affine_booleanity_bytes
             // ideal_checks_fq: count + sum of (length-prefix + body) per entry
             + u32::NUM_BYTES
             + ideal_checks_fq_bytes
@@ -569,6 +603,16 @@ pub enum ProtocolError<F: SetElement> {
     Booleanity(#[from] BooleanityError<F>),
     #[error("booleanity proof missing from proof object")]
     BooleanityProofMissing,
+    #[error("affine virtual source projection failed: {0}")]
+    AffineVirtualSourceProjection(PolyEvaluationError),
+    #[error(
+        "affine virtual bridge mismatch at spec {spec_index}: got {got:?}, expected {expected:?}"
+    )]
+    AffineVirtualBridgeMismatch {
+        spec_index: usize,
+        got: F,
+        expected: F,
+    },
     #[error("non-canonical proof element: lifted integer >= family modulus")]
     NonCanonicalElement,
     #[error("proof family count mismatch: got {got}, expected {expected}")]
@@ -708,28 +752,25 @@ fn compute_lifted_evals<C: BaseFieldConfig, const D: usize>(
     result
 }
 
-/// Compute the $\alpha'$ Schwartz-Zippel bridge scalars for the witness
-/// binary-poly columns:
+/// Collapse column-major bit-slice evaluations at $\alpha'$:
 ///
 /// $$
 ///   c_j \;=\; \sum_{i=0}^{D-1} (\alpha')^{i} \cdot
 ///     \text{bit\_slice\_evals}[j \cdot D + i].
 /// $$
 ///
-/// One $c_j$ is produced per witness binary-poly column (in column-major
-/// order, matching `BooleanityProof::bit_slice_evals`). The result is
-/// appended to `MultipointEval`'s `up_evals` and bound to the committed
-/// witness column by the MP sumcheck + PCS chain at a fresh random
-/// $\alpha'$, replacing the previous (underconstrained for $D > 1$)
-/// $\psi_a$ linear pin-down.
+/// One $c_j$ is produced per input column, in the same column-major order as
+/// `BooleanityProof::bit_slice_evals`. Committed witness results are appended
+/// to `MultipointEval`'s `up_evals`; affine virtual results are checked against
+/// the corresponding affine combination of source results.
 #[allow(clippy::arithmetic_side_effects)]
-fn alpha_prime_bridge_up_evals<C: BaseFieldConfig, const D: usize>(
+fn collapse_bit_slice_evals<C: BaseFieldConfig, const D: usize>(
     bit_slice_evals: &[C::Element],
-    num_wit_bin: usize,
+    num_cols: usize,
     alpha_prime: &C::Element,
     field_cfg: &C,
 ) -> Vec<C::Element> {
-    debug_assert_eq!(bit_slice_evals.len(), num_wit_bin * D);
+    debug_assert_eq!(bit_slice_evals.len(), num_cols * D);
     let alpha_powers: Vec<C::Element> = powers(field_cfg, alpha_prime, D);
     bit_slice_evals
         .chunks_exact(D)
@@ -743,6 +784,89 @@ fn alpha_prime_bridge_up_evals<C: BaseFieldConfig, const D: usize>(
                 })
         })
         .collect()
+}
+
+/// Reconstruct the expected alpha-prime projection of each unshifted affine
+/// virtual from the corresponding source-column projections.
+#[allow(clippy::arithmetic_side_effects)]
+fn expected_affine_virtual_bridge_evals<C, P, const D: usize>(
+    signature: &UairSignature<P>,
+    source_bridge_evals: &[C::Element],
+    alpha_prime: &C::Element,
+    field_cfg: &C,
+) -> Vec<C::Element>
+where
+    C: BaseFieldConfig + ProjectPrimitiveIntegersWithConfig,
+    P: Semiring,
+{
+    debug_assert_eq!(
+        source_bridge_evals.len(),
+        signature.total_cols().num_binary_poly_cols()
+    );
+
+    let ones_projection = powers(field_cfg, alpha_prime, D).into_iter().fold(
+        field_cfg.zero(),
+        |mut acc, alpha_power| {
+            field_cfg.add_assign(&mut acc, &alpha_power);
+            acc
+        },
+    );
+
+    signature
+        .affine_virtual_specs()
+        .iter()
+        .map(|spec| {
+            let mut expected = field_cfg.mul(
+                &field_cfg.project(&spec.ones_coefficient()),
+                &ones_projection,
+            );
+            for term in spec.terms() {
+                debug_assert_eq!(term.row_shift(), 0);
+                let term_eval = field_cfg.mul(
+                    &field_cfg.project(&term.coefficient()),
+                    &source_bridge_evals[term.source_col()],
+                );
+                field_cfg.add_assign(&mut expected, &term_eval);
+            }
+            expected
+        })
+        .collect()
+}
+
+/// Project a binary-polynomial column at a field element by evaluating each
+/// bit-packed cell $\sum_i \mathrm{bit}_i X^i$ at that element.
+#[allow(clippy::arithmetic_side_effects)]
+fn project_binary_col_at_field<C, const D: usize>(
+    col: &DenseMultilinearExtension<BinaryPoly<D>>,
+    alpha_powers: &[C::Element],
+    field_cfg: &C,
+) -> DenseMultilinearExtension<C::Element>
+where
+    C: BaseFieldConfig,
+{
+    debug_assert_eq!(alpha_powers.len(), D);
+    let zero = field_cfg.zero();
+
+    // Sequential row loop: per-row work is at most `D` conditional adds.
+    // Callers parallelize the outer loop over binary-polynomial columns.
+    let evaluations: Vec<C::Element> = col
+        .evaluations
+        .iter()
+        .map(|entry| {
+            let mut acc = zero.clone();
+            for (i, bit) in entry.iter().enumerate() {
+                if *bit.inner() {
+                    field_cfg.add_assign(&mut acc, &alpha_powers[i]);
+                }
+            }
+            acc
+        })
+        .collect();
+
+    DenseMultilinearExtension {
+        num_vars: col.num_vars,
+        evaluations,
+    }
 }
 
 /// Project a DensePolynomial scalar to DynamicPolynomial by projecting each
@@ -833,7 +957,8 @@ mod tests {
     use zinc_primality::MillerRabin;
     use zinc_test_uair::{
         BigLinearUair, BigLinearUairWithPublicInput, BinaryDecompositionUair, GenerateRandomTrace,
-        ShaProxy, TestUairBitOpsFqFamily, TestUairFqLargePrime, TestUairMixedShifts,
+        ShaProxy, TestUairAffineVirtualPublicOnly, TestUairAffineVirtualUnshifted,
+        TestUairBitOpsFqFamily, TestUairFqLargePrime, TestUairMixedShifts,
         TestUairNoMultiplication, TestUairSimpleMultiplication,
     };
     use zinc_uair::{
@@ -1250,6 +1375,181 @@ mod tests {
             |_| {},
             |res| res.unwrap(),
         );
+    }
+
+    /// End-to-end test for the unshifted affine Ch-style booleanity bridge.
+    #[test]
+    fn test_e2e_affine_virtual_unshifted() {
+        let num_vars = 8;
+        do_test::<TestZincTypesIprs, TestUairAffineVirtualUnshifted<ZtInt, ZtFmod>>(
+            num_vars,
+            (
+                make_iprs(num_vars),
+                make_iprs(num_vars),
+                make_iprs(num_vars),
+            ),
+            default_project_ideal!(),
+            |ideal, field_cfg| ideal.map(|i| DegreeOneIdeal::project(field_cfg, i)),
+            |proof| {
+                assert_eq!(
+                    proof
+                        .booleanity_proof
+                        .as_ref()
+                        .expect("witness binary columns require a booleanity proof")
+                        .bit_slice_evals
+                        .len(),
+                    3 * D,
+                );
+                assert_eq!(
+                    proof
+                        .affine_booleanity_proof
+                        .as_ref()
+                        .expect("affine virtuals require an affine booleanity proof")
+                        .bit_slice_evals
+                        .len(),
+                    2 * D,
+                );
+            },
+            |res| res.unwrap(),
+        );
+    }
+
+    /// Affine virtuals can be bound entirely to public source columns without
+    /// adding witness PCS or multipoint-evaluation bridge columns.
+    #[test]
+    fn test_e2e_affine_virtual_public_only() {
+        let num_vars = 8;
+        do_test::<TestZincTypesIprs, TestUairAffineVirtualPublicOnly<ZtInt, ZtFmod>>(
+            num_vars,
+            (
+                make_iprs(num_vars),
+                make_iprs(num_vars),
+                make_iprs(num_vars),
+            ),
+            default_project_ideal!(),
+            |ideal, field_cfg| ideal.map(|i| DegreeOneIdeal::project(field_cfg, i)),
+            |proof| {
+                assert!(proof.booleanity_proof.is_none());
+                assert_eq!(
+                    proof
+                        .affine_booleanity_proof
+                        .as_ref()
+                        .expect("affine virtuals require an affine booleanity proof")
+                        .bit_slice_evals
+                        .len(),
+                    2 * D,
+                );
+            },
+            |res| res.unwrap(),
+        );
+    }
+
+    /// A prover cannot omit affine bit-slice evaluations: their number is
+    /// derived from the public UAIR signature.
+    #[test]
+    fn test_affine_virtual_truncated_bit_slice_evals() {
+        let num_vars = 8;
+        do_test::<TestZincTypesIprs, TestUairAffineVirtualUnshifted<ZtInt, ZtFmod>>(
+            num_vars,
+            (
+                make_iprs(num_vars),
+                make_iprs(num_vars),
+                make_iprs(num_vars),
+            ),
+            default_project_ideal!(),
+            |ideal, field_cfg| ideal.map(|i| DegreeOneIdeal::project(field_cfg, i)),
+            |proof| {
+                proof
+                    .affine_booleanity_proof
+                    .as_mut()
+                    .expect("affine virtuals require an affine booleanity proof")
+                    .bit_slice_evals
+                    .pop();
+            },
+            |res| {
+                assert!(matches!(
+                    res.unwrap_err(),
+                    ProtocolError::Booleanity(BooleanityError::WrongBitSliceEvalsNumber { .. })
+                ));
+            },
+        );
+    }
+
+    /// The involution `b -> 1-b` preserves `b(b-1)`, so this tamper passes
+    /// affine Booleanity and can only be rejected by the source-binding bridge.
+    #[test]
+    fn test_affine_virtual_source_binding_rejects_booleanity_preserving_tamper() {
+        type U = TestUairAffineVirtualUnshifted<ZtInt, ZtFmod>;
+        type Piop = ZincPlusPiop<TestZincTypesIprs, U, F, D, QUARTER_D>;
+        type Ideal = IdealOrZero<DegreeOneIdeal<E>>;
+
+        let num_vars = 8;
+        let pp = setup_pp::<TestZincTypesIprs>(
+            num_vars,
+            (
+                make_iprs(num_vars),
+                make_iprs(num_vars),
+                make_iprs(num_vars),
+            ),
+        );
+        let trace = U::generate_random_trace(num_vars, &mut rng());
+        let public_trace = trace.public(&U::signature());
+        let mut proof =
+            Piop::prove::<false, CHECKED>(&pp, &trace, num_vars, project_scalar_fn).expect("prove");
+
+        let cfg = Piop::step0_reconstruct_transcript::<Ideal>(
+            &pp,
+            proof.clone(),
+            &public_trace,
+            num_vars,
+        )
+        .and_then(|s| s.step1_prime_projection())
+        .and_then(|s| {
+            s.step2_ideal_check(default_project_ideal!(), |ideal, field_cfg| {
+                ideal.map(|i| DegreeOneIdeal::project(field_cfg, i))
+            })
+        })
+        .and_then(|s| s.step3_eval_projection(project_scalar_fn))
+        .expect("steps 0..=3")
+        .field_cfg()
+        .clone();
+
+        let affine_evals = &mut proof
+            .affine_booleanity_proof
+            .as_mut()
+            .expect("affine virtuals require an affine booleanity proof")
+            .bit_slice_evals;
+        let one = cfg.one();
+        let tamper_index = affine_evals
+            .iter()
+            .position(|wire_eval| {
+                let eval: E = cfg.project(wire_eval);
+                eval != cfg.sub(&one, &eval)
+            })
+            .expect("at least one affine endpoint must differ from its complement");
+        let eval: E = cfg.project(&affine_evals[tamper_index]);
+        let tampered_eval = cfg.sub(&one, &eval);
+        assert_eq!(
+            cfg.mul(&eval, &cfg.sub(&eval, &one)),
+            cfg.mul(&tampered_eval, &cfg.sub(&tampered_eval, &one)),
+            "b -> 1-b must preserve the Booleanity residue",
+        );
+        affine_evals[tamper_index] = cfg.lift(&tampered_eval);
+
+        let err = Piop::verify::<Ideal, CHECKED>(
+            &pp,
+            proof,
+            &public_trace,
+            num_vars,
+            project_scalar_fn,
+            default_project_ideal!(),
+            |ideal, field_cfg| ideal.map(|i| DegreeOneIdeal::project(field_cfg, i)),
+        )
+        .expect_err("the affine source-binding bridge must reject the tamper");
+        assert!(matches!(
+            err,
+            ProtocolError::AffineVirtualBridgeMismatch { .. }
+        ));
     }
 
     /// End-to-end test: [`BigLinearUair`].

--- a/protocol/src/prover.rs
+++ b/protocol/src/prover.rs
@@ -7,7 +7,7 @@ use std::{
 use zinc_piop::{
     combined_poly_resolver::CombinedPolyResolver,
     ideal_check::{IdealCheckProtocol, Proof as IdealCheckProof},
-    lookup::booleanity::{BooleanityChecker, BooleanityProof},
+    lookup::booleanity::{BoolProverAncillary, BooleanityChecker, BooleanityProof},
     multipoint_eval::{MultipointEval, MultipointEvalFamilyInputs, Proof as MultipointEvalProof},
     projections::{
         ColumnMajorTrace, ProjectedScalars, ProjectedTrace, RowMajorTrace,
@@ -310,14 +310,15 @@ pub struct ProverSumchecked<
     combined_sumchecks_fq: Vec<MultiDegreeSumcheckProof<C::Element>>,
     lookup_proof: Option<BatchedLookupProof<C::Element>>,
     booleanity_proof: Option<BooleanityProof<C::Element>>,
+    affine_booleanity_proof: Option<BooleanityProof<C::Element>>,
     /// Fresh challenge sampled after `bit_slice_evals` were absorbed by
     /// booleanity's `finalize_prover`. Used by the next step to (a) build the
     /// extra $\alpha'$-projected witness-bin trace MLEs and (b) compute
     /// the per-column bridge scalars $c_j = \sum_i (\alpha')^i b_{j,i}$
     /// appended to multipoint-eval's `up_evals`.
     ///
-    /// `None` iff there are no witness binary-poly columns (no booleanity
-    /// argument).
+    /// `None` iff there are neither witness binary-poly columns nor affine
+    /// virtual booleanity targets.
     alpha_prime_f: Option<C::Element>,
 }
 
@@ -351,6 +352,7 @@ pub struct ProverMultipointEvaled<
     combined_sumchecks_fq: Vec<MultiDegreeSumcheckProof<C::Element>>,
     lookup_proof: Option<BatchedLookupProof<C::Element>>,
     booleanity_proof: Option<BooleanityProof<C::Element>>,
+    affine_booleanity_proof: Option<BooleanityProof<C::Element>>,
 
     // New
     mp_proof: MultipointEvalProof<C::Element>,
@@ -386,6 +388,7 @@ pub struct ProverLifted<
     combined_sumchecks_fq: Vec<MultiDegreeSumcheckProof<C::Element>>,
     lookup_proof: Option<BatchedLookupProof<C::Element>>,
     booleanity_proof: Option<BooleanityProof<C::Element>>,
+    affine_booleanity_proof: Option<BooleanityProof<C::Element>>,
     mp_proof: MultipointEvalProof<C::Element>,
     /// Per-prime multipoint-eval proofs threaded forward from
     /// `ProverMultipointEvaled`.
@@ -438,6 +441,7 @@ pub struct ProverPcsOpened<
     combined_sumchecks_fq: Vec<MultiDegreeSumcheckProof<C::Element>>,
     lookup_proof: Option<BatchedLookupProof<C::Element>>,
     booleanity_proof: Option<BooleanityProof<C::Element>>,
+    affine_booleanity_proof: Option<BooleanityProof<C::Element>>,
     mp_proof: MultipointEvalProof<C::Element>,
     /// Per-prime multipoint-eval proofs threaded forward.
     mp_proofs_fq: Vec<MultipointEvalProof<C::Element>>,
@@ -965,13 +969,16 @@ impl_with_type_bounds!(ProverEvalProjected
     /// `up_evals`/`down_evals` (CPR), `bit_slice_evals` (booleanity), and
     /// lookup auxiliary witnesses at `r*`.
     ///
-    /// After booleanity's `finalize_prover` absorbs `bit_slice_evals` into
+    /// After booleanity's `finalize_prover` absorbs all committed and affine
+    /// `bit_slice_evals` into
     /// the transcript, this step squeezes a fresh challenge $\alpha'$ and
     /// stores it on `ProverSumchecked`. The actual Schwartz-Zippel bridge
     /// is installed in `step6_multipoint_eval`, which appends one extra
     /// $\alpha'$-projected witness-bin column MLE (and matching up_eval
     /// $c_j = \sum_i b_{j,i} (\alpha')^i$) per witness binary-poly column
-    /// to the multipoint-eval inputs. Shifts continue to reference the
+    /// to the multipoint-eval inputs. Unshifted affine virtuals are collapsed
+    /// at the same $\alpha'$ and checked directly by the verifier against
+    /// their source projections at $r^*$. Shifts continue to reference the
     /// original $\psi_a$-projected witness-bin slot, so `down_evals` are
     /// untouched: shifted booleanity is inherited from un-shifted
     /// booleanity (same committed column).
@@ -1034,6 +1041,25 @@ impl_with_type_bounds!(ProverEvalProjected
             Some(anc)
         } else {
             None
+        };
+
+        // Affine virtuals are a separate generic group. Their residual cells
+        // are not binary, so the committed-column round-1 fast path cannot
+        // represent them.
+        let affine_bool_ancillary = if sig.affine_virtual_specs().is_empty() {
+            None
+        } else {
+            let (affine_group, anc) =
+                BooleanityChecker::prepare_affine_virtual_sumcheck_group::<D>(
+                    &mut self.base.pcs_transcript.fs_transcript,
+                    &self.base.original_trace.binary_poly,
+                    sig.affine_virtual_specs(),
+                    self.base.num_vars,
+                    &self.field_cfg,
+                )
+                .map_err(ProtocolError::Booleanity)?;
+            q_groups.push(affine_group);
+            Some(anc)
         };
 
         // TODO: for each LookupGroup from group_lookup_specs(lookup_specs):
@@ -1102,20 +1128,22 @@ impl_with_type_bounds!(ProverEvalProjected
             &self.field_cfg,
         )?;
 
-        let booleanity_proof = if let Some(anc) = bool_ancillary {
-            let state = md_iter.next().expect("booleanity group present");
-            Some(
-                BooleanityChecker::finalize_prover(
-                    &mut self.base.pcs_transcript.fs_transcript,
-                    state,
-                    anc,
-                    &self.field_cfg,
-                )
-                .map_err(ProtocolError::Booleanity)?,
-            )
-        } else {
-            None
+        let mut finalize_booleanity_group = |ancillary: Option<BoolProverAncillary>| {
+            ancillary
+                .map(|ancillary| {
+                    BooleanityChecker::finalize_prover(
+                        &mut self.base.pcs_transcript.fs_transcript,
+                        md_iter.next().expect("booleanity group present"),
+                        ancillary,
+                        &self.field_cfg,
+                    )
+                    .map_err(ProtocolError::Booleanity)
+                })
+                .transpose()
         };
+        let booleanity_proof = finalize_booleanity_group(bool_ancillary)?;
+        let affine_booleanity_proof = finalize_booleanity_group(affine_bool_ancillary)?;
+        debug_assert!(md_iter.next().is_none());
 
         // TODO: build BatchedLookupProof from collected lookup_proofs + lookup_metas
         let lookup_proof = None;
@@ -1145,14 +1173,15 @@ impl_with_type_bounds!(ProverEvalProjected
             cpr_eval_points_fq.push(cpr_state_i.evaluation_point);
         }
 
-        // Booleanity -> multipoint-eval `alpha_prime` bridge: squeeze
-        // \alpha' after `bit_slice_evals` were absorbed by `finalize_prover`.
-        let alpha_prime_f: Option<C::Element> = booleanity_proof.as_ref().map(|_| {
-            self.base
-                .pcs_transcript
-                .fs_transcript
-                .get_field_challenge(&self.field_cfg)
-        });
+        // Booleanity bridges: squeeze alpha' after the committed and affine
+        // bit-slice evaluations were absorbed by their finalize calls.
+        let alpha_prime_f: Option<C::Element> =
+            (booleanity_proof.is_some() || affine_booleanity_proof.is_some()).then(|| {
+                self.base
+                    .pcs_transcript
+                    .fs_transcript
+                    .get_field_challenge(&self.field_cfg)
+            });
 
         Ok(ProverSumchecked {
             base: self.base,
@@ -1175,6 +1204,7 @@ impl_with_type_bounds!(ProverEvalProjected
             combined_sumchecks_fq,
             lookup_proof,
             booleanity_proof,
+            affine_booleanity_proof,
             alpha_prime_f,
         })
     }
@@ -1245,16 +1275,21 @@ impl_with_type_bounds!(ProverSumchecked
                 .collect();
             debug_assert_eq!(extra_trace_mles.len(), num_wit_bin);
 
-            let bp = self
-                .booleanity_proof
-                .as_ref()
-                .expect("booleanity_proof present iff alpha_prime_f is Some");
-            let extra_up_evals = alpha_prime_bridge_up_evals::<C, D>(
-                &bp.bit_slice_evals,
-                num_wit_bin,
-                alpha_prime,
-                &self.field_cfg,
-            );
+            let extra_up_evals = if num_wit_bin == 0 {
+                debug_assert!(self.booleanity_proof.is_none());
+                Vec::new()
+            } else {
+                let proof = self
+                    .booleanity_proof
+                    .as_ref()
+                    .expect("witness binary columns require a booleanity proof");
+                collapse_bit_slice_evals::<C, D>(
+                    &proof.bit_slice_evals,
+                    num_wit_bin,
+                    alpha_prime,
+                    &self.field_cfg,
+                )
+            };
 
             projected_trace_f.extend(extra_trace_mles);
 
@@ -1358,6 +1393,7 @@ impl_with_type_bounds!(ProverSumchecked
             combined_sumchecks_fq: self.combined_sumchecks_fq,
             lookup_proof: self.lookup_proof,
             booleanity_proof: self.booleanity_proof,
+            affine_booleanity_proof: self.affine_booleanity_proof,
             mp_proof: mp_proof_q,
             r_0: r_0_q,
             mp_proofs_fq,
@@ -1545,6 +1581,7 @@ impl_with_type_bounds!(ProverMultipointEvaled
             combined_sumchecks_fq: self.combined_sumchecks_fq,
             lookup_proof: self.lookup_proof,
             booleanity_proof: self.booleanity_proof,
+            affine_booleanity_proof: self.affine_booleanity_proof,
             mp_proof: self.mp_proof,
             mp_proofs_fq: self.mp_proofs_fq,
             lifted_evals,
@@ -1632,6 +1669,7 @@ impl_with_type_bounds!(ProverLifted
             combined_sumchecks_fq: self.combined_sumchecks_fq,
             lookup_proof: self.lookup_proof,
             booleanity_proof: self.booleanity_proof,
+            affine_booleanity_proof: self.affine_booleanity_proof,
             mp_proof: self.mp_proof,
             mp_proofs_fq: self.mp_proofs_fq,
             lifted_evals: self.lifted_evals,
@@ -1702,6 +1740,10 @@ impl_with_type_bounds!(ProverPcsOpened
                 None => None,
             },
             booleanity_proof: match &self.booleanity_proof {
+                Some(p) => Some(lift!(self.field_cfg, p)?),
+                None => None,
+            },
+            affine_booleanity_proof: match &self.affine_booleanity_proof {
                 Some(p) => Some(lift!(self.field_cfg, p)?),
                 None => None,
             },
@@ -1790,46 +1832,5 @@ fn commit_optionally<Zt: ZipTypes, Lc: LinearCode<Zt>>(
     } else {
         let (hint, commitment) = ZipPlus::commit(pp, trace)?;
         Ok((Some(hint), commitment))
-    }
-}
-
-/// Project a single witness binary-poly column at a field element by
-/// evaluating each bit-packed cell $\sum_i \text{bit}_i \cdot X^i$ at
-/// $X = \alpha$.
-///
-/// Used to build the appended $\alpha'$-projected witness-binary-poly MLEs that
-/// participate in `MultipointEval` as the Schwartz-Zippel bridge from
-/// booleanity into the PCS chain.
-#[allow(clippy::arithmetic_side_effects)]
-fn project_binary_col_at_field<C, const D: usize>(
-    col: &DenseMultilinearExtension<BinaryPoly<D>>,
-    alpha_powers: &[C::Element],
-    field_cfg: &C,
-) -> DenseMultilinearExtension<C::Element>
-where
-    C: BaseFieldConfig,
-{
-    debug_assert_eq!(alpha_powers.len(), D);
-    let zero = field_cfg.zero();
-
-    // Sequential row loop: per-row work is at most `D` conditional adds.
-    // The caller parallelizes the outer loop over witness binary-poly columns.
-    let evaluations: Vec<C::Element> = col
-        .evaluations
-        .iter()
-        .map(|entry| {
-            let mut acc = zero.clone();
-            for (i, bit) in entry.iter().enumerate() {
-                if *bit.inner() {
-                    field_cfg.add_assign(&mut acc, &alpha_powers[i]);
-                }
-            }
-            acc
-        })
-        .collect();
-
-    DenseMultilinearExtension {
-        num_vars: col.num_vars,
-        evaluations,
     }
 }

--- a/protocol/src/verifier.rs
+++ b/protocol/src/verifier.rs
@@ -4,7 +4,7 @@ use std::io::Cursor;
 use zinc_piop::{
     combined_poly_resolver::CombinedPolyResolver,
     ideal_check::{self, IdealCheckProtocol},
-    lookup::booleanity::{BooleanityChecker, BooleanityProof},
+    lookup::booleanity::{BoolVerifierAncillary, BooleanityChecker, BooleanityProof},
     multipoint_eval::{self, MultipointEval, MultipointEvalFamilyInputs},
     projections::{
         ProjectedScalars, ProjectedTrace, project_scalars, project_scalars_to_field,
@@ -23,7 +23,7 @@ use zinc_uair::{
     ideal::{Ideal, IdealCheck},
     ideal_collector::IdealOrZero,
 };
-use zinc_utils::{add, projectable_to_field::ProjectableToField, sub};
+use zinc_utils::{add, powers, projectable_to_field::ProjectableToField, sub};
 use zip_plus::{
     pcs::structs::{ZipPlus, ZipPlusParams, ZipTypes},
     pcs_transcript::PcsVerifierTranscript,
@@ -81,6 +81,7 @@ pub struct VerifierTranscriptReconstructed<
     proof_witness_lifted_evals_pp: Option<Vec<DynamicPolynomial<Zt::Fmod>>>,
     proof_lookup_proof: Option<BatchedLookupProof<Zt::Fmod>>,
     proof_booleanity: Option<BooleanityProof<Zt::Fmod>>,
+    proof_affine_booleanity: Option<BooleanityProof<Zt::Fmod>>,
     proof_ideal_checks_fq: Vec<IdealCheckProof<Zt::Fmod>>,
     proof_cpr_fq: Vec<CombinedPolyResolverProof<Zt::Fmod>>,
     proof_combined_sumchecks_fq: Vec<MultiDegreeSumcheckProof<Zt::Fmod>>,
@@ -116,6 +117,7 @@ pub struct VerifierPrimeProjected<
     proof_witness_lifted_evals_pp: Option<Vec<DynamicPolynomial<Zt::Fmod>>>,
     proof_lookup_proof: Option<BatchedLookupProof<C::Element>>,
     proof_booleanity: Option<BooleanityProof<C::Element>>,
+    proof_affine_booleanity: Option<BooleanityProof<C::Element>>,
     proof_ideal_checks_fq: Vec<IdealCheckProof<C::Element>>,
     proof_cpr_fq: Vec<CombinedPolyResolverProof<C::Element>>,
     proof_combined_sumchecks_fq: Vec<MultiDegreeSumcheckProof<C::Element>>,
@@ -164,6 +166,7 @@ pub struct VerifierIdealChecked<
     proof_witness_lifted_evals_pp: Option<Vec<DynamicPolynomial<Zt::Fmod>>>,
     proof_lookup_proof: Option<BatchedLookupProof<C::Element>>,
     proof_booleanity: Option<BooleanityProof<C::Element>>,
+    proof_affine_booleanity: Option<BooleanityProof<C::Element>>,
     /// Per-prime CPR proofs (one per declared prime).
     proof_cpr_fq: Vec<CombinedPolyResolverProof<C::Element>>,
     /// Per-prime multi-degree sumcheck proofs (one per declared prime).
@@ -221,6 +224,7 @@ pub struct VerifierEvalProjected<
     proof_witness_lifted_evals_pp: Option<Vec<DynamicPolynomial<Zt::Fmod>>>,
     proof_lookup_proof: Option<BatchedLookupProof<C::Element>>,
     proof_booleanity: Option<BooleanityProof<C::Element>>,
+    proof_affine_booleanity: Option<BooleanityProof<C::Element>>,
     /// Per-prime CPR proofs (one per declared prime).
     proof_cpr_fq: Vec<CombinedPolyResolverProof<C::Element>>,
     /// Per-prime multi-degree sumcheck proofs (one per declared prime),
@@ -273,11 +277,15 @@ pub struct VerifierSumchecked<
     ///
     /// `None` iff there are no witness binary-poly columns.
     bool_bit_slice_evals: Option<Vec<C::Element>>,
+    /// Affine-virtual bit-slice evaluations carried separately from the
+    /// committed-column Booleanity proof.
+    affine_bool_bit_slice_evals: Option<Vec<C::Element>>,
     /// Fresh challenge sampled after `bit_slice_evals` were absorbed by
     /// booleanity's `finalize_verifier`. Consumed in step 5 (bridge
     /// scalars) and step 6 (appended $\alpha'$-projected open_evals).
     ///
-    /// `None` iff there are no witness binary-poly columns.
+    /// `None` iff there are neither witness binary-poly columns nor affine
+    /// virtual booleanity targets.
     alpha_prime_f: Option<C::Element>,
 
     // Proof leftovers
@@ -369,6 +377,74 @@ pub struct VerifierPcsVerified<IdealOverF> {
     _phantom: PhantomData<IdealOverF>,
 }
 
+fn prepare_booleanity_verifier_group<C>(
+    transcript: &mut Blake3Transcript,
+    claimed_sums: &[C::Element],
+    group_idx: &mut usize,
+    num_cols: usize,
+    bit_width: usize,
+    num_vars: usize,
+    field_cfg: &C,
+) -> Result<Option<BoolVerifierAncillary<C::Element>>, ProtocolError<C::Element>>
+where
+    C: BaseFieldConfig + ProjectPrimitiveIntegersWithConfig + 'static,
+    C::Integer: ConstTranscribable,
+{
+    if num_cols == 0 {
+        return Ok(None);
+    }
+
+    let claimed_sum = claimed_sums
+        .get(*group_idx)
+        .ok_or(ProtocolError::BooleanityProofMissing)?;
+    let ancillary = BooleanityChecker::<C>::prepare_verifier(
+        transcript,
+        claimed_sum,
+        num_cols,
+        bit_width,
+        num_vars,
+        field_cfg,
+    )
+    .map_err(ProtocolError::Booleanity)?;
+    *group_idx = add!(*group_idx, 1);
+    Ok(Some(ancillary))
+}
+
+fn finalize_booleanity_verifier_group<C>(
+    transcript: &mut Blake3Transcript,
+    proof: Option<BooleanityProof<C::Element>>,
+    shared_point: &[C::Element],
+    expected_evaluations: &[C::Element],
+    group_idx: &mut usize,
+    ancillary: Option<BoolVerifierAncillary<C::Element>>,
+    field_cfg: &C,
+) -> Result<Option<Vec<C::Element>>, ProtocolError<C::Element>>
+where
+    C: BaseFieldConfig + ProjectPrimitiveIntegersWithConfig + 'static,
+    C::Integer: ConstTranscribable,
+{
+    let (proof, ancillary) = match (proof, ancillary) {
+        (None, None) => return Ok(None),
+        (Some(proof), Some(ancillary)) => (proof, ancillary),
+        _ => return Err(ProtocolError::BooleanityProofMissing),
+    };
+    let expected_eval = expected_evaluations
+        .get(*group_idx)
+        .ok_or(ProtocolError::BooleanityProofMissing)?;
+    *group_idx = add!(*group_idx, 1);
+
+    let subclaim = BooleanityChecker::<C>::finalize_verifier(
+        transcript,
+        proof,
+        shared_point.to_vec(),
+        expected_eval,
+        ancillary,
+        field_cfg,
+    )
+    .map_err(ProtocolError::Booleanity)?;
+    Ok(Some(subclaim.bit_slice_evals))
+}
+
 //
 // Step implementations
 //
@@ -402,10 +478,11 @@ where
             num_vars > 0,
             "Attempt to verify a constant: num_vars must be > 0"
         );
+        let uair_signature = U::signature();
         let zip_proof = std::mem::take(&mut proof.zip);
         let mut base = VerifierBase {
             num_vars,
-            uair_signature: U::signature(),
+            uair_signature,
             public_trace,
             pcs_transcript: PcsVerifierTranscript {
                 fs_transcript: Blake3Transcript::default(),
@@ -448,6 +525,7 @@ where
             proof_witness_lifted_evals_pp: proof.witness_lifted_evals_pp,
             proof_lookup_proof: proof.lookup_proof,
             proof_booleanity: proof.booleanity_proof,
+            proof_affine_booleanity: proof.affine_booleanity_proof,
             proof_ideal_checks_fq: proof.ideal_checks_fq,
             proof_cpr_fq: proof.cpr_proofs_fq,
             proof_combined_sumchecks_fq: proof.combined_sumchecks_fq,
@@ -543,6 +621,10 @@ where
                 None => None,
             },
             proof_booleanity: match &self.proof_booleanity {
+                Some(p) => Some(project!(&field_cfg, p)?),
+                None => None,
+            },
+            proof_affine_booleanity: match &self.proof_affine_booleanity {
                 Some(p) => Some(project!(&field_cfg, p)?),
                 None => None,
             },
@@ -682,6 +764,7 @@ where
             proof_witness_lifted_evals_pp: self.proof_witness_lifted_evals_pp,
             proof_lookup_proof: self.proof_lookup_proof,
             proof_booleanity: self.proof_booleanity,
+            proof_affine_booleanity: self.proof_affine_booleanity,
             proof_cpr_fq: self.proof_cpr_fq,
             proof_combined_sumchecks_fq: self.proof_combined_sumchecks_fq,
             proof_multipoint_evals_fq: self.proof_multipoint_evals_fq,
@@ -771,6 +854,7 @@ where
             proof_witness_lifted_evals_pp: self.proof_witness_lifted_evals_pp,
             proof_lookup_proof: self.proof_lookup_proof,
             proof_booleanity: self.proof_booleanity,
+            proof_affine_booleanity: self.proof_affine_booleanity,
             proof_cpr_fq: self.proof_cpr_fq,
             proof_combined_sumchecks_fq: self.proof_combined_sumchecks_fq,
             proof_multipoint_evals_fq: self.proof_multipoint_evals_fq,
@@ -847,29 +931,28 @@ where
         let sig = self.base.uair_signature.clone();
         let num_pub_bin = sig.public_cols().num_binary_poly_cols();
         let num_total_bin = sig.total_cols().num_binary_poly_cols();
-        let bin_wit_present = num_total_bin > num_pub_bin;
+        let num_wit_bin = num_total_bin.saturating_sub(num_pub_bin);
+        let num_affine_virtuals = sig.affine_virtual_specs().len();
+        let mut bool_group_idx = 1;
 
-        let bool_verifier_ancillary = if bin_wit_present {
-            // booleanity is group index 1 (right after CPR) on the Q-family.
-            let bool_claimed_sum = self
-                .proof_combined_sumcheck
-                .claimed_sums()
-                .get(1)
-                .ok_or(ProtocolError::BooleanityProofMissing)?;
-            let num_wit_bin = num_total_bin.saturating_sub(num_pub_bin);
-            let anc = BooleanityChecker::<C>::prepare_verifier(
-                &mut self.base.pcs_transcript.fs_transcript,
-                bool_claimed_sum,
-                num_wit_bin,
-                D,
-                self.base.num_vars,
-                &self.field_cfg,
-            )
-            .map_err(ProtocolError::Booleanity)?;
-            Some(anc)
-        } else {
-            None
-        };
+        let bool_verifier_ancillary = prepare_booleanity_verifier_group(
+            &mut self.base.pcs_transcript.fs_transcript,
+            self.proof_combined_sumcheck.claimed_sums(),
+            &mut bool_group_idx,
+            num_wit_bin,
+            D,
+            self.base.num_vars,
+            &self.field_cfg,
+        )?;
+        let affine_bool_verifier_ancillary = prepare_booleanity_verifier_group(
+            &mut self.base.pcs_transcript.fs_transcript,
+            self.proof_combined_sumcheck.claimed_sums(),
+            &mut bool_group_idx,
+            num_affine_virtuals,
+            D,
+            self.base.num_vars,
+            &self.field_cfg,
+        )?;
 
         // -------- Per-prime families: CPR pre-sumcheck ------------------
         let mut fq_cpr_ancillaries: Vec<_> = Vec::with_capacity(n_fq);
@@ -930,33 +1013,25 @@ where
         // After `finalize_verifier` (residue check + transcript absorption of
         // `bit_slice_evals`), squeeze `alpha_prime` and carry both forward to the
         // next step.
-        let bool_bit_slice_evals: Option<Vec<C::Element>> =
-            if let Some(anc) = bool_verifier_ancillary {
-                let booleanity_proof = self
-                    .proof_booleanity
-                    .take()
-                    .ok_or(ProtocolError::BooleanityProofMissing)?;
-                let expected_eval = q_md_subclaims
-                    .expected_evaluations()
-                    .get(1)
-                    .ok_or(ProtocolError::BooleanityProofMissing)?;
-
-                // Sumcheck residue check at r* against the bit-slice evals.
-                // Absorbs bit_slice_evals.
-                let bool_subclaim = BooleanityChecker::<C>::finalize_verifier(
-                    &mut self.base.pcs_transcript.fs_transcript,
-                    booleanity_proof,
-                    q_md_subclaims.point().to_vec(),
-                    expected_eval,
-                    anc,
-                    &self.field_cfg,
-                )
-                .map_err(ProtocolError::Booleanity)?;
-
-                Some(bool_subclaim.bit_slice_evals)
-            } else {
-                None
-            };
+        let mut bool_group_idx = 1;
+        let bool_bit_slice_evals = finalize_booleanity_verifier_group(
+            &mut self.base.pcs_transcript.fs_transcript,
+            self.proof_booleanity.take(),
+            q_md_subclaims.point(),
+            q_md_subclaims.expected_evaluations(),
+            &mut bool_group_idx,
+            bool_verifier_ancillary,
+            &self.field_cfg,
+        )?;
+        let affine_bool_bit_slice_evals = finalize_booleanity_verifier_group(
+            &mut self.base.pcs_transcript.fs_transcript,
+            self.proof_affine_booleanity.take(),
+            q_md_subclaims.point(),
+            q_md_subclaims.expected_evaluations(),
+            &mut bool_group_idx,
+            affine_bool_verifier_ancillary,
+            &self.field_cfg,
+        )?;
 
         // -------- Per-prime family finalize ---------------------------
         // Mirror the prover's loop: pop next subclaim per family, call
@@ -994,12 +1069,13 @@ where
         }
 
         // Squeeze alpha_prime in the same transcript order as the prover.
-        let alpha_prime_f: Option<C::Element> = bool_bit_slice_evals.as_ref().map(|_| {
-            self.base
-                .pcs_transcript
-                .fs_transcript
-                .get_field_challenge(&self.field_cfg)
-        });
+        let alpha_prime_f: Option<C::Element> =
+            (bool_bit_slice_evals.is_some() || affine_bool_bit_slice_evals.is_some()).then(|| {
+                self.base
+                    .pcs_transcript
+                    .fs_transcript
+                    .get_field_challenge(&self.field_cfg)
+            });
 
         let cpr_eval_point = cpr_subclaim.evaluation_point;
 
@@ -1023,6 +1099,7 @@ where
             cpr_bit_op_evals_fq,
             cpr_down_evals_fq,
             bool_bit_slice_evals,
+            affine_bool_bit_slice_evals,
             alpha_prime_f,
             proof_commitments: self.proof_commitments,
             proof_multipoint_eval: self.proof_multipoint_eval,
@@ -1076,30 +1153,81 @@ where
             });
         }
 
-        // Q[X] family up_evals
-        // (with booleanity-bridge appended when alpha_prime is present) and num_wit_bin
-        // extension width.
-        let (q_up_evals, num_wit_bin): (Vec<C::Element>, usize) =
-            if let (Some(bit_slice_evals), Some(alpha_prime)) =
-                (&self.bool_bit_slice_evals, &self.alpha_prime_f)
+        // Q[X] family up_evals, extended only by the committed-column
+        // Booleanity bridge. Affine virtuals stay separate and are checked
+        // directly against their source-column projections below.
+        let sig = self.base.uair_signature.clone();
+        let num_pub_bin = sig.public_cols().num_binary_poly_cols();
+        let num_total_bin = sig.total_cols().num_binary_poly_cols();
+        let num_wit_bin = num_total_bin.saturating_sub(num_pub_bin);
+        let num_affine_virtuals = sig.affine_virtual_specs().len();
+        let alpha_prime = self.alpha_prime_f.as_ref();
+
+        let witness_bridge_evals = if num_wit_bin == 0 {
+            Vec::new()
+        } else {
+            collapse_bit_slice_evals::<C, D>(
+                self.bool_bit_slice_evals
+                    .as_ref()
+                    .ok_or(ProtocolError::BooleanityProofMissing)?,
+                num_wit_bin,
+                alpha_prime.ok_or(ProtocolError::BooleanityProofMissing)?,
+                &self.field_cfg,
+            )
+        };
+
+        if num_affine_virtuals > 0 {
+            let alpha_prime = alpha_prime.ok_or(ProtocolError::BooleanityProofMissing)?;
+            let alpha_powers = powers(&self.field_cfg, alpha_prime, D);
+            let mut source_bridge_evals: Vec<C::Element> = self
+                .base
+                .public_trace
+                .binary_poly
+                .iter()
+                .map(|col| {
+                    project_binary_col_at_field::<C, D>(col, &alpha_powers, &self.field_cfg)
+                        .evaluate(&self.field_cfg, &self.cpr_eval_point)
+                        .map_err(ProtocolError::AffineVirtualSourceProjection)
+                })
+                .collect::<Result<_, _>>()?;
+            debug_assert_eq!(source_bridge_evals.len(), num_pub_bin);
+            source_bridge_evals.extend(witness_bridge_evals.iter().cloned());
+
+            let affine_bridge_evals = collapse_bit_slice_evals::<C, D>(
+                self.affine_bool_bit_slice_evals
+                    .as_ref()
+                    .ok_or(ProtocolError::BooleanityProofMissing)?,
+                num_affine_virtuals,
+                alpha_prime,
+                &self.field_cfg,
+            );
+            let expected_affine_evals = expected_affine_virtual_bridge_evals::<C, _, D>(
+                &sig,
+                &source_bridge_evals,
+                alpha_prime,
+                &self.field_cfg,
+            );
+            for (spec_index, (got, expected)) in affine_bridge_evals
+                .into_iter()
+                .zip(expected_affine_evals)
+                .enumerate()
             {
-                let sig = self.base.uair_signature.clone();
-                let num_pub_bin = sig.public_cols().num_binary_poly_cols();
-                let num_total_bin = sig.total_cols().num_binary_poly_cols();
-                let num_wit_bin = num_total_bin.saturating_sub(num_pub_bin);
-                let extra = alpha_prime_bridge_up_evals::<C, D>(
-                    bit_slice_evals,
-                    num_wit_bin,
-                    alpha_prime,
-                    &self.field_cfg,
-                );
-                (
-                    self.cpr_up_evals.iter().cloned().chain(extra).collect(),
-                    num_wit_bin,
-                )
-            } else {
-                (self.cpr_up_evals.clone(), 0)
-            };
+                if got != expected {
+                    return Err(ProtocolError::AffineVirtualBridgeMismatch {
+                        spec_index,
+                        got,
+                        expected,
+                    });
+                }
+            }
+        }
+
+        let q_up_evals: Vec<C::Element> = self
+            .cpr_up_evals
+            .iter()
+            .cloned()
+            .chain(witness_bridge_evals)
+            .collect();
 
         // Per-prime families: zero-pad up_evals to match Q's column count
         //

--- a/test-uair/src/lib.rs
+++ b/test-uair/src/lib.rs
@@ -20,8 +20,8 @@ use zinc_poly::{
     },
 };
 use zinc_uair::{
-    BitOp, BitOpSpec, ConstraintBuilder, PublicColumnLayout, ShiftSpec, TotalColumnLayout,
-    TraceRow, Uair, UairSignature, UairTrace,
+    AffineVirtualSpec, AffineVirtualTerm, BitOp, BitOpSpec, ConstraintBuilder, PublicColumnLayout,
+    ShiftSpec, TotalColumnLayout, TraceRow, Uair, UairSignature, UairTrace,
     ideal::{DegreeOneIdeal, ImpossibleIdeal},
 };
 use zinc_utils::from_ref::FromRef;
@@ -1139,6 +1139,124 @@ where
     }
 }
 
+/// UAIR fixture for affine virtual booleanity targets while an independent F_q
+/// constraint family is present.
+///
+/// For public `e` and witness `g`, the witnesses `u_not = (!e) & g` and
+/// `u_and = e & g` are characterized by the paper's two Ch membership
+/// expressions
+///
+/// ```text
+/// (1_32 - e) + g - 2u_not in {0, 1}^{<32}[X]
+/// e + g - 2u_and in {0, 1}^{<32}[X].
+/// ```
+#[derive(Clone, Debug)]
+pub struct TestUairAffineVirtual<R, P, const NUM_PUBLIC_BINARY: usize>(PhantomData<(R, P)>);
+
+/// Unshifted variant with one public and three witness binary columns.
+pub type TestUairAffineVirtualUnshifted<R, P> = TestUairAffineVirtual<R, P, 1>;
+
+/// Unshifted variant with all four binary columns public.
+pub type TestUairAffineVirtualPublicOnly<R, P> = TestUairAffineVirtual<R, P, 4>;
+
+impl<R, P, const NUM_PUBLIC_BINARY: usize> Uair for TestUairAffineVirtual<R, P, NUM_PUBLIC_BINARY>
+where
+    R: ConstSemiring + 'static,
+    P: Semiring + From<u64> + 'static,
+{
+    type Ideal = DegreeOneIdeal<R>;
+    type FqIdeal = DegreeOneIdeal<R>;
+    type Scalar = DensePolynomial<R, 32>;
+    type Prime = P;
+
+    fn signature() -> UairSignature<Self::Prime> {
+        UairSignature::new(
+            TotalColumnLayout::new(4, 0, 0),
+            PublicColumnLayout::new(NUM_PUBLIC_BINARY, 0, 0),
+            vec![],
+            vec![],
+        )
+        .with_affine_virtual_specs(vec![
+            AffineVirtualSpec::with_ones_coefficient(
+                vec![
+                    AffineVirtualTerm::new(0, -1),
+                    AffineVirtualTerm::new(1, 1),
+                    AffineVirtualTerm::new(2, -2),
+                ],
+                1,
+            ),
+            AffineVirtualSpec::new(vec![
+                AffineVirtualTerm::new(0, 1),
+                AffineVirtualTerm::new(1, 1),
+                AffineVirtualTerm::new(3, -2),
+            ]),
+        ])
+        .with_primes(vec![P::from(MERSENNE_61_PRIME)])
+    }
+
+    fn constrain_general<C, B, FromR, MulByScalar, IFromR, IFqFromR>(
+        b: &mut B,
+        expr_cfg: &C,
+        up: TraceRow<C::Element>,
+        _down: TraceRow<C::Element>,
+        _from_ref: FromR,
+        _mbs: MulByScalar,
+        ideal_from_ref: IFromR,
+        fq_ideal_from_ref: IFqFromR,
+    ) where
+        C: SemiringConfig,
+        B: ConstraintBuilder<Expr = C::Element>,
+        IFromR: Fn(&Self::Ideal) -> B::Ideal,
+        IFqFromR: Fn(&Self::FqIdeal) -> B::FqIdeal,
+    {
+        // Keep independent zero identities in both constraint families so the
+        // fixture exercises affine booleanity alongside Q and F_q CPR. The Ch
+        // relations themselves are enforced by booleanity.
+        let identity = expr_cfg.sub(&up.binary_poly[1], &up.binary_poly[1]);
+        b.assert_in_ideal(
+            identity.clone(),
+            &ideal_from_ref(&DegreeOneIdeal::new(R::ONE)),
+        );
+        b.assert_in_fq_ideal(
+            0,
+            identity,
+            &fq_ideal_from_ref(&DegreeOneIdeal::new(R::ONE)),
+        );
+    }
+}
+
+impl<R, P, const NUM_PUBLIC_BINARY: usize> GenerateRandomTrace<32>
+    for TestUairAffineVirtual<R, P, NUM_PUBLIC_BINARY>
+where
+    R: ConstSemiring + 'static,
+    P: Semiring + From<u64> + 'static,
+{
+    type PolyCoeff = R;
+    type Int = R;
+
+    fn generate_random_trace<G: Rng + ?Sized>(
+        num_vars: usize,
+        rng: &mut G,
+    ) -> UairTrace<'static, R, R, 32, 32> {
+        let n = 1usize << num_vars;
+        let e: Vec<u32> = (0..n).map(|_| rng.next_u32()).collect();
+        let g: Vec<u32> = (0..n).map(|_| rng.next_u32()).collect();
+        let u_not: Vec<u32> = e.iter().zip(&g).map(|(e, g)| !e & g).collect();
+        let u_and: Vec<u32> = e.iter().zip(&g).map(|(e, g)| e & g).collect();
+
+        UairTrace {
+            binary_poly: vec![
+                e.into_iter().map(BinaryPoly::from).collect(),
+                g.into_iter().map(BinaryPoly::from).collect(),
+                u_not.into_iter().map(BinaryPoly::from).collect(),
+                u_and.into_iter().map(BinaryPoly::from).collect(),
+            ]
+            .into(),
+            ..Default::default()
+        }
+    }
+}
+
 /// A UAIR exercising the Flavor-1 $F_{q}[X]$-constraint surface
 /// for **multiple large primes**.
 ///
@@ -1285,6 +1403,8 @@ mod tests {
         assert_uair_shape::<TestUairMixedShifts<Int<LIMBS>, u64>>(&[1, 1]);
         assert_uair_shape::<TestUairBitOpsMixedSplice<Int<LIMBS>, u64>>(&[1, 1, 1]);
         assert_uair_shape::<TestUairBitOpsFqFamily<Int<LIMBS>, u64>>(&[1, 1]);
+        assert_uair_shape::<TestUairAffineVirtualUnshifted<Int<LIMBS>, u64>>(&[1, 1]);
+        assert_uair_shape::<TestUairAffineVirtualPublicOnly<Int<LIMBS>, u64>>(&[1, 1]);
         // TestUairFqLargePrime: two F_{q_i}[X] linear constraints (one per
         // declared prime).
         assert_uair_shape::<TestUairFqLargePrime<Int<LIMBS>, u64>>(&[1, 1]);

--- a/transcript/Cargo.toml
+++ b/transcript/Cargo.toml
@@ -13,9 +13,9 @@ bench = false
 blake3 = { workspace = true }
 crypto-bigint = { workspace = true }
 crypto-primitives = { workspace = true }
-thiserror = { workspace = true}
 itertools = { workspace = true }
 num-traits = { workspace = true }
+thiserror = { workspace = true }
 zinc-primality = { workspace = true }
 zinc-utils = { workspace = true }
 

--- a/uair/src/lib.rs
+++ b/uair/src/lib.rs
@@ -230,6 +230,9 @@ impl AffineVirtualTerm {
     }
 
     /// Construct a shifted term `coefficient * source_col[row + row_shift]`.
+    ///
+    /// [`UairSignature::with_affine_virtual_specs`] currently rejects shifted
+    /// terms until the protocol binds row-shifted source projections.
     pub fn new_shifted(source_col: usize, coefficient: i64, row_shift: usize) -> Self {
         assert!(row_shift > 0, "row shift must be non-zero");
         Self {
@@ -548,17 +551,17 @@ impl<Prime: Semiring> UairSignature<Prime> {
 
     /// Attach affine virtual booleanity specs to the signature.
     ///
-    /// Each term in each spec must reference a binary_poly column. Affine
-    /// virtuals describe Q-side `{0,1}^{<D}[X]` membership targets such as the
-    /// Ch/Maj linear combinations in the Zinc+ paper. They are not committed
-    /// columns and do not affect the down-row layout.
+    /// Each term in each spec must be unshifted and reference a binary_poly
+    /// column. Affine virtuals describe Q-side `{0,1}^{<D}[X]` membership
+    /// targets such as the Ch/Maj linear combinations in the Zinc+ paper. They
+    /// are not committed columns and do not affect the down-row layout.
     pub fn with_affine_virtual_specs(
         mut self,
         affine_virtual_specs: Vec<AffineVirtualSpec>,
     ) -> Self {
         let binary_poly_end = self.total_cols.num_binary_poly_cols();
-        for spec in &affine_virtual_specs {
-            for term in spec.terms() {
+        for (spec_index, spec) in affine_virtual_specs.iter().enumerate() {
+            for (term_index, term) in spec.terms().iter().enumerate() {
                 assert!(
                     term.source_col() < binary_poly_end,
                     "AffineVirtualTerm source_col {} is not a binary_poly column \
@@ -566,6 +569,12 @@ impl<Prime: Semiring> UairSignature<Prime> {
                      are only defined over binary_poly cells.",
                     term.source_col(),
                     binary_poly_end,
+                );
+                assert!(
+                    term.row_shift() == 0,
+                    "shifted affine virtual terms are not supported: spec {spec_index}, \
+                     term {term_index}, row shift {}",
+                    term.row_shift(),
                 );
             }
         }
@@ -896,14 +905,11 @@ mod tests {
         let specs = vec![
             AffineVirtualSpec::new(vec![
                 AffineVirtualTerm::new(0, 1),
-                AffineVirtualTerm::new_shifted(1, 1, 2),
+                AffineVirtualTerm::new(1, 1),
                 AffineVirtualTerm::new(0, -2),
             ]),
             AffineVirtualSpec::with_ones_coefficient(
-                vec![
-                    AffineVirtualTerm::new(0, -1),
-                    AffineVirtualTerm::new_shifted(1, 1, 1),
-                ],
+                vec![AffineVirtualTerm::new(0, -1), AffineVirtualTerm::new(1, 1)],
                 1,
             ),
         ];
@@ -913,7 +919,7 @@ mod tests {
         assert_eq!(sig.affine_virtual_specs(), specs);
         assert_eq!(sig.affine_virtual_specs()[0].terms()[1].source_col(), 1);
         assert_eq!(sig.affine_virtual_specs()[0].terms()[1].coefficient(), 1);
-        assert_eq!(sig.affine_virtual_specs()[0].terms()[1].row_shift(), 2);
+        assert_eq!(sig.affine_virtual_specs()[0].terms()[1].row_shift(), 0);
         assert_eq!(sig.affine_virtual_specs()[1].ones_coefficient(), 1);
         assert_eq!(sig.down_cols().num_binary_poly_cols(), 1);
         assert_eq!(sig.down_cols().num_arbitrary_poly_cols(), 1);
@@ -948,6 +954,17 @@ mod tests {
         let _ =
             signature_with_mixed_shifts().with_affine_virtual_specs(vec![AffineVirtualSpec::new(
                 vec![AffineVirtualTerm::new(2, 1)],
+            )]);
+    }
+
+    #[test]
+    #[should_panic(
+        expected = "shifted affine virtual terms are not supported: spec 0, term 0, row shift 1"
+    )]
+    fn affine_virtual_specs_reject_shifted_terms() {
+        let _ =
+            signature_with_mixed_shifts().with_affine_virtual_specs(vec![AffineVirtualSpec::new(
+                vec![AffineVirtualTerm::new_shifted(0, 1, 1)],
             )]);
     }
 }


### PR DESCRIPTION
Goes towards #185, which blocks #91. Follow-up to #221 and #222.

This wires unshifted affine virtual Booleanity targets through the full protocol:
* Prover runs the affine Booleanity group alongside the committed binary-column group and records the two results as separate optional proof components.
* Verifier prepares and finalizes the two Booleanity proofs separately, with affine counts derived from the public UAIR signature.
* Public source endpoints are recomputed from the public trace, while witness source endpoints reuse the existing multipoint-evaluation/PCS bridge.
* The affine endpoint reconstructed from those sources is checked against the endpoint proved Boolean; a mismatch returns `AffineVirtualBridgeMismatch`.

Affine virtuals remain uncommitted $Q[X]$ Booleanity targets, so this adds no PCS openings or $F_q[X]$ padding. `UairSignature::with_affine_virtual_specs` rejects shifted affine terms during signature construction; supporting them requires binding row-shifted source projections rather than treating them as unshifted.

Tests cover the honest path and separate proof shapes, signature-derived length rejection, a Booleanity-preserving `b -> 1-b` source-binding attack, the public-only path with no witness binary columns, and signature-level shifted-term rejection.

The PR also sorts `transcript/Cargo.toml` dependencies so the repository's `cargo sort --workspace --check` pre-push step passes after #231.

Validation: `.githooks/pre-push`.
