### PR TITLE
Bind shifted affine virtuals to source columns

### DIFF
--- a/piop/src/lookup/booleanity.rs
+++ b/piop/src/lookup/booleanity.rs
@@ -54,11 +54,6 @@
 //!   b_{j,i}\,\alpha'^{\,i}$ (where $b_{j,i} = \widetilde{v_{j,i}}(r^\star)$
 //!   from `bit_slice_evals`).
 //!
-//! No `ShiftSpec` references the appended slot, so down-evals / shifts
-//! pass through unchanged: row-shifted projections of witness binary-poly
-//! columns inherit booleanity from the un-shifted, $\psi_a$-projected
-//! slot they already reference in the multipoint-eval sumcheck.
-//!
 //! Multipoint-eval / PCS is $\psi$-oblivious, so the appended slot
 //! combined with the lifted-evals step evaluating the corresponding
 //! $\bar u_j$ at $\alpha'$ enforces
@@ -67,14 +62,13 @@
 //! not the true bit-decomposition then equality fails with probability
 //! $\le (D-1)/|F|$, so the verifier rejects.
 //!
-//! For an unshifted affine virtual, the protocol collapses its bit-slice
-//! claims at the same $\alpha'$ and compares the result directly with the
-//! declared affine combination of source-column collapses at $r^\star$.
-//! Public source collapses are recomputed from the public trace; witness source
+//! For an affine virtual, the protocol collapses its bit-slice claims at the
+//! same $\alpha'$ and compares the result with the declared affine combination
+//! of source-column collapses at $r^\star$. Public source collapses, including
+//! shifted ones, are recomputed from the public trace. Unshifted witness
 //! collapses are the committed-column values bound through the MP/PCS chain
-//! above. Shifted affine terms require a separate row-shift opening and are
-//! rejected when affine specs are attached to the UAIR signature until that
-//! binding is implemented.
+//! above; unique shifted witness sources add bridge-only `ShiftSpec` claims
+//! over the appended $\alpha'$ slots and use MP's existing shift kernel.
 
 use crate::{
     CombFn,
@@ -840,7 +834,9 @@ where
             for row_idx in 0..n_rows {
                 let mut residual = ones.clone();
                 for (source_col, coeff, row_shift) in &terms {
-                    let shifted_row = add!(row_idx, *row_shift);
+                    let Some(shifted_row) = row_idx.checked_add(*row_shift) else {
+                        continue;
+                    };
                     if shifted_row >= n_rows {
                         continue;
                     }

--- a/piop/src/shift_predicate.rs
+++ b/piop/src/shift_predicate.rs
@@ -14,6 +14,9 @@ use zinc_poly::utils::next_mle_eval;
 ///
 /// where `k = ceil(log2(2c))` determines the split point.
 ///
+/// Returns zero when `c >= 2^m`, since every shifted row is outside the
+/// domain.
+///
 /// Cost: O(m + c · log c) field operations.
 #[allow(clippy::arithmetic_side_effects)]
 pub fn eval_shift_predicate<C: SemiringConfig>(
@@ -24,6 +27,11 @@ pub fn eval_shift_predicate<C: SemiringConfig>(
 ) -> C::Element {
     let m = x.len();
     assert_eq!(y.len(), m);
+    let n = 1usize << m;
+
+    if c >= n {
+        return cfg.zero();
+    }
 
     // S_0(x, y) = eq(x, y): identity shift.
     if c == 0 {
@@ -35,7 +43,6 @@ pub fn eval_shift_predicate<C: SemiringConfig>(
         return next_mle_eval(cfg, x, y);
     }
 
-    assert!(c < (1usize << m), "shift c must satisfy c < 2^m");
     // k = ceil(log2(2*c))
     let k = (2 * c).next_power_of_two().trailing_zeros() as usize;
     if k >= m {
@@ -381,6 +388,20 @@ mod tests {
                 "expected {} nonzero entries for c={c}",
                 n - c
             );
+        }
+    }
+
+    #[test]
+    fn test_shift_predicate_at_or_past_domain_is_zero() {
+        let cfg = test_config();
+        let mut rng = rand::rng();
+        let m = 3;
+        let n = 1usize << m;
+        let x: Vec<E> = (0..m).map(|_| rand_field(&cfg, &mut rng)).collect();
+        let y: Vec<E> = (0..m).map(|_| rand_field(&cfg, &mut rng)).collect();
+
+        for c in [n, n + 1, usize::MAX] {
+            assert_eq!(eval_shift_predicate(&cfg, &x, &y, c), cfg.zero());
         }
     }
 

--- a/poly/src/utils.rs
+++ b/poly/src/utils.rs
@@ -78,6 +78,9 @@ pub fn build_eq_x_r_vec<C: SemiringConfig>(
 ///
 /// Uses the identity `next_c_mle(r, b) = eq(r, b - c)` for `b >= c` and
 /// `0` for `b < c`.
+///
+/// If `c >= 2^num_vars`, every shifted row lies outside the domain and the
+/// selector is identically zero.
 pub fn build_next_c_r_mle<C: SemiringConfig>(
     cfg: &C,
     r: &[C::Element],
@@ -85,7 +88,12 @@ pub fn build_next_c_r_mle<C: SemiringConfig>(
 ) -> Result<DenseMultilinearExtension<C::Element>, ArithErrors> {
     let num_vars = r.len();
     let n = 1 << num_vars;
-    assert!(c < n, "shift c={c} must be < domain size {n}");
+    if c >= n {
+        return Ok(DenseMultilinearExtension {
+            num_vars,
+            evaluations: vec![cfg.zero(); n],
+        });
+    }
 
     let eq_r = build_eq_x_r(cfg, r)?;
     if c == 0 {
@@ -478,6 +486,20 @@ mod tests {
                     "c={c}, b={b}: mismatch"
                 );
             }
+        }
+    }
+
+    #[test]
+    #[cfg_attr(miri, ignore)] // long running
+    fn next_c_r_mle_at_or_past_domain_is_zero() {
+        let num_vars: usize = 4;
+        let n = 1 << num_vars;
+        let r: Vec<F> = (0..num_vars).map(|i| F::from((i + 5) as u32)).collect();
+
+        for c in [n, n + 1, usize::MAX] {
+            let next_c = build_next_c_r_mle(&cfg(), &r, c).unwrap();
+            assert_eq!(next_c.num_vars, num_vars);
+            assert_eq!(next_c.evaluations, vec![F::zero(); n]);
         }
     }
 

--- a/protocol/src/lib.rs
+++ b/protocol/src/lib.rs
@@ -18,9 +18,10 @@
 //!   `bit_slice_evals` are absorbed, and append one extra $\alpha'$-projected
 //!   MLE + up-eval to the multipoint-eval inputs per witness binary-poly column
 //!   (see `BooleanityChecker`)
-//! - Affine virtual bridge: collapse each unshifted virtual at the same
-//!   `alpha'` and compare it directly with the affine combination of its
-//!   public/committed source projections at `r*`
+//! - Affine virtual bridge: collapse each virtual at the same `alpha'` and
+//!   compare it with the affine combination of its source projections at `r*`;
+//!   shifted witness sources are bound through MP's shift kernel, while shifted
+//!   public sources are recomputed
 //! - Multi-point evaluation sumcheck (combines up/down evals at `r*` into a
 //!   single evaluation point `r_0`)
 //! - Lift-and-project (unprojected MLE evaluations at `r_0`)
@@ -64,14 +65,17 @@ use zinc_poly::{
         dense::DensePolynomial,
         dynamic::{DynamicPolyVec, DynamicPolynomial, HasDynamicPolynomialConfig},
     },
+    utils::build_next_c_r_mle,
 };
 use zinc_primality::PrimalityTest;
 use zinc_transcript::{
     TranscriptError,
     traits::{ConstTranscribable, GenTranscribable, Transcribable, Transcript},
 };
-use zinc_uair::{Uair, UairSignature};
-use zinc_utils::{cfg_extend, cfg_into_iter, cfg_iter, from_ref::FromRef, named::Named, powers};
+use zinc_uair::{ShiftSpec, Uair, UairSignature};
+use zinc_utils::{
+    add, cfg_extend, cfg_into_iter, cfg_iter, from_ref::FromRef, named::Named, powers, sub,
+};
 use zip_plus::{
     ZipError,
     code::LinearCode,
@@ -81,6 +85,74 @@ use zip_plus::{
 //
 // Data structures
 //
+
+/// Affine-virtual proof data.
+///
+/// The Booleanity proof establishes that each affine target has binary
+/// coefficients. `shifted_witness_evals` separately carries one
+/// $\alpha'$-projected evaluation for every unique shifted witness source in
+/// public-signature order. Multipoint evaluation binds those claims back to
+/// the corresponding committed source columns; shifted public sources are
+/// recomputed by the verifier and need no proof entries.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct AffineVirtualProof<F> {
+    /// Booleanity proof for the affine target columns.
+    pub booleanity_proof: BooleanityProof<F>,
+    /// Alpha-prime projected shifted-witness claims in public-signature order.
+    pub shifted_witness_evals: Vec<F>,
+}
+
+impl<F> AffineVirtualProof<F> {
+    fn try_map<T, E>(
+        &self,
+        f: impl FnMut(&F) -> Result<T, E> + Copy,
+    ) -> Result<AffineVirtualProof<T>, E> {
+        Ok(AffineVirtualProof {
+            booleanity_proof: self.booleanity_proof.try_map(f)?,
+            shifted_witness_evals: self
+                .shifted_witness_evals
+                .iter()
+                .map(f)
+                .collect::<Result<Vec<_>, _>>()?,
+        })
+    }
+}
+
+impl<F> GenTranscribable for AffineVirtualProof<F>
+where
+    F: ConstTranscribable,
+{
+    fn read_transcription_bytes_exact(bytes: &[u8]) -> Self {
+        let (booleanity_proof, bytes) =
+            BooleanityProof::<F>::read_transcription_bytes_subset(bytes);
+        let (shifted_witness_evals, bytes) = Vec::<F>::read_transcription_bytes_subset(bytes);
+        assert!(bytes.is_empty(), "all affine virtual proof bytes consumed");
+        Self {
+            booleanity_proof,
+            shifted_witness_evals,
+        }
+    }
+
+    fn write_transcription_bytes_exact(&self, mut buf: &mut [u8]) {
+        buf = self.booleanity_proof.write_transcription_bytes_subset(buf);
+        let _ = self
+            .shifted_witness_evals
+            .write_transcription_bytes_subset(buf);
+    }
+}
+
+impl<F> Transcribable for AffineVirtualProof<F>
+where
+    F: ConstTranscribable,
+{
+    #[allow(clippy::arithmetic_side_effects)]
+    fn get_num_bytes(&self) -> usize {
+        BooleanityProof::<F>::LENGTH_NUM_BYTES
+            + self.booleanity_proof.get_num_bytes()
+            + Vec::<F>::LENGTH_NUM_BYTES
+            + self.shifted_witness_evals.get_num_bytes()
+    }
+}
 
 /// Full proof produced by the Zinc+ PIOP for UCS.
 ///
@@ -133,9 +205,9 @@ pub struct Proof<F> {
     /// has no witness binary-poly columns (the argument is omitted from
     /// the multi-degree sumcheck in that case).
     pub booleanity_proof: Option<BooleanityProof<F>>,
-    /// Affine-virtual booleanity argument proof. `None` when the UAIR has no
-    /// affine virtual specs.
-    pub affine_booleanity_proof: Option<BooleanityProof<F>>,
+    /// Affine-virtual argument proof. `None` when the UAIR has no affine
+    /// virtual specs.
+    pub affine_virtual_proof: Option<AffineVirtualProof<F>>,
     /// Per-prime $F_{q_i}[X]$ ideal-check proofs, one per declared
     /// prime in [`zinc_uair::UairSignature::primes`], in the same order.
     /// Empty for UAIRs with $Q[X]$-only constraints.
@@ -167,25 +239,22 @@ pub struct Proof<F> {
     pub witness_lifted_evals_pp: Option<Vec<DynamicPolynomial<F>>>,
 }
 
-fn read_optional_booleanity_proof<F>(bytes: &[u8]) -> (Option<BooleanityProof<F>>, &[u8])
+fn read_optional_proof<T>(bytes: &[u8]) -> (Option<T>, &[u8])
 where
-    F: ConstTranscribable,
+    T: Transcribable,
 {
     let (presence, bytes) = u32::read_transcription_bytes_subset(bytes);
     if presence == 0 {
         (None, bytes)
     } else {
-        let (proof, bytes) = BooleanityProof::read_transcription_bytes_subset(bytes);
+        let (proof, bytes) = T::read_transcription_bytes_subset(bytes);
         (Some(proof), bytes)
     }
 }
 
-fn write_optional_booleanity_proof<'a, F>(
-    proof: &Option<BooleanityProof<F>>,
-    mut buf: &'a mut [u8],
-) -> &'a mut [u8]
+fn write_optional_proof<'a, T>(proof: &Option<T>, mut buf: &'a mut [u8]) -> &'a mut [u8]
 where
-    F: ConstTranscribable,
+    T: Transcribable,
 {
     buf = u32::from(proof.is_some()).write_transcription_bytes_subset(buf);
     if let Some(proof) = proof {
@@ -195,13 +264,13 @@ where
 }
 
 #[allow(clippy::arithmetic_side_effects)]
-fn optional_booleanity_proof_num_bytes<F>(proof: &Option<BooleanityProof<F>>) -> usize
+fn optional_proof_num_bytes<T>(proof: &Option<T>) -> usize
 where
-    F: ConstTranscribable,
+    T: Transcribable,
 {
-    proof.as_ref().map_or(0, |proof| {
-        BooleanityProof::<F>::LENGTH_NUM_BYTES + proof.get_num_bytes()
-    })
+    proof
+        .as_ref()
+        .map_or(0, |proof| T::LENGTH_NUM_BYTES + proof.get_num_bytes())
 }
 
 impl<F> GenTranscribable for Proof<F>
@@ -238,8 +307,8 @@ where
             bytes = rest;
         }
 
-        let (booleanity_proof, bytes) = read_optional_booleanity_proof(bytes);
-        let (affine_booleanity_proof, bytes) = read_optional_booleanity_proof(bytes);
+        let (booleanity_proof, bytes) = read_optional_proof(bytes);
+        let (affine_virtual_proof, bytes) = read_optional_proof(bytes);
 
         // ideal_checks_fq: u32 count, then that many length-prefixed
         // IdealCheckProof entries (one per declared prime).
@@ -309,7 +378,7 @@ where
             witness_lifted_evals,
             lookup_proof: None,
             booleanity_proof,
-            affine_booleanity_proof,
+            affine_virtual_proof,
             ideal_checks_fq,
             cpr_proofs_fq,
             combined_sumchecks_fq,
@@ -353,8 +422,8 @@ where
             buf = DynamicPolyVec::reinterpret(wlf).write_transcription_bytes_subset(buf);
         }
 
-        buf = write_optional_booleanity_proof(&self.booleanity_proof, buf);
-        buf = write_optional_booleanity_proof(&self.affine_booleanity_proof, buf);
+        buf = write_optional_proof(&self.booleanity_proof, buf);
+        buf = write_optional_proof(&self.affine_virtual_proof, buf);
 
         // ideal_checks_fq: u32 count + that many length-prefixed entries.
         let n_fq = u32::try_from(self.ideal_checks_fq.len())
@@ -408,9 +477,8 @@ where
 {
     #[allow(clippy::arithmetic_side_effects)]
     fn get_num_bytes(&self) -> usize {
-        let booleanity_bytes = optional_booleanity_proof_num_bytes(&self.booleanity_proof);
-        let affine_booleanity_bytes =
-            optional_booleanity_proof_num_bytes(&self.affine_booleanity_proof);
+        let booleanity_bytes = optional_proof_num_bytes(&self.booleanity_proof);
+        let affine_virtual_bytes = optional_proof_num_bytes(&self.affine_virtual_proof);
         let ideal_checks_fq_bytes: usize = self
             .ideal_checks_fq
             .iter()
@@ -466,9 +534,9 @@ where
             // committed-column booleanity presence flag + optional payload
             + u32::NUM_BYTES
             + booleanity_bytes
-            // affine-virtual booleanity presence flag + optional payload
+            // affine-virtual presence flag + optional payload
             + u32::NUM_BYTES
-            + affine_booleanity_bytes
+            + affine_virtual_bytes
             // ideal_checks_fq: count + sum of (length-prefix + body) per entry
             + u32::NUM_BYTES
             + ideal_checks_fq_bytes
@@ -613,6 +681,8 @@ pub enum ProtocolError<F: SetElement> {
         got: F,
         expected: F,
     },
+    #[error("affine virtual shifted-witness eval length mismatch: got {got}, expected {expected}")]
+    AffineVirtualShiftEvalsLengthMismatch { got: usize, expected: usize },
     #[error("non-canonical proof element: lifted integer >= family modulus")]
     NonCanonicalElement,
     #[error("proof family count mismatch: got {got}, expected {expected}")]
@@ -786,12 +856,96 @@ fn collapse_bit_slice_evals<C: BaseFieldConfig, const D: usize>(
         .collect()
 }
 
-/// Reconstruct the expected alpha-prime projection of each unshifted affine
-/// virtual from the corresponding source-column projections.
+/// A unique non-zero row shift used by an affine virtual term.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+struct AffineVirtualShift {
+    source_col: usize,
+    row_shift: usize,
+}
+
+/// Return shifted affine sources in first-occurrence order, deduplicated by
+/// `(source_col, row_shift)`.
+fn affine_virtual_shifts<P: Semiring>(signature: &UairSignature<P>) -> Vec<AffineVirtualShift> {
+    let mut shifts = Vec::new();
+    for spec in signature.affine_virtual_specs() {
+        for term in spec.terms() {
+            let shift = AffineVirtualShift {
+                source_col: term.source_col(),
+                row_shift: term.row_shift(),
+            };
+            if shift.row_shift > 0 && !shifts.contains(&shift) {
+                shifts.push(shift);
+            }
+        }
+    }
+    shifts
+}
+
+/// Shifted witness sources that require proof-carried evaluations.
+fn affine_virtual_witness_shifts<P: Semiring>(
+    signature: &UairSignature<P>,
+) -> Vec<AffineVirtualShift> {
+    let num_pub_bin = signature.public_cols().num_binary_poly_cols();
+    affine_virtual_shifts(signature)
+        .into_iter()
+        .filter(|shift| shift.source_col >= num_pub_bin)
+        .collect()
+}
+
+/// Extend the UAIR's ordinary shifts with the bridge-only shifts over the
+/// appended alpha-prime witness MLEs.
+fn multipoint_shifts_with_affine_virtuals<P: Semiring>(
+    signature: &UairSignature<P>,
+) -> Vec<ShiftSpec> {
+    let num_pub_bin = signature.public_cols().num_binary_poly_cols();
+    let appended_start = signature.total_cols().cols();
+    signature
+        .shifts()
+        .iter()
+        .cloned()
+        .chain(
+            affine_virtual_witness_shifts(signature)
+                .into_iter()
+                .map(|shift| {
+                    ShiftSpec::new(
+                        add!(appended_start, sub!(shift.source_col, num_pub_bin)),
+                        shift.row_shift,
+                    )
+                }),
+        )
+        .collect()
+}
+
+/// Evaluate the zero-padded forward shift of `source` at `point` using the
+/// same selector kernel as multipoint evaluation.
+fn evaluate_shifted_mle<C: BaseFieldConfig>(
+    source: &DenseMultilinearExtension<C::Element>,
+    point: &[C::Element],
+    row_shift: usize,
+    field_cfg: &C,
+) -> Result<C::Element, MultipointEvalError<C::Element>> {
+    let selector = build_next_c_r_mle(field_cfg, point, row_shift)?;
+    assert_eq!(
+        selector.evaluations.len(),
+        source.evaluations.len(),
+        "shift selector and source MLE must share a domain",
+    );
+    Ok(selector.evaluations.iter().zip(&source.evaluations).fold(
+        field_cfg.zero(),
+        |mut acc, (selector_eval, source_eval)| {
+            field_cfg.add_assign(&mut acc, &field_cfg.mul(selector_eval, source_eval));
+            acc
+        },
+    ))
+}
+
+/// Reconstruct the expected alpha-prime projection of each affine virtual
+/// from the corresponding unshifted and shifted source-column projections.
 #[allow(clippy::arithmetic_side_effects)]
 fn expected_affine_virtual_bridge_evals<C, P, const D: usize>(
     signature: &UairSignature<P>,
     source_bridge_evals: &[C::Element],
+    shifted_source_bridge_evals: &[(AffineVirtualShift, C::Element)],
     alpha_prime: &C::Element,
     field_cfg: &C,
 ) -> Vec<C::Element>
@@ -821,11 +975,19 @@ where
                 &ones_projection,
             );
             for term in spec.terms() {
-                debug_assert_eq!(term.row_shift(), 0);
-                let term_eval = field_cfg.mul(
-                    &field_cfg.project(&term.coefficient()),
-                    &source_bridge_evals[term.source_col()],
-                );
+                let source_eval = if term.row_shift() == 0 {
+                    &source_bridge_evals[term.source_col()]
+                } else {
+                    &shifted_source_bridge_evals
+                        .iter()
+                        .find(|(shift, _)| {
+                            shift.source_col == term.source_col()
+                                && shift.row_shift == term.row_shift()
+                        })
+                        .expect("shifted bridge eval is derived from the signature")
+                        .1
+                };
+                let term_eval = field_cfg.mul(&field_cfg.project(&term.coefficient()), source_eval);
                 field_cfg.add_assign(&mut expected, &term_eval);
             }
             expected
@@ -957,7 +1119,9 @@ mod tests {
     use zinc_primality::MillerRabin;
     use zinc_test_uair::{
         BigLinearUair, BigLinearUairWithPublicInput, BinaryDecompositionUair, GenerateRandomTrace,
-        ShaProxy, TestUairAffineVirtualPublicOnly, TestUairAffineVirtualUnshifted,
+        ShaProxy, TestUairAffineVirtualOversizedShifts, TestUairAffineVirtualPublicOnly,
+        TestUairAffineVirtualShiftedMixed, TestUairAffineVirtualShiftedPublicOnly,
+        TestUairAffineVirtualShiftedWitness, TestUairAffineVirtualUnshifted,
         TestUairBitOpsFqFamily, TestUairFqLargePrime, TestUairMixedShifts,
         TestUairNoMultiplication, TestUairSimpleMultiplication,
     };
@@ -1402,9 +1566,10 @@ mod tests {
                 );
                 assert_eq!(
                     proof
-                        .affine_booleanity_proof
+                        .affine_virtual_proof
                         .as_ref()
                         .expect("affine virtuals require an affine booleanity proof")
+                        .booleanity_proof
                         .bit_slice_evals
                         .len(),
                     2 * D,
@@ -1432,15 +1597,273 @@ mod tests {
                 assert!(proof.booleanity_proof.is_none());
                 assert_eq!(
                     proof
-                        .affine_booleanity_proof
+                        .affine_virtual_proof
                         .as_ref()
                         .expect("affine virtuals require an affine booleanity proof")
+                        .booleanity_proof
                         .bit_slice_evals
                         .len(),
                     2 * D,
                 );
             },
             |res| res.unwrap(),
+        );
+    }
+
+    #[test]
+    fn test_affine_virtual_shift_descriptors_are_deduplicated() {
+        type U = TestUairAffineVirtualShiftedWitness<ZtInt, ZtFmod>;
+
+        let signature = U::signature();
+        assert_eq!(
+            affine_virtual_witness_shifts(&signature),
+            vec![
+                AffineVirtualShift {
+                    source_col: 1,
+                    row_shift: 1,
+                },
+                AffineVirtualShift {
+                    source_col: 1,
+                    row_shift: 2,
+                },
+            ],
+        );
+
+        let shifts = multipoint_shifts_with_affine_virtuals(&signature);
+        assert_eq!(shifts.len(), 3);
+        assert_eq!(shifts[0].source_col(), 0);
+        assert_eq!(shifts[0].shift_amount(), 1);
+        assert_eq!(shifts[1].source_col(), signature.total_cols().cols());
+        assert_eq!(shifts[1].shift_amount(), 1);
+        assert_eq!(shifts[2].source_col(), signature.total_cols().cols());
+        assert_eq!(shifts[2].shift_amount(), 2);
+    }
+
+    #[test]
+    fn test_affine_virtual_mixed_shift_descriptors_preserve_witness_order() {
+        type U = TestUairAffineVirtualShiftedMixed<ZtInt, ZtFmod>;
+
+        let signature = U::signature();
+        assert_eq!(
+            affine_virtual_shifts(&signature),
+            vec![
+                AffineVirtualShift {
+                    source_col: 0,
+                    row_shift: 1,
+                },
+                AffineVirtualShift {
+                    source_col: 3,
+                    row_shift: 2,
+                },
+                AffineVirtualShift {
+                    source_col: 1,
+                    row_shift: 2,
+                },
+                AffineVirtualShift {
+                    source_col: 2,
+                    row_shift: 1,
+                },
+            ],
+        );
+        assert_eq!(
+            affine_virtual_witness_shifts(&signature),
+            vec![
+                AffineVirtualShift {
+                    source_col: 3,
+                    row_shift: 2,
+                },
+                AffineVirtualShift {
+                    source_col: 2,
+                    row_shift: 1,
+                },
+            ],
+        );
+
+        let shifts = multipoint_shifts_with_affine_virtuals(&signature);
+        assert_eq!(shifts.len(), 2);
+        assert_eq!(shifts[0].source_col(), 9);
+        assert_eq!(shifts[0].shift_amount(), 2);
+        assert_eq!(shifts[1].source_col(), 8);
+        assert_eq!(shifts[1].shift_amount(), 1);
+    }
+
+    /// End-to-end shifted affine bridge with a committed shifted source.
+    #[test]
+    fn test_e2e_affine_virtual_shifted_witness() {
+        let num_vars = 8;
+        do_test::<TestZincTypesIprs, TestUairAffineVirtualShiftedWitness<ZtInt, ZtFmod>>(
+            num_vars,
+            (
+                make_iprs(num_vars),
+                make_iprs(num_vars),
+                make_iprs(num_vars),
+            ),
+            default_project_ideal!(),
+            |ideal, field_cfg| ideal.map(|i| DegreeOneIdeal::project(field_cfg, i)),
+            |proof| {
+                let affine = proof
+                    .affine_virtual_proof
+                    .as_ref()
+                    .expect("affine virtuals require an affine proof");
+                assert_eq!(affine.booleanity_proof.bit_slice_evals.len(), 3 * D);
+                assert_eq!(
+                    affine.shifted_witness_evals.len(),
+                    2,
+                    "the repeated shift-one source must use one proof claim",
+                );
+            },
+            |res| res.unwrap(),
+        );
+    }
+
+    /// Shifted public sources are recomputed and add no proof-carried shift
+    /// evaluations or PCS openings.
+    #[test]
+    fn test_e2e_affine_virtual_shifted_public_only() {
+        let num_vars = 8;
+        do_test::<TestZincTypesIprs, TestUairAffineVirtualShiftedPublicOnly<ZtInt, ZtFmod>>(
+            num_vars,
+            (
+                make_iprs(num_vars),
+                make_iprs(num_vars),
+                make_iprs(num_vars),
+            ),
+            default_project_ideal!(),
+            |ideal, field_cfg| ideal.map(|i| DegreeOneIdeal::project(field_cfg, i)),
+            |proof| {
+                assert!(proof.booleanity_proof.is_none());
+                let affine = proof
+                    .affine_virtual_proof
+                    .as_ref()
+                    .expect("affine virtuals require an affine proof");
+                assert_eq!(affine.booleanity_proof.bit_slice_evals.len(), 3 * D);
+                assert!(affine.shifted_witness_evals.is_empty());
+            },
+            |res| res.unwrap(),
+        );
+    }
+
+    /// Interleaved shifted public and witness sources preserve signature order
+    /// while witness claims bind to their appended alpha-prime source slots.
+    #[test]
+    fn test_e2e_affine_virtual_shifted_mixed_sources() {
+        let num_vars = 8;
+        do_test::<TestZincTypesIprs, TestUairAffineVirtualShiftedMixed<ZtInt, ZtFmod>>(
+            num_vars,
+            (
+                make_iprs(num_vars),
+                make_iprs(num_vars),
+                make_iprs(num_vars),
+            ),
+            default_project_ideal!(),
+            |ideal, field_cfg| ideal.map(|i| DegreeOneIdeal::project(field_cfg, i)),
+            |proof| {
+                let affine = proof
+                    .affine_virtual_proof
+                    .as_ref()
+                    .expect("affine virtuals require an affine proof");
+                assert_eq!(affine.booleanity_proof.bit_slice_evals.len(), 4 * D);
+                assert_eq!(affine.shifted_witness_evals.len(), 2);
+            },
+            |res| res.unwrap(),
+        );
+    }
+
+    /// Shifts beginning at and beyond the trace length are zero-padded rather
+    /// than rejected by the shared multipoint selector.
+    #[test]
+    fn test_e2e_affine_virtual_oversized_shifts_are_zero() {
+        let num_vars = 3;
+        do_test::<TestZincTypesIprs, TestUairAffineVirtualOversizedShifts<ZtInt, ZtFmod>>(
+            num_vars,
+            (
+                make_iprs(num_vars),
+                make_iprs(num_vars),
+                make_iprs(num_vars),
+            ),
+            default_project_ideal!(),
+            |ideal, field_cfg| ideal.map(|i| DegreeOneIdeal::project(field_cfg, i)),
+            |proof| {
+                let affine = proof
+                    .affine_virtual_proof
+                    .as_ref()
+                    .expect("affine virtuals require an affine proof");
+                assert_eq!(affine.booleanity_proof.bit_slice_evals.len(), 3 * D);
+                assert_eq!(affine.shifted_witness_evals.len(), 2);
+                assert!(affine.shifted_witness_evals.iter().all(Zero::is_zero));
+            },
+            |res| res.unwrap(),
+        );
+    }
+
+    /// The shifted-witness claim count comes from the public signature, not
+    /// from the proof.
+    #[test]
+    fn test_affine_virtual_rejects_truncated_shift_evals() {
+        let num_vars = 8;
+        do_test::<TestZincTypesIprs, TestUairAffineVirtualShiftedWitness<ZtInt, ZtFmod>>(
+            num_vars,
+            (
+                make_iprs(num_vars),
+                make_iprs(num_vars),
+                make_iprs(num_vars),
+            ),
+            default_project_ideal!(),
+            |ideal, field_cfg| ideal.map(|i| DegreeOneIdeal::project(field_cfg, i)),
+            |proof| {
+                proof
+                    .affine_virtual_proof
+                    .as_mut()
+                    .expect("affine virtuals require an affine proof")
+                    .shifted_witness_evals
+                    .pop();
+            },
+            |res| {
+                assert!(matches!(
+                    res.unwrap_err(),
+                    ProtocolError::AffineVirtualShiftEvalsLengthMismatch {
+                        got: 1,
+                        expected: 2,
+                    }
+                ));
+            },
+        );
+    }
+
+    /// The affine bridge consumes each shifted-source claim before MP-eval;
+    /// changing one therefore produces an exact bridge mismatch. The existing
+    /// multipoint-eval down-claim tests separately isolate binding that claim
+    /// to its source opening.
+    #[test]
+    fn test_affine_virtual_rejects_tampered_shift_eval() {
+        let num_vars = 8;
+        do_test::<TestZincTypesIprs, TestUairAffineVirtualShiftedWitness<ZtInt, ZtFmod>>(
+            num_vars,
+            (
+                make_iprs(num_vars),
+                make_iprs(num_vars),
+                make_iprs(num_vars),
+            ),
+            default_project_ideal!(),
+            |ideal, field_cfg| ideal.map(|i| DegreeOneIdeal::project(field_cfg, i)),
+            |proof| {
+                let shifted_eval = &mut proof
+                    .affine_virtual_proof
+                    .as_mut()
+                    .expect("affine virtuals require an affine proof")
+                    .shifted_witness_evals[0];
+                *shifted_eval = if shifted_eval.is_zero() {
+                    ZtFmod::from(1_u64)
+                } else {
+                    ZtFmod::zero()
+                };
+            },
+            |res| {
+                assert!(matches!(
+                    res.unwrap_err(),
+                    ProtocolError::AffineVirtualBridgeMismatch { .. }
+                ));
+            },
         );
     }
 
@@ -1460,9 +1883,10 @@ mod tests {
             |ideal, field_cfg| ideal.map(|i| DegreeOneIdeal::project(field_cfg, i)),
             |proof| {
                 proof
-                    .affine_booleanity_proof
+                    .affine_virtual_proof
                     .as_mut()
                     .expect("affine virtuals require an affine booleanity proof")
+                    .booleanity_proof
                     .bit_slice_evals
                     .pop();
             },
@@ -1515,9 +1939,10 @@ mod tests {
         .clone();
 
         let affine_evals = &mut proof
-            .affine_booleanity_proof
+            .affine_virtual_proof
             .as_mut()
             .expect("affine virtuals require an affine booleanity proof")
+            .booleanity_proof
             .bit_slice_evals;
         let one = cfg.one();
         let tamper_index = affine_evals

--- a/protocol/src/prover.rs
+++ b/protocol/src/prover.rs
@@ -352,7 +352,7 @@ pub struct ProverMultipointEvaled<
     combined_sumchecks_fq: Vec<MultiDegreeSumcheckProof<C::Element>>,
     lookup_proof: Option<BatchedLookupProof<C::Element>>,
     booleanity_proof: Option<BooleanityProof<C::Element>>,
-    affine_booleanity_proof: Option<BooleanityProof<C::Element>>,
+    affine_virtual_proof: Option<AffineVirtualProof<C::Element>>,
 
     // New
     mp_proof: MultipointEvalProof<C::Element>,
@@ -388,7 +388,7 @@ pub struct ProverLifted<
     combined_sumchecks_fq: Vec<MultiDegreeSumcheckProof<C::Element>>,
     lookup_proof: Option<BatchedLookupProof<C::Element>>,
     booleanity_proof: Option<BooleanityProof<C::Element>>,
-    affine_booleanity_proof: Option<BooleanityProof<C::Element>>,
+    affine_virtual_proof: Option<AffineVirtualProof<C::Element>>,
     mp_proof: MultipointEvalProof<C::Element>,
     /// Per-prime multipoint-eval proofs threaded forward from
     /// `ProverMultipointEvaled`.
@@ -441,7 +441,7 @@ pub struct ProverPcsOpened<
     combined_sumchecks_fq: Vec<MultiDegreeSumcheckProof<C::Element>>,
     lookup_proof: Option<BatchedLookupProof<C::Element>>,
     booleanity_proof: Option<BooleanityProof<C::Element>>,
-    affine_booleanity_proof: Option<BooleanityProof<C::Element>>,
+    affine_virtual_proof: Option<AffineVirtualProof<C::Element>>,
     mp_proof: MultipointEvalProof<C::Element>,
     /// Per-prime multipoint-eval proofs threaded forward.
     mp_proofs_fq: Vec<MultipointEvalProof<C::Element>>,
@@ -976,12 +976,11 @@ impl_with_type_bounds!(ProverEvalProjected
     /// is installed in `step6_multipoint_eval`, which appends one extra
     /// $\alpha'$-projected witness-bin column MLE (and matching up_eval
     /// $c_j = \sum_i b_{j,i} (\alpha')^i$) per witness binary-poly column
-    /// to the multipoint-eval inputs. Unshifted affine virtuals are collapsed
-    /// at the same $\alpha'$ and checked directly by the verifier against
-    /// their source projections at $r^*$. Shifts continue to reference the
-    /// original $\psi_a$-projected witness-bin slot, so `down_evals` are
-    /// untouched: shifted booleanity is inherited from un-shifted
-    /// booleanity (same committed column).
+    /// to the multipoint-eval inputs. Affine virtuals are collapsed at the
+    /// same $\alpha'$ and checked by the verifier against their source
+    /// projections at $r^*$. Each unique shifted witness source adds a
+    /// bridge-only shift claim over the appended $\alpha'$ slot; shifted
+    /// public sources are recomputed by the verifier.
     ///
     /// The PCS chain (`step6_multipoint_eval` + lifted-evals + Zip+ open)
     /// closes the bridge: at the random sumcheck output $r_0$,
@@ -1229,10 +1228,12 @@ impl_with_type_bounds!(ProverSumchecked
     /// claim to make there). The shared layout lets a single $(n+1)$-family
     /// lockstep MP-eval produce a single shared $r_0$ across all families,
     /// which Phases H/I rely on for the lift-to-$Z$ + $q''$-anchored
-    /// PCS open. No `ShiftSpec` references those indices, so
-    /// `down_evals`/`shifts` are untouched and shifted booleanity is
-    /// inherited from the un-shifted column (which continues to live at
-    /// its original $\psi_a$-projected slot).
+    /// PCS open. Ordinary UAIR shifts do not reference those indices.
+    /// Shifted affine witness sources add one bridge-only `down_eval` and
+    /// `ShiftSpec` per unique `(source_col, row_shift)` pair. These shifts
+    /// reference the appended $\alpha'$-projected witness MLEs, so MP-eval
+    /// binds them to the same committed source columns without adding PCS
+    /// openings. Shifted public sources are recomputed by the verifier.
     /// See the module-level `BooleanityChecker` docs for the soundness
     /// argument (Schwartz-Zippel at $\alpha'$ + MP/PCS chain at $r_0$).
     #[allow(clippy::arithmetic_side_effects, clippy::too_many_lines)]
@@ -1241,7 +1242,9 @@ impl_with_type_bounds!(ProverSumchecked
     ) -> Result<ProverMultipointEvaled<'a, Zt, U, C, D, FD>, ProtocolError<C::Element>> {
         let n_fq = self.projected_trace_f_fq.len();
         let q_star_cfg = self.all_field_cfgs[self.q_star_idx].clone();
-        let shifts = self.base.uair_signature.shifts();
+        let affine_witness_shifts =
+            affine_virtual_witness_shifts(&self.base.uair_signature);
+        let shifts = multipoint_shifts_with_affine_virtuals(&self.base.uair_signature);
         let num_vars = self.base.num_vars;
 
         // --- Q[X] family (booleanity-bridge appended iff alpha_prime present)
@@ -1257,7 +1260,7 @@ impl_with_type_bounds!(ProverSumchecked
         // them; the verifier's downstream lifted-eval projection at
         // $\alpha'$ closes the loop.
         let mut projected_trace_f = self.projected_trace_f;
-        let (q_up_evals, num_wit_bin) = if let Some(alpha_prime) =
+        let (q_up_evals, num_wit_bin, affine_shifted_witness_evals) = if let Some(alpha_prime) =
             &self.alpha_prime_f
         {
             let sig = &self.base.uair_signature;
@@ -1291,14 +1294,43 @@ impl_with_type_bounds!(ProverSumchecked
                 )
             };
 
+            let shifted_witness_evals = affine_witness_shifts
+                .iter()
+                .map(|shift| {
+                    let witness_col = sub!(shift.source_col, num_pub_bin);
+                    evaluate_shifted_mle(
+                        &extra_trace_mles[witness_col],
+                        &self.cpr_eval_point,
+                        shift.row_shift,
+                        &self.field_cfg,
+                    )
+                })
+                .collect::<Result<Vec<_>, _>>()?;
+
             projected_trace_f.extend(extra_trace_mles);
 
             let mut up_evals = self.cpr_proof.up_evals.clone();
             up_evals.extend(extra_up_evals);
-            (up_evals, num_wit_bin)
+            (up_evals, num_wit_bin, shifted_witness_evals)
         } else {
-            (self.cpr_proof.up_evals.clone(), 0)
+            debug_assert!(affine_witness_shifts.is_empty());
+            (self.cpr_proof.up_evals.clone(), 0, Vec::new())
         };
+
+        if !affine_shifted_witness_evals.is_empty() {
+            let mut transcription_buf = vec![0; C::Integer::NUM_BYTES];
+            self.base
+                .pcs_transcript
+                .fs_transcript
+                .absorb_field_element_slice(
+                    &self.field_cfg,
+                    &affine_shifted_witness_evals,
+                    &mut transcription_buf,
+                );
+        }
+
+        let mut q_down_evals = self.cpr_proof.down_evals.clone();
+        q_down_evals.extend(affine_shifted_witness_evals.iter().cloned());
 
         // --- Per-prime families (zero-padded to match Q-family column count)
         //
@@ -1312,6 +1344,7 @@ impl_with_type_bounds!(ProverSumchecked
         let mut fq_trace_mles_padded: Vec<Vec<DenseMultilinearExtension<C::Element>>> =
             Vec::with_capacity(n_fq);
         let mut fq_up_evals_padded: Vec<Vec<C::Element>> = Vec::with_capacity(n_fq);
+        let mut fq_down_evals_padded: Vec<Vec<C::Element>> = Vec::with_capacity(n_fq);
         for (prime_idx, mut trace_i) in self.projected_trace_f_fq.into_iter().enumerate() {
             let family_idx = add!(prime_idx, 1);
             let cfg_i = &self.all_field_cfgs[family_idx];
@@ -1330,6 +1363,10 @@ impl_with_type_bounds!(ProverSumchecked
             let mut up_i = self.cpr_proofs_fq[prime_idx].up_evals.clone();
             up_i.extend((0..num_wit_bin).map(|_| zero_i.clone()));
             fq_up_evals_padded.push(up_i);
+
+            let mut down_i = self.cpr_proofs_fq[prime_idx].down_evals.clone();
+            down_i.extend((0..affine_witness_shifts.len()).map(|_| zero_i.clone()));
+            fq_down_evals_padded.push(down_i);
         }
 
         // --- Single (n+1)-family lockstep MP-eval ---------------------
@@ -1346,7 +1383,7 @@ impl_with_type_bounds!(ProverSumchecked
             eval_point: &self.cpr_eval_point,
             up_evals: &q_up_evals,
             bit_op_evals: &self.cpr_proof.bit_op_evals,
-            down_evals: &self.cpr_proof.down_evals,
+            down_evals: &q_down_evals,
         });
         for prime_idx in 0..n_fq {
             let family_idx = add!(prime_idx, 1);
@@ -1357,14 +1394,14 @@ impl_with_type_bounds!(ProverSumchecked
                 eval_point: &self.cpr_eval_points_fq[prime_idx],
                 up_evals: &fq_up_evals_padded[prime_idx],
                 bit_op_evals: &self.cpr_proofs_fq[prime_idx].bit_op_evals,
-                down_evals: &self.cpr_proofs_fq[prime_idx].down_evals,
+                down_evals: &fq_down_evals_padded[prime_idx],
             });
         }
 
         let mut outputs_iter = MultipointEval::prove_as_subprotocol(
             &mut self.base.pcs_transcript.fs_transcript,
             all_families,
-            shifts,
+            &shifts,
             &q_star_cfg,
         )?
         .into_iter();
@@ -1378,6 +1415,13 @@ impl_with_type_bounds!(ProverSumchecked
             mp_proofs_fq.push(proof_i);
             r_0_fq.push(state_i.eval_point);
         }
+
+        let affine_virtual_proof = self.affine_booleanity_proof.map(|booleanity_proof| {
+            AffineVirtualProof {
+                booleanity_proof,
+                shifted_witness_evals: affine_shifted_witness_evals,
+            }
+        });
 
         Ok(ProverMultipointEvaled {
             base: self.base,
@@ -1393,7 +1437,7 @@ impl_with_type_bounds!(ProverSumchecked
             combined_sumchecks_fq: self.combined_sumchecks_fq,
             lookup_proof: self.lookup_proof,
             booleanity_proof: self.booleanity_proof,
-            affine_booleanity_proof: self.affine_booleanity_proof,
+            affine_virtual_proof,
             mp_proof: mp_proof_q,
             r_0: r_0_q,
             mp_proofs_fq,
@@ -1581,7 +1625,7 @@ impl_with_type_bounds!(ProverMultipointEvaled
             combined_sumchecks_fq: self.combined_sumchecks_fq,
             lookup_proof: self.lookup_proof,
             booleanity_proof: self.booleanity_proof,
-            affine_booleanity_proof: self.affine_booleanity_proof,
+            affine_virtual_proof: self.affine_virtual_proof,
             mp_proof: self.mp_proof,
             mp_proofs_fq: self.mp_proofs_fq,
             lifted_evals,
@@ -1669,7 +1713,7 @@ impl_with_type_bounds!(ProverLifted
             combined_sumchecks_fq: self.combined_sumchecks_fq,
             lookup_proof: self.lookup_proof,
             booleanity_proof: self.booleanity_proof,
-            affine_booleanity_proof: self.affine_booleanity_proof,
+            affine_virtual_proof: self.affine_virtual_proof,
             mp_proof: self.mp_proof,
             mp_proofs_fq: self.mp_proofs_fq,
             lifted_evals: self.lifted_evals,
@@ -1743,7 +1787,7 @@ impl_with_type_bounds!(ProverPcsOpened
                 Some(p) => Some(lift!(self.field_cfg, p)?),
                 None => None,
             },
-            affine_booleanity_proof: match &self.affine_booleanity_proof {
+            affine_virtual_proof: match &self.affine_virtual_proof {
                 Some(p) => Some(lift!(self.field_cfg, p)?),
                 None => None,
             },

--- a/protocol/src/verifier.rs
+++ b/protocol/src/verifier.rs
@@ -81,7 +81,7 @@ pub struct VerifierTranscriptReconstructed<
     proof_witness_lifted_evals_pp: Option<Vec<DynamicPolynomial<Zt::Fmod>>>,
     proof_lookup_proof: Option<BatchedLookupProof<Zt::Fmod>>,
     proof_booleanity: Option<BooleanityProof<Zt::Fmod>>,
-    proof_affine_booleanity: Option<BooleanityProof<Zt::Fmod>>,
+    proof_affine_virtual: Option<AffineVirtualProof<Zt::Fmod>>,
     proof_ideal_checks_fq: Vec<IdealCheckProof<Zt::Fmod>>,
     proof_cpr_fq: Vec<CombinedPolyResolverProof<Zt::Fmod>>,
     proof_combined_sumchecks_fq: Vec<MultiDegreeSumcheckProof<Zt::Fmod>>,
@@ -117,7 +117,7 @@ pub struct VerifierPrimeProjected<
     proof_witness_lifted_evals_pp: Option<Vec<DynamicPolynomial<Zt::Fmod>>>,
     proof_lookup_proof: Option<BatchedLookupProof<C::Element>>,
     proof_booleanity: Option<BooleanityProof<C::Element>>,
-    proof_affine_booleanity: Option<BooleanityProof<C::Element>>,
+    proof_affine_virtual: Option<AffineVirtualProof<C::Element>>,
     proof_ideal_checks_fq: Vec<IdealCheckProof<C::Element>>,
     proof_cpr_fq: Vec<CombinedPolyResolverProof<C::Element>>,
     proof_combined_sumchecks_fq: Vec<MultiDegreeSumcheckProof<C::Element>>,
@@ -166,7 +166,7 @@ pub struct VerifierIdealChecked<
     proof_witness_lifted_evals_pp: Option<Vec<DynamicPolynomial<Zt::Fmod>>>,
     proof_lookup_proof: Option<BatchedLookupProof<C::Element>>,
     proof_booleanity: Option<BooleanityProof<C::Element>>,
-    proof_affine_booleanity: Option<BooleanityProof<C::Element>>,
+    proof_affine_virtual: Option<AffineVirtualProof<C::Element>>,
     /// Per-prime CPR proofs (one per declared prime).
     proof_cpr_fq: Vec<CombinedPolyResolverProof<C::Element>>,
     /// Per-prime multi-degree sumcheck proofs (one per declared prime).
@@ -224,7 +224,7 @@ pub struct VerifierEvalProjected<
     proof_witness_lifted_evals_pp: Option<Vec<DynamicPolynomial<Zt::Fmod>>>,
     proof_lookup_proof: Option<BatchedLookupProof<C::Element>>,
     proof_booleanity: Option<BooleanityProof<C::Element>>,
-    proof_affine_booleanity: Option<BooleanityProof<C::Element>>,
+    proof_affine_virtual: Option<AffineVirtualProof<C::Element>>,
     /// Per-prime CPR proofs (one per declared prime).
     proof_cpr_fq: Vec<CombinedPolyResolverProof<C::Element>>,
     /// Per-prime multi-degree sumcheck proofs (one per declared prime),
@@ -280,6 +280,9 @@ pub struct VerifierSumchecked<
     /// Affine-virtual bit-slice evaluations carried separately from the
     /// committed-column Booleanity proof.
     affine_bool_bit_slice_evals: Option<Vec<C::Element>>,
+    /// One claimed alpha-prime projection for every unique shifted witness
+    /// source used by the affine virtual specs, in public-signature order.
+    affine_shifted_witness_evals: Vec<C::Element>,
     /// Fresh challenge sampled after `bit_slice_evals` were absorbed by
     /// booleanity's `finalize_verifier`. Consumed in step 5 (bridge
     /// scalars) and step 6 (appended $\alpha'$-projected open_evals).
@@ -525,7 +528,7 @@ where
             proof_witness_lifted_evals_pp: proof.witness_lifted_evals_pp,
             proof_lookup_proof: proof.lookup_proof,
             proof_booleanity: proof.booleanity_proof,
-            proof_affine_booleanity: proof.affine_booleanity_proof,
+            proof_affine_virtual: proof.affine_virtual_proof,
             proof_ideal_checks_fq: proof.ideal_checks_fq,
             proof_cpr_fq: proof.cpr_proofs_fq,
             proof_combined_sumchecks_fq: proof.combined_sumchecks_fq,
@@ -624,7 +627,7 @@ where
                 Some(p) => Some(project!(&field_cfg, p)?),
                 None => None,
             },
-            proof_affine_booleanity: match &self.proof_affine_booleanity {
+            proof_affine_virtual: match &self.proof_affine_virtual {
                 Some(p) => Some(project!(&field_cfg, p)?),
                 None => None,
             },
@@ -764,7 +767,7 @@ where
             proof_witness_lifted_evals_pp: self.proof_witness_lifted_evals_pp,
             proof_lookup_proof: self.proof_lookup_proof,
             proof_booleanity: self.proof_booleanity,
-            proof_affine_booleanity: self.proof_affine_booleanity,
+            proof_affine_virtual: self.proof_affine_virtual,
             proof_cpr_fq: self.proof_cpr_fq,
             proof_combined_sumchecks_fq: self.proof_combined_sumchecks_fq,
             proof_multipoint_evals_fq: self.proof_multipoint_evals_fq,
@@ -854,7 +857,7 @@ where
             proof_witness_lifted_evals_pp: self.proof_witness_lifted_evals_pp,
             proof_lookup_proof: self.proof_lookup_proof,
             proof_booleanity: self.proof_booleanity,
-            proof_affine_booleanity: self.proof_affine_booleanity,
+            proof_affine_virtual: self.proof_affine_virtual,
             proof_cpr_fq: self.proof_cpr_fq,
             proof_combined_sumchecks_fq: self.proof_combined_sumchecks_fq,
             proof_multipoint_evals_fq: self.proof_multipoint_evals_fq,
@@ -1023,9 +1026,15 @@ where
             bool_verifier_ancillary,
             &self.field_cfg,
         )?;
+        let (affine_booleanity_proof, affine_shifted_witness_evals) = self
+            .proof_affine_virtual
+            .take()
+            .map_or((None, Vec::new()), |proof| {
+                (Some(proof.booleanity_proof), proof.shifted_witness_evals)
+            });
         let affine_bool_bit_slice_evals = finalize_booleanity_verifier_group(
             &mut self.base.pcs_transcript.fs_transcript,
-            self.proof_affine_booleanity.take(),
+            affine_booleanity_proof,
             q_md_subclaims.point(),
             q_md_subclaims.expected_evaluations(),
             &mut bool_group_idx,
@@ -1100,6 +1109,7 @@ where
             cpr_down_evals_fq,
             bool_bit_slice_evals,
             affine_bool_bit_slice_evals,
+            affine_shifted_witness_evals,
             alpha_prime_f,
             proof_commitments: self.proof_commitments,
             proof_multipoint_eval: self.proof_multipoint_eval,
@@ -1132,7 +1142,8 @@ where
     /// These collapse the bit-slice claims at $r^\star$ into the
     /// multipoint-eval consistency equation; the matching
     /// $\alpha'$-projected `open_evals` are produced in step 6.
-    /// `down_evals` are passed through unchanged.
+    /// Shifted witness sources append signature-derived claims to
+    /// `down_evals`; shifted public sources are recomputed directly.
     #[allow(clippy::arithmetic_side_effects)]
     pub fn step5_multipoint_eval<U: Uair>(
         mut self,
@@ -1162,6 +1173,26 @@ where
         let num_wit_bin = num_total_bin.saturating_sub(num_pub_bin);
         let num_affine_virtuals = sig.affine_virtual_specs().len();
         let alpha_prime = self.alpha_prime_f.as_ref();
+        let affine_witness_shifts = affine_virtual_witness_shifts(&sig);
+        let expected_shift_evals = affine_witness_shifts.len();
+        if self.affine_shifted_witness_evals.len() != expected_shift_evals {
+            return Err(ProtocolError::AffineVirtualShiftEvalsLengthMismatch {
+                got: self.affine_shifted_witness_evals.len(),
+                expected: expected_shift_evals,
+            });
+        }
+
+        if !self.affine_shifted_witness_evals.is_empty() {
+            let mut transcription_buf = vec![0; C::Integer::NUM_BYTES];
+            self.base
+                .pcs_transcript
+                .fs_transcript
+                .absorb_field_element_slice(
+                    &self.field_cfg,
+                    &self.affine_shifted_witness_evals,
+                    &mut transcription_buf,
+                );
+        }
 
         let witness_bridge_evals = if num_wit_bin == 0 {
             Vec::new()
@@ -1179,19 +1210,44 @@ where
         if num_affine_virtuals > 0 {
             let alpha_prime = alpha_prime.ok_or(ProtocolError::BooleanityProofMissing)?;
             let alpha_powers = powers(&self.field_cfg, alpha_prime, D);
-            let mut source_bridge_evals: Vec<C::Element> = self
+            let public_bridge_mles: Vec<DenseMultilinearExtension<C::Element>> = self
                 .base
                 .public_trace
                 .binary_poly
                 .iter()
-                .map(|col| {
-                    project_binary_col_at_field::<C, D>(col, &alpha_powers, &self.field_cfg)
-                        .evaluate(&self.field_cfg, &self.cpr_eval_point)
+                .map(|col| project_binary_col_at_field::<C, D>(col, &alpha_powers, &self.field_cfg))
+                .collect();
+            let mut source_bridge_evals: Vec<C::Element> = public_bridge_mles
+                .iter()
+                .map(|mle| {
+                    mle.evaluate(&self.field_cfg, &self.cpr_eval_point)
                         .map_err(ProtocolError::AffineVirtualSourceProjection)
                 })
                 .collect::<Result<_, _>>()?;
             debug_assert_eq!(source_bridge_evals.len(), num_pub_bin);
             source_bridge_evals.extend(witness_bridge_evals.iter().cloned());
+
+            let mut witness_shift_evals = self.affine_shifted_witness_evals.iter();
+            let shifted_source_bridge_evals = affine_virtual_shifts(&sig)
+                .into_iter()
+                .map(|shift| {
+                    let value = if shift.source_col < num_pub_bin {
+                        evaluate_shifted_mle(
+                            &public_bridge_mles[shift.source_col],
+                            &self.cpr_eval_point,
+                            shift.row_shift,
+                            &self.field_cfg,
+                        )?
+                    } else {
+                        witness_shift_evals
+                            .next()
+                            .expect("witness shift count checked above")
+                            .clone()
+                    };
+                    Ok((shift, value))
+                })
+                .collect::<Result<Vec<_>, MultipointEvalError<C::Element>>>()?;
+            debug_assert!(witness_shift_evals.next().is_none());
 
             let affine_bridge_evals = collapse_bit_slice_evals::<C, D>(
                 self.affine_bool_bit_slice_evals
@@ -1204,6 +1260,7 @@ where
             let expected_affine_evals = expected_affine_virtual_bridge_evals::<C, _, D>(
                 &sig,
                 &source_bridge_evals,
+                &shifted_source_bridge_evals,
                 alpha_prime,
                 &self.field_cfg,
             );
@@ -1228,6 +1285,8 @@ where
             .cloned()
             .chain(witness_bridge_evals)
             .collect();
+        let mut q_down_evals = self.cpr_down_evals.clone();
+        q_down_evals.extend(self.affine_shifted_witness_evals.iter().cloned());
 
         // Per-prime families: zero-pad up_evals to match Q's column count
         //
@@ -1243,8 +1302,17 @@ where
                 up_i
             })
             .collect();
+        let fq_down_evals_ext: Vec<Vec<C::Element>> = (0..n_fq)
+            .map(|prime_idx| {
+                let family_idx = add!(prime_idx, 1);
+                let zero_i = self.all_field_cfgs[family_idx].zero();
+                let mut down_i = self.cpr_down_evals_fq[prime_idx].clone();
+                down_i.extend((0..expected_shift_evals).map(|_| zero_i.clone()));
+                down_i
+            })
+            .collect();
 
-        let shifts = self.base.uair_signature.shifts();
+        let shifts = multipoint_shifts_with_affine_virtuals(&sig);
         let num_vars = self.base.num_vars;
         let q_star_cfg = self.all_field_cfgs[self.q_star_idx].clone();
 
@@ -1265,7 +1333,7 @@ where
             eval_point: &self.cpr_eval_point,
             up_evals: &q_up_evals,
             bit_op_evals: &self.cpr_bit_op_evals,
-            down_evals: &self.cpr_down_evals,
+            down_evals: &q_down_evals,
         });
 
         for (prime_idx, up_evals) in fq_up_evals_ext.iter().enumerate() {
@@ -1277,7 +1345,7 @@ where
                 eval_point: &self.cpr_eval_points_fq[prime_idx],
                 up_evals,
                 bit_op_evals: &self.cpr_bit_op_evals_fq[prime_idx],
-                down_evals: &self.cpr_down_evals_fq[prime_idx],
+                down_evals: &fq_down_evals_ext[prime_idx],
             });
         }
 
@@ -1285,7 +1353,7 @@ where
             &mut self.base.pcs_transcript.fs_transcript,
             all_proofs,
             all_families,
-            shifts,
+            &shifts,
             num_vars,
             &q_star_cfg,
         )?
@@ -1395,6 +1463,7 @@ where
         let num_wit_bin = wit_cols.num_binary_poly_cols();
         let num_wit_arb = wit_cols.num_arbitrary_poly_cols();
         let num_wit_int = wit_cols.num_int_cols();
+        let multipoint_shifts = multipoint_shifts_with_affine_virtuals(&self.base.uair_signature);
 
         // Since the entire vector is absorbed into the FS transcript below,
         // prevent a malicious prover from adding entries not tied to a
@@ -1532,7 +1601,7 @@ where
                 &self.projecting_elements[0],
                 &self.field_cfg,
             )?,
-            self.base.uair_signature.shifts(),
+            &multipoint_shifts,
             &self.field_cfg,
         )?;
 
@@ -1571,7 +1640,7 @@ where
                     &self.projecting_elements[family_idx],
                     cfg_i,
                 )?,
-                self.base.uair_signature.shifts(),
+                &multipoint_shifts,
                 cfg_i,
             )?;
         }

--- a/test-uair/src/lib.rs
+++ b/test-uair/src/lib.rs
@@ -1257,6 +1257,273 @@ where
     }
 }
 
+/// UAIR fixture for shifted affine Ch-style Booleanity targets.
+///
+/// By default, column `a` is read at forward shifts one and two. The first
+/// shifted pair is reused by two affine specs, which pins proof-claim
+/// deduplication. The signature also carries an ordinary shift of `b`, pinning
+/// coexistence and ordering between CPR down claims and affine bridge claims.
+/// The zero-padded shifted cells define:
+///
+/// ```text
+/// a[t+1] + b[t] - 2(a[t+1] & b[t])
+/// 1_32 - a[t+1] + b[t] - 2(!a[t+1] & b[t])
+/// a[t+2] + b[t] - 2(a[t+2] & b[t]).
+/// ```
+#[derive(Clone, Debug)]
+pub struct TestUairAffineVirtualShifted<
+    R,
+    P,
+    const NUM_PUBLIC_BINARY: usize,
+    const SHIFT_ONE: usize = 1,
+    const SHIFT_TWO: usize = 2,
+>(PhantomData<(R, P)>);
+
+/// Mixed variant: `b` is public while shifted source `a` and target columns
+/// are witnesses.
+pub type TestUairAffineVirtualShiftedWitness<R, P> = TestUairAffineVirtualShifted<R, P, 1>;
+
+/// Variant in which every source and target column is public.
+pub type TestUairAffineVirtualShiftedPublicOnly<R, P> = TestUairAffineVirtualShifted<R, P, 5>;
+
+/// Variant whose two shifted witness terms start at and past an eight-row
+/// trace domain. It is used with `num_vars = 3`.
+pub type TestUairAffineVirtualOversizedShifts<R, P> = TestUairAffineVirtualShifted<R, P, 1, 8, 9>;
+
+impl<R, P, const NUM_PUBLIC_BINARY: usize, const SHIFT_ONE: usize, const SHIFT_TWO: usize> Uair
+    for TestUairAffineVirtualShifted<R, P, NUM_PUBLIC_BINARY, SHIFT_ONE, SHIFT_TWO>
+where
+    R: ConstSemiring + 'static,
+    P: Semiring + From<u64> + 'static,
+{
+    type Ideal = DegreeOneIdeal<R>;
+    type FqIdeal = DegreeOneIdeal<R>;
+    type Scalar = DensePolynomial<R, 32>;
+    type Prime = P;
+
+    fn signature() -> UairSignature<Self::Prime> {
+        UairSignature::new(
+            TotalColumnLayout::new(5, 0, 0),
+            PublicColumnLayout::new(NUM_PUBLIC_BINARY, 0, 0),
+            vec![ShiftSpec::new(0, 1)],
+            vec![],
+        )
+        .with_affine_virtual_specs(vec![
+            AffineVirtualSpec::new(vec![
+                AffineVirtualTerm::new_shifted(1, 1, SHIFT_ONE),
+                AffineVirtualTerm::new(0, 1),
+                AffineVirtualTerm::new(2, -2),
+            ]),
+            AffineVirtualSpec::with_ones_coefficient(
+                vec![
+                    AffineVirtualTerm::new_shifted(1, -1, SHIFT_ONE),
+                    AffineVirtualTerm::new(0, 1),
+                    AffineVirtualTerm::new(3, -2),
+                ],
+                1,
+            ),
+            AffineVirtualSpec::new(vec![
+                AffineVirtualTerm::new_shifted(1, 1, SHIFT_TWO),
+                AffineVirtualTerm::new(0, 1),
+                AffineVirtualTerm::new(4, -2),
+            ]),
+        ])
+        .with_primes(vec![P::from(MERSENNE_61_PRIME)])
+    }
+
+    fn constrain_general<C, B, FromR, MulByScalar, IFromR, IFqFromR>(
+        b: &mut B,
+        expr_cfg: &C,
+        up: TraceRow<C::Element>,
+        _down: TraceRow<C::Element>,
+        _from_ref: FromR,
+        _mbs: MulByScalar,
+        ideal_from_ref: IFromR,
+        fq_ideal_from_ref: IFqFromR,
+    ) where
+        C: SemiringConfig,
+        B: ConstraintBuilder<Expr = C::Element>,
+        IFromR: Fn(&Self::Ideal) -> B::Ideal,
+        IFqFromR: Fn(&Self::FqIdeal) -> B::FqIdeal,
+    {
+        let identity = expr_cfg.sub(&up.binary_poly[0], &up.binary_poly[0]);
+        b.assert_in_ideal(
+            identity.clone(),
+            &ideal_from_ref(&DegreeOneIdeal::new(R::ONE)),
+        );
+        b.assert_in_fq_ideal(
+            0,
+            identity,
+            &fq_ideal_from_ref(&DegreeOneIdeal::new(R::ONE)),
+        );
+    }
+}
+
+impl<R, P, const NUM_PUBLIC_BINARY: usize, const SHIFT_ONE: usize, const SHIFT_TWO: usize>
+    GenerateRandomTrace<32>
+    for TestUairAffineVirtualShifted<R, P, NUM_PUBLIC_BINARY, SHIFT_ONE, SHIFT_TWO>
+where
+    R: ConstSemiring + 'static,
+    P: Semiring + From<u64> + 'static,
+{
+    type PolyCoeff = R;
+    type Int = R;
+
+    fn generate_random_trace<G: Rng + ?Sized>(
+        num_vars: usize,
+        rng: &mut G,
+    ) -> UairTrace<'static, R, R, 32, 32> {
+        let n = 1usize << num_vars;
+        let b: Vec<u32> = (0..n).map(|_| rng.next_u32()).collect();
+        let a: Vec<u32> = (0..n).map(|_| rng.next_u32()).collect();
+        let shifted = |row: usize, amount: usize| {
+            row.checked_add(amount)
+                .and_then(|shifted_row| a.get(shifted_row))
+                .copied()
+                .unwrap_or(0)
+        };
+        let and_shift_1: Vec<u32> = (0..n).map(|row| shifted(row, SHIFT_ONE) & b[row]).collect();
+        let not_and_shift_1: Vec<u32> = (0..n)
+            .map(|row| !shifted(row, SHIFT_ONE) & b[row])
+            .collect();
+        let and_shift_2: Vec<u32> = (0..n).map(|row| shifted(row, SHIFT_TWO) & b[row]).collect();
+
+        UairTrace {
+            binary_poly: vec![b, a, and_shift_1, not_and_shift_1, and_shift_2]
+                .into_iter()
+                .map(|values| values.into_iter().map(BinaryPoly::from).collect())
+                .collect::<Vec<_>>()
+                .into(),
+            ..Default::default()
+        }
+    }
+}
+
+/// UAIR fixture interleaving shifted public and witness affine sources.
+///
+/// The shifted sources occur in signature order `(public_0, witness_1,
+/// public_1, witness_0)`. Filtering to proof-carried witness shifts must
+/// therefore preserve `(witness_1, witness_0)`, including their non-monotonic
+/// appended-column indices.
+#[derive(Clone, Debug)]
+pub struct TestUairAffineVirtualShiftedMixed<R, P>(PhantomData<(R, P)>);
+
+impl<R, P> Uair for TestUairAffineVirtualShiftedMixed<R, P>
+where
+    R: ConstSemiring + 'static,
+    P: Semiring + From<u64> + 'static,
+{
+    type Ideal = DegreeOneIdeal<R>;
+    type FqIdeal = DegreeOneIdeal<R>;
+    type Scalar = DensePolynomial<R, 32>;
+    type Prime = P;
+
+    fn signature() -> UairSignature<Self::Prime> {
+        UairSignature::new(
+            TotalColumnLayout::new(8, 0, 0),
+            PublicColumnLayout::new(2, 0, 0),
+            vec![],
+            vec![],
+        )
+        .with_affine_virtual_specs(vec![
+            AffineVirtualSpec::new(vec![
+                AffineVirtualTerm::new_shifted(0, 1, 1),
+                AffineVirtualTerm::new(1, 1),
+                AffineVirtualTerm::new(4, -2),
+            ]),
+            AffineVirtualSpec::new(vec![
+                AffineVirtualTerm::new_shifted(3, 1, 2),
+                AffineVirtualTerm::new(0, 1),
+                AffineVirtualTerm::new(5, -2),
+            ]),
+            AffineVirtualSpec::new(vec![
+                AffineVirtualTerm::new_shifted(1, 1, 2),
+                AffineVirtualTerm::new(0, 1),
+                AffineVirtualTerm::new(6, -2),
+            ]),
+            AffineVirtualSpec::new(vec![
+                AffineVirtualTerm::new_shifted(2, 1, 1),
+                AffineVirtualTerm::new(1, 1),
+                AffineVirtualTerm::new(7, -2),
+            ]),
+        ])
+        .with_primes(vec![P::from(MERSENNE_61_PRIME)])
+    }
+
+    fn constrain_general<C, B, FromR, MulByScalar, IFromR, IFqFromR>(
+        b: &mut B,
+        expr_cfg: &C,
+        up: TraceRow<C::Element>,
+        _down: TraceRow<C::Element>,
+        _from_ref: FromR,
+        _mbs: MulByScalar,
+        ideal_from_ref: IFromR,
+        fq_ideal_from_ref: IFqFromR,
+    ) where
+        C: SemiringConfig,
+        B: ConstraintBuilder<Expr = C::Element>,
+        IFromR: Fn(&Self::Ideal) -> B::Ideal,
+        IFqFromR: Fn(&Self::FqIdeal) -> B::FqIdeal,
+    {
+        let identity = expr_cfg.sub(&up.binary_poly[0], &up.binary_poly[0]);
+        b.assert_in_ideal(
+            identity.clone(),
+            &ideal_from_ref(&DegreeOneIdeal::new(R::ONE)),
+        );
+        b.assert_in_fq_ideal(
+            0,
+            identity,
+            &fq_ideal_from_ref(&DegreeOneIdeal::new(R::ONE)),
+        );
+    }
+}
+
+impl<R, P> GenerateRandomTrace<32> for TestUairAffineVirtualShiftedMixed<R, P>
+where
+    R: ConstSemiring + 'static,
+    P: Semiring + From<u64> + 'static,
+{
+    type PolyCoeff = R;
+    type Int = R;
+
+    fn generate_random_trace<G: Rng + ?Sized>(
+        num_vars: usize,
+        rng: &mut G,
+    ) -> UairTrace<'static, R, R, 32, 32> {
+        let n = 1usize << num_vars;
+        let public_0: Vec<u32> = (0..n).map(|_| rng.next_u32()).collect();
+        let public_1: Vec<u32> = (0..n).map(|_| rng.next_u32()).collect();
+        let witness_0: Vec<u32> = (0..n).map(|_| rng.next_u32()).collect();
+        let witness_1: Vec<u32> = (0..n).map(|_| rng.next_u32()).collect();
+        let shifted_and = |source: &[u32], amount: usize, other: &[u32]| {
+            (0..n)
+                .map(|row| {
+                    row.checked_add(amount)
+                        .and_then(|shifted_row| source.get(shifted_row))
+                        .copied()
+                        .unwrap_or(0)
+                        & other[row]
+                })
+                .collect::<Vec<_>>()
+        };
+        let target_0 = shifted_and(&public_0, 1, &public_1);
+        let target_1 = shifted_and(&witness_1, 2, &public_0);
+        let target_2 = shifted_and(&public_1, 2, &public_0);
+        let target_3 = shifted_and(&witness_0, 1, &public_1);
+
+        UairTrace {
+            binary_poly: vec![
+                public_0, public_1, witness_0, witness_1, target_0, target_1, target_2, target_3,
+            ]
+            .into_iter()
+            .map(|values| values.into_iter().map(BinaryPoly::from).collect())
+            .collect::<Vec<_>>()
+            .into(),
+            ..Default::default()
+        }
+    }
+}
+
 /// A UAIR exercising the Flavor-1 $F_{q}[X]$-constraint surface
 /// for **multiple large primes**.
 ///
@@ -1405,6 +1672,10 @@ mod tests {
         assert_uair_shape::<TestUairBitOpsFqFamily<Int<LIMBS>, u64>>(&[1, 1]);
         assert_uair_shape::<TestUairAffineVirtualUnshifted<Int<LIMBS>, u64>>(&[1, 1]);
         assert_uair_shape::<TestUairAffineVirtualPublicOnly<Int<LIMBS>, u64>>(&[1, 1]);
+        assert_uair_shape::<TestUairAffineVirtualShiftedWitness<Int<LIMBS>, u64>>(&[1, 1]);
+        assert_uair_shape::<TestUairAffineVirtualShiftedPublicOnly<Int<LIMBS>, u64>>(&[1, 1]);
+        assert_uair_shape::<TestUairAffineVirtualOversizedShifts<Int<LIMBS>, u64>>(&[1, 1]);
+        assert_uair_shape::<TestUairAffineVirtualShiftedMixed<Int<LIMBS>, u64>>(&[1, 1]);
         // TestUairFqLargePrime: two F_{q_i}[X] linear constraints (one per
         // declared prime).
         assert_uair_shape::<TestUairFqLargePrime<Int<LIMBS>, u64>>(&[1, 1]);

--- a/uair/src/lib.rs
+++ b/uair/src/lib.rs
@@ -231,8 +231,8 @@ impl AffineVirtualTerm {
 
     /// Construct a shifted term `coefficient * source_col[row + row_shift]`.
     ///
-    /// [`UairSignature::with_affine_virtual_specs`] currently rejects shifted
-    /// terms until the protocol binds row-shifted source projections.
+    /// Rows past the trace domain are zero padded. Shifts at or beyond the
+    /// domain size therefore contribute the all-zero column.
     pub fn new_shifted(source_col: usize, coefficient: i64, row_shift: usize) -> Self {
         assert!(row_shift > 0, "row shift must be non-zero");
         Self {
@@ -551,17 +551,17 @@ impl<Prime: Semiring> UairSignature<Prime> {
 
     /// Attach affine virtual booleanity specs to the signature.
     ///
-    /// Each term in each spec must be unshifted and reference a binary_poly
-    /// column. Affine virtuals describe Q-side `{0,1}^{<D}[X]` membership
-    /// targets such as the Ch/Maj linear combinations in the Zinc+ paper. They
-    /// are not committed columns and do not affect the down-row layout.
+    /// Each term in each spec must reference a binary_poly column. Affine
+    /// virtuals describe Q-side `{0,1}^{<D}[X]` membership targets such as the
+    /// Ch/Maj linear combinations in the Zinc+ paper. They are not committed
+    /// columns and do not affect the down-row layout.
     pub fn with_affine_virtual_specs(
         mut self,
         affine_virtual_specs: Vec<AffineVirtualSpec>,
     ) -> Self {
         let binary_poly_end = self.total_cols.num_binary_poly_cols();
-        for (spec_index, spec) in affine_virtual_specs.iter().enumerate() {
-            for (term_index, term) in spec.terms().iter().enumerate() {
+        for spec in &affine_virtual_specs {
+            for term in spec.terms() {
                 assert!(
                     term.source_col() < binary_poly_end,
                     "AffineVirtualTerm source_col {} is not a binary_poly column \
@@ -569,12 +569,6 @@ impl<Prime: Semiring> UairSignature<Prime> {
                      are only defined over binary_poly cells.",
                     term.source_col(),
                     binary_poly_end,
-                );
-                assert!(
-                    term.row_shift() == 0,
-                    "shifted affine virtual terms are not supported: spec {spec_index}, \
-                     term {term_index}, row shift {}",
-                    term.row_shift(),
                 );
             }
         }
@@ -958,13 +952,13 @@ mod tests {
     }
 
     #[test]
-    #[should_panic(
-        expected = "shifted affine virtual terms are not supported: spec 0, term 0, row shift 1"
-    )]
-    fn affine_virtual_specs_reject_shifted_terms() {
-        let _ =
+    fn affine_virtual_specs_support_shifted_terms() {
+        let sig =
             signature_with_mixed_shifts().with_affine_virtual_specs(vec![AffineVirtualSpec::new(
-                vec![AffineVirtualTerm::new_shifted(0, 1, 1)],
+                vec![AffineVirtualTerm::new_shifted(0, 1, 2)],
             )]);
+
+        assert_eq!(sig.affine_virtual_specs()[0].terms()[0].row_shift(), 2);
+        assert_eq!(sig.down_cols().num_binary_poly_cols(), 1);
     }
 }


### PR DESCRIPTION
Goes towards #185, which blocks #91. Follow-up to #230.

This extends affine virtual Booleanity targets to forward-row-shifted sources:
* Shifted source pairs are deduplicated in public UAIR-signature order.
* The prover carries one evaluation per unique shifted witness source and appends signature-derived shifts over the existing alpha-prime-projected witness slots to multipoint evaluation.
* Shifted witness evaluations are absorbed before multipoint challenges and bound to committed source openings through the existing shift kernel and PCS chain.
* The verifier derives the exact witness-claim count from the public signature, recomputes shifted public sources directly, and reconstructs each expected affine endpoint from its shifted and unshifted terms.
* Per-prime families receive matching zero padding because affine virtual Booleanity targets remain in $Q[X]$.

Shifts at or beyond the trace domain now consistently represent the all-zero, zero-padded column in both the prover MLE selector and verifier shift predicate. The affine materializer also handles index overflow as an out-of-range row.

Affine virtuals remain uncommitted Booleanity targets, so shifted witness terms reuse existing committed source openings and add no PCS commitments. SHA-256/ECDSA UAIR adoption remains separate.

Tests cover shifted witness-only and public-only paths, interleaved public/witness ordering across two witness sources, first-occurrence deduplication and appended-source indices, signature-derived length rejection, tampered shifted claims, and shifts equal to or greater than the trace length.