### PR TITLE
Transcript IO rework

### DIFF
--- a/piop/benches/multipoint_eval.rs
+++ b/piop/benches/multipoint_eval.rs
@@ -81,7 +81,7 @@ fn bench_multipoint_eval(c: &mut Criterion, num_vars: usize, num_cols: usize) {
 
     // Prepare a transcript with the seed absorbed once.
     let mut base_transcript = Blake3Transcript::new();
-    base_transcript.absorb_slice(b"bench");
+    base_transcript.absorb_bytes(b"bench");
 
     // --- Bench prover (single-family shape) ---
     group.bench_function(BenchmarkId::new("Prover", &params), |bench| {
@@ -113,7 +113,7 @@ fn bench_multipoint_eval(c: &mut Criterion, num_vars: usize, num_cols: usize) {
     // --- Bench verifier ---
     // First produce a valid proof.
     let mut prover_transcript = Blake3Transcript::new();
-    prover_transcript.absorb_slice(b"bench");
+    prover_transcript.absorb_bytes(b"bench");
     let mut prover_outputs = MultipointEval::<F>::prove_as_subprotocol(
         &mut prover_transcript,
         vec![MultipointEvalFamilyInputs {

--- a/piop/benches/sumcheck.rs
+++ b/piop/benches/sumcheck.rs
@@ -30,7 +30,6 @@ pub fn bench_simple_product<C, const LIMBS: usize>(
     witness_size: usize,
 ) where
     C: BaseFieldConfig + ProjectPrimitiveIntegersWithConfig + 'static,
-    C::Element: ConstTranscribable,
     C::Integer: ConstTranscribable + ConstIntSemiring + FromRef<C::Integer>,
     MillerRabin: PrimalityTest<C::Integer>,
 {

--- a/piop/src/combined_poly_resolver.rs
+++ b/piop/src/combined_poly_resolver.rs
@@ -64,7 +64,6 @@ pub struct CombinedPolyResolver<C: SetConfig>(PhantomData<C>);
 impl<C> CombinedPolyResolver<C>
 where
     C: BaseFieldConfig + ProjectPrimitiveIntegersWithConfig + 'static,
-    C::Element: ConstTranscribable,
     C::Integer: ConstTranscribable,
 {
     /// Build the CPR sumcheck group for use in the multi-degree sumcheck.
@@ -328,10 +327,10 @@ where
         down_evals.extend_from_slice(&evals[up_end..bit_op_start]);
         down_evals.extend_from_slice(&evals[bit_op_end..]);
 
-        let mut transcription_buf: Vec<u8> = vec![0; <C::Element as ConstTranscribable>::NUM_BYTES];
-        transcript.absorb_field_element_slice(&up_evals, &mut transcription_buf);
-        transcript.absorb_field_element_slice(&down_evals, &mut transcription_buf);
-        transcript.absorb_field_element_slice(&bit_op_evals, &mut transcription_buf);
+        let mut transcription_buf: Vec<u8> = vec![0; <C::Integer as ConstTranscribable>::NUM_BYTES];
+        transcript.absorb_field_element_slice(field_cfg, &up_evals, &mut transcription_buf);
+        transcript.absorb_field_element_slice(field_cfg, &down_evals, &mut transcription_buf);
+        transcript.absorb_field_element_slice(field_cfg, &bit_op_evals, &mut transcription_buf);
         Ok((
             CprProof {
                 up_evals,
@@ -526,10 +525,14 @@ where
             });
         }
 
-        let mut transcription_buf: Vec<u8> = vec![0; <C::Element as ConstTranscribable>::NUM_BYTES];
-        transcript.absorb_field_element_slice(&proof.up_evals, &mut transcription_buf);
-        transcript.absorb_field_element_slice(&proof.down_evals, &mut transcription_buf);
-        transcript.absorb_field_element_slice(&proof.bit_op_evals, &mut transcription_buf);
+        let mut transcription_buf: Vec<u8> = vec![0; <C::Integer as ConstTranscribable>::NUM_BYTES];
+        transcript.absorb_field_element_slice(field_cfg, &proof.up_evals, &mut transcription_buf);
+        transcript.absorb_field_element_slice(field_cfg, &proof.down_evals, &mut transcription_buf);
+        transcript.absorb_field_element_slice(
+            field_cfg,
+            &proof.bit_op_evals,
+            &mut transcription_buf,
+        );
 
         Ok(VerifierSubclaim {
             up_evals: proof.up_evals,

--- a/piop/src/ideal_check.rs
+++ b/piop/src/ideal_check.rs
@@ -83,7 +83,7 @@ impl<U: Uair> IdealCheckProtocol<U> {
     ) -> Result<Proof<C::Element>, IdealCheckError<C::Element>>
     where
         C: BaseFieldConfig + ProjectPrimitiveIntegersWithConfig,
-        C::Element: ConstTranscribable,
+        C::Integer: ConstTranscribable,
     {
         // Classify constraints to drive dispatch below:
         // * Linear non-zero-ideal goes through the column-major MLE-first path
@@ -167,9 +167,9 @@ impl<U: Uair> IdealCheckProtocol<U> {
             }
         }
 
-        let mut transcription_buf: Vec<u8> = vec![0; <C::Element as ConstTranscribable>::NUM_BYTES];
+        let mut transcription_buf: Vec<u8> = vec![0; <C::Integer as ConstTranscribable>::NUM_BYTES];
         combined_mle_values.iter().for_each(|cv| {
-            transcript.absorb_field_element_slice(&cv.coeffs, &mut transcription_buf);
+            transcript.absorb_field_element_slice(field_cfg, &cv.coeffs, &mut transcription_buf);
         });
 
         Ok(Proof {
@@ -210,7 +210,7 @@ impl<U: Uair> IdealCheckProtocol<U> {
     ) -> Result<Proof<C::Element>, IdealCheckError<C::Element>>
     where
         C: BaseFieldConfig + ProjectPrimitiveIntegersWithConfig,
-        C::Element: ConstTranscribable,
+        C::Integer: ConstTranscribable,
     {
         // Collect ideals to identify assert_zero constraints whose
         // combined polynomial is zero by construction (for honest provers).
@@ -249,10 +249,10 @@ impl<U: Uair> IdealCheckProtocol<U> {
             }
         };
 
-        let mut transcription_buf: Vec<u8> = vec![0; <C::Element as ConstTranscribable>::NUM_BYTES];
+        let mut transcription_buf: Vec<u8> = vec![0; <C::Integer as ConstTranscribable>::NUM_BYTES];
 
         combined_mle_values.iter().for_each(|v| {
-            transcript.absorb_field_element_slice(&v.coeffs, &mut transcription_buf);
+            transcript.absorb_field_element_slice(field_cfg, &v.coeffs, &mut transcription_buf);
         });
 
         Ok(Proof {
@@ -295,17 +295,21 @@ impl<U: Uair> IdealCheckProtocol<U> {
     ) -> Result<VerifierSubclaim<C::Element>, IdealCheckError<C::Element>>
     where
         C: BaseFieldConfig,
-        C::Element: ConstTranscribable,
+        C::Integer: ConstTranscribable,
         IdealOverF: Ideal + IdealCheck<DynamicPolynomialConfig<'cfg, C>>,
         IdealOverFFromRef: Fn(&IdealOrZero<U::Ideal>) -> IdealOverF,
         IdealOverFFromFqRef: Fn(&IdealOrZero<U::FqIdeal>) -> IdealOverF,
     {
-        let mut transcription_buf: Vec<u8> = vec![0; <C::Element as ConstTranscribable>::NUM_BYTES];
+        let mut transcription_buf: Vec<u8> = vec![0; <C::Integer as ConstTranscribable>::NUM_BYTES];
 
         let combined_mle_values = proof.combined_mle_values;
 
         for mle_value in &combined_mle_values {
-            transcript.absorb_field_element_slice(&mle_value.coeffs, &mut transcription_buf);
+            transcript.absorb_field_element_slice(
+                field_cfg,
+                &mle_value.coeffs,
+                &mut transcription_buf,
+            );
         }
 
         let ideal_collector = collect_ideals::<U>(num_constraints);

--- a/piop/src/lookup/booleanity.rs
+++ b/piop/src/lookup/booleanity.rs
@@ -921,7 +921,7 @@ mod tests {
 
     fn make_transcript() -> Blake3Transcript {
         let mut t = Blake3Transcript::default();
-        t.absorb_slice(b"booleanity test");
+        t.absorb_bytes(b"booleanity test");
         t
     }
 

--- a/piop/src/lookup/booleanity.rs
+++ b/piop/src/lookup/booleanity.rs
@@ -186,7 +186,6 @@ pub struct BoolVerifierSubclaim<F> {
 impl<C> BooleanityChecker<C>
 where
     C: BaseFieldConfig + ProjectPrimitiveIntegersWithConfig + 'static,
-    C::Element: ConstTranscribable,
     C::Integer: ConstTranscribable,
 {
     /// Build the booleanity sumcheck group, to be appended to the
@@ -337,8 +336,8 @@ where
 
         debug_assert_eq!(bit_slice_evals.len(), active_len);
 
-        let mut transcription_buf: Vec<u8> = vec![0; <C::Element as ConstTranscribable>::NUM_BYTES];
-        transcript.absorb_field_element_slice(&bit_slice_evals, &mut transcription_buf);
+        let mut transcription_buf: Vec<u8> = vec![0; <C::Integer as ConstTranscribable>::NUM_BYTES];
+        transcript.absorb_field_element_slice(field_cfg, &bit_slice_evals, &mut transcription_buf);
 
         Ok(BooleanityProof { bit_slice_evals })
     }
@@ -428,8 +427,12 @@ where
             });
         }
 
-        let mut transcription_buf: Vec<u8> = vec![0; <C::Element as ConstTranscribable>::NUM_BYTES];
-        transcript.absorb_field_element_slice(&proof.bit_slice_evals, &mut transcription_buf);
+        let mut transcription_buf: Vec<u8> = vec![0; <C::Integer as ConstTranscribable>::NUM_BYTES];
+        transcript.absorb_field_element_slice(
+            field_cfg,
+            &proof.bit_slice_evals,
+            &mut transcription_buf,
+        );
 
         Ok(BoolVerifierSubclaim {
             bit_slice_evals: proof.bit_slice_evals,

--- a/piop/src/lookup/booleanity.rs
+++ b/piop/src/lookup/booleanity.rs
@@ -731,7 +731,6 @@ fn booleanity_zerocheck_setup<C>(
 ) -> BooleanityZerocheckSetup<C::Element>
 where
     C: BaseFieldConfig + ProjectPrimitiveIntegersWithConfig + 'static,
-    C::Element: ConstTranscribable,
     C::Integer: ConstTranscribable,
 {
     // Order of challenge squeezing must match between prover and verifier.

--- a/piop/src/multipoint_eval.rs
+++ b/piop/src/multipoint_eval.rs
@@ -784,7 +784,7 @@ mod tests {
 
     fn make_transcript() -> Blake3Transcript {
         let mut t = Blake3Transcript::default();
-        t.absorb_slice(b"Lorem ipsum");
+        t.absorb_bytes(b"Lorem ipsum");
         t
     }
 

--- a/piop/src/multipoint_eval.rs
+++ b/piop/src/multipoint_eval.rs
@@ -176,7 +176,6 @@ pub struct MultipointEval<C>(PhantomData<C>);
 impl<C> MultipointEval<C>
 where
     C: BaseFieldConfig + ProjectPrimitiveIntegersWithConfig + 'static,
-    C::Element: ConstTranscribable,
     C::Integer: ConstTranscribable,
 {
     /// Multi-point evaluation protocol prover (lockstep over families).

--- a/piop/src/random_field_sumcheck.rs
+++ b/piop/src/random_field_sumcheck.rs
@@ -38,7 +38,6 @@ impl<C: SetConfig, R> RFProverState<C, R> {
 impl<C, R> RFSumcheck<C, R>
 where
     C: BaseFieldConfig + ProjectPrimitiveIntegersWithConfig,
-    C::Element: ConstTranscribable,
     C::Integer: ConstTranscribable,
     R: SetElement + ProjectableToField<C>,
 {

--- a/piop/src/sumcheck.rs
+++ b/piop/src/sumcheck.rs
@@ -101,7 +101,6 @@ impl<F: ConstTranscribable> Transcribable for SumcheckProof<F> {
 impl<C> MLSumcheck<C>
 where
     C: BaseFieldConfig + ProjectPrimitiveIntegersWithConfig,
-    C::Element: ConstTranscribable,
     C::Integer: ConstTranscribable,
 {
     /// Sumcheck prover main entry point.
@@ -165,12 +164,12 @@ where
             panic!("Attempt to prove a constant")
         }
 
-        let mut buf = vec![0; <C::Element as ConstTranscribable>::NUM_BYTES];
+        let mut buf = vec![0; <C::Integer as ConstTranscribable>::NUM_BYTES];
         let nvars_field = config.project(&(nvars as u64));
         let degree_field = config.project(&(degree as u64));
 
-        transcript.absorb_field_element(&nvars_field, &mut buf);
-        transcript.absorb_field_element(&degree_field, &mut buf);
+        transcript.absorb_field_element(config, &nvars_field, &mut buf);
+        transcript.absorb_field_element(config, &degree_field, &mut buf);
 
         let mut prover_state = ProverState::new(mles, nvars, degree);
         let mut verifier_msg = None;
@@ -178,10 +177,10 @@ where
 
         for _ in 0..nvars {
             let prover_msg = prover_state.prove_round(&verifier_msg, &comb_fn, config);
-            transcript.absorb_field_element_slice(&prover_msg.0.tail_evaluations, &mut buf);
+            transcript.absorb_field_element_slice(config, &prover_msg.0.tail_evaluations, &mut buf);
             prover_msgs.push(prover_msg);
             let next_verifier_msg = transcript.get_field_challenge(config);
-            transcript.absorb_field_element(&next_verifier_msg, &mut buf);
+            transcript.absorb_field_element(config, &next_verifier_msg, &mut buf);
 
             verifier_msg = Some(next_verifier_msg);
         }
@@ -264,7 +263,7 @@ where
             panic!("Attempt to verify a sumcheck claim for 0 variables")
         }
 
-        let mut buf = vec![0; <C::Element as ConstTranscribable>::NUM_BYTES];
+        let mut buf = vec![0; <C::Integer as ConstTranscribable>::NUM_BYTES];
 
         let (nvars_field, degree_field) = {
             (
@@ -272,8 +271,8 @@ where
                 config.project(&(degree as u64)),
             )
         };
-        transcript.absorb_field_element(&nvars_field, &mut buf);
-        transcript.absorb_field_element(&degree_field, &mut buf);
+        transcript.absorb_field_element(config, &nvars_field, &mut buf);
+        transcript.absorb_field_element(config, &degree_field, &mut buf);
 
         if proof.messages.len() != num_vars {
             return Err(SumCheckError::InvalidProofLength {
@@ -286,9 +285,9 @@ where
 
         for i in 0..num_vars {
             let prover_msg = &proof.messages[i];
-            transcript.absorb_field_element_slice(&prover_msg.0.tail_evaluations, &mut buf);
+            transcript.absorb_field_element_slice(config, &prover_msg.0.tail_evaluations, &mut buf);
             let verifier_msg = verifier_state.verify_round(prover_msg, transcript);
-            transcript.absorb_field_element(&verifier_msg, &mut buf);
+            transcript.absorb_field_element(config, &verifier_msg, &mut buf);
         }
 
         verifier_state.check_and_generate_subclaim(proof.claimed_sum.clone())

--- a/piop/src/sumcheck/multi_degree.rs
+++ b/piop/src/sumcheck/multi_degree.rs
@@ -278,7 +278,6 @@ pub struct MultiDegreeSumcheck<C>(PhantomData<C>);
 impl<C> MultiDegreeSumcheck<C>
 where
     C: BaseFieldConfig + ProjectPrimitiveIntegersWithConfig,
-    C::Element: ConstTranscribable,
     C::Integer: ConstTranscribable,
 {
     /// Multi-degree sumcheck prover.
@@ -351,14 +350,14 @@ where
         }
 
         let num_families = families.len();
-        let mut buf = vec![0; <C::Element as ConstTranscribable>::NUM_BYTES];
+        let mut buf = vec![0; <C::Integer as ConstTranscribable>::NUM_BYTES];
 
         // Metadata: absorb (num_vars, num_families) under `q_star_cfg` so the
         // transcript layout is canonical across families.
         let nvars_field = q_star_cfg.project(&(num_vars as u64));
         let nfamilies_field = q_star_cfg.project(&(num_families as u64));
-        transcript.absorb_field_element(&nvars_field, &mut buf);
-        transcript.absorb_field_element(&nfamilies_field, &mut buf);
+        transcript.absorb_field_element(q_star_cfg, &nvars_field, &mut buf);
+        transcript.absorb_field_element(q_star_cfg, &nfamilies_field, &mut buf);
 
         // Per-family state, one `Vec` per family.
         let mut per_family_group_messages: Vec<Vec<Vec<SumcheckProverMsg<C::Element>>>> =
@@ -375,7 +374,7 @@ where
         for (groups, cfg) in families {
             let num_groups = groups.len();
             let ngroups_field = q_star_cfg.project(&(num_groups as u64));
-            transcript.absorb_field_element(&ngroups_field, &mut buf);
+            transcript.absorb_field_element(q_star_cfg, &ngroups_field, &mut buf);
 
             let group_messages: Vec<Vec<SumcheckProverMsg<C::Element>>> = (0..num_groups)
                 .map(|_| Vec::with_capacity(num_vars))
@@ -387,7 +386,7 @@ where
 
             for group in groups {
                 let degree_field = q_star_cfg.project(&(group.degree as u64));
-                transcript.absorb_field_element(&degree_field, &mut buf);
+                transcript.absorb_field_element(q_star_cfg, &degree_field, &mut buf);
 
                 prover_states.push(SumcheckProverState::new(group.poly, num_vars, group.degree));
                 comb_fns.push(group.comb_fn);
@@ -433,7 +432,7 @@ where
                         .collect();
 
                 for msg in &round_msgs {
-                    transcript.absorb_field_element_slice(&msg.0.tail_evaluations, &mut buf);
+                    transcript.absorb_field_element_slice(cfg, &msg.0.tail_evaluations, &mut buf);
                 }
 
                 for (j, msg) in round_msgs.into_iter().enumerate() {
@@ -443,7 +442,7 @@ where
 
             // 2. Sample one shared integer challenge in [0, q*) via q_star_cfg.
             let shared_chal_q_star: C::Element = transcript.get_field_challenge(q_star_cfg);
-            transcript.absorb_field_element(&shared_chal_q_star, &mut buf);
+            transcript.absorb_field_element(q_star_cfg, &shared_chal_q_star, &mut buf);
             let shared_chal_int = q_star_cfg.lift(&shared_chal_q_star);
 
             // 3. Per family: lift the shared integer into its field and feed each group.
@@ -544,13 +543,13 @@ where
         assert!(!proofs.is_empty(), "need at least one family");
 
         let num_families = proofs.len();
-        let mut buf = vec![0; <C::Element as ConstTranscribable>::NUM_BYTES];
+        let mut buf = vec![0; <C::Integer as ConstTranscribable>::NUM_BYTES];
 
         // Metadata: (num_vars, num_families) under q_star_cfg.
         let nvars_field = q_star_cfg.project(&(num_vars as u64));
         let nfamilies_field = q_star_cfg.project(&(num_families as u64));
-        transcript.absorb_field_element(&nvars_field, &mut buf);
-        transcript.absorb_field_element(&nfamilies_field, &mut buf);
+        transcript.absorb_field_element(q_star_cfg, &nvars_field, &mut buf);
+        transcript.absorb_field_element(q_star_cfg, &nfamilies_field, &mut buf);
 
         let mut per_family_verifier_states: Vec<Vec<VerifierState<C>>> =
             Vec::with_capacity(num_families);
@@ -558,13 +557,13 @@ where
             let num_groups = proof.degrees.len();
             assert!(num_groups != 0, "every family needs at least one group");
             let ngroups_field = q_star_cfg.project(&(num_groups as u64));
-            transcript.absorb_field_element(&ngroups_field, &mut buf);
+            transcript.absorb_field_element(q_star_cfg, &ngroups_field, &mut buf);
 
             let states: Vec<VerifierState<C>> = (0..num_groups)
                 .map(|j| {
                     let degree = proof.degrees[j];
                     let degree_field = q_star_cfg.project(&(degree as u64));
-                    transcript.absorb_field_element(&degree_field, &mut buf);
+                    transcript.absorb_field_element(q_star_cfg, &degree_field, &mut buf);
                     VerifierState::new(num_vars, degree, *cfg)
                 })
                 .collect();
@@ -592,15 +591,19 @@ where
         for i in 0..num_vars {
             // Absorb all families' messages in family-major order to match
             // the prover.
-            for (proof, _) in proofs {
+            for (proof, cfg) in proofs {
                 proof.group_messages.iter().for_each(|msg| {
-                    transcript.absorb_field_element_slice(&msg[i].0.tail_evaluations, &mut buf)
+                    transcript.absorb_field_element_slice(
+                        *cfg,
+                        &msg[i].0.tail_evaluations,
+                        &mut buf,
+                    )
                 });
             }
 
             // One shared integer challenge per round under q_star_cfg.
             let shared_chal_q_star: C::Element = transcript.get_field_challenge(q_star_cfg);
-            transcript.absorb_field_element(&shared_chal_q_star, &mut buf);
+            transcript.absorb_field_element(q_star_cfg, &shared_chal_q_star, &mut buf);
             let shared_chal_int = q_star_cfg.lift(&shared_chal_q_star);
 
             for (b, (proof, cfg)) in proofs.iter().enumerate() {

--- a/piop/src/sumcheck/tests.rs
+++ b/piop/src/sumcheck/tests.rs
@@ -421,7 +421,7 @@ fn subclaim_changes_if_transcript_is_tampered() {
     .unwrap();
 
     let mut tampered_transcript = Blake3Transcript::default();
-    tampered_transcript.absorb_slice(b"tampering the transcript");
+    tampered_transcript.absorb_bytes(b"tampering the transcript");
     let tampered_res = MLSumcheck::verify_as_subprotocol(
         &mut tampered_transcript,
         num_vars,

--- a/protocol/src/lib.rs
+++ b/protocol/src/lib.rs
@@ -609,7 +609,7 @@ fn absorb_public_columns<T: ConstTranscribable>(
     for col in cols {
         for entry in col.iter() {
             entry.write_transcription_bytes_exact(&mut buf);
-            transcript.absorb_slice(&buf);
+            transcript.absorb_bytes(&buf);
         }
     }
 }

--- a/protocol/src/lib.rs
+++ b/protocol/src/lib.rs
@@ -824,7 +824,7 @@ mod tests {
         crypto_bigint_monty::{MontyField, MontyFieldElement},
         crypto_bigint_uint::{U64, Uint},
     };
-    use num_traits::{ConstOne, Zero};
+    use num_traits::{ConstOne, WrappingAdd, Zero};
     use rand::rng;
     use zinc_piop::{
         combined_poly_resolver::CombinedPolyResolverError, multipoint_eval::MultipointEvalError,
@@ -1709,10 +1709,9 @@ mod tests {
                     .booleanity_proof
                     .as_mut()
                     .expect("BigLinearUair has binary-poly witnesses");
-                // The Q-family cfg (random q_0) is not carried by raw
-                // elements; swapping two (distinct w.o.p.) evals is an
-                // equally non-trivial perturbation of the residue.
-                bp.bit_slice_evals.swap(0, 1);
+                // Add a constant to the raw wire integer.
+                let tampered = bp.bit_slice_evals[0].wrapping_add(&Uint::from(7_u64));
+                bp.bit_slice_evals[0] = tampered
             },
             |res| {
                 assert!(matches!(

--- a/protocol/src/lib.rs
+++ b/protocol/src/lib.rs
@@ -63,7 +63,10 @@ use zinc_poly::{
     },
 };
 use zinc_primality::PrimalityTest;
-use zinc_transcript::traits::{ConstTranscribable, GenTranscribable, Transcribable, Transcript};
+use zinc_transcript::{
+    TranscriptError,
+    traits::{ConstTranscribable, GenTranscribable, Transcribable, Transcript},
+};
 use zinc_uair::{Uair, UairSignature};
 use zinc_utils::{cfg_extend, cfg_into_iter, cfg_iter, from_ref::FromRef, named::Named, powers};
 use zip_plus::{
@@ -574,6 +577,10 @@ pub enum ProtocolError<F: SetElement> {
     Pcs(#[from] ZipError),
     #[error("PCS verification failed at column {0}: {1}")]
     PcsVerification(usize, ZipError),
+    /// Happens outside of Zip+, otherwise it would be wrapped in
+    /// [`ZipError::Transcript`]
+    #[error("transcript failure: {0}")]
+    Transcript(#[from] TranscriptError),
     #[error("F_q[X] ideal check failed at prime_idx {prime_idx} (q = {q}): {source}")]
     FqIdealCheck {
         prime_idx: usize,
@@ -1607,6 +1614,35 @@ mod tests {
                     res.unwrap_err(),
                     ProtocolError::NonCanonicalElement
                 ));
+            },
+        );
+    }
+
+    /// Bytes appended past the end of the proof stream are never read, and so
+    /// are never absorbed into the transcript. They must be rejected rather
+    /// than ignored: otherwise every verifying proof admits unboundedly many
+    /// accepted variants, which breaks proof uniqueness wherever proofs are
+    /// hashed, deduplicated, or compared for equality.
+    #[test]
+    fn test_big_linear_tamper_trailing_proof_bytes() {
+        let num_vars = 8;
+        do_test::<TestZincTypesIprs, BigLinearUairWithPublicInput<ZtInt, ZtFmod>>(
+            num_vars,
+            (
+                make_iprs(num_vars),
+                make_iprs(num_vars),
+                make_iprs(num_vars),
+            ),
+            default_project_ideal!(),
+            default_project_fq_ideal!(),
+            |proof| proof.zip.push(0),
+            |res| {
+                assert!(res.is_err(), "trailing proof bytes were accepted");
+                let err = res.unwrap_err();
+                assert!(
+                    matches!(err, ProtocolError::Transcript(_)),
+                    "trailing proof bytes resulted in {err:?} rather than a transcript error"
+                );
             },
         );
     }

--- a/protocol/src/prover.rs
+++ b/protocol/src/prover.rs
@@ -1516,12 +1516,13 @@ impl_with_type_bounds!(ProverMultipointEvaled
         // Uniform order: each constraint family's witness-only lifted
         // evals, then the q'' family. Mirrored in step6_lifted_evals.
         let mut transcription_buf: Vec<u8> = vec![0; C::Integer::NUM_BYTES];
-        for lifted_i in &lifted_evals {
+        debug_assert_eq!(self.all_field_cfgs.len(), lifted_evals.len());
+        for (cfg_i, lifted_i) in self.all_field_cfgs.iter().zip(&lifted_evals) {
             for bar_u in lifted_i {
                 self.base
                     .pcs_transcript
                     .fs_transcript
-                    .absorb_field_element_slice(&self.field_cfg, &bar_u.coeffs, &mut transcription_buf);
+                    .absorb_field_element_slice(cfg_i, &bar_u.coeffs, &mut transcription_buf);
             }
         }
         if let Some(ref lifted_pp) = lifted_evals_pp {

--- a/protocol/src/prover.rs
+++ b/protocol/src/prover.rs
@@ -470,7 +470,7 @@ macro_rules! impl_with_type_bounds {
                 + ProjectElementWithConfig<Zt::CombR>
                 + ProjectElementWithConfig<Zt::Chal>
                 + 'static,
-            C::Element: ConstTranscribable,
+            C::Integer: ConstTranscribable,
         {
             $($code)*
         }
@@ -1515,13 +1515,13 @@ impl_with_type_bounds!(ProverMultipointEvaled
         // --- Absorb all per-family coefficients into the transcript ---
         // Uniform order: each constraint family's witness-only lifted
         // evals, then the q'' family. Mirrored in step6_lifted_evals.
-        let mut transcription_buf: Vec<u8> = vec![0; C::Element::NUM_BYTES];
+        let mut transcription_buf: Vec<u8> = vec![0; C::Integer::NUM_BYTES];
         for lifted_i in &lifted_evals {
             for bar_u in lifted_i {
                 self.base
                     .pcs_transcript
                     .fs_transcript
-                    .absorb_field_element_slice(&bar_u.coeffs, &mut transcription_buf);
+                    .absorb_field_element_slice(&self.field_cfg, &bar_u.coeffs, &mut transcription_buf);
             }
         }
         if let Some(ref lifted_pp) = lifted_evals_pp {
@@ -1529,7 +1529,7 @@ impl_with_type_bounds!(ProverMultipointEvaled
                 self.base
                     .pcs_transcript
                     .fs_transcript
-                    .absorb_field_element_slice(&bar_u.coeffs, &mut transcription_buf);
+                    .absorb_field_element_slice(&q_pp_cfg, &bar_u.coeffs, &mut transcription_buf);
             }
         }
 
@@ -1732,7 +1732,6 @@ where
         + Send
         + Sync
         + 'static,
-    C::Element: ConstTranscribable,
     C::Integer: Display,
     U: Uair<Prime = Zt::Fmod> + 'static,
 {

--- a/protocol/src/verifier.rs
+++ b/protocol/src/verifier.rs
@@ -365,6 +365,7 @@ pub struct VerifierLiftedEvalsChecked<
 /// [`finish`](VerifierPcsVerified::finish).
 #[derive(Clone, Debug)]
 pub struct VerifierPcsVerified<IdealOverF> {
+    pcs_transcript: PcsVerifierTranscript,
     _phantom: PhantomData<IdealOverF>,
 }
 
@@ -1641,6 +1642,7 @@ where
         );
 
         Ok(VerifierPcsVerified {
+            pcs_transcript: self.base.pcs_transcript,
             _phantom: PhantomData,
         })
     }
@@ -1648,7 +1650,10 @@ where
 
 impl<IdealOverF: Ideal> VerifierPcsVerified<IdealOverF> {
     /// Complete verification.
+    ///
+    /// Asserts that the proof stream has been fully consumed.
     pub fn finish<E: SetElement>(self) -> Result<(), ProtocolError<E>> {
+        self.pcs_transcript.check_eof()?;
         Ok(())
     }
 }

--- a/protocol/src/verifier.rs
+++ b/protocol/src/verifier.rs
@@ -420,7 +420,7 @@ where
             &proof.commitments.1,
             &proof.commitments.2,
         ] {
-            base.pcs_transcript.fs_transcript.absorb_slice(&comm.root);
+            base.pcs_transcript.fs_transcript.absorb_bytes(&comm.root);
         }
 
         absorb_public_columns(

--- a/protocol/src/verifier.rs
+++ b/protocol/src/verifier.rs
@@ -1451,16 +1451,20 @@ where
         // Absorb all families' coefficients into the FS transcript in the same uniform
         // order as the prover
         let mut transcription_buf: Vec<u8> = vec![0; C::Integer::NUM_BYTES];
-        for witness_lifted_i in &self.proof_witness_lifted_evals {
+        debug_assert_eq!(
+            self.all_field_cfgs.len(),
+            self.proof_witness_lifted_evals.len()
+        );
+        for (cfg_i, witness_lifted_i) in self
+            .all_field_cfgs
+            .iter()
+            .zip(&self.proof_witness_lifted_evals)
+        {
             for bar_u in witness_lifted_i {
                 self.base
                     .pcs_transcript
                     .fs_transcript
-                    .absorb_field_element_slice(
-                        &self.field_cfg,
-                        &bar_u.coeffs,
-                        &mut transcription_buf,
-                    );
+                    .absorb_field_element_slice(cfg_i, &bar_u.coeffs, &mut transcription_buf);
             }
         }
         if let Some(ref lifted_evals_pp) = proof_witness_lifted_evals_pp {

--- a/protocol/src/verifier.rs
+++ b/protocol/src/verifier.rs
@@ -461,7 +461,6 @@ impl<'a, Zt, U, C, IdealOverF, const D: usize, const FD: usize>
 where
     Zt: ZincTypes<D, FD>,
     C: BaseFieldConfig<Integer = Zt::Fmod> + Clone + Send + Sync + 'static,
-    C::Element: ConstTranscribable,
     U: Uair,
     IdealOverF: Ideal,
 {
@@ -571,7 +570,6 @@ where
         + Send
         + Sync
         + 'static,
-    C::Element: ConstTranscribable,
     U: Uair + 'static,
     IdealOverF: Ideal + for<'cfg> IdealCheck<DynamicPolynomialConfig<'cfg, C>>,
 {
@@ -701,7 +699,6 @@ where
         + Send
         + Sync
         + 'static,
-    C::Element: ConstTranscribable,
     U: Uair<Prime = Zt::Fmod> + 'static,
     IdealOverF: Ideal,
 {
@@ -796,7 +793,6 @@ where
         + Send
         + Sync
         + 'static,
-    C::Element: ConstTranscribable,
     U: Uair<Prime = Zt::Fmod> + 'static,
     IdealOverF: Ideal,
 {
@@ -1048,7 +1044,6 @@ where
         + Send
         + Sync
         + 'static,
-    C::Element: ConstTranscribable,
     IdealOverF: Ideal,
 {
     /// Step 5: Multi-point evaluation sumcheck.
@@ -1202,7 +1197,6 @@ where
         + Send
         + Sync
         + 'static,
-    C::Element: ConstTranscribable,
     IdealOverF: Ideal,
 {
     /// Step 6: Per-family lifted-eval consistency check.
@@ -1455,13 +1449,17 @@ where
 
         // Absorb all families' coefficients into the FS transcript in the same uniform
         // order as the prover
-        let mut transcription_buf: Vec<u8> = vec![0; C::Element::NUM_BYTES];
+        let mut transcription_buf: Vec<u8> = vec![0; C::Integer::NUM_BYTES];
         for witness_lifted_i in &self.proof_witness_lifted_evals {
             for bar_u in witness_lifted_i {
                 self.base
                     .pcs_transcript
                     .fs_transcript
-                    .absorb_field_element_slice(&bar_u.coeffs, &mut transcription_buf);
+                    .absorb_field_element_slice(
+                        &self.field_cfg,
+                        &bar_u.coeffs,
+                        &mut transcription_buf,
+                    );
             }
         }
         if let Some(ref lifted_evals_pp) = proof_witness_lifted_evals_pp {
@@ -1469,7 +1467,7 @@ where
                 self.base
                     .pcs_transcript
                     .fs_transcript
-                    .absorb_field_element_slice(&bar_u.coeffs, &mut transcription_buf);
+                    .absorb_field_element_slice(&q_pp_cfg, &bar_u.coeffs, &mut transcription_buf);
             }
         }
 
@@ -1510,7 +1508,6 @@ where
         + Send
         + Sync
         + 'static,
-    C::Element: ConstTranscribable,
     IdealOverF: Ideal,
 {
     /// Step 7: PCS verification at $r^\star := r_0 \bmod q''$,
@@ -1693,7 +1690,6 @@ where
         + Send
         + Sync
         + 'static,
-    C::Element: ConstTranscribable,
     U: Uair<Prime = Zt::Fmod> + 'static,
 {
     /// Zinc+ full PIOP verifier.

--- a/transcript/Cargo.toml
+++ b/transcript/Cargo.toml
@@ -13,7 +13,7 @@ bench = false
 blake3 = { workspace = true }
 crypto-bigint = { workspace = true }
 crypto-primitives = { workspace = true }
-
+thiserror = { workspace = true}
 itertools = { workspace = true }
 num-traits = { workspace = true }
 zinc-primality = { workspace = true }

--- a/transcript/src/lib.rs
+++ b/transcript/src/lib.rs
@@ -19,11 +19,23 @@ impl Default for Blake3Transcript {
     }
 }
 
+/// Domain-separation label bound into every transcript at construction.
+///
+/// Absorbed before any protocol data, so transcripts belonging to different
+/// protocols, or to different versions of this one, cannot coincide even on
+/// byte-identical prover messages. The per-message tags applied by
+/// [`Transcript::absorb_bytes`] delimit values within a transcript; this label
+/// separates one transcript's whole message schedule from another's.
+///
+/// Bump the version suffix on any change to the wire encoding or to the
+/// message schedule of the protocol.
+const DOMAIN_SEPARATOR: &[u8] = b"zinc-plus/transcript/v1";
+
 impl Blake3Transcript {
     pub fn new() -> Self {
-        Self {
-            hasher: blake3::Hasher::new(),
-        }
+        let mut hasher = blake3::Hasher::new();
+        hasher.update(DOMAIN_SEPARATOR);
+        Self { hasher }
     }
 
     /// Generates a specified number of pseudorandom bytes based on the current

--- a/transcript/src/lib.rs
+++ b/transcript/src/lib.rs
@@ -2,6 +2,8 @@ pub mod traits;
 
 use crate::traits::{ConstTranscribable, GenTranscribable, Transcript};
 use crypto_primitives::{BaseFieldConfig, ConstIntSemiring};
+use std::io::ErrorKind;
+use thiserror::Error;
 use zinc_primality::PrimalityTest;
 
 /// A cryptographic transcript implementation using the BLAKE3 hash
@@ -107,3 +109,7 @@ where
     modulus.write_transcription_bytes_exact(buf);
     rest
 }
+
+#[derive(Clone, Debug, PartialEq, Error)]
+#[error("{1}")]
+pub struct TranscriptError(pub ErrorKind, pub String);

--- a/transcript/src/lib.rs
+++ b/transcript/src/lib.rs
@@ -38,7 +38,7 @@ impl Blake3Transcript {
 
     fn gen_random<R: ConstTranscribable>(&mut self, buf: &mut [u8]) -> R {
         self.fill_with_random_bytes(buf);
-        self.absorb_inner(buf);
+        self.absorb_bytes(buf);
         R::read_transcription_bytes_exact(buf)
     }
 }

--- a/transcript/src/traits.rs
+++ b/transcript/src/traits.rs
@@ -381,7 +381,8 @@ pub trait Transcript {
     /// Should not be used directly.
     fn absorb_inner(&mut self, v: &[u8]);
 
-    /// Absorbs a byte slice into the transcript.
+    /// Absorbs a byte slice into the transcript, delimited by
+    /// domain-separation tags.
     fn absorb_bytes(&mut self, buf: &[u8]) {
         self.absorb_inner(&[0x06]);
         self.absorb_inner(buf);

--- a/transcript/src/traits.rs
+++ b/transcript/src/traits.rs
@@ -382,10 +382,10 @@ pub trait Transcript {
     fn absorb_inner(&mut self, v: &[u8]);
 
     /// Absorbs a byte slice into the transcript.
-    fn absorb_slice(&mut self, buf: &[u8]) {
-        self.absorb_inner(&[0x6]);
+    fn absorb_bytes(&mut self, buf: &[u8]) {
+        self.absorb_inner(&[0x06]);
         self.absorb_inner(buf);
-        self.absorb_inner(&[0x7]);
+        self.absorb_inner(&[0x07]);
     }
 
     /// Absorbs a field element (its raw inner representation) into the
@@ -416,10 +416,8 @@ pub trait Transcript {
     where
         S: Semiring + Transcribable,
     {
-        self.absorb_inner(&[0x1]);
         v.write_transcription_bytes_exact(buf);
-        self.absorb_inner(buf);
-        self.absorb_inner(&[0x3])
+        self.absorb_bytes(buf);
     }
 
     /// Absorbs a slice of integer into the transcript.

--- a/transcript/src/traits.rs
+++ b/transcript/src/traits.rs
@@ -4,8 +4,8 @@
 
 use crypto_bigint::{Word, modular::ConstMontyParams};
 use crypto_primitives::{
-    BaseFieldConfig, ConstBaseField, ConstIntSemiring, FieldConfig, ProjectElementWithConfig,
-    Semiring, boolean::Boolean, crypto_bigint_boxed_uint::BoxedUint,
+    BaseFieldConfig, ConstBaseField, ConstIntSemiring, FieldConfig, LiftElementWithConfig,
+    ProjectElementWithConfig, Semiring, boolean::Boolean, crypto_bigint_boxed_uint::BoxedUint,
     crypto_bigint_const_monty::ConstMontyField, crypto_bigint_int::Int,
     crypto_bigint_monty::MontyFieldElement, crypto_bigint_uint::Uint,
 };
@@ -393,22 +393,22 @@ pub trait Transcript {
     ///
     /// The field modulus is NOT absorbed here: it is bound into the transcript
     /// separately, when the field is sampled.
-    fn absorb_field_element<E>(&mut self, v: &E, buf: &mut [u8])
+    fn absorb_field_element<C, I>(&mut self, cfg: &C, v: &C::Element, buf: &mut [u8])
     where
-        E: Transcribable,
+        C: FieldConfig + LiftElementWithConfig<I>,
+        I: Semiring + Transcribable,
     {
-        self.absorb_inner(&[0x3]);
-        v.write_transcription_bytes_exact(buf);
-        self.absorb_inner(buf);
-        self.absorb_inner(&[0x5]);
+        self.absorb_int(&cfg.lift(v), buf);
     }
 
     /// Absorbs a slice of field element into the transcript.
-    fn absorb_field_element_slice<E>(&mut self, v: &[E], buf: &mut [u8])
+    fn absorb_field_element_slice<C, I>(&mut self, cfg: &C, v: &[C::Element], buf: &mut [u8])
     where
-        E: Transcribable,
+        C: FieldConfig + LiftElementWithConfig<I>,
+        I: Semiring + Transcribable,
     {
-        v.iter().for_each(|x| self.absorb_field_element(x, buf));
+        v.iter()
+            .for_each(|x| self.absorb_field_element(cfg, x, buf));
     }
 
     /// Absorbs an integer into the transcript.
@@ -420,6 +420,14 @@ pub trait Transcript {
         v.write_transcription_bytes_exact(buf);
         self.absorb_inner(buf);
         self.absorb_inner(&[0x3])
+    }
+
+    /// Absorbs a slice of integer into the transcript.
+    fn absorb_int_slice<S>(&mut self, v: &[S], buf: &mut [u8])
+    where
+        S: Semiring + Transcribable,
+    {
+        v.iter().for_each(|x| self.absorb_int(x, buf));
     }
 }
 
@@ -580,11 +588,6 @@ impl<const LIMBS: usize> GenTranscribable for MontyFieldElement<LIMBS> {
     fn write_transcription_bytes_exact(&self, buf: &mut [u8]) {
         self.0.write_transcription_bytes_exact(buf)
     }
-}
-
-impl<const LIMBS: usize> ConstTranscribable for MontyFieldElement<LIMBS> {
-    const NUM_BYTES: usize = Uint::<LIMBS>::NUM_BYTES;
-    const NUM_BITS: usize = Uint::<LIMBS>::NUM_BITS;
 }
 
 impl<Mod: ConstMontyParams<LIMBS>, const LIMBS: usize> GenTranscribable

--- a/zip-plus/benches/zip_common.rs
+++ b/zip-plus/benches/zip_common.rs
@@ -388,7 +388,7 @@ pub fn verify<
                     // Initializing the verification transcript with the commitment and getting
                     // field config and projecting element are (arguably) verifier's responsibility
                     // and should be included in the verification time.
-                    transcript.fs_transcript.absorb_slice(&commitment.root);
+                    transcript.fs_transcript.absorb_bytes(&commitment.root);
                     let field_cfg = transcript
                         .fs_transcript
                         .get_random_field_cfg::<Cfg, Zt::Fmod, Zt::PrimeTest>();

--- a/zip-plus/src/lib.rs
+++ b/zip-plus/src/lib.rs
@@ -1,14 +1,12 @@
 pub mod code;
+pub mod merkle;
 pub mod pcs;
 pub mod pcs_transcript;
 pub mod utils;
 
-pub mod merkle;
-
-use std::io::ErrorKind;
-
 use crypto_primitives::FieldError;
 use thiserror::Error;
+use zinc_transcript::TranscriptError;
 
 #[derive(Clone, Debug, PartialEq, Error)]
 pub enum ZipError {
@@ -20,8 +18,8 @@ pub enum ZipError {
     InvalidSnark(String),
     #[error("Serialization Error: {0}")]
     Serialization(String),
-    #[error("Transcript failure: {1}")]
-    Transcript(ErrorKind, String),
+    #[error("Transcript failure: {0}")]
+    Transcript(#[from] TranscriptError),
     #[error("Error during polynomial evaluation: {0}")]
     PolynomialEvaluationError(zinc_poly::EvaluationError),
     #[error("Non-canonical field element: lifted integer >= modulus")]

--- a/zip-plus/src/lib.rs
+++ b/zip-plus/src/lib.rs
@@ -22,8 +22,6 @@ pub enum ZipError {
     Transcript(#[from] TranscriptError),
     #[error("Error during polynomial evaluation: {0}")]
     PolynomialEvaluationError(zinc_poly::EvaluationError),
-    #[error("Non-canonical field element: lifted integer >= modulus")]
-    NonCanonicalFieldElement,
     #[error("Error during inner product computation: {0}")]
     InnerProductError(zinc_utils::inner_product::InnerProductError),
 }

--- a/zip-plus/src/pcs/phase_prove.rs
+++ b/zip-plus/src/pcs/phase_prove.rs
@@ -94,7 +94,6 @@ impl<Zt: ZipTypes, Lc: LinearCode<Zt>> ZipPlus<Zt, Lc> {
             + ProjectElementWithConfig<Zt::Pt>
             + ProjectElementWithConfig<Zt::CombR>
             + Sync,
-        C::Element: ConstTranscribable,
         C::Integer: ConstTranscribable,
         Zt::CombR: MulByScalar<Zt::Chal>,
     {
@@ -125,7 +124,6 @@ impl<Zt: ZipTypes, Lc: LinearCode<Zt>> ZipPlus<Zt, Lc> {
     ) -> Result<C::Element, ZipError>
     where
         C: BaseFieldConfig + ProjectElementWithConfig<Zt::CombR> + Sync,
-        C::Element: ConstTranscribable,
         C::Integer: ConstTranscribable,
         Zt::CombR: MulByScalar<Zt::Chal>,
     {
@@ -277,7 +275,6 @@ impl<Zt: ZipTypes, Lc: LinearCode<Zt>> ZipPlus<Zt, Lc> {
             + ProjectElementWithConfig<Zt::Pt>
             + ProjectElementWithConfig<Zt::CombR>
             + Sync,
-        C::Element: ConstTranscribable,
         C::Integer: ConstTranscribable,
         Zt::CombR: MulByScalar<Zt::Chal>,
     {

--- a/zip-plus/src/pcs/phase_prove.rs
+++ b/zip-plus/src/pcs/phase_prove.rs
@@ -295,7 +295,7 @@ impl<Zt: ZipTypes, Lc: LinearCode<Zt>> ZipPlus<Zt, Lc> {
     ) -> Result<(), ZipError> {
         for cw_matrix in &commit_hint.cw_matrices {
             let column_values = cw_matrix.as_rows().map(|row| &row[column_idx]);
-            transcript.write_const_many_iter(column_values, cw_matrix.num_rows)?;
+            transcript.write_const_many_iter::<Zt::Cw, _>(column_values, cw_matrix.num_rows)?;
         }
 
         let merkle_proof = commit_hint

--- a/zip-plus/src/pcs/phase_verify.rs
+++ b/zip-plus/src/pcs/phase_verify.rs
@@ -163,9 +163,7 @@ impl<Zt: ZipTypes, Lc: LinearCode<Zt>> ZipPlus<Zt, Lc> {
         let (q_0, q_1) = point_to_tensor(field_cfg, point_f, vp.num_rows)?;
         let zero_f = field_cfg.zero();
 
-        let b: Vec<C::Element> = transcript
-            .read_field_elements(field_cfg, num_rows)
-            .map_err(|_| ZipError::NonCanonicalFieldElement)?;
+        let b: Vec<C::Element> = transcript.read_field_elements(field_cfg, num_rows)?;
 
         // Check 1: <q_0, b> == eval_f
         let q_0_dot_b =

--- a/zip-plus/src/pcs/phase_verify.rs
+++ b/zip-plus/src/pcs/phase_verify.rs
@@ -634,7 +634,7 @@ mod tests {
         let eval_mle1_f = field_cfg.project(&eval_mle1);
 
         let mut verifier_transcript = prover_transcript.into_verification_transcript();
-        verifier_transcript.fs_transcript.absorb_slice(&comm.root);
+        verifier_transcript.fs_transcript.absorb_bytes(&comm.root);
         let field_cfg = get_field_cfg::<Zt, Cfg>(&mut verifier_transcript.fs_transcript);
 
         let verification_result = TestZip::verify::<_, CHECKED>(
@@ -688,7 +688,7 @@ mod tests {
         let point_f: Vec<F> = point.iter().map(|v| field_cfg.project(v)).collect();
 
         let mut verifier_transcript = prover_transcript.into_verification_transcript();
-        verifier_transcript.fs_transcript.absorb_slice(&comm.root);
+        verifier_transcript.fs_transcript.absorb_bytes(&comm.root);
         let field_cfg = get_field_cfg::<Zt, Cfg>(&mut verifier_transcript.fs_transcript);
 
         let verification_result = TestZip::verify::<_, CHECKED>(
@@ -731,7 +731,7 @@ mod tests {
         let point_f: Vec<F> = point.iter().map(|v| field_cfg.project(v)).collect();
 
         let mut verifier_transcript = prover_transcript.into_verification_transcript();
-        verifier_transcript.fs_transcript.absorb_slice(&comm.root);
+        verifier_transcript.fs_transcript.absorb_bytes(&comm.root);
         let field_cfg = get_field_cfg::<Zt, Cfg>(&mut verifier_transcript.fs_transcript);
 
         let verification_result = TestZip::verify::<_, CHECKED>(
@@ -796,7 +796,7 @@ mod tests {
         let flip_at = column_values_start + bytes_per_cw / 2;
         verifier_transcript.stream.get_mut()[flip_at] ^= 0x01;
 
-        verifier_transcript.fs_transcript.absorb_slice(&comm.root);
+        verifier_transcript.fs_transcript.absorb_bytes(&comm.root);
         let field_cfg = get_field_cfg::<Zt, Cfg>(&mut verifier_transcript.fs_transcript);
 
         let res = TestZip::verify::<_, CHECKED>(
@@ -851,7 +851,7 @@ mod tests {
         let flip_at = <Cfg as WithAssociatedInteger>::Integer::NUM_BYTES / 4;
 
         let mut verifier_transcript = prover_transcript.into_verification_transcript();
-        verifier_transcript.fs_transcript.absorb_slice(&comm.root);
+        verifier_transcript.fs_transcript.absorb_bytes(&comm.root);
         get_field_cfg::<Zt, Cfg>(&mut verifier_transcript.fs_transcript);
         assert!(
             flip_at < verifier_transcript.stream.get_ref().len(),
@@ -905,7 +905,7 @@ mod tests {
         let point_f: Vec<F> = point.iter().map(|v| field_cfg.project(v)).collect();
 
         let mut verifier_transcript = prover_transcript.into_verification_transcript();
-        verifier_transcript.fs_transcript.absorb_slice(&comm.root);
+        verifier_transcript.fs_transcript.absorb_bytes(&comm.root);
         let field_cfg = get_field_cfg::<Zt, Cfg>(&mut verifier_transcript.fs_transcript);
 
         let res = TestZip::verify::<_, CHECKED>(
@@ -949,7 +949,7 @@ mod tests {
         let point_f: Vec<F> = point.iter().map(|v| field_cfg.project(v)).collect();
 
         let mut verifier_transcript = prover_transcript.into_verification_transcript();
-        verifier_transcript.fs_transcript.absorb_slice(&comm.root);
+        verifier_transcript.fs_transcript.absorb_bytes(&comm.root);
         let field_cfg = get_field_cfg::<Zt, Cfg>(&mut verifier_transcript.fs_transcript);
 
         let res = TestZip::verify::<_, CHECKED>(
@@ -995,7 +995,7 @@ mod tests {
         let point_f: Vec<F> = point.iter().map(|v| field_cfg.project(v)).collect();
 
         let mut verifier_transcript = prover_transcript.into_verification_transcript();
-        verifier_transcript.fs_transcript.absorb_slice(&comm.root);
+        verifier_transcript.fs_transcript.absorb_bytes(&comm.root);
         let field_cfg = get_field_cfg::<Zt, Cfg>(&mut verifier_transcript.fs_transcript);
 
         let verification_result = TestZip::verify::<_, CHECKED>(
@@ -1039,7 +1039,7 @@ mod tests {
         let point_f: Vec<F> = point.iter().map(|v| field_cfg.project(v)).collect();
 
         let mut verifier_transcript = prover_transcript.into_verification_transcript();
-        verifier_transcript.fs_transcript.absorb_slice(&comm.root);
+        verifier_transcript.fs_transcript.absorb_bytes(&comm.root);
         let field_cfg = get_field_cfg::<Zt, Cfg>(&mut verifier_transcript.fs_transcript);
 
         let verification_result = TestZip::verify::<_, CHECKED>(
@@ -1162,7 +1162,7 @@ mod tests {
             *b = 0xFF;
         }
 
-        verifier_transcript.fs_transcript.absorb_slice(&comm.root);
+        verifier_transcript.fs_transcript.absorb_bytes(&comm.root);
         let field_cfg = get_field_cfg::<Zt, Cfg>(&mut verifier_transcript.fs_transcript);
 
         let res = TestZip::verify::<_, CHECKED>(
@@ -1209,7 +1209,7 @@ mod tests {
             let mut verifier_transcript = prover_transcript.into_verification_transcript();
             verifier_transcript
                 .fs_transcript
-                .absorb_slice(&commitment.root);
+                .absorb_bytes(&commitment.root);
             let field_cfg = get_field_cfg::<Zt, Cfg>(&mut verifier_transcript.fs_transcript);
 
             let zero_f = field_cfg.zero();
@@ -1266,7 +1266,7 @@ mod tests {
             let point_f: Vec<F> = point.iter().map(|v| field_cfg.project(v)).collect();
 
             let mut verifier_transcript = prover_transcript.into_verification_transcript();
-            verifier_transcript.fs_transcript.absorb_slice(&comm.root);
+            verifier_transcript.fs_transcript.absorb_bytes(&comm.root);
             let field_cfg = get_field_cfg::<PolyZt, Cfg>(&mut verifier_transcript.fs_transcript);
 
             // Verifier replays verification from the same proof (also like the bench)
@@ -1317,7 +1317,7 @@ mod tests {
         let point_f: Vec<F> = point.iter().map(|v| field_cfg.project(v)).collect();
 
         let mut verifier_transcript = prover_transcript.into_verification_transcript();
-        verifier_transcript.fs_transcript.absorb_slice(&comm.root);
+        verifier_transcript.fs_transcript.absorb_bytes(&comm.root);
         let field_cfg = get_field_cfg::<PolyZt, Cfg>(&mut verifier_transcript.fs_transcript);
 
         let res = TestZip::verify::<_, CHECKED>(
@@ -1383,7 +1383,7 @@ mod tests {
         let point_f: Vec<F> = point.iter().map(|v| field_cfg.project(v)).collect();
 
         let mut verifier_transcript = prover_transcript.into_verification_transcript();
-        verifier_transcript.fs_transcript.absorb_slice(&comm.root);
+        verifier_transcript.fs_transcript.absorb_bytes(&comm.root);
         let field_cfg = get_field_cfg::<Zt, Cfg>(&mut verifier_transcript.fs_transcript);
 
         let res = TestZip::verify::<_, CHECKED>(

--- a/zip-plus/src/pcs/phase_verify.rs
+++ b/zip-plus/src/pcs/phase_verify.rs
@@ -163,7 +163,9 @@ impl<Zt: ZipTypes, Lc: LinearCode<Zt>> ZipPlus<Zt, Lc> {
         let (q_0, q_1) = point_to_tensor(field_cfg, point_f, vp.num_rows)?;
         let zero_f = field_cfg.zero();
 
-        let b: Vec<C::Element> = transcript.read_field_elements(field_cfg, num_rows)?;
+        let b: Vec<C::Element> = transcript
+            .read_field_elements(field_cfg, num_rows)
+            .map_err(|_| ZipError::NonCanonicalFieldElement)?;
 
         // Check 1: <q_0, b> == eval_f
         let q_0_dot_b =

--- a/zip-plus/src/pcs/phase_verify.rs
+++ b/zip-plus/src/pcs/phase_verify.rs
@@ -108,7 +108,6 @@ impl<Zt: ZipTypes, Lc: LinearCode<Zt>> ZipPlus<Zt, Lc> {
         C: BaseFieldConfig
             + ProjectElementWithConfig<Zt::CombR>
             + ProjectElementWithConfig<Zt::Chal>,
-        C::Element: ConstTranscribable,
         C::Integer: ConstTranscribable,
     {
         let per_poly_alphas = Self::sample_alphas(&mut transcript.fs_transcript, comm.batch_size);
@@ -144,7 +143,6 @@ impl<Zt: ZipTypes, Lc: LinearCode<Zt>> ZipPlus<Zt, Lc> {
         C: BaseFieldConfig
             + ProjectElementWithConfig<Zt::CombR>
             + ProjectElementWithConfig<Zt::Chal>,
-        C::Element: ConstTranscribable,
         C::Integer: ConstTranscribable,
     {
         let batch_size = comm.batch_size;
@@ -324,7 +322,7 @@ mod tests {
         pcs_transcript::{PcsProverTranscript, PcsVerifierTranscript},
     };
     use crypto_primitives::{
-        FixedConfig, IntSemiring, ProjectElementWithConfig, SemiringConfig,
+        FixedConfig, IntSemiring, ProjectElementWithConfig, SemiringConfig, WithAssociatedInteger,
         crypto_bigint_int::Int,
         crypto_bigint_monty::{MontyField, MontyFieldElement},
         crypto_bigint_uint::{U64, Uint},
@@ -783,7 +781,7 @@ mod tests {
         // To trigger "Proximity failure", corrupt a column value (past b +
         // combined_row).
         let row_len = pp.linear_code.row_len();
-        let b_section_size = pp.num_rows * F::NUM_BYTES;
+        let b_section_size = pp.num_rows * <Cfg as WithAssociatedInteger>::Integer::NUM_BYTES;
         let bytes_per_comb_r = M * size_of::<crypto_bigint::Word>();
         let combined_row_size = row_len * bytes_per_comb_r;
         let column_values_start = b_section_size + combined_row_size;
@@ -850,7 +848,7 @@ mod tests {
 
         // The transcript starts with the raw b field elements. Flip a byte
         // inside the first b element's value to corrupt eval consistency.
-        let flip_at = F::NUM_BYTES / 4;
+        let flip_at = <Cfg as WithAssociatedInteger>::Integer::NUM_BYTES / 4;
 
         let mut verifier_transcript = prover_transcript.into_verification_transcript();
         verifier_transcript.fs_transcript.absorb_slice(&comm.root);
@@ -1149,7 +1147,7 @@ mod tests {
         let point_f: Vec<F> = point.iter().map(|v| field_cfg.project(v)).collect();
 
         // Offset past b section to reach combined_row (CombR = Int<M>).
-        let b_section_size = pp.num_rows * F::NUM_BYTES;
+        let b_section_size = pp.num_rows * <Cfg as WithAssociatedInteger>::Integer::NUM_BYTES;
         let bytes_to_corrupt = M * size_of::<crypto_bigint::Word>();
 
         let mut verifier_transcript = prover_transcript.into_verification_transcript();

--- a/zip-plus/src/pcs/test_utils.rs
+++ b/zip-plus/src/pcs/test_utils.rs
@@ -168,9 +168,7 @@ where
         + ProjectElementWithConfig<<TestZipTypes<N, K, M> as ZipTypes>::Pt>
         + ProjectElementWithConfig<<TestZipTypes<N, K, M> as ZipTypes>::CombR>
         + Sync,
-    C::Element: ConstTranscribable,
-    C::Integer: ConstTranscribable,
-    C::Integer: FromRef<<TestZipTypes<N, K, M> as ZipTypes>::Fmod>,
+    C::Integer: ConstTranscribable + FromRef<<TestZipTypes<N, K, M> as ZipTypes>::Fmod>,
 {
     setup_full_protocol_inner::<_, _, C, N>(num_vars, setup_test_params, || {
         (0..num_vars).map(|i| Int::from(i as i32 + 2)).collect()
@@ -200,9 +198,8 @@ where
         + ProjectElementWithConfig<<TestBinPolyZipTypes<K, M, DEGREE_PLUS_ONE> as ZipTypes>::Pt>
         + ProjectElementWithConfig<<TestBinPolyZipTypes<K, M, DEGREE_PLUS_ONE> as ZipTypes>::CombR>
         + Sync,
-    C::Element: ConstTranscribable,
-    C::Integer: ConstTranscribable,
-    C::Integer: FromRef<<TestBinPolyZipTypes<K, M, DEGREE_PLUS_ONE> as ZipTypes>::Fmod>,
+    C::Integer: ConstTranscribable
+        + FromRef<<TestBinPolyZipTypes<K, M, DEGREE_PLUS_ONE> as ZipTypes>::Fmod>,
 {
     setup_full_protocol_inner::<_, _, C, N>(num_vars, setup_poly_test_params, || {
         (0..num_vars).map(|i| i as i128 + 2).collect()
@@ -228,7 +225,6 @@ where
         + ProjectElementWithConfig<Zt::Pt>
         + ProjectElementWithConfig<Zt::CombR>
         + Sync,
-    C::Element: ConstTranscribable,
     C::Integer: ConstTranscribable,
     C::Integer: FromRef<Zt::Fmod>,
 {

--- a/zip-plus/src/pcs/test_utils.rs
+++ b/zip-plus/src/pcs/test_utils.rs
@@ -243,7 +243,7 @@ where
 
     let mut transcript = transcript.into_verification_transcript();
 
-    transcript.fs_transcript.absorb_slice(&comm.root.0);
+    transcript.fs_transcript.absorb_bytes(&comm.root.0);
 
     (pp, comm, point_f, eval_f, transcript)
 }

--- a/zip-plus/src/pcs_transcript.rs
+++ b/zip-plus/src/pcs_transcript.rs
@@ -43,6 +43,9 @@ macro_rules! common_methods {
 /// A transcript for Polynomial Commitment Scheme (PCS) operations.
 /// Manages both Fiat-Shamir transformations and serialization/deserialization
 /// of proof data.
+///
+/// Every byte written to the proof stream is absorbed into the Fiat-Shamir
+/// transcript by the same call
 #[derive(Debug, Clone)]
 pub struct PcsProverTranscript {
     /// Handles Fiat-Shamir transformations for non-interactive zero-knowledge
@@ -121,6 +124,9 @@ impl PcsProverTranscript {
                 .take(T::LENGTH_NUM_BYTES)
                 .collect_vec();
             self.stream.write_all(&len_bytes)?;
+            // A length that selects how much of the stream is read later is
+            // itself a prover message, so it has to bind.
+            self.fs_transcript.absorb_bytes(&len_bytes);
         }
 
         let prev_pos = safe_cast!(self.stream.position(), u64, usize)?;
@@ -131,7 +137,9 @@ impl PcsProverTranscript {
             inner.resize(next_pos, 0_u8);
         }
 
-        v.write_transcription_bytes_exact(&mut inner[prev_pos..next_pos]);
+        let inner_slice = &mut inner[prev_pos..next_pos];
+        v.write_transcription_bytes_exact(inner_slice);
+        self.fs_transcript.absorb_bytes(inner_slice);
 
         self.stream.set_position(safe_cast!(next_pos, usize, u64)?);
         Ok(())
@@ -207,6 +215,26 @@ pub struct PcsVerifierTranscript {
 impl PcsVerifierTranscript {
     common_methods!();
 
+    /// Returns an error unless the whole proof stream has been consumed.
+    ///
+    /// Call this once at the end of verification, after every component
+    /// sharing the stream has read its section.
+    pub fn check_eof(&self) -> Result<(), ZipError> {
+        let position = safe_cast!(self.stream.position(), u64, usize)?;
+        let len = self.stream.get_ref().len();
+        if position == len {
+            Ok(())
+        } else {
+            Err(ZipError::Transcript(
+                ErrorKind::InvalidData,
+                format!(
+                    "proof stream not fully consumed: {} unread byte(s)",
+                    len.saturating_sub(position)
+                ),
+            ))
+        }
+    }
+
     /// Reads canonical lifted integers from the proof stream, strictly
     /// validates them against the field modulus, projects them into the
     /// field, and absorbs the resulting elements into the transcript. The
@@ -232,6 +260,7 @@ impl PcsVerifierTranscript {
         let data_len = if T::LENGTH_NUM_BYTES > 0 {
             let mut len_buf = vec![0u8; T::LENGTH_NUM_BYTES];
             self.stream.read_exact(&mut len_buf)?;
+            self.fs_transcript.absorb_bytes(&len_buf);
             T::read_num_bytes(&len_buf)
         } else {
             // LENGTH_NUM_BYTES == 0 means size is known at compile time via
@@ -241,6 +270,7 @@ impl PcsVerifierTranscript {
         };
 
         read_stream_slice(&mut self.stream, data_len, |slice| {
+            self.fs_transcript.absorb_bytes(slice);
             Ok(T::read_transcription_bytes_exact(slice))
         })
     }
@@ -375,6 +405,115 @@ mod tests {
             read_const_many,
             original_hashes,
             "hashes vector"
+        );
+    }
+
+    const CAP: usize = 1 << 24;
+
+    /// Every byte on the wire must bind the challenges drawn after it.
+    ///
+    /// This pins the invariant whose absence let a prover choose
+    /// `combined_row` *after* learning the column indices it was supposed to
+    /// be committed to beforehand. Before wire writes were absorbed, the two
+    /// payloads below produced identical challenges.
+    #[test]
+    fn wire_writes_bind_subsequent_challenges() {
+        let comm = ZipPlusCommitment::default();
+
+        let challenge_after = |payload: &[u64]| {
+            let mut transcript = PcsProverTranscript::new_from_commitment(&comm);
+            transcript
+                .write_const_many(payload)
+                .expect("write should succeed");
+            transcript.squeeze_challenge_idx(CAP)
+        };
+
+        assert_ne!(
+            challenge_after(&[1, 2, 3, 4]),
+            challenge_after(&[1, 2, 3, 5]),
+            "changing a written value left the next challenge unchanged: \
+             wire bytes are not entering the transcript"
+        );
+    }
+
+    /// A length prefix selects how much of the stream is read later, so it is
+    /// a prover message and must bind just like a payload.
+    #[test]
+    fn length_prefixed_writes_bind_subsequent_challenges() {
+        let comm = ZipPlusCommitment::default();
+
+        let challenge_after = |value: u64| {
+            let mut transcript = PcsProverTranscript::new_from_commitment(&comm);
+            transcript.write(&value).expect("write should succeed");
+            transcript.squeeze_challenge_idx(CAP)
+        };
+
+        assert_ne!(
+            challenge_after(7),
+            challenge_after(8),
+            "`write` is not absorbing its payload"
+        );
+    }
+
+    /// Prover and verifier must reach the same state after the same logical
+    /// message, no matter how either side chunks it into calls.
+    ///
+    /// Absorbs are framed, so call granularity is normally significant. The
+    /// `write_const_many_iter` / `read_const_many` pair frames one fixed-size
+    /// element at a time rather than one call at a time, which is what makes
+    /// the split into calls irrelevant here. That property is load-bearing:
+    /// the prover writes column values one codeword matrix at a time while
+    /// the verifier reads them in a single batched call.
+    #[test]
+    fn transcript_state_is_independent_of_call_chunking() {
+        let comm = ZipPlusCommitment::default();
+        let payload: Vec<u64> = (0..8).collect();
+
+        // Prover emits the run as two calls ...
+        let mut prover = PcsProverTranscript::new_from_commitment(&comm);
+        prover
+            .write_const_many(&payload[..3])
+            .expect("write should succeed");
+        prover
+            .write_const_many(&payload[3..])
+            .expect("write should succeed");
+        let prover_challenge = prover.squeeze_challenge_idx(CAP);
+
+        // ... the verifier consumes it as one.
+        let mut verifier = prover.into_verification_transcript();
+        verifier.fs_transcript.absorb_bytes(&comm.root);
+        let read: Vec<u64> = verifier
+            .read_const_many(payload.len())
+            .expect("read should succeed");
+        let verifier_challenge = verifier.squeeze_challenge_idx(CAP);
+
+        assert_eq!(read, payload, "round-trip lost data");
+        assert_eq!(
+            prover_challenge, verifier_challenge,
+            "prover and verifier transcripts diverged on identical data"
+        );
+        verifier
+            .check_eof()
+            .expect("stream should be fully consumed");
+    }
+
+    /// Trailing bytes are bytes that never entered the transcript, so they
+    /// must be rejected rather than silently ignored.
+    #[test]
+    fn check_eof_rejects_unread_trailing_bytes() {
+        let comm = ZipPlusCommitment::default();
+        let mut prover = PcsProverTranscript::new_from_commitment(&comm);
+        prover
+            .write_const_many(&[1u64, 2, 3])
+            .expect("write should succeed");
+
+        let mut verifier = prover.into_verification_transcript();
+        verifier.fs_transcript.absorb_bytes(&comm.root);
+        let _: Vec<u64> = verifier.read_const_many(2).expect("read should succeed");
+
+        assert!(
+            verifier.check_eof().is_err(),
+            "check_eof accepted a stream with unread trailing bytes"
         );
     }
 }

--- a/zip-plus/src/pcs_transcript.rs
+++ b/zip-plus/src/pcs_transcript.rs
@@ -1,4 +1,4 @@
-use crate::{ZipError, merkle::MerkleProof, pcs::structs::ZipPlusCommitment};
+use crate::{merkle::MerkleProof, pcs::structs::ZipPlusCommitment};
 use crypto_primitives::BaseFieldConfig;
 use itertools::Itertools;
 use std::{
@@ -6,7 +6,7 @@ use std::{
     io::{Cursor, ErrorKind, Read, Write},
 };
 use zinc_transcript::{
-    Blake3Transcript,
+    Blake3Transcript, TranscriptError,
     traits::{ConstTranscribable, Transcribable, Transcript},
 };
 use zinc_utils::{add, mul, rem};
@@ -14,7 +14,7 @@ use zinc_utils::{add, mul, rem};
 macro_rules! safe_cast {
     ($value:expr, $from:ident, $to:ident) => {
         $to::try_from($value).map_err(|_err| {
-            ZipError::Transcript(
+            TranscriptError(
                 ErrorKind::Unsupported,
                 format!(
                     "Failed to convert {} to {}",
@@ -105,7 +105,11 @@ impl PcsProverTranscript {
     /// Absorbs the elements into the Fiat-Shamir transcript (raw inner
     /// representation) and writes their canonical lifted integers to the
     /// proof stream. The wire never carries raw Montgomery residues.
-    pub fn write_field_elements<C>(&mut self, cfg: &C, elems: &[C::Element]) -> Result<(), ZipError>
+    pub fn write_field_elements<C>(
+        &mut self,
+        cfg: &C,
+        elems: &[C::Element],
+    ) -> Result<(), TranscriptError>
     where
         C: BaseFieldConfig,
         C::Integer: ConstTranscribable,
@@ -113,7 +117,7 @@ impl PcsProverTranscript {
         self.write_const_many_iter(elems.iter().map(|e| cfg.lift(e)), elems.len())
     }
 
-    pub fn write<T: Transcribable>(&mut self, v: &T) -> Result<(), ZipError> {
+    pub fn write<T: Transcribable>(&mut self, v: &T) -> Result<(), TranscriptError> {
         let data_len = v.get_num_bytes();
 
         // Write the length prefix when it is not known at compile time.
@@ -123,7 +127,9 @@ impl PcsProverTranscript {
                 .into_iter()
                 .take(T::LENGTH_NUM_BYTES)
                 .collect_vec();
-            self.stream.write_all(&len_bytes)?;
+            self.stream
+                .write_all(&len_bytes)
+                .map_err(to_transcript_error)?;
             // A length that selects how much of the stream is read later is
             // itself a prover message, so it has to bind.
             self.fs_transcript.absorb_bytes(&len_bytes);
@@ -148,14 +154,21 @@ impl PcsProverTranscript {
     // Note(alex):
     // Parallelizing this greatly degrades performance rather than improving it.
     // Maybe we should think of breakpoints for parallelization later.
-    pub fn write_const_many<T: ConstTranscribable>(&mut self, vs: &[T]) -> Result<(), ZipError> {
+    pub fn write_const_many<T: ConstTranscribable>(
+        &mut self,
+        vs: &[T],
+    ) -> Result<(), TranscriptError> {
         self.write_const_many_iter::<T, _>(vs, vs.len())
     }
 
     // Note(alex):
     // Parallelizing this greatly degrades performance rather than improving it.
     // Maybe we should think of breakpoints for parallelization later.
-    pub fn write_const_many_iter<'a, T, I>(&mut self, vs: I, vs_len: usize) -> Result<(), ZipError>
+    pub fn write_const_many_iter<'a, T, I>(
+        &mut self,
+        vs: I,
+        vs_len: usize,
+    ) -> Result<(), TranscriptError>
     where
         T: ConstTranscribable + 'a,
         I: IntoIterator,
@@ -180,12 +193,12 @@ impl PcsProverTranscript {
         Ok(())
     }
 
-    fn write_usize(&mut self, value: usize) -> Result<(), ZipError> {
+    fn write_usize(&mut self, value: usize) -> Result<(), TranscriptError> {
         let value_u64 = safe_cast!(value, usize, u64)?;
         self.write(&value_u64)
     }
 
-    pub fn write_merkle_proof(&mut self, proof: &MerkleProof) -> Result<(), ZipError> {
+    pub fn write_merkle_proof(&mut self, proof: &MerkleProof) -> Result<(), TranscriptError> {
         // Write the dimensions of matrix used to construct the Merkle tree
         self.write_usize(proof.leaf_index)?;
         self.write_usize(proof.leaf_count)?;
@@ -219,13 +232,13 @@ impl PcsVerifierTranscript {
     ///
     /// Call this once at the end of verification, after every component
     /// sharing the stream has read its section.
-    pub fn check_eof(&self) -> Result<(), ZipError> {
+    pub fn check_eof(&self) -> Result<(), TranscriptError> {
         let position = safe_cast!(self.stream.position(), u64, usize)?;
         let len = self.stream.get_ref().len();
         if position == len {
             Ok(())
         } else {
-            Err(ZipError::Transcript(
+            Err(TranscriptError(
                 ErrorKind::InvalidData,
                 format!(
                     "proof stream not fully consumed: {} unread byte(s)",
@@ -242,7 +255,11 @@ impl PcsVerifierTranscript {
     ///
     /// Rejects any integer `>= modulus`: every field value has exactly one
     /// accepted encoding on the wire.
-    pub fn read_field_elements<C>(&mut self, cfg: &C, n: usize) -> Result<Vec<C::Element>, ZipError>
+    pub fn read_field_elements<C>(
+        &mut self,
+        cfg: &C,
+        n: usize,
+    ) -> Result<Vec<C::Element>, TranscriptError>
     where
         C: BaseFieldConfig,
         C::Integer: ConstTranscribable,
@@ -250,16 +267,21 @@ impl PcsVerifierTranscript {
         let ints: Vec<C::Integer> = self.read_const_many(n)?;
         let modulus = cfg.modulus();
         if ints.iter().any(|int| *int >= modulus) {
-            return Err(ZipError::NonCanonicalFieldElement);
+            return Err(TranscriptError(
+                ErrorKind::InvalidData,
+                "Non-canonical field element".to_owned(),
+            ));
         }
         let elems = ints.iter().map(|int| cfg.project(int)).collect_vec();
         Ok(elems)
     }
 
-    pub fn read<T: Transcribable>(&mut self) -> Result<T, ZipError> {
+    pub fn read<T: Transcribable>(&mut self) -> Result<T, TranscriptError> {
         let data_len = if T::LENGTH_NUM_BYTES > 0 {
             let mut len_buf = vec![0u8; T::LENGTH_NUM_BYTES];
-            self.stream.read_exact(&mut len_buf)?;
+            self.stream
+                .read_exact(&mut len_buf)
+                .map_err(to_transcript_error)?;
             self.fs_transcript.absorb_bytes(&len_buf);
             T::read_num_bytes(&len_buf)
         } else {
@@ -275,7 +297,10 @@ impl PcsVerifierTranscript {
         })
     }
 
-    pub fn read_const_many<T: ConstTranscribable>(&mut self, n: usize) -> Result<Vec<T>, ZipError> {
+    pub fn read_const_many<T: ConstTranscribable>(
+        &mut self,
+        n: usize,
+    ) -> Result<Vec<T>, TranscriptError> {
         read_stream_slice(&mut self.stream, mul!(n, T::NUM_BYTES), |slice| {
             Ok(slice
                 .chunks(T::NUM_BYTES)
@@ -287,12 +312,12 @@ impl PcsVerifierTranscript {
         })
     }
 
-    fn read_usize(&mut self) -> Result<usize, ZipError> {
+    fn read_usize(&mut self) -> Result<usize, TranscriptError> {
         let value = self.read::<u64>()?;
         safe_cast!(value, u64, usize)
     }
 
-    pub fn read_merkle_proof(&mut self) -> Result<MerkleProof, ZipError> {
+    pub fn read_merkle_proof(&mut self) -> Result<MerkleProof, TranscriptError> {
         // Read the dimensions of matrix used to construct the Merkle tree
         let leaf_index = self.read_usize()?;
         let leaf_count = self.read_usize()?;
@@ -314,14 +339,14 @@ impl PcsVerifierTranscript {
 fn read_stream_slice<T>(
     stream: &mut Cursor<Vec<u8>>,
     length: usize,
-    mut action: impl FnMut(&[u8]) -> Result<T, ZipError>,
-) -> Result<T, ZipError> {
+    mut action: impl FnMut(&[u8]) -> Result<T, TranscriptError>,
+) -> Result<T, TranscriptError> {
     let prev_pos = safe_cast!(stream.position(), u64, usize)?;
     let next_pos = add!(prev_pos, length);
 
     let stream_vec = stream.get_ref();
     if next_pos > stream_vec.len() {
-        return Err(ZipError::Transcript(
+        return Err(TranscriptError(
             ErrorKind::UnexpectedEof,
             format!(
                 "Attempted to read beyond the end of the stream: {} + {} exceeds stream length {}",
@@ -337,10 +362,8 @@ fn read_stream_slice<T>(
 }
 
 // Do not expose this outside
-impl From<std::io::Error> for ZipError {
-    fn from(err: std::io::Error) -> Self {
-        ZipError::Transcript(err.kind(), err.to_string())
-    }
+fn to_transcript_error(err: std::io::Error) -> TranscriptError {
+    TranscriptError(err.kind(), err.to_string())
 }
 
 #[cfg(test)]

--- a/zip-plus/src/pcs_transcript.rs
+++ b/zip-plus/src/pcs_transcript.rs
@@ -102,13 +102,11 @@ impl PcsProverTranscript {
     pub fn write_field_elements<C>(&mut self, cfg: &C, elems: &[C::Element]) -> Result<(), ZipError>
     where
         C: BaseFieldConfig,
-        C::Element: ConstTranscribable,
         C::Integer: ConstTranscribable,
     {
-        let mut buf = vec![0; C::Element::NUM_BYTES];
-        self.fs_transcript
-            .absorb_field_element_slice(elems, &mut buf);
+        let mut buf = vec![0; C::Integer::NUM_BYTES];
         let lifted: Vec<C::Integer> = elems.iter().map(|e| cfg.lift(e)).collect();
+        self.fs_transcript.absorb_int_slice(&lifted, &mut buf);
         self.write_const_many(&lifted)
     }
 
@@ -218,7 +216,6 @@ impl PcsVerifierTranscript {
     pub fn read_field_elements<C>(&mut self, cfg: &C, n: usize) -> Result<Vec<C::Element>, ZipError>
     where
         C: BaseFieldConfig,
-        C::Element: ConstTranscribable,
         C::Integer: ConstTranscribable,
     {
         let ints: Vec<C::Integer> = self.read_const_many(n)?;
@@ -227,9 +224,8 @@ impl PcsVerifierTranscript {
             return Err(ZipError::NonCanonicalFieldElement);
         }
         let elems = ints.iter().map(|int| cfg.project(int)).collect_vec();
-        let mut buf = vec![0; C::Element::NUM_BYTES];
-        self.fs_transcript
-            .absorb_field_element_slice(&elems, &mut buf);
+        let mut buf = vec![0; C::Integer::NUM_BYTES];
+        self.fs_transcript.absorb_int_slice(&ints, &mut buf);
         Ok(elems)
     }
 

--- a/zip-plus/src/pcs_transcript.rs
+++ b/zip-plus/src/pcs_transcript.rs
@@ -1,7 +1,10 @@
 use crate::{ZipError, merkle::MerkleProof, pcs::structs::ZipPlusCommitment};
 use crypto_primitives::BaseFieldConfig;
 use itertools::Itertools;
-use std::io::{Cursor, ErrorKind, Read, Write};
+use std::{
+    borrow::Borrow,
+    io::{Cursor, ErrorKind, Read, Write},
+};
 use zinc_transcript::{
     Blake3Transcript,
     traits::{ConstTranscribable, Transcribable, Transcript},
@@ -66,7 +69,7 @@ impl PcsProverTranscript {
         };
 
         for comm in comms {
-            result.fs_transcript.absorb_slice(&comm.root);
+            result.fs_transcript.absorb_bytes(&comm.root);
         }
 
         result
@@ -104,10 +107,7 @@ impl PcsProverTranscript {
         C: BaseFieldConfig,
         C::Integer: ConstTranscribable,
     {
-        let mut buf = vec![0; C::Integer::NUM_BYTES];
-        let lifted: Vec<C::Integer> = elems.iter().map(|e| cfg.lift(e)).collect();
-        self.fs_transcript.absorb_int_slice(&lifted, &mut buf);
-        self.write_const_many(&lifted)
+        self.write_const_many_iter(elems.iter().map(|e| cfg.lift(e)), elems.len())
     }
 
     pub fn write<T: Transcribable>(&mut self, v: &T) -> Result<(), ZipError> {
@@ -141,7 +141,7 @@ impl PcsProverTranscript {
     // Parallelizing this greatly degrades performance rather than improving it.
     // Maybe we should think of breakpoints for parallelization later.
     pub fn write_const_many<T: ConstTranscribable>(&mut self, vs: &[T]) -> Result<(), ZipError> {
-        self.write_const_many_iter(vs.iter(), vs.len())
+        self.write_const_many_iter::<T, _>(vs, vs.len())
     }
 
     // Note(alex):
@@ -150,7 +150,8 @@ impl PcsProverTranscript {
     pub fn write_const_many_iter<'a, T, I>(&mut self, vs: I, vs_len: usize) -> Result<(), ZipError>
     where
         T: ConstTranscribable + 'a,
-        I: IntoIterator<Item = &'a T>,
+        I: IntoIterator,
+        I::Item: Borrow<T>,
     {
         let prev_pos = safe_cast!(self.stream.position(), u64, usize)?;
         let data_len = mul!(vs_len, T::NUM_BYTES);
@@ -162,10 +163,10 @@ impl PcsProverTranscript {
             inner.resize(next_pos, 0_u8);
         }
 
-        inner[prev_pos..next_pos]
-            .chunks_mut(T::NUM_BYTES)
-            .zip(vs)
-            .for_each(|(chunk, v)| v.write_transcription_bytes_exact(chunk));
+        for (chunk, v) in inner[prev_pos..next_pos].chunks_mut(T::NUM_BYTES).zip(vs) {
+            v.borrow().write_transcription_bytes_exact(chunk);
+            self.fs_transcript.absorb_bytes(chunk);
+        }
 
         self.stream.set_position(next_pos as u64);
         Ok(())
@@ -224,8 +225,6 @@ impl PcsVerifierTranscript {
             return Err(ZipError::NonCanonicalFieldElement);
         }
         let elems = ints.iter().map(|int| cfg.project(int)).collect_vec();
-        let mut buf = vec![0; C::Integer::NUM_BYTES];
-        self.fs_transcript.absorb_int_slice(&ints, &mut buf);
         Ok(elems)
     }
 
@@ -250,7 +249,10 @@ impl PcsVerifierTranscript {
         read_stream_slice(&mut self.stream, mul!(n, T::NUM_BYTES), |slice| {
             Ok(slice
                 .chunks(T::NUM_BYTES)
-                .map(T::read_transcription_bytes_exact)
+                .map(|bs| {
+                    self.fs_transcript.absorb_bytes(bs);
+                    T::read_transcription_bytes_exact(bs)
+                })
                 .collect_vec())
         })
     }
@@ -282,7 +284,7 @@ impl PcsVerifierTranscript {
 fn read_stream_slice<T>(
     stream: &mut Cursor<Vec<u8>>,
     length: usize,
-    action: impl Fn(&[u8]) -> Result<T, ZipError>,
+    mut action: impl FnMut(&[u8]) -> Result<T, ZipError>,
 ) -> Result<T, ZipError> {
     let prev_pos = safe_cast!(stream.position(), u64, usize)?;
     let next_pos = add!(prev_pos, length);
@@ -326,7 +328,7 @@ mod tests {
                 .$write_fn(&$original_value)
                 .expect(&format!("Failed to write {}", $assert_msg));
             let mut transcript: PcsVerifierTranscript = transcript.into_verification_transcript();
-            transcript.fs_transcript.absorb_slice(&comm.root);
+            transcript.fs_transcript.absorb_bytes(&comm.root);
             let read_value = transcript
                 .$read_fn()
                 .expect(&format!("Failed to read {}", $assert_msg));
@@ -348,7 +350,7 @@ mod tests {
                 .$write_fn(&$original_values)
                 .expect(&format!("Failed to write {}", $assert_msg));
             let mut transcript: PcsVerifierTranscript = transcript.into_verification_transcript();
-            transcript.fs_transcript.absorb_slice(&comm.root);
+            transcript.fs_transcript.absorb_bytes(&comm.root);
             let read_values = transcript
                 .$read_fn($original_values.len())
                 .expect(&format!("Failed to read {}", $assert_msg));


### PR DESCRIPTION
Supersedes #225

As discovered by @latifkasuli, writing non-field elements without absorbing them relied on caller explicitly calling `absorb_`, and at least in one case forgetting to do so leaded to a soundness gap.

To resolve this and other similar cases potentially present in the codebase, transcript API was reworked:
* Anything written to or read from a transcript is now unconditionally absorbed.
* Field elements are now read/written to a transcript in a lifted form, as integers. 
  * `C::Element` is no longer required to be `Transcribable`, nor should it be.
* Introduced `TranscriptError` separate from `ZipError`.
* Added a domain separator prefix at the beginning of the transcript.

This does lead to a negligible performance hit (<5%).

Additionally, fixed a flaky test